### PR TITLE
Bumped PyMC version and limited numpy version

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install poetry
         uses: snok/install-poetry@v1
@@ -82,7 +82,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-3.9-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-${{ runner.os }}-3.11-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install poetry
         uses: snok/install-poetry@v1
@@ -33,7 +33,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-3.9-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-${{ runner.os }}-3.11-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-pymc = ">=5.8.2"
+pymc = ">=5.9.0"
 scipy = "1.10.1"
 arviz = "^0.14.0"
 numpy = ">=1.23.4,<1.26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-pymc = ">=5.6.0,<5.7.0"
+pymc = ">=5.8.2"
 scipy = "1.10.1"
 arviz = "^0.14.0"
-numpy = "^1.23.4"
+numpy = ">=1.23.4,<1.26"
 onnx = "^1.12.0"
 jax = "^0.4.0"
 jaxlib = "^0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/lnccbrown/HSSM"
 keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.10,<3.12"
 pymc = ">=5.9.0"
 scipy = "1.10.1"
 arviz = "^0.14.0"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -22,7 +22,9 @@ def fixture_path():
 def onnx_session(fixture_path):
     model_path = str(fixture_path / "angle.onnx")
 
-    return onnxruntime.InferenceSession(model_path, None)
+    return onnxruntime.InferenceSession(
+        model_path, None, providers=["CPUExecutionProvider"]
+    )
 
 
 def test_interpret_onnx(onnx_session, fixture_path):


### PR DESCRIPTION
PyMC fixed pytensor import error in 5.8.2. Using that version onwards.

Also numpy 1.26 is causing some compatibility issues with pytensor. Pytensor is limiting the version of numpy and we are doing the same until they resolve this.