### PR TITLE
Update reference to jax.config

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=req.txt
+          poetry export --with dev --without-hashes --output=req.txt
           grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -36,7 +36,8 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=requirements.txt
+          poetry export --with dev --output=req.txt
+          grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=req.txt
+          poetry export --with dev --without-hashes --output=req.txt
           grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,8 @@ jobs:
 
       - name: install hssm
         run: |
-          poetry export --with dev --output=requirements.txt
+          poetry export --with dev --output=req.txt
+          grep -v -E '^jax\[cuda12\]|^nvidia|^jax\-cuda12' req.txt >> requirements.txt
           pip install -r requirements.txt
           pip install -e .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ bambi = "^0.13.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
-jax = "^0.4.23"
+jax = { version = "^0.4.23", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"
@@ -42,6 +42,9 @@ mkdocs = "^1.6.0"
 mkdocs-material = "^9.5.21"
 mkdocstrings-python = "^1.10.0"
 mkdocs-jupyter = "^0.24.7"
+
+[tool.poetry.extras]
+cuda12 = ["jax"]
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ bambi = "^0.13.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
-jax = { version = "^0.4.23", extras = ["cuda12"], optional = true }
+jax = { version = ">=0.4.23,<0.4.28", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ bambi = "^0.13.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
-jax = { version = ">=0.4.23,<0.4.28", extras = ["cuda12"], optional = true }
+jax = { version = "^0.4.25", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -13,13 +13,13 @@ import logging
 from typing import Any, Iterable, Literal, NewType
 
 import bambi as bmb
+import jax
 import numpy as np
 import pandas as pd
 import pytensor
 import xarray as xr
 from bambi.terms import CommonTerm, GroupSpecificTerm, HSGPTerm, OffsetTerm
 from huggingface_hub import hf_hub_download
-from jax import config
 from pymc.model_graph import ModelGraph
 from pytensor import function
 
@@ -258,7 +258,7 @@ class HSSMModelGraph(ModelGraph):
         return graph
 
 
-def set_floatX(dtype: Literal["float32", "float64"], jax: bool = True):
+def set_floatX(dtype: Literal["float32", "float64"], update_jax: bool = True):
     """Set float types for pytensor and Jax.
 
     Often we wish to work with a specific type of float in both PyTensor and JAX.
@@ -268,7 +268,7 @@ def set_floatX(dtype: Literal["float32", "float64"], jax: bool = True):
     ----------
     dtype
         Either `float32` or `float64`. Float type for pytensor (and jax if `jax=True`).
-    jax : optional
+    update_jax : optional
         Whether this function also sets float type for JAX by changing the
         `jax_enable_x64` setting in JAX config. Defaults to True.
     """
@@ -278,9 +278,9 @@ def set_floatX(dtype: Literal["float32", "float64"], jax: bool = True):
     pytensor.config.floatX = dtype
     _logger.info("Setting PyTensor floatX type to %s.", dtype)
 
-    if jax:
+    if update_jax:
         jax_enable_x64 = dtype == "float64"
-        config.update("jax_enable_x64", jax_enable_x64)
+        jax.config.update("jax_enable_x64", jax_enable_x64)
 
         _logger.info(
             'Setting "jax_enable_x64" to %s. '

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -10,7 +10,7 @@ import pymc as pm
 
 from hssm.utils import _rearrange_data
 
-hssm.set_floatX("float32", jax=True)
+hssm.set_floatX("float32", update_jax=True)
 
 # AF-TODO: Include more tests that use different link functions!
 

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -7,7 +7,7 @@ from hssm import HSSM
 from hssm.utils import download_hf
 from hssm.likelihoods import DDM, logp_ddm
 
-hssm.set_floatX("float32", jax=True)
+hssm.set_floatX("float32", update_jax=True)
 
 param_v = {
     "name": "v",


### PR DESCRIPTION
JAX has marked `from jax import config` as deprecated as of 0.4.25 and this API was removed in 0.4.29. This affects the `hssm.set_floatX` API. We fix that in this PR