### PR TITLE
Support for arbitrary additional fields

### DIFF
--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -8,6 +8,7 @@ The module includes a dictionary, `default_model_config`, that provides default 
 
 - `ddm`
 - `ddm_sdv`
+- `full_ddm`
 - `angle`
 - `levy`
 - `ornstein`
@@ -72,7 +73,7 @@ For each model, a dictionary is defined containing configurations for each `Logl
   - v: Uniform (-10.0, 10.0)
   - sv: HalfNormal with sigma 2.0
   - a: HalfNormal with sigma 2.0
-  - t: Uniform (0.0, 5.0) with initial value 0.0
+  - t: Uniform (0.0, 5.0) with initial value 0.1
 
 #### Approx Differentiable
 - **Log-likelihood kind:** Approx Differentiable

--- a/docs/getting_started/getting_started.ipynb
+++ b/docs/getting_started/getting_started.ipynb
@@ -2358,6 +2358,7 @@
     "\n",
     "- ddm\n",
     "- ddm_sdv\n",
+    "- full_ddm\n",
     "- angle\n",
     "- levy\n",
     "- ornstein\n",

--- a/docs/tutorials/likelihoods.ipynb
+++ b/docs/tutorials/likelihoods.ipynb
@@ -223,6 +223,7 @@
     "\n",
     "- For `analytical` kind: `ddm` and `ddm_sdv` models.\n",
     "- For `approx_differentiable` kind: `ddm`, `ddm_sdv`, `angle`, `levy`, `ornstein`, `weibull`, `race_no_bias_angle_4` and `ddm_seq2_no_bias`.\n",
+    "- For `blackbox` kind: `ddm`, `ddm_sdv` and `full_ddm` models.\n",
     "\n",
     "For a model that has default likelihood functions, only the `model` argument needs to be specified."
    ]
@@ -3058,7 +3059,7 @@
     "\n",
     "2. Specify a `model_config`. It typically contains the following fields:\n",
     "\n",
-    "   - `\"list_params\"`: Required if your `model` string is not one of `ddm`, `ddm_sdv`, `angle`, `levy`, `ornstein`, `weibull`, `race_no_bias_angle_4` and `ddm_seq2_no_bias`. A list of `str` indicating the parameters of the model.\n",
+    "   - `\"list_params\"`: Required if your `model` string is not one of `ddm`, `ddm_sdv`, `full_ddm`, `angle`, `levy`, `ornstein`, `weibull`, `race_no_bias_angle_4` and `ddm_seq2_no_bias`. A list of `str` indicating the parameters of the model.\n",
     "     The order in which the parameters are specified in this list is important.\n",
     "     Values for each parameter will be passed to the likelihood function in this\n",
     "     order.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ huggingface-hub = "^0.15.1"
 onnxruntime = "^1.15.0"
 bambi = "^0.12.0"
 numpyro = "^0.12.1"
+hddm-wfpt = {git = "https://github.com/brown-ccv/hddm-wfpt.git"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
@@ -36,7 +37,6 @@ mypy = "^1.4.1"
 pre-commit = "^2.20.0"
 jupyterlab = "^4.0.2"
 ipykernel = "^6.16.0"
-hddm-wfpt = { git = "https://github.com/brown-ccv/hddm-wfpt.git" }
 ipywidgets = "^8.0.3"
 graphviz = "^0.20.1"
 ruff = "^0.0.272"

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -25,6 +25,7 @@ class Config:
     loglik: LogLik | None = None
     backend: Literal["jax", "pytensor"] | None = None
     rv: RandomVariable | None = None
+    extra_fields: list[str] | None = None
     # Fields with dictionaries are automatically deepcopied
     default_priors: dict[str, ParamSpec] = field(default_factory=dict)
     bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
@@ -162,3 +163,4 @@ class ModelConfig:
     bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
     backend: Literal["jax", "pytensor"] | None = None
     rv: RandomVariable | None = None
+    extra_fields: list[str] | None = None

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -42,6 +42,7 @@ class LoglikConfig(TypedDict):
     backend: Optional[Literal["jax", "pytensor"]]
     default_priors: dict[str, ParamSpec]
     bounds: dict[str, tuple[float, float]]
+    extra_fields: Optional[list[str]]
 
 
 LoglikConfigs = dict[LoglikKind, LoglikConfig]
@@ -73,6 +74,7 @@ default_model_config: DefaultConfigs = {
                         "initval": 0.1,
                     },
                 },
