### PR TITLE
One-command support for JAX GPU

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=req.txt
+          poetry export --with dev --without-hashes --output=req.txt
           grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,7 +36,8 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=requirements.txt
+          poetry export --with dev --output=req.txt
+          grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=req.txt
+          poetry export --with dev --without-hashes --output=req.txt
           grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=requirements.txt
+          poetry export --with dev --output=req.txt
+          grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ bambi = "^0.13.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
-jax = "^0.4.23"
+jax = { version = "^0.4.23", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"
@@ -42,6 +42,9 @@ mkdocs = "^1.6.0"
 mkdocs-material = "^9.5.21"
 mkdocstrings-python = "^1.10.0"
 mkdocs-jupyter = "^0.24.7"
+
+[tool.poetry.extras]
+cuda12 = ["jax"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ bambi = "^0.13.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
-jax = { version = "^0.4.23", extras = ["cuda12"], optional = true }
+jax = { version = ">=0.4.23,<0.4.28", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"


### PR DESCRIPTION
After this pr is merged, one can install `hssm` with GPU support with `pip install hssm[cuda12]` (not available on cuda)