### PR TITLE
Refactor: the Param class

### DIFF
--- a/src/hssm/__init__.py
+++ b/src/hssm/__init__.py
@@ -7,6 +7,7 @@ from .config import ModelConfig
 from .datasets import load_data
 from .defaults import show_defaults
 from .hssm import HSSM
+from .param import Param
 from .prior import Prior
 from .simulator import simulate_data
 from .utils import set_floatX
@@ -20,6 +21,7 @@ __all__ = [
     "HSSM",
     "load_data",
     "ModelConfig",
+    "Param",
     "Prior",
     "simulate_data",
     "set_floatX",

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -680,6 +680,11 @@ class HSSM:
 
         for param in include:
             name = param["name"]
+            if name is None:
+                raise ValueError(
+                    "One or more parameters do not have a name. "
+                    + "Please ensure that names are specified to all of them."
+                )
             if name not in self.list_params:
                 raise ValueError(f"{name} is not included in the list of parameters.")
             param_with_default = self._fill_default(param, name)

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -174,7 +174,7 @@ class HSSM:
         self,
         data: pd.DataFrame,
         model: SupportedModels | str = "ddm",
-        include: list[dict] | None = None,
+        include: list[dict | Param] | None = None,
         model_config: ModelConfig | dict | None = None,
         loglik: str
         | PathLike
@@ -603,18 +603,39 @@ class HSSM:
                 + "parameter is not None"
             )
 
-    def _fill_default(self, p: dict, param: str) -> dict:
+    def _fill_default(self, p: dict | Param, param_name: str) -> dict | Param:
         """Fill parameter specification in include with defaults from config."""
-        default_prior, default_bounds = self.model_config.get_defaults(param)
-        if p.get("bounds") is None:
-            p["bounds"] = default_bounds
+        default_prior, default_bounds = self.model_config.get_defaults(param_name)
+        filled_default_bounds = False
+        if isinstance(p, dict):
+            if p.get("bounds") is None:
+                p["bounds"] = default_bounds
+                filled_default_bounds = True
 
-        if "formula" not in p and p.get("prior") is None:
-            if default_prior is not None:
-                p["prior"] = default_prior
-            else:
-                if p["bounds"] is not None:
-                    p["prior"] = _make_default_prior(p["bounds"])
+            if "formula" not in p and p.get("prior") is None:
+                if default_prior is not None:
+                    p["prior"] = default_prior
+                    if filled_default_bounds:
+                        p_param = Param(**p)
+                        p_param.do_not_truncate()
+                        return p_param
+                else:
+                    if p["bounds"] is not None:
+                        p["prior"] = _make_default_prior(p["bounds"])
+
+        else:
+            if not p.bounds:
+                p.bounds = default_bounds
+                filled_default_bounds = True
+
+            if not p.formula and not p.prior:
+                if default_prior is not None:
+                    p.prior = default_prior
+                    if filled_default_bounds:
+                        p.do_not_truncate()
+                else:
+                    if p.bounds is not None:
+                        p.prior = _make_default_prior(p.bounds)
 
         return p
 
@@ -653,7 +674,7 @@ class HSSM:
 
         return include, other_kwargs
 
-    def _process_include(self, include: list) -> dict[str, Param]:
+    def _process_include(self, include: list[dict | Param]) -> dict[str, Param]:
         """Turn parameter specs in include into Params."""
         result: dict[str, Param] = {}
 
@@ -662,8 +683,13 @@ class HSSM:
             if name not in self.list_params:
                 raise ValueError(f"{name} is not included in the list of parameters.")
             param_with_default = self._fill_default(param, name)
-            is_parent = name == self._parent
-            result[name] = Param(is_parent=is_parent, **param_with_default)
+            result[name] = (
+                Param(**param_with_default)
+                if isinstance(param_with_default, dict)
+                else param_with_default
+            )
+            if name == self._parent:
+                result[name].set_parent()
 
         return result
 
@@ -673,7 +699,6 @@ class HSSM:
 
         for param_str in self.list_params:
             if param_str not in processed:
-                is_parent = param_str == self._parent
                 if self.hierarchical:
                     bounds = self.model_config.bounds.get(param_str)
                     param = Param(
@@ -681,29 +706,22 @@ class HSSM:
                         formula="1 + (1|participant_id)",
                         link="identity",
                         bounds=bounds,
-                        is_parent=is_parent,
                     )
                 else:
                     prior, bounds = self.model_config.get_defaults(param_str)