+                "extra_fields": None,
             },
             "approx_differentiable": {
                 "loglik": "ddm.onnx",
@@ -84,6 +86,7 @@ default_model_config: DefaultConfigs = {
                     "z": (0.0, 1.0),
                     "t": (0.0, 2.0),
                 },
+                "extra_fields": None,
             },
             "blackbox": {
                 "loglik": logp_ddm_bbox,
@@ -96,6 +99,7 @@ default_model_config: DefaultConfigs = {
                         "initval": 0.1,
                     },
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -114,6 +118,7 @@ default_model_config: DefaultConfigs = {
                         "initval": 0.1,
                     },
                 },
+                "extra_fields": None,
             },
             "approx_differentiable": {
                 "loglik": "ddm_sdv.onnx",
@@ -126,6 +131,7 @@ default_model_config: DefaultConfigs = {
                     "t": (0.0, 2.0),
                     "sv": (0.0, 1.0),
                 },
+                "extra_fields": None,
             },
             "blackbox": {
                 "loglik": logp_ddm_sdv_bbox,
@@ -138,6 +144,7 @@ default_model_config: DefaultConfigs = {
                         "initval": 0.1,
                     },
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -156,6 +163,7 @@ default_model_config: DefaultConfigs = {
                         "initval": 0.1,
                     },
                 },
+                "extra_fields": None,
             }
         },
     },
@@ -174,6 +182,7 @@ default_model_config: DefaultConfigs = {
                     "t": (0.001, 2.0),
                     "theta": (-0.1, 1.3),
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -192,6 +201,7 @@ default_model_config: DefaultConfigs = {
                     "alpha": (1.0, 2.0),
                     "t": (1e-3, 2.0),
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -210,6 +220,7 @@ default_model_config: DefaultConfigs = {
                     "g": (-1.0, 1.0),
                     "t": (1e-3, 2.0),
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -229,6 +240,7 @@ default_model_config: DefaultConfigs = {
                     "alpha": (0.31, 4.99),
                     "beta": (0.31, 6.99),
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -250,6 +262,7 @@ default_model_config: DefaultConfigs = {
                     "ndt": (0.0, 2.0),
                     "theta": (-0.1, 1.45),
                 },
+                "extra_fields": None,
             },
         },
     },
@@ -268,6 +281,7 @@ default_model_config: DefaultConfigs = {
                     "a": (0.3, 2.5),
                     "t": (0.0, 2.0),
                 },
+                "extra_fields": None,
             },
         },
     },

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -13,6 +13,7 @@ from .likelihoods.analytical import (
     logp_ddm,
     logp_ddm_sdv,
 )
+from .likelihoods.blackbox import logp_ddm_bbox, logp_ddm_sdv_bbox
 from .param import ParamSpec, _make_default_prior
 
 LogLik = Union[str, PathLike, Callable, Op, type[Distribution]]
@@ -81,6 +82,18 @@ default_model_config: DefaultConfigs = {
                     "t": (0.0, 2.0),
                 },
             },
