### PR TITLE
Major refactor of `hssm.HSSM` via `Config`

### DIFF
--- a/src/hssm/__init__.py
+++ b/src/hssm/__init__.py
@@ -3,8 +3,9 @@
 import logging
 import sys
 
-from .config import show_defaults
+from .config import ModelConfig
 from .datasets import load_data
+from .defaults import show_defaults
 from .hssm import HSSM
 from .prior import Prior
 from .simulator import simulate_data
@@ -15,4 +16,12 @@ _logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(stream=sys.stdout)
 _logger.addHandler(handler)
 
-__all__ = ["HSSM", "load_data", "Prior", "simulate_data", "set_floatX", "show_defaults"]
+__all__ = [
+    "HSSM",
+    "load_data",
+    "ModelConfig",
+    "Prior",
+    "simulate_data",
+    "set_floatX",
+    "show_defaults",
+]

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -1,263 +1,164 @@
-"""Provide default configurations for models in the HSSM class."""
-from typing import Any, Literal, Optional
-
-import bambi as bmb
-
-from .likelihoods.analytical import (
-    ddm_bounds,
-    ddm_params,
-    ddm_sdv_params,
-    logp_ddm,
-    logp_ddm_sdv,
-)
-from .param import _make_default_prior
-
-SupportedModels = Literal[
-    "ddm",
-    "ddm_sdv",
-    "angle",
-    "levy",
-    "ornstein",
-    "weibull",
-    "race_no_bias_angle_4",
-    "ddm_seq2_no_bias",
-]
-
-LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
-
-ConfigParams = Literal[
-    "loglik",
-    "list_params",
-    "default_priors",
-    "backend",
-    "bounds",
-    "rv",
-]
-
-Config = dict[ConfigParams, Any]
-
-default_model_config: dict[SupportedModels, dict[Literal[LoglikKind], Config]] = {
-    "ddm": {
-        "analytical": {
-            "loglik": logp_ddm,
-            "bounds": ddm_bounds,
-            "default_priors": {
-                "t": {"name": "Uniform", "lower": 0.0, "upper": 2.0, "initval": 0.1},
-            },
-        },
-        "approx_differentiable": {
-            "loglik": "ddm.onnx",
-            "bounds": {
-                "v": (-3.0, 3.0),
-                "a": (0.3, 2.5),
-                "z": (0.0, 1.0),
-                "t": (0.0, 2.0),
-            },
-        },
-    },
-    "ddm_sdv": {
-        "analytical": {
-            "loglik": logp_ddm_sdv,
-            "bounds": ddm_bounds,
-            "default_priors": {
-                "t": {"name": "Uniform", "lower": 0.0, "upper": 2.0, "initval": 0.1},
-            },
-        },
-        "approx_differentiable": {
-            "loglik": "ddm_sdv.onnx",
-            "bounds": {
-                "v": (-3.0, 3.0),
-                "a": (0.3, 2.5),
-                "z": (0.1, 0.9),
-                "t": (0.0, 2.0),
-                "sv": (0.0, 1.0),
-            },
-        },
-    },
-    "angle": {
-        "approx_differentiable": {
-            "loglik": "angle.onnx",
-            "bounds": {
-                "v": (-3.0, 3.0),
-                "a": (0.3, 3.0),
-                "z": (0.1, 0.9),
-                "t": (0.001, 2.0),
-                "theta": (-0.1, 1.3),
-            },
-        },
-    },
-    "levy": {
-        "approx_differentiable": {
-            "loglik": "levy.onnx",
-            "bounds": {
-                "v": (-3.0, 3.0),
-                "a": (0.3, 3.0),
-                "z": (0.1, 0.9),
-                "alpha": (1.0, 2.0),
-                "t": (1e-3, 2.0),
-            },
-        },
-    },
-    "ornstein": {
-        "approx_differentiable": {
-            "loglik": "ornstein.onnx",
-            "bounds": {
-                "v": (-2.0, 2.0),
-                "a": (0.3, 3.0),
-                "z": (0.1, 0.9),
-                "g": (-1.0, 1.0),
-                "t": (1e-3, 2.0),
-            },
-        },
-    },
-    "weibull": {
-        "approx_differentiable": {
-            "loglik": "weibull.onnx",
-            "bounds": {
-                "v": (-2.5, 2.5),
-                "a": (0.3, 2.5),
-                "z": (0.2, 0.8),
-                "t": (1e-3, 2.0),
-                "alpha": (0.31, 4.99),
-                "beta": (0.31, 6.99),
-            },
-        },
-    },
-    "race_no_bias_angle_4": {
-        "approx_differentiable": {
-            "loglik": "race_no_bias_angle_4.onnx",
-            "bounds": {
-                "v0": (0.0, 2.5),
-                "v1": (0.0, 2.5),
-                "v2": (0.0, 2.5),
-                "v3": (0.0, 2.5),
-                "a": (1.0, 3.0),
-                "z": (0.0, 0.9),
-                "ndt": (0.0, 2.0),
-                "theta": (-0.1, 1.45),
-            },
-        },
-    },
-    "ddm_seq2_no_bias": {
-        "approx_differentiable": {
-            "loglik": "ddm_seq2_no_bias.onnx",
-            "bounds": {
-                "vh": (-4.0, 4.0),
-                "vl1": (-4.0, 4.0),
-                "vl2": (-4.0, 4.0),
-                "a": (0.3, 2.5),
-                "t": (0.0, 2.0),
-            },
-        },
-    },
-}
-
-default_params: dict[SupportedModels, list[str]] = {
-    "ddm": ddm_params,
-    "ddm_sdv": ddm_sdv_params,
-    "angle": ["v", "a", "z", "t", "theta"],
-    "levy": ["v", "a", "z", "alpha", "t"],
-    "ornstein": ["v", "a", "z", "g", "t"],
-    "weibull": ["v", "a", "z", "t", "alpha", "beta"],
-    "race_no_bias_angle_4": ["v0", "v1", "v2", "v3", "a", "z", "ndt", "theta"],
-    "ddm_seq2_no_bias": ["vh", "vl1", "vl2", "a", "t"],
-}
+"""Config and ModelConfig classes that process configs."""
 
 
-def show_defaults(model: SupportedModels, loglik_kind=Optional[LoglikKind]) -> str:
-    """Show the defaults for supported models.
+from __future__ import annotations
 
-    Parameters
-    ----------
-    model
-        One of the supported model strings.
-    loglik_kind : optional
-        The kind of likelihood function, by default None, in which case the defaults for
-        all likelihoods will be shown.
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal, cast
 
-    Returns
-    -------
-    str
-        A nicely organized printout for the defaults of provided model.
-    """
-    if model not in default_model_config:
-        raise ValueError(f"{model} does not currently have defaults in HSSM.")
+from .defaults import LogLik, LoglikKind, SupportedModels, default_model_config
 
-    model_config = default_model_config[model]
+if TYPE_CHECKING:
+    from pytensor.tensor.random.op import RandomVariable
 
