### PR TITLE
release pymc version to newest and adjust git action accordingly

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install pymc and poetry
         run: |
           mamba info
-          mamba install -c conda-forge pymc=5.10 poetry
+          mamba install -c conda-forge pymc=5.12 poetry
 
       - name: install hssm
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-pymc = ">=5.10.4, <5.11.0"
+pymc = ">=5.12"
 scipy = "^1.12.0"
 arviz = "^0.17.0"
 numpy = "^1.26.4"


### PR DESCRIPTION
This PR gets pymc version up to 5.12.
There are a few improvements to pymc that are of direct benefit to us. 

1. The new `var_names` argument should allow us to drop deterministics where we don't want them
2. The implicit update to pytensor, gets us a fix to  `dot` function. This should erase a few errors when compiling complicated models.