+            "blackbox": {
+                "loglik": logp_ddm_bbox,
+                "backend": None,
+                "bounds": ddm_bounds,
+                "default_priors": {
+                    "t": {
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
+                        "initval": 0.1,
+                    },
+                },
+            },
         },
     },
     "ddm_sdv": {
@@ -109,6 +122,18 @@ default_model_config: DefaultConfigs = {
                     "z": (0.1, 0.9),
                     "t": (0.0, 2.0),
                     "sv": (0.0, 1.0),
+                },
+            },
+            "blackbox": {
+                "loglik": logp_ddm_sdv_bbox,
+                "backend": None,
+                "bounds": ddm_bounds,
+                "default_priors": {
+                    "t": {
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
+                        "initval": 0.1,
+                    },
                 },
             },
         },

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -477,6 +477,8 @@ def make_distribution_from_onnx(
         if params_is_reg is None:
             params_is_reg = [False for param in list_params if param != "p_outlier"]
 
+        # Extra fields are passed to the likelihood functions as vectors
+        # They do not need to be broadcast, so param_is_reg is padded with True
         if extra_fields:
             params_is_reg += [True for _ in extra_fields]
 

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -191,6 +191,9 @@ def make_ssm_rv(
                 size = args[-1]
                 args = args[:-1]
 
+            if size is None:
+                size = 1
+
             # Although we got around the ndims_supp issue, the size parameter passed
             # here is still an array with one element. We need to take it out.
             if not np.isscalar(size):
@@ -225,7 +228,7 @@ def make_ssm_rv(
                 # All parameters are scalars
 
                 theta = np.stack(arg_arrays)
-                n_samples = 1 if not size else size
+                n_samples = size
             else:
                 # Preprocess all parameters, reshape them into a matrix of dimension
                 # (size, n_params) where size is the number of elements in the largest
@@ -240,7 +243,7 @@ def make_ssm_rv(
                     [np.broadcast_to(arg, max_shape).reshape(-1) for arg in arg_arrays]
                 )
 
-                if size is None:
+                if size is None or size == 1:
                     n_samples = 1
                 elif size % new_data_size != 0:
                     raise ValueError(

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -63,7 +63,7 @@ class HSSM:
         columns "rt" and "response".
     model
         The name of the model to use. Currently supported models are "ddm", "ddm_sdv",
-        "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
+        "full_ddm", "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
         "ddm_seq2_no_bias". If any other string is passed, the model will be considered
         custom, in which case all `model_config`, `loglik`, and `loglik_kind` have to be
         provided by the user.

--- a/src/hssm/likelihoods/__init__.py
+++ b/src/hssm/likelihoods/__init__.py
@@ -1,5 +1,13 @@
 """Likelihood functions and distributions that use them."""
 
 from .analytical import DDM, DDM_SDV, logp_ddm, logp_ddm_sdv
+from .blackbox import logp_ddm_bbox, logp_ddm_sdv_bbox
 
-__all__ = ["logp_ddm", "logp_ddm_sdv", "DDM", "DDM_SDV"]
+__all__ = [
+    "logp_ddm",
+    "logp_ddm_sdv",
+    "DDM",
+    "DDM_SDV",
+    "logp_ddm_bbox",
+    "logp_ddm_sdv_bbox",
+]

--- a/src/hssm/likelihoods/__init__.py
+++ b/src/hssm/likelihoods/__init__.py
@@ -1,7 +1,7 @@
 """Likelihood functions and distributions that use them."""
 
 from .analytical import DDM, DDM_SDV, logp_ddm, logp_ddm_sdv
-from .blackbox import logp_ddm_bbox, logp_ddm_sdv_bbox
+from .blackbox import logp_ddm_bbox, logp_ddm_sdv_bbox, logp_full_ddm
 
 __all__ = [
     "logp_ddm",
@@ -10,4 +10,5 @@ __all__ = [
     "DDM_SDV",
     "logp_ddm_bbox",
     "logp_ddm_sdv_bbox",
+    "logp_full_ddm",
 ]

--- a/src/hssm/likelihoods/blackbox.py
+++ b/src/hssm/likelihoods/blackbox.py
@@ -1,0 +1,53 @@
+"""Black box likelihoods written in Cython for "ddm" and "ddm_sdv" models."""
+
+from __future__ import annotations
+
+import hddm_wfpt
+import numpy as np
+
+
+def logp_ddm_bbox(data: np.ndarray, v, a, z, t) -> np.ndarray:
+    """Compute blackbox log-likelihoods for ddm models."""
+    x = (data[:, 0] * data[:, 1]).astype(np.float64)
+    size = len(data)
+
+    v, a, z, t = [_broadcast(param, size) for param in [v, a, z, t]]
+    zeros = np.zeros(size, dtype=np.float64)
+
+    return hddm_wfpt.wfpt.wiener_logp_array(
+        x=x,
+        v=v,
+        sv=zeros,
+        a=a * 2,  # Ensure compatibility with HSSM.
+        z=z,
+        sz=zeros,
+        t=t,
+        st=zeros,
+        err=1e-8,
+    ).astype(data.dtype)
+
+
+def logp_ddm_sdv_bbox(data: np.ndarray, v, a, z, t, sv) -> np.ndarray:
+    """Compute blackbox log-likelihoods for ddm models."""
+    x = (data[:, 0] * data[:, 1]).astype(np.float64)
+    size = len(x)
+
+    v, a, z, t, sv = [_broadcast(param, size) for param in [v, a, z, t, sv]]
+    zeros = np.zeros(size, dtype=np.float64)
+
+    return hddm_wfpt.wfpt.wiener_logp_array(
+        x=x,
+        v=v,
+        sv=zeros,
+        a=a * 2,  # Ensure compatibility with HSSM.
+        z=z,
+        sz=zeros,
+        t=t,
+        st=zeros,
+        err=1e-8,
+    ).astype(data.dtype)
+
+
+def _broadcast(x: float | np.ndarray, size: int):
+    """Broadcast a scalar or an array to size of `size`."""
+    return np.broadcast_to(np.array(x, dtype=np.float64), size)

--- a/src/hssm/likelihoods/blackbox.py
+++ b/src/hssm/likelihoods/blackbox.py
@@ -14,7 +14,7 @@ def logp_ddm_bbox(data: np.ndarray, v, a, z, t) -> np.ndarray:
     v, a, z, t = [_broadcast(param, size) for param in [v, a, z, t]]
     zeros = np.zeros(size, dtype=np.float64)
 
-    return hddm_wfpt.wfpt.wiener_logp_array(
+    logp = hddm_wfpt.wfpt.wiener_logp_array(
         x=x,
         v=v,
         sv=zeros,
@@ -24,18 +24,22 @@ def logp_ddm_bbox(data: np.ndarray, v, a, z, t) -> np.ndarray:
         t=t,
         st=zeros,
         err=1e-8,
-    ).astype(data.dtype)
+    )
+
+    logp = np.where(np.isfinite(logp), logp, -66.1)
+
+    return logp.astype(data.dtype)
 
 
 def logp_ddm_sdv_bbox(data: np.ndarray, v, a, z, t, sv) -> np.ndarray:
-    """Compute blackbox log-likelihoods for ddm models."""
+    """Compute blackbox log-likelihoods for ddm_sdv models."""
     x = (data[:, 0] * data[:, 1]).astype(np.float64)
     size = len(x)
 
     v, a, z, t, sv = [_broadcast(param, size) for param in [v, a, z, t, sv]]
     zeros = np.zeros(size, dtype=np.float64)
 
-    return hddm_wfpt.wfpt.wiener_logp_array(
+    logp = hddm_wfpt.wfpt.wiener_logp_array(
         x=x,
         v=v,
         sv=zeros,
@@ -45,7 +49,37 @@ def logp_ddm_sdv_bbox(data: np.ndarray, v, a, z, t, sv) -> np.ndarray:
         t=t,
         st=zeros,
         err=1e-8,
-    ).astype(data.dtype)
+    )
+
+    logp = np.where(np.isfinite(logp), logp, -66.1)
+
+    return logp.astype(data.dtype)
+
+
+def logp_full_ddm(data: np.ndarray, v, a, z, t, sv, sz, st):
+    """Compute blackbox log-likelihoods for full_ddm models."""
+    x = (data[:, 0] * data[:, 1]).astype(np.float64)
+    size = len(x)
+
+    v, a, z, t, sv, sz, st = [
+        _broadcast(param, size) for param in [v, a, z, t, sv, sz, st]
+    ]
+
+    logp = hddm_wfpt.wfpt.wiener_logp_array(
+        x=x,
+        v=v,
+        sv=sv,
+        a=a * 2,  # Ensure compatibility with HSSM.
+        z=z,
+        sz=sz,
+        t=t,
+        st=st,
+        err=1e-8,
+    )
+
+    logp = np.where(np.isfinite(logp), logp, -66.1)
+
+    return logp.astype(data.dtype)
 
 
 def _broadcast(x: float | np.ndarray, size: int):

--- a/src/hssm/param.py
+++ b/src/hssm/param.py
@@ -377,49 +377,6 @@ def _make_priors_recursive(prior: dict[str, Any]) -> Prior:
     return bmb.Prior(**prior)
 
 
-def _parse_bambi(
-    params: dict[str, Param],
-) -> tuple[bmb.Formula, dict | None, dict[str, str | bmb.Link] | str]:
-    """From a dict of Params, retrieve three items that helps with bambi model building.
-
-    Parameters
-    ----------
-    params
-        A dict of Param objects.
-
-    Returns
-    -------
-    tuple
-        A tuple containing:
-            1. A bmb.Formula object.
-            2. A dictionary of priors, if any is specified.
-            3. A dictionary of link functions, if any is specified.
-    """
-    # Handle the edge case where list_params is empty:
-    if not params:
-        return bmb.Formula("c(rt, response) ~ 1"), None, "identity"
-
-    formulas = []
-    priors: dict[str, Any] = {}
-    links: dict[str, str | bmb.Link] = {}
-
-    for _, param in params.items():
-        formula, prior, link = param.parse_bambi()
-
-        if formula is not None:
-            formulas.append(formula)
-        if prior is not None:
-            priors |= prior
-        if link is not None:
-            links |= link
-
-    result_formula: bmb.Formula = bmb.Formula(formulas[0], *formulas[1:])
-    result_priors = None if not priors else priors
-    result_links: dict | str = "identity" if not links else links
-
-    return result_formula, result_priors, result_links
-
-
 def _make_bounded_prior(
     param_name: str, prior: ParamSpec, bounds: tuple[float, float]
 ) -> float | Prior:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def data_angle():
 def data_ddm_reg():
     # Generate some fake simulation data
     intercept = 0.3
-    x = np.random.uniform(0.5, 0.2, size=1000)
+    x = np.random.uniform(0.5, 0.7, size=1000)
     y = np.random.uniform(0.4, 0.1, size=1000)
 
     v = intercept + 0.8 * x + 0.3 * y

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -10,7 +10,8 @@ import pytest
 from numpy.random import rand
 
 # pylint: disable=C0413
-from hssm.likelihoods.analytical import compare_k, logp_ddm_sdv
+from hssm.likelihoods.analytical import compare_k, logp_ddm, logp_ddm_sdv
+from hssm.likelihoods.blackbox import logp_ddm_bbox, logp_ddm_sdv_bbox
 
 
 def test_kterm(data_ddm):
@@ -97,3 +98,18 @@ def test_no_inf_values_v(data_ddm, shared_params):
         assert np.all(
             np.isfinite(logp.eval())
         ), f"log_pdf_sv() returned non-finite values for v = {v}."
+
+
+def test_bbox(data_ddm):
+    true_values = (0.5, 1.5, 0.5, 0.5)
+    true_values_sdv = (0.5, 1.5, 0.5, 0.5, 0)
+    data = data_ddm.values
+
+    np.testing.assert_almost_equal(
+        logp_ddm(data, *true_values).eval(), logp_ddm_bbox(data, *true_values)
+    )
+
+    np.testing.assert_almost_equal(
+        logp_ddm_sdv(data, *true_values_sdv).eval(),
+        logp_ddm_sdv_bbox(data, *true_values_sdv),
+    )

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -106,10 +106,13 @@ def test_bbox(data_ddm):
     data = data_ddm.values
 
     np.testing.assert_almost_equal(
-        logp_ddm(data, *true_values).eval(), logp_ddm_bbox(data, *true_values)
+        logp_ddm(data, *true_values).eval(),
+        logp_ddm_bbox(data, *true_values),
+        decimal=4,
     )
 
     np.testing.assert_almost_equal(
         logp_ddm_sdv(data, *true_values_sdv).eval(),
         logp_ddm_sdv_bbox(data, *true_values_sdv),
+        decimal=4,
     )

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,3 +1,5 @@
+import pytest
+
 import hssm
 
 hssm.set_floatX("float32")
@@ -11,6 +13,10 @@ def test_non_reg_models(data_ddm):
     model2 = hssm.HSSM(data_ddm, loglik_kind="approx_differentiable")
     model2.sample(cores=1, chains=1, tune=10, draws=10)
     model2.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+
+    model3 = hssm.HSSM(data_ddm, loglik_kind="blackbox")
+    model3.sample(cores=1, chains=1, tune=10, draws=10)
+    model3.sample(cores=1, chains=1, tune=10, draws=10)
 
 
 def test_reg_models(data_ddm_reg):
@@ -26,14 +32,38 @@ def test_reg_models(data_ddm_reg):
     model1 = hssm.HSSM(data_ddm_reg, v=param_reg)
     model1.sample(cores=1, chains=1, tune=10, draws=10)
     model1.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+
     model2 = hssm.HSSM(data_ddm_reg, loglik_kind="approx_differentiable", v=param_reg)
     model2.sample(cores=1, chains=1, tune=10, draws=10)
-    model2.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+    model2.sample(sampler="mcmc", cores=1, chains=1, tune=10, draws=10)
 
-    model3 = hssm.HSSM(data_ddm_reg, a=param_reg)
+    model3 = hssm.HSSM(data_ddm_reg, loglik_kind="blackbox", v=param_reg)
     model3.sample(cores=1, chains=1, tune=10, draws=10)
-    model3.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
 
-    model4 = hssm.HSSM(data_ddm_reg, loglik_kind="approx_differentiable", a=param_reg)
-    model4.sample(cores=1, chains=1, tune=10, draws=10)
-    model4.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+    with pytest.raises(ValueError):
+        model3.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+
+
+def test_reg_models_a(data_ddm_reg):
+    param_reg = dict(
+        formula="a ~ 1 + x + y",
+        prior={
+            "Intercept": {"name": "Uniform", "lower": -3.0, "upper": 3.0},
+            "x": {"name": "Uniform", "lower": -0.50, "upper": 0.50},
+            "y": {"name": "Uniform", "lower": -0.50, "upper": 0.50},
+        },
+    )
+
+    model1 = hssm.HSSM(data_ddm_reg, a=param_reg)
+    model1.sample(cores=1, chains=1, tune=10, draws=10)
+    model1.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+
+    model2 = hssm.HSSM(data_ddm_reg, loglik_kind="approx_differentiable", a=param_reg)
+    model2.sample(cores=1, chains=1, tune=10, draws=10)
+    model2.sample(sampler="mcmc", cores=1, chains=1, tune=10, draws=10)
+
+    model3 = hssm.HSSM(data_ddm_reg, loglik_kind="blackbox", a=param_reg)
+    model3.sample(cores=1, chains=1, tune=10, draws=10)
+
+    with pytest.raises(ValueError):
+        model3.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -7,6 +7,8 @@ hssm.set_floatX("float32")
 
 def test_non_reg_models(data_ddm):
     model1 = hssm.HSSM(data_ddm)
+    model1.sample_prior_predictive(draws=10)
+
     model1.sample(cores=1, chains=1, tune=10, draws=10)
     model1.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
 
@@ -17,6 +19,8 @@ def test_non_reg_models(data_ddm):
     model3 = hssm.HSSM(data_ddm, loglik_kind="blackbox")
     model3.sample(cores=1, chains=1, tune=10, draws=10)
     model3.sample(cores=1, chains=1, tune=10, draws=10)
+
+    model1.sample_posterior_predictive(data=data_ddm.iloc[:10, :])
 
 
 def test_reg_models(data_ddm_reg):
@@ -30,6 +34,8 @@ def test_reg_models(data_ddm_reg):
     )
 
     model1 = hssm.HSSM(data_ddm_reg, v=param_reg)
+    model1.sample_prior_predictive(draws=10)
+
     model1.sample(cores=1, chains=1, tune=10, draws=10)
     model1.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
 
@@ -42,6 +48,8 @@ def test_reg_models(data_ddm_reg):
 
     with pytest.raises(ValueError):
         model3.sample(sampler="nuts_numpyro", cores=1, chains=1, tune=10, draws=10)
+
+    model1.sample_posterior_predictive(data=data_ddm_reg.iloc[:10, :])
 
 
 def test_reg_models_a(data_ddm_reg):

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -6,56 +6,9 @@ import hssm
 from hssm.param import (
     Param,
     _make_default_prior,
-    _parse_bambi,
     _make_priors_recursive,
     _make_bounded_prior,
 )
-
-
-def test__parse_bambi():
-    prior_dict = {"name": "Uniform", "lower": 0.3, "upper": 1.0}
-    prior_obj = bmb.Prior("Uniform", lower=0.3, upper=1.0)
-
-    param_parent_non_regression = Param("v", prior=prior_dict)
-    param_parent_regression = Param(
-        "v",
-        formula="1 + x1",
-        prior={
-            "Intercept": prior_dict,
-            "x1": prior_dict,
-        },
-    )
-
-    param_parent_non_regression.set_parent()
-    param_parent_non_regression.convert()
-
-    param_parent_regression.set_parent()
-    param_parent_regression.convert()
-
-    empty_dict = {}
-    dict_one_parent_non_regression = {"v": param_parent_non_regression}
-    dict_one_parent_regression = {"v": param_parent_regression}
-
-    f0, p0, l0 = _parse_bambi(empty_dict)
-
-    assert f0.main == "c(rt, response) ~ 1"
-    assert p0 is None
-    assert l0 == "identity"
-
-    f3, p3, l3 = _parse_bambi(dict_one_parent_non_regression)
-
-    assert f3.main == "c(rt, response) ~ 1"
-    assert p3 is not None
-    assert p3["c(rt, response)"]["Intercept"] == prior_obj
-    assert l3 == {"v": "identity"}
-
-    f4, p4, l4 = _parse_bambi(dict_one_parent_regression)
-
-    assert f4.main == "c(rt, response) ~ 1 + x1"
-    assert p4 is not None
-    assert p4["c(rt, response)"]["Intercept"] == prior_obj
-    assert p4["c(rt, response)"]["x1"] == prior_obj
-    assert l4 == {"v": "identity"}
 
 
 def test_param_creation_non_regression():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,11 +64,13 @@ def test_get_alias_dict():
 
     assert alias_regression["c(rt, response)"] == "rt,response"
     assert alias_regression["Intercept"] == "v_Intercept"
+    assert alias_regression["x"] == "v_x"
     assert alias_regression["1|group"] == "v_1|group"
 
-    assert alias_regression_a["c(rt, response)"]["c(rt, response)"] == "rt,response"
-    assert alias_regression_a["c(rt, response)"]["Intercept"] == "v"
-    assert alias_regression_a["a"]["a"] == "a"
+    assert alias_regression_a["c(rt, response)"] == "rt,response"
+    assert alias_regression_a["Intercept"] == "a_Intercept"
+    assert alias_regression_a["x"] == "a_x"
+    assert alias_regression_a["1|group"] == "a_1|group"
 
 
 def test_set_floatX():


### PR DESCRIPTION
We now support additional data fields passed to the likelihood function. This is achieved through manipulating `dist()` method in SSM_Distribution so that `extra_fields`, which is now saved as a class attribute, is also passed to `logp()` method as part of `dist_params`. This way, any `RandomVariable` class will also receive these extra fields, but the classes themselves do not keep an extra reference to this object. This makes it easier to keep these extra fields consistent.

Please note that `extra_fields` is now a part of `model_config`. It is now possible to set `extra_fields` as a default for a likelihood function, as long as the likelihood function accepts these extra_fields as arguments.