-    output = []
-    output.append("Default model config:")
-    output.append(f"Model: {model}")
+    from .param import ParamSpec
 
-    # Will implement later
-    # if "description" in model_config:
-    #     output.append("Description:")
-    #     output.append(f"    {model_config['description']}")
 
-    output.append(f"Default parameters: {default_params[model]}")
-    output.append("")
+@dataclass
+class Config:
+    """Config class that stores the configurations for models."""
 
-    if loglik_kind is not None:
-        if loglik_kind not in model_config:
+    model_name: SupportedModels | str
+    loglik_kind: LoglikKind
+    list_params: list[str] | None = None
+    description: str | None = None
+    loglik: LogLik | None = None
+    backend: Literal["jax", "pytensor"] | None = None
+    rv: RandomVariable | None = None
+    # Fields with dictionaries are automatically deepcopied
+    default_priors: dict[str, ParamSpec] = field(default_factory=dict)
+    bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
+
+    @classmethod
+    def from_defaults(
+        cls, model_name: SupportedModels | str, loglik_kind: LoglikKind | None
+    ):
+        """Generate a Config object from defaults.
+
+        Parameters
+        ----------
+        model_name
+            The name of the model.
+        loglik_kind
+            The kind of the log-likelihood for the model.
+        """
+        if loglik_kind is None:
+            if model_name not in default_model_config:
+                raise ValueError(
+                    "When using a custom model, please provide a `loglik_kind.`"
+                )
+            # Setting loglik_kind to be the first of analytical or
+            # approx_differentiable
+            for kind in ["analytical", "approx_differentiable", "blackbox"]:
+                model_name = cast(SupportedModels, model_name)
+                default_config = default_model_config[model_name]
+                if kind in default_config["likelihoods"]:
+                    kind = cast(LoglikKind, kind)
+                    loglik_config = default_config["likelihoods"][kind]
+
+                    return Config(
+                        model_name,
+                        kind,
+                        list_params=default_config["list_params"],
+                        description=default_config["description"],
+                        **loglik_config,
+                    )
+
             raise ValueError(
-                f"{model} does not currently have defaults for `{loglik_kind}` "
-                + "log-likelihoods in HSSM."
+                "No default model_config is found. Please provide a `loglik_kind."
             )
-
-        output += _show_defaults_helper(model, loglik_kind)
-
-    else:
-        for loglik_kind in model_config.keys():
-            output += _show_defaults_helper(model, loglik_kind)
-            output.append("")
-
-        output = output[:-1]
-
-    return "\r\n".join(output)
-
-
-def _show_defaults_helper(model: SupportedModels, loglik_kind: LoglikKind) -> list[str]:
-    """Show the defaults for supported models.
-
-    Parameters
-    ----------
-    model
-        One of the supported model strings.
-    loglik_kind
-        The kind of likelihood function.
-
-    Returns
-    -------
-    list[str]
-        A list of nicely organized printout for the defaults of provided model.
-    """
-    output = []
-    params = default_params[model]
-    model_defaults = default_model_config[model][loglik_kind]
-
-    output.append(f"Log-likelihood kind: {loglik_kind}")
-    output.append(f"Log-likelihood: {model_defaults['loglik']}")
-    if loglik_kind == "approx_differentiable":
-        output.append("Default backend: jax")
-    output.append("Default priors:")
-
-    default_priors = model_defaults.get("default_priors", {})
-    default_bounds = model_defaults.get("bounds", {})
-
-    for param in params:
-        prior = default_priors.get(param, None)
-        if prior is None:
-            bounds = default_bounds.get(param, None)
-            prior = _make_default_prior(bounds) if bounds is not None else None
         else:
-            if isinstance(prior, dict):
-                prior = bmb.Prior(**prior)
+            if loglik_kind not in [
+                "analytical",
+                "approx_differentiable",
+                "blackbox",
+            ]:
+                raise ValueError(
+                    "`loglik_kind`, when provided, must be one of "
+                    + '"analytical", "approx_differentiable", "blackbox".'
+                )
+            if model_name in default_model_config:
+                model_name = cast(SupportedModels, model_name)
+                default_config = default_model_config[model_name]
+                if loglik_kind in default_config["likelihoods"]:
+                    loglik_config = default_config["likelihoods"][loglik_kind]
+                    return Config(
+                        model_name,
+                        loglik_kind,
+                        list_params=default_config["list_params"],
+                        description=default_config["description"],
+                        **loglik_config,
+                    )
+                return Config(
+                    model_name,
+                    loglik_kind,
+                    list_params=default_config["list_params"],
+                    description=default_config["description"],
+                )
 
-        output.append(f"    {param} ~ {prior}")
+            return Config(model_name, loglik_kind)
 
-    output.append("Default bounds:")
+    def update_loglik(self, loglik: Any | None) -> None:
+        """Update the log-likelihood function from user input.
 
-    for param in params:
-        output.append(f"    {param}: {default_bounds.get(param, None)}")
+        Parameters
+        ----------
+        loglik : optional
+            A user-defined log-likelihood function.
+        """
+        if loglik is None:
+            return
 
