### PR TITLE
Replace negative non-decision time in likelihood computation with a small value

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ HSSM is a Python toolbox that provides a seamless combination of state-of-the-ar
 
 ## Installation
 
-`hssm` is available through PyPI. You can install it with Pip via:
+`hssm` is available through PyPI. You can install it with pip via:
 
 ```
 pip install hssm
 ```
 
-You can also install the bleeding edge version of `hssm` directly from this repo:
+You can also install the bleeding-edge version of `hssm` directly from this repo:
 
 ```
 pip install git+https://github.com/lnccbrown/HSSM.git
@@ -51,7 +51,7 @@ for more detailed instructions.
 [here](https://github.com/lnccbrown/HSSM/discussions). We recommend leveraging an
 environment manager with Python 3.10~3.11 to prevent any problems with dependencies
 during the installation process. Please note that hssm is tested for python 3.10,
-3.11. As of HSSM v0.1.6, support for Python 3.9 is dropped. Use other python
+3.11. As of HSSM v0.2.0, support for Python 3.9 is dropped. Use other python
 versions with caution.
 
 ## Example

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,6 @@
 
 **HSSM** (Hierarchical Sequential Sampling Modeling) is a modern Python toolbox that provides state-of-the-art likelihood approximation methods within the Python Bayesian ecosystem. It facilitates hierarchical model building and inference via fast and robust MCMC samplers. User-friendly, extensible, and flexible, HSSM can rigorously estimate the impact of neural and other trial-by-trial covariates through parameter-wise mixed-effects models for a large variety of cognitive process models.
 
-
 HSSM is a [BRAINSTORM](https://ccbs.carney.brown.edu/brainstorm) project in collaboration with the [Center for Computation and Visualization (CCV)](https://ccv.brown.edu/) and the [Center for Computational Brain Science](https://ccbs.carney.brown.edu/) within the [Carney Institute at Brown University](https://www.brown.edu/carney/).
 
 ## Features
@@ -30,7 +29,7 @@ HSSM is a [BRAINSTORM](https://ccbs.carney.brown.edu/brainstorm) project in coll
 
 ## Installation
 
-`hssm` is available through PyPI. You can install it with Pip via:
+`hssm` is available through PyPI. You can install it with pip via:
 
 ```bash
 pip install hssm
@@ -50,9 +49,8 @@ For more detailed guidance, please check out our [installation guide](getting_st
     [here](https://github.com/lnccbrown/HSSM/discussions). We recommend leveraging an
     environment manager with Python 3.10~3.11 to prevent any problems with dependencies
     during the installation process. Please note that hssm is tested for python 3.10,
-    3.11. As of HSSM v0.1.6, support for Python 3.9 is dropped. Use other python
+    3.11. As of HSSM v0.2.0, support for Python 3.9 is dropped. Use other python
     versions with caution.
-
 
 ### Setting global float type
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,7 +5,7 @@
   </span>
   Navigate the site here!
 </span>
-<span class="right-margin"> v0.2.0b1 is released! </span>
+<span class="right-margin"> v0.2.0 is released! </span>
 <span>
   <span class="twemoji">
     {% include ".icons/material/head-question.svg" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "HSSM"
-version = "0.2.0b1"
+version = "0.2.0"
 description = "Bayesian inference for hierarchical sequential sampling models."
 authors = [
     "Alexander Fengler <alexander_fengler@brown.edu>",

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -251,7 +251,7 @@ default_model_config: DefaultConfigs = {
         },
     },
     "race_no_bias_angle_4": {
-        "list_params": ["v0", "v1", "v2", "v3", "a", "z", "ndt", "theta"],
+        "list_params": ["v0", "v1", "v2", "v3", "a", "z", "t", "theta"],
         "description": None,
         "likelihoods": {
             "approx_differentiable": {
@@ -265,7 +265,7 @@ default_model_config: DefaultConfigs = {
                     "v3": (0.0, 2.5),
                     "a": (1.0, 3.0),
                     "z": (0.0, 0.9),
-                    "ndt": (0.0, 2.0),
+                    "t": (0.0, 2.0),
                     "theta": (-0.1, 1.45),
                 },
                 "extra_fields": None,


### PR DESCRIPTION
In the analytical likelihood computation, wherever `rt - t <= epsilon`, we replace the likelihood value with a very small number. However, this is not done for other types of likelihoods.

We add a `ensure_positive_ndt` function and apply it at the end of all likelihood computation to ensure this.

In doing so, we assume that all parameter named "t" means non-decision time. There is a default parameter in `race_no_bias_angle_4` named `ndt`. We are now changing it to `t` to conform with this assumption.