### PR TITLE
Allow users to specify the number of choices

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -49,8 +49,11 @@ jobs:
       - name: Linting
         run: ruff check src/hssm
 
-      - name: Run tests
-        run: pytest -n auto -s
+      - name: Run fast tests
+        run: pytest -n auto -s --ignore=tests/slow
+
+      - name: Run slow tests
+        run: pytest -n auto -s tests/slow
 
   publish:
     name: Build wheel and publish to test-PyPI, and then PyPI, and publish docs

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,8 +47,11 @@ jobs:
       - name: Linting
         run: ruff check src/hssm
 
-      - name: Run tests
-        run: pytest -n auto -s
+      - name: Run fast tests
+        run: pytest -n auto -s --ignore=tests/slow
+
+      - name: Run slow tests
+        run: pytest -n auto -s tests/slow
 
       - name: build docs
         run: mkdocs build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,30 @@ def data_ddm_reg():
     return dataset_reg_v
 
 
+@pytest.fixture(scope="module")
+def data_ddm_reg_va():
+    # Generate some fake simulation data
+    intercept = 1.5
+    intercept_a = 1.0
+    x = np.random.uniform(-0.5, 0.5, size=100)
+    y = np.random.uniform(-0.5, 0.5, size=100)
+
+    v = intercept + 0.8 * x + 0.3 * y
+    a = intercept_a + 0.8 * x + 0.3 * y
+    true_values = np.column_stack([v, a, np.repeat([[0.5, 0.5]], axis=0, repeats=100)])
+
+    dataset_reg_va = hssm.simulate_data(
+        model="ddm",
+        theta=true_values,
+        size=1,  # Generate one data point for each of the 1000 set of true values
+    )
+
+    dataset_reg_va["x"] = x
+    dataset_reg_va["y"] = y
+
+    return dataset_reg_va
+
+
 @pytest.fixture
 def cav_idata():
     return az.from_netcdf("tests/fixtures/cavanagh_idata.nc")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,8 +65,11 @@ def data_ddm_reg_va():
     x = np.random.uniform(-0.5, 0.5, size=100)
     y = np.random.uniform(-0.5, 0.5, size=100)
 
+    m = np.random.uniform(-0.5, 0.5, size=100)
+    n = np.random.uniform(-0.5, 0.5, size=100)
+
     v = intercept + 0.8 * x + 0.3 * y
-    a = intercept_a + 0.8 * x + 0.3 * y
+    a = intercept_a + 0.1 * m + 0.1 * n
     true_values = np.column_stack([v, a, np.repeat([[0.5, 0.5]], axis=0, repeats=100)])
 
     dataset_reg_va = hssm.simulate_data(
@@ -77,6 +80,8 @@ def data_ddm_reg_va():
 
     dataset_reg_va["x"] = x
     dataset_reg_va["y"] = y
+    dataset_reg_va["m"] = m
+    dataset_reg_va["n"] = n
 
     return dataset_reg_va
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,8 @@ def data_angle():
 def data_ddm_reg():
     # Generate some fake simulation data
     intercept = 1.5
-    x = np.random.uniform(-5.0, 5.0, size=1000)
-    y = np.random.uniform(-5.0, 5.0, size=1000)
+    x = np.random.uniform(-0.5, 0.5, size=1000)
+    y = np.random.uniform(-0.5, 0.5, size=1000)
 
     v = intercept + 0.8 * x + 0.3 * y
     true_values = np.column_stack(

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -204,11 +204,11 @@ def test_reg_models_v_a(data_ddm_reg, loglik_kind, backend, sampler, step, expec
             "Intercept": {
                 "name": "Uniform",
                 "lower": 0.5,
-                "upper": 3.0,
-                "initval": 1.0,
+                "upper": 1.0,
+                "initval": 0.75,
             },
-            "x": {"name": "Uniform", "lower": -0.50, "upper": 0.50, "initval": 0.0},
-            "y": {"name": "Uniform", "lower": -0.50, "upper": 0.50, "initval": 0.0},
+            "x": {"name": "Uniform", "lower": -0.10, "upper": 0.10, "initval": 0.0},
+            "y": {"name": "Uniform", "lower": -0.10, "upper": 0.10, "initval": 0.0},
         },
         link="identity",
     )

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -184,7 +184,7 @@ def test_reg_models(data_ddm_reg, loglik_kind, backend, sampler, step, expected)
 
 
 @pytest.mark.parametrize(parameter_names, parameter_grid)
-def test_reg_models_v_a(data_ddm_reg, loglik_kind, backend, sampler, step, expected):
+def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, sampler, step, expected):
     print("PYMC VERSION: ")
     print(pm.__version__)
     print("TEST INPUTS WERE: ")