-    return output
+        self.loglik = loglik
+
+    def update_config(self, user_config: ModelConfig) -> None:
+        """Update the object from a ModelConfig object.
+
+        Parameters
+        ----------
+        loglik : optional
+            A user-defined log-likelihood function.
+        """
+        if user_config.list_params is not None:
+            self.list_params = user_config.list_params
+
+        if (
+            self.loglik_kind == "approx_differentiable"
+            and user_config.backend is not None
+        ):
+            self.backend = user_config.backend
+
+        self.default_priors |= user_config.default_priors
+        self.bounds |= user_config.bounds
+
+    def validate(self) -> None:
+        """Ensure that mandatory fields are not None."""
+        if self.list_params is None:
+            raise ValueError("Please provide `list_params` via `model_config`.")
+        if self.loglik is None:
+            raise ValueError("Please provide a log-likelihood function via `loglik`.")
+        if self.loglik_kind == "approx_differentiable" and self.backend is None:
+            raise ValueError("Please provide `backend` via `model_config`.")
+
+    def get_defaults(
+        self, param: str
+    ) -> tuple[ParamSpec | None, tuple[float, float] | None]:
+        """Return the default prior and bounds for a parameter.
+
+        Parameters
+        ----------
+        param
+            The name of the parameter.
+        """
+        return self.default_priors.get(param), self.bounds.get(param)
+
+
+@dataclass
+class ModelConfig:
+    """Representation for model_config provided by the user."""
+
+    list_params: list[str] | None = None
+    default_priors: dict[str, ParamSpec] = field(default_factory=dict)
+    bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
+    backend: Literal["jax", "pytensor"] | None = None
+    rv: RandomVariable | None = None

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -64,9 +64,8 @@ default_model_config: DefaultConfigs = {
                 "bounds": ddm_bounds,
                 "default_priors": {
                     "t": {
-                        "name": "Uniform",
-                        "lower": 0.0,
-                        "upper": 2.0,
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
                         "initval": 0.1,
                     },
                 },
@@ -94,9 +93,8 @@ default_model_config: DefaultConfigs = {
                 "bounds": ddm_bounds,
                 "default_priors": {
                     "t": {
-                        "name": "Uniform",
-                        "lower": 0.0,
-                        "upper": 2.0,
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
                         "initval": 0.1,
                     },
                 },

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -1,0 +1,328 @@
+"""Provide default configurations for models in the HSSM class."""
+from os import PathLike
+from typing import Callable, Literal, Optional, TypedDict, Union
+
+import bambi as bmb
+from pymc import Distribution
+from pytensor.graph.op import Op
+
+from .likelihoods.analytical import (
+    ddm_bounds,
+    ddm_params,
+    ddm_sdv_params,
+    logp_ddm,
+    logp_ddm_sdv,
+)
+from .param import ParamSpec, _make_default_prior
+
+LogLik = Union[str, PathLike, Callable, Op, type[Distribution]]
+
+SupportedModels = Literal[
+    "ddm",
+    "ddm_sdv",
+    "angle",
+    "levy",
+    "ornstein",
+    "weibull",
+    "race_no_bias_angle_4",
+    "ddm_seq2_no_bias",
+]
+
+LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
+
+
+class LoglikConfig(TypedDict):
+    """Type for the value of LoglikConfig."""
+
+    loglik: LogLik
+    backend: Optional[Literal["jax", "pytensor"]]
+    default_priors: dict[str, ParamSpec]
+    bounds: dict[str, tuple[float, float]]
+
+
+LoglikConfigs = dict[LoglikKind, LoglikConfig]
+
+
+class DefaultConfig(TypedDict):
+    """Type for the value of DefaultConfig."""
+
+    list_params: list[str]
+    description: Optional[str]
+    likelihoods: LoglikConfigs
+
+
+DefaultConfigs = dict[SupportedModels, DefaultConfig]
+
+default_model_config: DefaultConfigs = {
+    "ddm": {
+        "list_params": ddm_params,
+        "description": "The Drift Diffusion Model (DDM)",
+        "likelihoods": {
+            "analytical": {
+                "loglik": logp_ddm,
+                "backend": None,
+                "bounds": ddm_bounds,
+                "default_priors": {
+                    "t": {
+                        "name": "Uniform",
+                        "lower": 0.0,
+                        "upper": 2.0,
+                        "initval": 0.1,
+                    },
+                },
+            },
+            "approx_differentiable": {
+                "loglik": "ddm.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-3.0, 3.0),
+                    "a": (0.3, 2.5),
+                    "z": (0.0, 1.0),
+                    "t": (0.0, 2.0),
+                },
+            },
+        },
+    },
+    "ddm_sdv": {
+        "list_params": ddm_sdv_params,
+        "description": "The Drift Diffusion Model (DDM) with standard deviation for v",
+        "likelihoods": {
+            "analytical": {
+                "loglik": logp_ddm_sdv,
+                "backend": None,
+                "bounds": ddm_bounds,
+                "default_priors": {
+                    "t": {
+                        "name": "Uniform",
+                        "lower": 0.0,
+                        "upper": 2.0,
+                        "initval": 0.1,
+                    },
+                },
+            },
+            "approx_differentiable": {
+                "loglik": "ddm_sdv.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-3.0, 3.0),
+                    "a": (0.3, 2.5),
+                    "z": (0.1, 0.9),
+                    "t": (0.0, 2.0),
+                    "sv": (0.0, 1.0),
+                },
+            },
+        },
+    },
+    "angle": {
+        "list_params": ["v", "a", "z", "t", "theta"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "angle.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-3.0, 3.0),
+                    "a": (0.3, 3.0),
+                    "z": (0.1, 0.9),
+                    "t": (0.001, 2.0),
+                    "theta": (-0.1, 1.3),
+                },
+            },
+        },
+    },
+    "levy": {
+        "list_params": ["v", "a", "z", "alpha", "t"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "levy.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-3.0, 3.0),
+                    "a": (0.3, 3.0),
+                    "z": (0.1, 0.9),
+                    "alpha": (1.0, 2.0),
+                    "t": (1e-3, 2.0),
+                },
+            },
+        },
+    },
+    "ornstein": {
+        "list_params": ["v", "a", "z", "g", "t"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "ornstein.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-2.0, 2.0),
+                    "a": (0.3, 3.0),
+                    "z": (0.1, 0.9),
+                    "g": (-1.0, 1.0),
+                    "t": (1e-3, 2.0),
+                },
+            },
+        },
+    },
+    "weibull": {
+        "list_params": ["v", "a", "z", "t", "alpha", "beta"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "weibull.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v": (-2.5, 2.5),
+                    "a": (0.3, 2.5),
+                    "z": (0.2, 0.8),
+                    "t": (1e-3, 2.0),
+                    "alpha": (0.31, 4.99),
+                    "beta": (0.31, 6.99),
+                },
+            },
+        },
+    },
+    "race_no_bias_angle_4": {
+        "list_params": ["v0", "v1", "v2", "v3", "a", "z", "ndt", "theta"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "race_no_bias_angle_4.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "v0": (0.0, 2.5),
+                    "v1": (0.0, 2.5),
+                    "v2": (0.0, 2.5),
+                    "v3": (0.0, 2.5),
+                    "a": (1.0, 3.0),
+                    "z": (0.0, 0.9),
+                    "ndt": (0.0, 2.0),
+                    "theta": (-0.1, 1.45),
+                },
+            },
+        },
+    },
+    "ddm_seq2_no_bias": {
+        "list_params": ["vh", "vl1", "vl2", "a", "t"],
+        "description": None,
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "ddm_seq2_no_bias.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    "vh": (-4.0, 4.0),
+                    "vl1": (-4.0, 4.0),
+                    "vl2": (-4.0, 4.0),
+                    "a": (0.3, 2.5),
+                    "t": (0.0, 2.0),
+                },
+            },
+        },
+    },
+}
+
+
+def show_defaults(model: SupportedModels, loglik_kind=Optional[LoglikKind]) -> str:
+    """Show the defaults for supported models.
+
+    Parameters
+    ----------
+    model
+        One of the supported model strings.
+    loglik_kind : optional
+        The kind of likelihood function, by default None, in which case the defaults for
+        all likelihoods will be shown.
+
+    Returns
+    -------
+    str
+        A nicely organized printout for the defaults of provided model.
+    """
+    if model not in default_model_config:
+        raise ValueError(f"{model} does not currently have defaults in HSSM.")
+
+    model_config = default_model_config[model]
+
+    output = []
+    output.append("Default model config:")
+    output.append(f"Model: {model}")
+
+    if model_config["description"] is not None:
+        output.append("Description:")
+        output.append(f"    {model_config['description']}")
+
+    output.append(f"Default parameters: {model_config['list_params']}")
+    output.append("")
+
+    if loglik_kind is not None:
+        if loglik_kind not in model_config["likelihoods"]:
+            raise ValueError(
+                f"{model} does not currently have defaults for `{loglik_kind}` "
+                + "log-likelihoods in HSSM."
+            )
+
+        output += _show_defaults_helper(model, loglik_kind)
+
+    else:
+        for loglik_kind in model_config["likelihoods"].keys():
+            output += _show_defaults_helper(model, loglik_kind)
+            output.append("")
+
+        output = output[:-1]
+
+    return "\r\n".join(output)
+
+
+def _show_defaults_helper(model: SupportedModels, loglik_kind: LoglikKind) -> list[str]:
+    """Show the defaults for supported models.
+
+    Parameters
+    ----------
+    model
+        One of the supported model strings.
+    loglik_kind
+        The kind of likelihood function.
+
+    Returns
+    -------
+    list[str]
+        A list of nicely organized printout for the defaults of provided model.
+    """
+    output = []
+    params = default_model_config[model]["list_params"]
+    model_defaults = default_model_config[model]["likelihoods"][loglik_kind]
+
+    output.append(f"Log-likelihood kind: {loglik_kind}")
+    output.append(f"Log-likelihood: {model_defaults['loglik']}")
+    if loglik_kind == "approx_differentiable":
+        output.append("Default backend: jax")
+    output.append("Default priors:")
+
+    default_priors = model_defaults.get("default_priors", {})
+    default_bounds = model_defaults.get("bounds", {})
+
+    for param in params:
+        prior = default_priors.get(param, None)
+        if prior is None:
+            bounds = default_bounds.get(param, None)
+            prior = _make_default_prior(bounds) if bounds is not None else None
+        else:
+            if isinstance(prior, dict):
+                prior = bmb.Prior(**prior)
+
+        output.append(f"    {param} ~ {prior}")
+
+    output.append("Default bounds:")
+
+    for param in params:
+        output.append(f"    {param}: {default_bounds.get(param, None)}")
+
+    return output

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -9,24 +9,15 @@ This file defines the entry class HSSM.
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 from inspect import isclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import bambi as bmb
 import pymc as pm
