### PR TITLE
Added prior predictive sampling

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -117,12 +117,15 @@ def make_ssm_rv(model_name: str, list_params: list[str]) -> Type[RandomVariable]
 
         # NOTE: This is wrong at the moment, but necessary
         # to get around the support checking in PyMC that would result in error
-        ndim_supp: int = 0
+        ndim_supp: int = 1
 
         ndims_params: list[int] = [0 for _ in list_params]
         dtype: str = "floatX"
         _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params
+
+        def _supp_shape_from_params(*args, **kwargs):
+            return (2,)
 
         # pylint: disable=arguments-renamed,bad-option-value,W0221
         # NOTE: `rng` now is a np.random.Generator instead of RandomState
@@ -159,6 +162,11 @@ def make_ssm_rv(model_name: str, list_params: list[str]) -> Type[RandomVariable]
             else:
                 size = args[-1]
                 args = args[:-1]
+
+            # Although we got around the ndims_supp issue, the size parameter passed
+            # here is still an array with one element. We need to take it out.
+            if not np.isscalar(size):
+                size = np.squeeze(size)
 
             arg_arrays = [np.asarray(arg) for arg in args]
 

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -114,8 +114,6 @@ def make_ssm_rv(model_name: str, list_params: list[str]) -> Type[RandomVariable]
         """WFPT random variable."""
 
         name: str = "SSM_RV"
-
-        # NOTE: This is wrong at the moment, but necessary
         # to get around the support checking in PyMC that would result in error
         ndim_supp: int = 1
 
@@ -124,6 +122,11 @@ def make_ssm_rv(model_name: str, list_params: list[str]) -> Type[RandomVariable]
         _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params
 
+        # PyTensor, as of version 2.12, enforces a check to ensure that
+        # at least one parameter has the same ndims as the support.
+        # This overrides that check and ensures that the dimension checks are correct.
+        # For more information, see this issue
+        # https://github.com/lnccbrown/HSSM/issues/36
         def _supp_shape_from_params(*args, **kwargs):
             return (2,)
 
@@ -153,6 +156,28 @@ def make_ssm_rv(model_name: str, list_params: list[str]) -> Type[RandomVariable]
             -------
             np.ndarray
                 An array of `(rt, response)` generated from the distribution.
+
+            Note
+            ----
+            How size is handled in this method:
+
+            We apply multiple tricks to get this method to work with ssm_simulators.
+
+            First, size could be an array with one element. We squeeze the array and
+            use that element as size.
+
+            Then, size could depend on whether the parameters passed to this method.
+            If all parameters passed are scalar, that is the easy case. We just
+            assemble all parameters into a 1D array and pass it to the `theta`
+            argument. In this case, size is number of observations.
+
+            If one of the parameters is a vector, which happens one or more parameters
+            is the target of a regression. In this case, we take the size of the
+            parameter with the largest size. If size is None, we will set size to be
+            this largest size. If size is not None, we check if size is a multiple of
+            the largest size. If not, an error is thrown. Otherwise, we assemble the
+            parameter as a matrix and pass it as the `theta` argument. The multiple then
+            becomes how many samples we draw from each trial.
             """
             # First figure out what the size specified here is
             # Since the number of unnamed arguments is undetermined,

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -522,7 +522,7 @@ class HSSM:
         draws: int = 500,
         var_names: str | list[str] | None = None,
         omit_offsets: bool = True,
-        random_seed: np.random.RandomGenerator | None = None,
+        random_seed: np.random.Generator | None = None,
     ) -> az.InferenceData:
         """Generate samples from the prior predictive distribution.
 

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from os import PathLike
 
     import arviz as az
+    import numpy as np
     import pandas as pd
     import pytensor
 
@@ -515,6 +516,37 @@ class HSSM:
                 )
             idata = self._inference_obj
         return self.model.predict(idata, kind, data, inplace, include_group_specific)