@@ -204,17 +204,17 @@ def test_reg_models_v_a(data_ddm_reg, loglik_kind, backend, sampler, step, expec
             "Intercept": {
                 "name": "Uniform",
                 "lower": 0.5,
-                "upper": 1.0,
-                "initval": 0.75,
+                "upper": 1.5,
+                "initval": 1.0,
             },
-            "x": {"name": "Uniform", "lower": -0.10, "upper": 0.10, "initval": 0.0},
-            "y": {"name": "Uniform", "lower": -0.10, "upper": 0.10, "initval": 0.0},
+            "x": {"name": "Uniform", "lower": 0.7, "upper": 0.9, "initval": 0.8},
+            "y": {"name": "Uniform", "lower": 0.2, "upper": 0.4, "initval": 0.3},
         },
         link="identity",
     )
 
     model = hssm.HSSM(
-        data_ddm_reg,
+        data_ddm_reg_va,
         loglik_kind=loglik_kind,
         model_config={"backend": backend},
         v=param_reg_v,

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -199,15 +199,15 @@ def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, sampler, step, ex
         },
     )
     param_reg_a = dict(
-        formula="a ~ 1 + x + y",
+        formula="a ~ 1 + m + n",
         prior={
             "Intercept": {
-                "name": "Uniform",
-                "lower": 0.5,
-                "upper": 1.5,
+                "name": "Normal",
+                "mu": 1.0,
+                "sigma": 0.5,
             },
-            "x": {"name": "Uniform", "lower": 0.7, "upper": 0.9},
-            "y": {"name": "Uniform", "lower": 0.2, "upper": 0.4},
+            "m": {"name": "Uniform", "lower": 0.0, "upper": 0.2},
+            "n": {"name": "Uniform", "lower": 0.0, "upper": 0.2},
         },
         link="identity",
     )
@@ -219,6 +219,7 @@ def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, sampler, step, ex
         v=param_reg_v,
         a=param_reg_a,
     )
+    print(model.params["a"])
     run_sample(model, sampler, step, expected)
 
     # Only runs once

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -205,10 +205,9 @@ def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, sampler, step, ex
                 "name": "Uniform",
                 "lower": 0.5,
                 "upper": 1.5,
-                "initval": 1.0,
             },
-            "x": {"name": "Uniform", "lower": 0.7, "upper": 0.9, "initval": 0.8},
-            "y": {"name": "Uniform", "lower": 0.2, "upper": 0.4, "initval": 0.3},
+            "x": {"name": "Uniform", "lower": 0.7, "upper": 0.9},
+            "y": {"name": "Uniform", "lower": 0.2, "upper": 0.4},
         },
         link="identity",
     )


### PR DESCRIPTION
We previously inferred `n_choices` from the number of unique responses from the user's data. This might have worked in the binary case, but in multiple-choice cases, some responses might be legitimately missing from some datasets. This PR adds a `choices` option that could be either an `int` or a list of `int`s to allow users to specify the number of choices. The data sanity check from this option is more robust. It will raise an error when data is miscoded and raise a warning to remind the users when certain values are missing from their dataset.

Also closes #429 