### PR TITLE
Possible to specify hyperpriors, also added shortcut ways to specify parameters

### DIFF
--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -167,3 +167,23 @@ def test_custom_model(data, example_model_config):
 
     assert model.model_name == "custom"
     assert model.model_config == example_model_config
+
+
+def test_model_definition_outside_include(data):
+
+    model_with_one_param_fixed = hssm.HSSM(data, a=0.5)
+
+    assert "a" in model_with_one_param_fixed.priors
+    assert model_with_one_param_fixed.priors["a"] == 0.5
+
+    model_with_one_param = hssm.HSSM(
+        data, a={"prior": {"name": "Normal", "mu": 0.5, "sigma": 0.1}}
+    )
+
+    assert "a" in model_with_one_param.priors
+    assert model_with_one_param.priors["a"].name == "Normal"
+
+    with pytest.raises(
+        ValueError, match='Parameter "a" is already specified in `include`'
+    ):
+        hssm.HSSM(data, include=[{"name": "a", "prior": 0.5}], a=0.5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 import ssms.basic_simulators
 
 import hssm
-from hssm.utils import Param, _parse_bambi
+from hssm.utils import Param, _make_priors_recursive, _parse_bambi
 
 
 def test_param_non_regression():
@@ -229,3 +229,17 @@ def test_get_alias_dict():
     assert alias_regression_a["c(rt, response)"]["c(rt, response)"] == "rt,response"
     assert alias_regression_a["c(rt, response)"]["Intercept"] == "v"
     #  assert alias_regression_a["a"]["Intercept"] == "v" # Undetermined, will add later
+
+
+def test__make_priors_recursive():
+
+    test_dict = {
+        "name": "Uniform",
+        "lower": 0.1,
+        "upper": {"name": "Normal", "mu": 0.5, "sigma": 0.1},
+    }
+
+    result_prior = _make_priors_recursive(test_dict)
+    assert isinstance(result_prior, bmb.Prior)
+    assert isinstance(result_prior.args["upper"], bmb.Prior)
+    assert result_prior.args["upper"].name == "Normal"


### PR DESCRIPTION
This PR mainly added the ability to specify hyperpriors mentioned in #84. Now you can use either a `dict` or a `bmb.Prior` to specify the parameters of a random effect. For example, you can now do this:

```python
model = hssm.HSSM(data, include=[{
    "name": "v",
    "formula": "v ~ (1|group)",
    "prior": {
        "1|group": {
            "name": "Normal",
            "mu": 0.0,
            "sigma": {"name": "Halfnormal", sigma=0.1, initval=0.1}
        }
    }
])
```

This PR also adds the shortcut way to add parameters directly through arguments to HSSM. This is the most convenient when we want to fix parameters. For example,

```python
model = hssm.HSSM(data, include=[{"name": "a", "prior": 0.8}])
```

is now simply

```python
model = hssm.HSSM(data, a=0.8)
```

Currently the two ways to specify priors are co-existing. There are situations when we have to specify parameters in `include`, which is when `list_params` contains parameter names that contain characters that are illegal to function arguments (such as `"|"`). Parameters specified in `include` cannot be specified in arguments to `HSSM`. Doing so will result in a `ValueError`.