-                    if prior is None:
-                        param = Param(
-                            name=param_str,
-                            prior=prior,
-                            bounds=bounds,
-                            is_parent=is_parent,
-                        )
-                    else:
-                        param = Param(
-                            name=param_str,
-                            prior=prior,
-                            bounds=None,
-                            is_parent=is_parent,
-                        )
-                        param.bounds = bounds
+                    param = Param(param_str, prior=prior, bounds=bounds)
+                    param.do_not_truncate()
+                if param_str == self._parent:
+                    param.set_parent()
                 not_in_include[param_str] = param
 
         processed |= not_in_include
-        sorted_params = {k: processed[k] for k in self.list_params}
+        sorted_params = {}
+
+        for param_name in self.list_params:
+            processed_param = processed[param_name]
+            processed_param.convert()
+            sorted_params[param_name] = processed_param
 
         return sorted_params
 

--- a/src/hssm/param.py
+++ b/src/hssm/param.py
@@ -102,6 +102,12 @@ class Param:
                 "Cannot process the object. It has already been processed."
             )
 
+        if self.name is None:
+            raise ValueError(
+                "One or more parameters do not have a name. "
+                + "Please ensure that names are specified to all of them."
+            )
+
         if self.bounds is not None:
             if any(not np.isscalar(bound) for bound in self.bounds):
                 raise ValueError(f"The bounds of {self.name} should both be scalar.")

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Iterable, Literal, NewType
+from typing import Any, Iterable, Literal, NewType
 
 import bambi as bmb
 import pytensor
@@ -23,8 +23,7 @@ from jax.config import config
 from pymc.model_graph import ModelGraph
 from pytensor import function
 
-if TYPE_CHECKING:
-    from .param import Param
+from .param import Param
 
 _logger = logging.getLogger("hssm")
 
@@ -280,15 +279,16 @@ def set_floatX(dtype: Literal["float32", "float64"], jax: bool = True):
         raise ValueError('`dtype` must be either "float32" or "float64".')
 
     pytensor.config.floatX = dtype
-    _logger.info(f"Setting PyTensor floatX type to {dtype}.")
+    _logger.info("Setting PyTensor floatX type to %s.", dtype)
 
     if jax:
-        mapping = dict(float32=False, float64=True)
-        config.update("jax_enable_x64", mapping[dtype])
+        jax_enable_x64 = dtype == "float64"
+        config.update("jax_enable_x64", jax_enable_x64)
 
         _logger.info(
-            f'Setting "jax_enable_x64" to {mapping[dtype]}. '
-            + "If this is not intended, please set `jax` to False."
+            'Setting "jax_enable_x64" to %s. '
+            + "If this is not intended, please set `jax` to False.",
+            jax_enable_x64,
         )
 
 
@@ -315,7 +315,9 @@ def _print_prior(term: CommonTerm | GroupSpecificTerm) -> str:
     return f"        {term_name} ~ {prior}"
 
 
-def _process_param_in_kwargs(name, prior: float | dict | bmb.Prior) -> dict:
+def _process_param_in_kwargs(
+    name, prior: float | dict | bmb.Prior | Param
+) -> dict | Param:
     """Process parameters specified in kwargs.
 
     Parameters
@@ -342,7 +344,11 @@ def _process_param_in_kwargs(name, prior: float | dict | bmb.Prior) -> dict:
             return prior | {"name": name}
         else:
             return {"name": name, "prior": prior}
+    elif isinstance(prior, Param):
+        prior["name"] = name
+        return prior
     else:
         raise ValueError(
-            f"Parameter {name} must be a float, a dict, or a bmb.Prior object."
+            f"Parameter {name} must be a float, a dict, a bmb.Prior, "
+            + "or a hssm.Param object."
         )

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -81,6 +81,7 @@ def make_alias_dict_from_parent(parent: Param) -> dict[str, str]:
         A dict that indicates how Bambi should alias its parameters.
     """
     assert parent.is_parent, "This Param object should be a parent!"
+    assert parent.name is not None
 
     result_dict = {"c(rt, response)": "rt,response"}
 


### PR DESCRIPTION
The Param class was meant to be an internal record-keeping mechanism to store user-supplied parameter specifications and provide an interface between HSSM and `bambi`. After this PR, the users will have the option to directly specify parameters using `hssm.Param` class. The advantage of this is that the fields and types are more explicit and some IDEs provide hints for fields and types.

To do this, the Param class was slightly modified. The information passed to it will not be immediately processed until `.convert()` is called, so that it can still be modified later in HSSM code (such as filling with defaults and setting parameters as parents, etc).

In this process, another bug was discovered. When filling in default_priors to user-specified `Param`s, if bounds was not already provided and there are default bounds, we should not truncate the default priors. We have now added a flag `Param.do_not_truncate()` to indicate this. Unnecessarily truncating priors leads to weird errors.