+
+    def sample_prior_predictive(
+        self,
+        draws: int = 500,
+        var_names: str | list[str] | None = None,
+        omit_offsets: bool = True,
+        random_seed: np.random.RandomGenerator | None = None,
+    ) -> az.InferenceData:
+        """Generate samples from the prior predictive distribution.
+
+        Parameters
+        ----------
+        draws
+            Number of draws to sample from the prior predictive distribution. Defaults
+            to 500.
+        var_names
+            A list of names of variables for which to compute the prior predictive
+            distribution. Defaults to ``None`` which means both observed and unobserved
+            RVs.
+        omit_offsets
+            Whether to omit offset terms in the plot. Defaults to ``True``.
+        random_seed
+            Seed for the random number generator.
+
+        Returns
+        -------
+        az.InferenceData
+            ``InferenceData`` object with the groups ``prior``, ``prior_predictive`` and
+            ``observed_data``.
+        """
+        return self.model.prior_predictive(draws, var_names, omit_offsets, random_seed)
 
     @property
     def pymc_model(self) -> pm.Model:

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -536,7 +536,7 @@ class HSSM:
             distribution. Defaults to ``None`` which means both observed and unobserved
             RVs.
         omit_offsets
-            Whether to omit offset terms in the plot. Defaults to ``True``.
+            Whether to omit offset terms. Defaults to ``True``.
         random_seed
             Seed for the random number generator.
 

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -220,7 +220,9 @@ def test_model_with_approx_differentiable_likelihood_type(data_angle):
 
 
 def test_sample_prior_predictive(data):
-    model_no_regression = HSSM(data=data.iloc[:10, :])
+    data = data.iloc[:10, :]
+
+    model_no_regression = HSSM(data=data)
     rng = np.random.default_rng()
 
     prior_predictive_1 = model_no_regression.sample_prior_predictive(draws=10)
@@ -228,7 +230,30 @@ def test_sample_prior_predictive(data):
         draws=10, random_seed=rng
     )
 
-    model_regression = HSSM(
-        data=data.iloc[:10, :], include=[dict(name="v", formula="v ~ 1 + x")]
-    )
+    model_regression = HSSM(data=data, include=[dict(name="v", formula="v ~ 1 + x")])
     prior_predictive_3 = model_regression.sample_prior_predictive(draws=10)
+
+    model_regression_a = HSSM(data=data, include=[dict(name="a", formula="a ~ 1 + x")])
+    prior_predictive_4 = model_regression_a.sample_prior_predictive(draws=10)
+
+    model_regression_multi = HSSM(
+        data=data,
+        include=[
+            dict(name="v", formula="v ~ 1 + x"),
+            dict(name="a", formula="a ~ 1 + y"),
+        ],
+    )
+    prior_predictive_5 = model_regression_multi.sample_prior_predictive(draws=10)
+
+    data["subject_id"] = np.arange(10)
+
+    model_regression_random_effect = HSSM(
+        data=data,
+        include=[
+            dict(name="v", formula="v ~ (1|subject_id) + x"),
+            dict(name="a", formula="a ~ (1|subject_id) + y"),
+        ],
+    )
+    prior_predictive_6 = model_regression_random_effect.sample_prior_predictive(
+        draws=10
+    )

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -217,3 +217,18 @@ def test_model_with_approx_differentiable_likelihood_type(data_angle):
     assert model.loglik == download_hf(loglik)
     trace = model.sample()
     assert isinstance(trace, az.InferenceData)
+
+
+def test_sample_prior_predictive(data):
+    model_no_regression = HSSM(data=data.iloc[:10, :])
+    rng = np.random.default_rng()
+
+    prior_predictive_1 = model_no_regression.sample_prior_predictive(draws=10)
+    prior_predictive_2 = model_no_regression.sample_prior_predictive(
+        draws=10, random_seed=rng
+    )
+
+    model_regression = HSSM(
+        data=data.iloc[:10, :], include=[dict(name="v", formula="v ~ 1 + x")]
+    )
+    prior_predictive_3 = model_regression.sample_prior_predictive(draws=10)


### PR DESCRIPTION
After using a hack mentioned [here](https://discourse.pymc.io/t/pm-sample-prior-predictive-fails-with-incorrect-size-info-passed-to-the-rng-fn-function-of-the-randomvariable/12513/5), the problem is successfully resolved.

We can now use `model.sample_prior_predictive()` to perform prior predictive sampling