+import pytensor
 from bambi.model_components import DistributionalComponent
-from numpy.typing import ArrayLike
-from pytensor.graph.op import Op
 
-from hssm.config import (
-    Config,
-    LoglikKind,
-    SupportedModels,
-    default_model_config,
-    default_params,
-)
 from hssm.distribution_utils import (
     make_blackbox_op,
     make_distribution,
@@ -35,6 +26,7 @@ from hssm.distribution_utils import (
 )
 from hssm.param import (
     Param,
+    _make_default_prior,
     _parse_bambi,
 )
 from hssm.utils import (
@@ -43,8 +35,9 @@ from hssm.utils import (
     _process_param_in_kwargs,
     download_hf,
     get_alias_dict,
-    merge_dicts,
 )
+
+from .config import Config, ModelConfig
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -52,9 +45,11 @@ if TYPE_CHECKING:
     import arviz as az
     import numpy as np
     import pandas as pd
-    import pytensor
 
-LogLikeFunc = Callable[..., ArrayLike]
+    from hssm.defaults import (
+        LoglikKind,
+        SupportedModels,
+    )
 
 _logger = logging.getLogger("hssm")
 
@@ -180,8 +175,13 @@ class HSSM:
         data: pd.DataFrame,
         model: SupportedModels | str = "ddm",
         include: list[dict] | None = None,
-        model_config: Config | None = None,
-        loglik: str | PathLike | LogLikeFunc | pytensor.graph.Op | None = None,
+        model_config: ModelConfig | dict | None = None,
+        loglik: str
+        | PathLike
+        | Callable
+        | pytensor.graph.Op
+        | type[pm.Distribution]
+        | None = None,
         loglik_kind: LoglikKind | None = None,
         p_outlier: float | dict | bmb.Prior | None = 0.05,
         lapse: dict | bmb.Prior | None = bmb.Prior("Uniform", lower=0.0, upper=10.0),
@@ -191,147 +191,49 @@ class HSSM:
         self.data = data
         self._inference_obj = None
         self.hierarchical = hierarchical and "participant_id" in data.columns
-        self.has_lapse = p_outlier is not None and p_outlier != 0
 
-        if loglik_kind is None:
-            if model not in default_model_config:
-                raise ValueError(
-                    "When using a custom model, please provide a `loglik_kind.`"
-                )
-            # Setting loglik_kind to be the first of analytical or
-            # approx_differentiable
-            for kind in ["analytical", "approx_differentiable", "blackbox"]:
-                model = cast(SupportedModels, model)
-                if kind in default_model_config[model]:
-                    kind = cast(LoglikKind, kind)
-                    loglik_kind = kind
-                    break
-            if loglik_kind is None:
-                raise ValueError(
-                    "No default model_config is found. Please provide a `loglik_kind."
-                )
-        else:
-            if loglik_kind not in [
-                "analytical",
-                "approx_differentiable",
-                "blackbox",
-            ]:
-                raise ValueError(
-                    "'loglike_kind', when provided, must be one of "
-                    + '"analytical", "approx_differentiable", "blackbox".'
-                )
-
-        self.loglik_kind = loglik_kind
-        self.model_name = model
-
-        # Check if model has default config
-        if _model_has_default(self.model_name, self.loglik_kind):
-            model = cast(SupportedModels, model)
-            default_config = default_model_config[model][loglik_kind]
-
-            self.model_config = (
-                deepcopy(default_config)
-                if model_config is None
-                else merge_dicts(default_config, model_config)
+        # Construct a model_config from defaults
+        self.model_config = Config.from_defaults(model, loglik_kind)
+        # Update defaults with user-provided config, if any
+        if model_config is not None:
+            self.model_config.update_config(
+                model_config
+                if isinstance(model_config, ModelConfig)
+                else ModelConfig(**model_config)  # also serves as dict validation
             )
-            self.loglik = self.model_config["loglik"] if loglik is None else loglik
-            self.list_params = default_params[model][:]
-        else:
-            # If there is no default, we require a log-likelihood
-            if loglik is None:
-                raise ValueError("Please provide a valid `loglik`.")
-            self.loglik = loglik
+        # Update loglik with user-provided value
+        self.model_config.update_loglik(loglik)
+        # Ensure that all required fields are valid
+        self.model_config.validate()
 
-            if model not in default_model_config:
-                # For custom models, require model_config
-                if model_config is None:
-                    raise ValueError(
-                        "For custom models, please provide a valid `model_config`."
-                    )
-                if "list_params" not in model_config:
-                    raise ValueError(
-                        "For custom models, please provide `list_params` in "
-                        + "`model_config`."
-                    )
-                self.model_config = model_config
-                self.list_params = model_config["list_params"]
-            else:
-                # For supported models without configs,
-                # We don't require a model_config (because list_params is known)
-                model = cast(SupportedModels, model)
-                self.model_config = {} if model_config is None else model_config
-                self.list_params = default_params[model][:]
-
-        if (
-            loglik_kind == "approx_differentiable"
-            and "backend" not in self.model_config
-        ):
-            self.model_config["backend"] = "jax"
-
-        # Logic for determining if p_outlier and lapse is specified correctly.
-        # Basically, avoid situations where only one of them is specified.
+        # Set up shortcuts so old code will work
+        self.list_params = self.model_config.list_params
+        self.model_name = self.model_config.model_name
+        self.loglik = self.model_config.loglik
+        self.loglik_kind = self.model_config.loglik_kind
         self._parent = self.list_params[0]
-        if self.has_lapse and lapse is None:
-            raise ValueError(
-                "You have specified `p_outlier`. Please also specify `lapse`."
-            )
-        if lapse is not None and not self.has_lapse:
-            _logger.warning(
-                "You have specified the `lapse` argument to include a lapse "
-                + "distribution, but `p_outlier` is set to either 0 or None. "
-                + "Your lapse distribution will be ignored."
-            )
-        if "p_outlier" in self.list_params and self.list_params[-1] != "p_outlier":
-            raise ValueError(
-                "Please do not include 'p_outlier' in `list_params`. "
-                + "We automatically append it to `list_params` when `p_outlier` "
-                + "parameter is not None"
-            )
 
+        # Process lapse distribution
+        self.has_lapse = p_outlier is not None and p_outlier != 0
+        self._check_lapse(lapse)
         if self.has_lapse and self.list_params[-1] != "p_outlier":
             self.list_params.append("p_outlier")
 
-        if include is None:
-            include = []
-        params_in_include = [param["name"] for param in include]
-
-        # Process kwargs
-        # If any of the keys is found in `list_params` it is a parameter specification
-        # We add the parameter specification to `include`, which will be processed later
-        # together with other parameter specifications in `include`.
-        # Otherwise we create another dict and pass it to `bmb.Model`.
-        other_kwargs: dict[Any, Any] = {}
-        for k, v in kwargs.items():
-            if k in self.list_params:
-                if k in params_in_include:
-                    raise ValueError(
-                        f'Parameter "{k}" is already specified in `include`.'
-                    )
-                include.append(_process_param_in_kwargs(k, v))
-            else:
-                other_kwargs |= {k: v}
-
-        # Process p_outliers the same way.
-        if self.has_lapse:
-            if "p_outlier" in params_in_include:
-                raise ValueError(
-                    "Please do not specify `p_outlier` in `include`. "
-                    + "Please specify it with `p_outlier` instead."
-                )
-            include.append(_process_param_in_kwargs("p_outlier", p_outlier))
-
-        self.params, self.formula, self.priors, self.link = self._transform_params(
-            include, self.model_config
+        # Process kwargs and p_outlier and add them to include
+        include, other_kwargs = self._add_kwargs_and_p_outlier_to_include(
+            include, kwargs, p_outlier
         )
+
+        # Process parameter specifications include
+        processed = self._process_include(include)
+        # Process parameter specifications not in include
+        self.params = self._process_rest(processed)
+
+        # Get the bambi formula, priors, and link
+        self.formula, self.priors, self.link = _parse_bambi(self.params)
 
         self._parent_param = self.params[self.list_params[0]]
         assert self._parent_param is not None
-
-        params_is_reg = [
-            param.is_regression
-            for param_name, param in self.params.items()
-            if param_name != "p_outlier"
-        ]
 
         # For parameters that are regression, apply bounds at the likelihood level to
         # ensure that the samples that are out of bounds are discarded (replaced with
@@ -342,67 +244,11 @@ class HSSM:
             if param.is_regression and param.bounds is not None
         }
 
+        # Set p_outlier and lapse
         self.p_outlier = self.params.get("p_outlier")
         self.lapse = lapse if self.has_lapse else None
 
-        ### Logic for different types of likelihoods:
-        # -`analytical` and `blackbox`:
-        #     loglik should be a `pm.Distribution`` or a Python callable (any arbitrary
-        #     function).
-        # - `approx_differentiable`:
-        #     In addition to `pm.Distribution` and any arbitrary function, it can also
-        #     be an str (which we will download from hugging face) or a Pathlike
-        #     which we will download and make a distribution.
-
-        # If user has already provided a log-likelihood function as a distribution
-        # Use it directly as the distribution
-        if isclass(self.loglik) and issubclass(self.loglik, pm.Distribution):
-            self.model_distribution = self.loglik
-        # If the user has provided an Op
-        # Wrap it around with a distribution
-        elif isinstance(self.loglik, Op):
-            self.model_distribution = make_distribution(
-                self.model_config.get("rv", self.model_name),
-                loglik=self.loglik,
-                list_params=self.list_params,
-                bounds=self.bounds,
-                lapse=self.lapse,
-            )  # type: ignore
-        # If the user has provided a callable (an arbitrary likelihood function)
-        # If `loglik_kind` is `blackbox`, wrap it in an op and then a distribution
-        # Otherwise, we assume that this function is differentiable with `pytensor`
-        # and wrap it directly in a distribution.
-        elif callable(self.loglik):
-            if self.loglik_kind == "blackbox":
-                self.loglik = make_blackbox_op(self.loglik)
-            self.model_distribution = make_distribution(
-                self.model_config.get("rv", self.model_name),
-                loglik=self.loglik,
-                list_params=self.list_params,
-                bounds=self.bounds,
-                lapse=self.lapse,
-            )  # type: ignore
-        # All other situations
-        else:
-            if self.loglik_kind != "approx_differentiable":
-                raise ValueError(
-                    "You set `loglik_kind` to `approx_differentiable "
-                    + "but did not provide a pm.Distribution, an Op, or a callable "
-                    + "as `loglik`."
-                )
-            if isinstance(self.loglik, str):
-                if not Path(self.loglik).exists():
-                    self.loglik = download_hf(self.loglik)
-
-            self.model_distribution = make_distribution_from_onnx(
-                rv=self.model_config.get("rv", self.model_name),
-                onnx_model=self.loglik,
-                list_params=self.list_params,
-                backend=self.model_config.get("backend", "jax"),
-                params_is_reg=params_is_reg,
-                bounds=self.bounds,
-                lapse=self.lapse,
-            )
+        self.model_distribution = self._make_model_distribution()
 
         self.family = make_family(
             self.model_distribution,
@@ -417,73 +263,6 @@ class HSSM:
 
         self._aliases = get_alias_dict(self.model, self._parent_param)
         self.set_alias(self._aliases)
-
-    def _transform_params(
-        self, include: list[dict] | None, model_config: Config
-    ) -> tuple[
-        dict[str, Param], bmb.Formula, dict | None, dict[str, str | bmb.Link] | str
-    ]:
-        """Transform parameters.
-
-        Transforms a list of dictionaries containing parameter information into a
-        list of Param objects. This function creates a formula, priors,and a link for
-        the Bambi package based on the parameters.
-
-        Parameters
-        ----------
-        include
-            A list of dictionaries containing information about the parameters.
-        model_config
-            A dict for the configuration for the model.
-
-        Returns
-        -------
-        list[Param], bmb.Formula, dict | None, dict | str
-            A tuple of 4 items, the latter 3 are for creating the bambi model.
-            - A list of the same length as self.list_params containing Param objects.
-            - A bmb.formula object.
-            - An optional dict containing prior information for Bambi.
-            - An optional dict of link functions for Bambi.
-        """
-        processed = []
-        params: dict[str, Param] = {}
-        if include:
-            for param_dict in include:
-                name = param_dict["name"]
-                processed.append(name)
-                for k in param_dict.keys():
-                    if k not in ["name", "formula", "prior", "link", "bounds"]:
-                        raise ValueError(
-                            f"Invalid key {k} for the specification of {name}!"
-                        )
-                param = _create_param(
-                    param_dict, model_config, is_parent=name == self._parent
-                )
-                params[name] = param
-
-        for param_str in self.list_params:
-            if param_str not in processed:
-                is_parent = param_str == self._parent
-                if self.hierarchical:
-                    bounds = (
-                        model_config["bounds"].get(param_str)
-                        if "bounds" in model_config
-                        else None
-                    )
-                    param = Param(
-                        param_str,
-                        formula="1 + (1|participant_id)",
-                        link="identity",
-                        bounds=bounds,
-                        is_parent=is_parent,
-                    )
-                else:
-                    param = _create_param(param_str, model_config, is_parent=is_parent)
-                params[param_str] = param
-
-        sorted_params = {k: params[k] for k in self.list_params}
-
-        return sorted_params, *_parse_bambi(list(sorted_params.values()))
 
     def sample(
         self,
@@ -517,7 +296,7 @@ class HSSM:
         if sampler is None:
             if (
                 self.loglik_kind == "approx_differentiable"
-                and self.model_config.get("backend") == "jax"
+                and self.model_config.backend == "jax"
             ):
                 sampler = "nuts_numpyro"
             else:
@@ -541,7 +320,7 @@ class HSSM:
 
         if (
             self.loglik_kind == "approx_differentiable"
-            and self.model_config.get("backend") == "jax"
+            and self.model_config.backend == "jax"
             and sampler == "mcmc"
             and kwargs.get("cores", None) != 1
         ):
@@ -804,89 +583,183 @@ class HSSM:
 
         return self._inference_obj
 
-
-def _model_has_default(model: SupportedModels | str, loglik_kind: LoglikKind) -> bool:
-    """Determine if the specified model has default configs.
-
-    Also checks if `model` and `loglik_kind` are valid.
-
-    Parameters
-    ----------
-    model
-        User-specified model type.
-    loglik_kind
-        User-specified likelihood kind.
-
-    Returns
-    -------
-    bool
-        Whether the model is supported.
-    """
-    if model not in default_model_config:
-        return False
-
-    model = cast(SupportedModels, model)
-    return loglik_kind in default_model_config[model]
-
-
-def _create_param(param: str | dict, model_config: dict, is_parent: bool) -> Param:
-    """Create a Param object.
-
-    Parameters
-    ----------
-    param
-        A dict or str containing parameter settings.
-    model_config
-        A dict containing the config for the model.
-    is_parent
-        Indicates whether this current param is a parent in bambi.
-
-    Returns
-    -------
-    Param
-        A Param object with info form param and model_config injected.
-    """
-    if isinstance(param, dict):
-        name = param["name"]
-        if "bounds" not in param:
-            bounds = (
-                model_config["bounds"].get(name, None)
-                if "bounds" in model_config
-                else None
+    def _check_lapse(self, lapse):
+        """Determine if p_outlier and lapse is specified correctly."""
+        # Basically, avoid situations where only one of them is specified.
+        if self.has_lapse and lapse is None:
+            raise ValueError(
+                "You have specified `p_outlier`. Please also specify `lapse`."
             )
-        else:
-            bounds = param["bounds"]
-        if "prior" not in param or param["prior"] is None:
-            if (
-                "default_priors" in model_config
-                and name in model_config["default_priors"]
-                and "formula" not in model_config
-            ):
-                prior = model_config["default_priors"][name]
-            else:
-                prior = None
-        else:
-            prior = param["prior"]
-        return Param(
-            name=name,
-            prior=prior,
-            formula=param.get("formula"),
-            link=param.get("link"),
-            bounds=bounds,
-            is_parent=is_parent,
-        )
+        if lapse is not None and not self.has_lapse:
+            _logger.warning(
+                "You have specified the `lapse` argument to include a lapse "
+                + "distribution, but `p_outlier` is set to either 0 or None. "
+                + "Your lapse distribution will be ignored."
+            )
+        if "p_outlier" in self.list_params and self.list_params[-1] != "p_outlier":
+            raise ValueError(
+                "Please do not include 'p_outlier' in `list_params`. "
+                + "We automatically append it to `list_params` when `p_outlier` "
+                + "parameter is not None"
+            )
 
-    bounds = (
-        model_config["bounds"].get(param, None) if "bounds" in model_config else None
-    )
-    prior = (
-        model_config["default_priors"].get(param, None)
-        if "default_priors" in model_config
-        else None
-    )
-    return Param(
-        name=param,
-        prior=prior,
-        bounds=bounds,
-        is_parent=is_parent,
-    )
+    def _fill_default(self, p: dict, param: str) -> dict:
+        """Fill parameter specification in include with defaults from config."""
+        default_prior, default_bounds = self.model_config.get_defaults(param)
+        if p.get("bounds") is None:
+            p["bounds"] = default_bounds
+
+        if "formula" not in p and p.get("prior") is None:
+            if default_prior is not None:
+                p["prior"] = default_prior
+            else:
+                if p["bounds"] is not None:
+                    p["prior"] = _make_default_prior(p["bounds"])
+
+        return p
+
+    def _add_kwargs_and_p_outlier_to_include(
+        self, include, kwargs, p_outlier
+    ) -> tuple[list, dict]:
+        """Process kwargs and p_outlier and add them to include."""
+        if include is None:
+            include = []
+        params_in_include = [param["name"] for param in include]
+
+        # Process kwargs
+        # If any of the keys is found in `list_params` it is a parameter specification
+        # We add the parameter specification to `include`, which will be processed later
+        # together with other parameter specifications in `include`.
+        # Otherwise we create another dict and pass it to `bmb.Model`.
+        other_kwargs: dict[Any, Any] = {}
+        for k, v in kwargs.items():
+            if k in self.list_params:
+                if k in params_in_include:
+                    raise ValueError(
+                        f'Parameter "{k}" is already specified in `include`.'
+                    )
+                include.append(_process_param_in_kwargs(k, v))
+            else:
+                other_kwargs |= {k: v}
+
+        # Process p_outliers the same way.
+        if self.has_lapse:
+            if "p_outlier" in params_in_include:
+                raise ValueError(
+                    "Please do not specify `p_outlier` in `include`. "
+                    + "Please specify it with `p_outlier` instead."
+                )
+            include.append(_process_param_in_kwargs("p_outlier", p_outlier))
+
+        return include, other_kwargs
+
+    def _process_include(self, include: list) -> dict[str, Param]:
+        """Turn parameter specs in include into Params."""
+        result: dict[str, Param] = {}
+
+        for param in include:
+            name = param["name"]
+            if name not in self.list_params:
+                raise ValueError(f"{name} is not included in the list of parameters.")
+            param_with_default = self._fill_default(param, name)
+            is_parent = name == self._parent
+            result[name] = Param(is_parent=is_parent, **param_with_default)
+
+        return result
+
+    def _process_rest(self, processed: dict[str, Param]) -> dict[str, Param]:
+        """Turn parameter specs not in include into Params."""
+        not_in_include = {}
+
+        for param_str in self.list_params:
+            if param_str not in processed:
+                is_parent = param_str == self._parent
+                if self.hierarchical:
+                    bounds = self.model_config.bounds.get(param_str)
+                    param = Param(
+                        param_str,
+                        formula="1 + (1|participant_id)",
+                        link="identity",
+                        bounds=bounds,
+                        is_parent=is_parent,
+                    )
+                else:
+                    prior, bounds = self.model_config.get_defaults(param_str)
+                    param = Param(
+                        name=param_str,
+                        prior=prior,
+                        bounds=bounds,
+                        is_parent=is_parent,
+                    )
+                not_in_include[param_str] = param
+
+        processed |= not_in_include
+        sorted_params = {k: processed[k] for k in self.list_params}
+
+        return sorted_params
+
+    def _make_model_distribution(self) -> type[pm.Distribution]:
+        """Make a pm.Distribution for the model."""
+        ### Logic for different types of likelihoods:
+        # -`analytical` and `blackbox`:
+        #     loglik should be a `pm.Distribution`` or a Python callable (any arbitrary
+        #     function).
+        # - `approx_differentiable`:
+        #     In addition to `pm.Distribution` and any arbitrary function, it can also
+        #     be an str (which we will download from hugging face) or a Pathlike
+        #     which we will download and make a distribution.
+
+        # If user has already provided a log-likelihood function as a distribution
+        # Use it directly as the distribution
+        if isclass(self.loglik) and issubclass(self.loglik, pm.Distribution):
+            return self.loglik
+        # If the user has provided an Op
+        # Wrap it around with a distribution
+        if isinstance(self.loglik, pytensor.graph.Op):
+            return make_distribution(
+                rv=self.model_config.rv or self.model_name,
+                loglik=self.loglik,
+                list_params=self.list_params,
+                bounds=self.bounds,
+                lapse=self.lapse,
+            )  # type: ignore
+        # If the user has provided a callable (an arbitrary likelihood function)
+        # If `loglik_kind` is `blackbox`, wrap it in an op and then a distribution
+        # Otherwise, we assume that this function is differentiable with `pytensor`
+        # and wrap it directly in a distribution.
+        if callable(self.loglik):
+            if self.loglik_kind == "blackbox":
+                self.loglik = make_blackbox_op(self.loglik)
+            return make_distribution(
+                rv=self.model_config.rv or self.model_name,
+                loglik=self.loglik,
+                list_params=self.list_params,
+                bounds=self.bounds,
+                lapse=self.lapse,
+            )  # type: ignore
+        # All other situations
+        if self.loglik_kind != "approx_differentiable":
+            raise ValueError(
+                "You set `loglik_kind` to `approx_differentiable "
+                + "but did not provide a pm.Distribution, an Op, or a callable "
+                + "as `loglik`."
+            )
+        if isinstance(self.loglik, str):
+            if not Path(self.loglik).exists():
+                self.loglik = download_hf(self.loglik)
+
+        params_is_reg = [
+            param.is_regression
+            for param_name, param in self.params.items()
+            if param_name != "p_outlier"
+        ]
+
+        return make_distribution_from_onnx(
+            rv=self.model_config.rv or self.model_name,
+            onnx_model=self.loglik,
+            list_params=self.list_params,
+            backend=self.model_config.backend or "jax",
+            params_is_reg=params_is_reg,
+            bounds=self.bounds,
+            lapse=self.lapse,
+        )

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -685,12 +685,21 @@ class HSSM:
                     )
                 else:
                     prior, bounds = self.model_config.get_defaults(param_str)
-                    param = Param(
-                        name=param_str,
-                        prior=prior,
-                        bounds=bounds,
-                        is_parent=is_parent,
-                    )
+                    if prior is None:
+                        param = Param(
+                            name=param_str,
+                            prior=prior,
+                            bounds=bounds,
+                            is_parent=is_parent,
+                        )
+                    else:
+                        param = Param(
+                            name=param_str,
+                            prior=prior,
+                            bounds=None,
+                            is_parent=is_parent,
+                        )
+                        param.bounds = bounds
                 not_in_include[param_str] = param
 
         processed |= not_in_include

--- a/src/hssm/param.py
+++ b/src/hssm/param.py
@@ -327,12 +327,12 @@ def _make_priors_recursive(prior: dict[str, Any]) -> Prior:
 def _parse_bambi(
     params: dict[str, Param],
 ) -> tuple[bmb.Formula, dict | None, dict[str, str | bmb.Link] | str]:
-    """From a list of Params, retrieve three items that helps with bambi model building.
+    """From a dict of Params, retrieve three items that helps with bambi model building.
 
     Parameters
     ----------
     params
-        A list of Param objects.
+        A dict of Param objects.
 
     Returns
     -------

--- a/src/hssm/param.py
+++ b/src/hssm/param.py
@@ -325,7 +325,7 @@ def _make_priors_recursive(prior: dict[str, Any]) -> Prior:
 
 
 def _parse_bambi(
-    params: list[Param],
+    params: dict[str, Param],
 ) -> tuple[bmb.Formula, dict | None, dict[str, str | bmb.Link] | str]:
     """From a list of Params, retrieve three items that helps with bambi model building.
 
@@ -346,29 +346,11 @@ def _parse_bambi(
     if not params:
         return bmb.Formula("c(rt, response) ~ 1"), None, "identity"
 
-    # Then, we check how many parameters in the specified list of params are parent.
-    num_parents = sum(param.is_parent for param in params)
-
-    # In the case where there is more than one parent:
-    assert num_parents <= 1, "More than one parent is specified!"
-
     formulas = []
     priors: dict[str, Any] = {}
     links: dict[str, str | bmb.Link] = {}
-    params_copy = params.copy()
 
-    parent_param = None
-
-    if num_parents == 1:
-        for idx, param in enumerate(params):
-            if param.is_parent:
-                parent_param = params_copy.pop(idx)
-                break
-
-        assert parent_param is not None
-        params_copy.insert(0, parent_param)
-
-    for param in params_copy:
+    for _, param in params.items():
         formula, prior, link = param._parse_bambi()
 
         if formula is not None:
@@ -378,13 +360,8 @@ def _parse_bambi(
         if link is not None:
             links |= link
 
-    result_formula: bmb.Formula = (
-        bmb.Formula("c(rt, response) ~ 1", *formulas)
-        if num_parents == 0
-        else bmb.Formula(formulas[0], *formulas[1:])
-    )
+    result_formula: bmb.Formula = bmb.Formula(formulas[0], *formulas[1:])
     result_priors = None if not priors else priors
-
     result_links: dict | str = "identity" if not links else links
 
     return result_formula, result_priors, result_links

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,75 @@
-from hssm import show_defaults
+import numpy as np
+import pytest
+
+import hssm
+from hssm.config import Config, ModelConfig
 
 
-def test_show_defaults():
-    print(show_defaults("ddm", None))
-    print(show_defaults("ddm", "analytical"))
+def test_from_default():
+    # Case 1: Has default prior
+    config1 = Config.from_defaults("ddm", "analytical")
+
+    assert config1.model_name == "ddm"
+    assert config1.list_params == ["v", "a", "z", "t"]
+    assert config1.loglik_kind == "analytical"
+    assert config1.loglik is not None
+    assert "t" in config1.default_priors
+    assert "v" in config1.bounds
+
+    # Case 2: Model supported, but no default prior
+    config2 = Config.from_defaults("angle", "analytical")
+
+    assert config2.model_name == "angle"
+    assert config2.list_params == ["v", "a", "z", "t", "theta"]
+    assert config2.loglik_kind == "analytical"
+    assert config2.loglik is None
+    assert config2.default_priors == {}
+    assert config2.bounds == {}
+
+    # Case 3: Model supported, loglik_kind is None
+    config3 = Config.from_defaults("ddm", None)
+
+    assert config3 == config1
+
+    # Case 4: No supported model, provided loglik_kind
+    config4 = Config.from_defaults("custom", "analytical")
+    assert config4.model_name == "custom"
+    assert config4.list_params is None
+    assert config4.loglik_kind == "analytical"
+    assert config4.loglik is None
+    assert config4.default_priors == {}
+    assert config4.bounds == {}
+
+    # Case 5: No supported model, did not provide loglik_kind
+    with pytest.raises(ValueError):
+        Config.from_defaults("custom", None)
+
+
+def test_update_config():
+    config1 = Config.from_defaults("ddm", "analytical")
+
+    v_prior, v_bounds = config1.get_defaults("v")
+
+    assert v_prior is None
+    assert v_bounds == (-np.inf, np.inf)
+
+    user_config = ModelConfig(
+        list_params=["a", "b", "c"],
+        backend="jax",
+        default_priors={
+            "t": hssm.Prior("Uniform", lower=-5, upper=5),
+            "v": hssm.Prior("Normal"),
+        },
+    )
+
+    config1.update_config(user_config)
+
+    assert config1.list_params == ["a", "b", "c"]
+    assert config1.backend is None
+    assert "t" in config1.default_priors
+    assert "a" not in config1.default_priors
+
+    v_prior, v_bounds = config1.get_defaults("v")
+
+    assert v_prior.name == "Normal"
+    assert v_bounds == (-np.inf, np.inf)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,6 @@
+from hssm import show_defaults
+
+
+def test_show_defaults():
+    print(show_defaults("ddm", None))
+    print(show_defaults("ddm", "analytical"))

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -8,7 +8,7 @@ hssm.set_floatX("float32")
 
 @pytest.fixture
 def non_reg_data():
-    data = hssm.simulate_data(model="ddm", theta=[0.5, 1.5, 0.5, 0.8], size=1000)
+    data = hssm.simulate_data(model="ddm", theta=[0.5, 1.5, 0.5, 0.1], size=1000)
     return data
 
 

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -8,7 +8,7 @@ hssm.set_floatX("float32")
 
 @pytest.fixture
 def non_reg_data():
-    data = hssm.simulate_data(model="ddm", theta=[0.5, 1.5, 0.5, 0.1], size=1000)
+    data = hssm.simulate_data(model="ddm", theta=[0.5, 1.5, 0.5, 0.8], size=1000)
     return data
 
 

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -16,18 +16,7 @@ def test__parse_bambi():
     prior_dict = {"name": "Uniform", "lower": 0.3, "upper": 1.0}
     prior_obj = bmb.Prior("Uniform", lower=0.3, upper=1.0)
 
-    param_non_parent_non_regression = Param("a", prior=prior_dict)
     param_parent_non_regression = Param("v", prior=prior_dict, is_parent=True)
-
-    param_non_parent_regression = Param(
-        "a",
-        formula="1 + x1",
-        prior={
-            "Intercept": prior_dict,
-            "x1": prior_dict,
-        },
-    )
-
     param_parent_regression = Param(
         "v",
         formula="1 + x1",
@@ -38,41 +27,27 @@ def test__parse_bambi():
         is_parent=True,
     )
 
-    empty_list = []
-    list_one_non_parent_non_regression = [param_non_parent_non_regression]
-    list_one_non_parent_regression = [param_non_parent_regression]
-    list_one_parent_non_regression = [param_parent_non_regression]
-    list_one_parent_regression = [param_parent_regression]
+    empty_dict = {}
+    dict_one_parent_non_regression = {"v": param_parent_non_regression}
+    dict_one_parent_regression = {"v": param_parent_regression}
 
-    f0, p0, l0 = _parse_bambi(empty_list)
+    f0, p0, l0 = _parse_bambi(empty_dict)
 
     assert f0.main == "c(rt, response) ~ 1"
     assert p0 is None
     assert l0 == "identity"
 
-    f1, p1, l1 = _parse_bambi(list_one_non_parent_non_regression)
-
-    assert f1.main == "c(rt, response) ~ 1"
-    assert p1["a"] == prior_obj
-    assert l1 == "identity"
-
-    f2, p2, l2 = _parse_bambi(list_one_non_parent_regression)
-
-    assert f2.main == "c(rt, response) ~ 1"
-    assert f2.additionals[0] == "a ~ 1 + x1"
-    assert p2["a"]["Intercept"] == prior_obj
-    assert p2["a"]["x1"] == prior_obj
-    assert l2 == {"a": "identity"}
-
-    f3, p3, l3 = _parse_bambi(list_one_parent_non_regression)
+    f3, p3, l3 = _parse_bambi(dict_one_parent_non_regression)
 
     assert f3.main == "c(rt, response) ~ 1"
+    assert p3 is not None
     assert p3["c(rt, response)"]["Intercept"] == prior_obj
     assert l3 == {"v": "identity"}
 
-    f4, p4, l4 = _parse_bambi(list_one_parent_regression)
+    f4, p4, l4 = _parse_bambi(dict_one_parent_regression)
 
     assert f4.main == "c(rt, response) ~ 1 + x1"
+    assert p4 is not None
     assert p4["c(rt, response)"]["Intercept"] == prior_obj
     assert p4["c(rt, response)"]["x1"] == prior_obj
     assert l4 == {"v": "identity"}


### PR DESCRIPTION
The initializer of the main class `HSSM` was getting very long and was due for a refactor. In this PR, I refactored the initializer with abstractions to make the body of the code much more readable. Here's what was done:

1. Use a Config dataclass instead of a dictionary to represent the internal config of the model.
2. Use a ModelConfig dataclass to represent and validate user input to `model_config`. Closes #242
3. Updated default model config specifications. Made typing more explicit. Closes #236 
4. Updated tests.