### PR TITLE
fix key error bug when going through initialization, make safe priors…

### DIFF
--- a/src/hssm/datasets.py
+++ b/src/hssm/datasets.py
@@ -5,7 +5,7 @@ Heavily influenced by Arviz's(scikit-learn's, and Bambi's) implementation.
 """
 
 import os
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Optional
 
 import pandas as pd
 
@@ -34,7 +34,7 @@ DATASETS = {
 }
 
 
-def load_data(dataset: Optional[str] = None) -> Union[pd.DataFrame, str]:
+def load_data(dataset: Optional[str] = None) -> pd.DataFrame | str:
     """
     Load a dataset as a pandas DataFrame.
 

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -348,8 +348,6 @@ INITVAL_SETTINGS = {
         "t": 0.025,
         "t_Intercept": 0.025,
         "a": 1.5,
-        # "v": 1.5,  # TODO: skip
-        # "v_Intercept": 0.3,
         "a_Intercept": 1.5,
         "p_outlier": 0.001,
     },

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -337,7 +337,7 @@ INITVAL_SETTINGS = {
     },
     # identity link function case,
     # need to take care of_log__ and _interval__ variables
-    "None": {
+    None: {
         "t": 0.025,
         "t_Intercept": 0.025,
         "a": 1.5,

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -328,6 +328,7 @@ default_model_config: DefaultConfigs = {
     },
 }
 
+# TODO: Initval settings could be specified directly in model config as well.
 INITVAL_SETTINGS = {
     # logit link function case
     # should never use priors with bounds,
@@ -347,6 +348,8 @@ INITVAL_SETTINGS = {
         "t": 0.025,
         "t_Intercept": 0.025,
         "a": 1.5,
+        # "v": 1.5,  # TODO: skip
+        # "v_Intercept": 0.3,
         "a_Intercept": 1.5,
         "p_outlier": 0.001,
     },

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -92,7 +92,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "extra_fields": None,
@@ -104,7 +103,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "bounds": {
@@ -123,7 +121,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "extra_fields": None,
@@ -143,7 +140,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "extra_fields": None,
@@ -155,7 +151,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "bounds": {
@@ -175,7 +170,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "extra_fields": None,
@@ -195,7 +189,6 @@ default_model_config: DefaultConfigs = {
                     "t": {
                         "name": "HalfNormal",
                         "sigma": 2.0,
-                        "initval": 0.05,
                     },
                 },
                 "extra_fields": None,

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -1729,8 +1729,13 @@ class HSSM:
 
     def _get_prefix(self, name_str: str) -> str:
         """Get parameters wise link setting function from parameter prefix."""
-        if "_" in name_str:
+        # `p_outlier` is the only basic parameter floating around that has
+        # an underscore in it's name.
+        # We need to handle it separately. (Renaming might be better...)
+        if "_" in name_str and "p_outlier" not in name_str:
             name_str_prefix = name_str.split("_")[0]
+        elif "_" in name_str and "p_outlier" in name_str:
+            name_str_prefix = "p_outlier"
         else:
             name_str_prefix = name_str
         return name_str_prefix
@@ -1741,9 +1746,18 @@ class HSSM:
         # or `paramname_Intercept`, because we only really provide special default
         # initial values for those types of parameters
 
-        if "_" in name_str:
+        # `p_outlier` is the only basic parameter floating around that has
+        # an underscore in it's name.
+        # We need to handle it separately. (Renaming might be better...)
+        if ("_" in name_str) and ("p_outlier" not in name_str):
             name_str_prefix = name_str.split("_")[0]
             name_str_suffix = name_str.split("_")[1]
+        elif ("_" in name_str) and ("p_outlier" in name_str):
+            name_str_prefix = "p_outlier"
+            if name_str == "p_outlier":
+                name_str_suffix = ""
+            else:
+                name_str_suffix = name_str.split("_")[2]
         else:
             name_str_prefix = name_str
             name_str_suffix = ""

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -367,7 +367,6 @@ class HSSM:
         # Get the bambi formula, priors, and link
         self.formula, self.priors, self.link = self._parse_bambi()
 
-        # print(self.priors)
         # For parameters that are regression, apply bounds at the likelihood level to
         # ensure that the samples that are out of bounds are discarded (replaced with
         # a large negative value).
@@ -407,10 +406,6 @@ class HSSM:
         self.set_alias(self._aliases)
         # _logger.info(self.pymc_model.initial_point())
 
-        print("PARAMS CREATED")
-        print(self.params)
-        print("PRIORS CREATED")
-        print(self.priors)
         if process_initvals:
             self._postprocess_initvals_deterministic(initval_settings=INITVAL_SETTINGS)
             self._jitter_initvals(
@@ -1317,8 +1312,6 @@ class HSSM:
         )
         for param in self.list_params:
             param_obj = self.params[param]
-            # print(param)
-            # print('bounds before prior settings: ', param_obj.bounds)
 
             if self.link_settings == "log_logit":
                 param_obj.override_default_link()
@@ -1678,7 +1671,7 @@ class HSSM:
         # Consider case where link functions are set to 'log_logit'
         # or 'None'
         if self.link_settings not in ["log_logit", "None", None]:
-            print(
+            _logger.info(
                 "Not preprocessing initial values, "
                 + "because none of the two standard link settings are chosen!"
             )
@@ -1692,7 +1685,6 @@ class HSSM:
         for name_, starting_value in self.pymc_model.initial_point().items():
             # strip name of `_log__` and `_interval__` suffixes
             name_tmp = name_.replace("_log__", "").replace("_interval__", "")
-            print("NEXT PARAM TO PROCESS: ", name_tmp)
 
             # We need to check if the parameter is actually backed by
             # a regression.
@@ -1716,11 +1708,6 @@ class HSSM:
                     )
                     continue
                 else:
-                    print("SETTING INITVAL FOR: ", name_tmp)
-                    print(
-                        "SETTING INITVAL TO VALUE: ",
-                        initval_settings[param_link_setting][name_tmp],
-                    )
                     # Apply specific settings from initval_settings dictionary
                     self.pymc_model.set_initval(
                         self.pymc_model.named_vars[name_tmp],
@@ -1762,39 +1749,18 @@ class HSSM:
             name_str_prefix = name_str
             name_str_suffix = ""
 
-        print("NAME_STR_PREFIX: ", name_str_prefix)
-        print("NAME_STR_SUFFIX: ", name_str_suffix)
-        print("NAME_STR: ", name_str)
-
         if isinstance(self.priors, dict):
-            print("PRIORS: ", self.priors)
             if name_str_prefix == self._parent:
-                print("RENAMING tmp_param")
-                # if self.params[name_str_prefix].is_regression:
                 tmp_param = "c(rt, response)"
-                # else:
-                #     tmp_param = name_str_prefix
-                print("Renamed param:", tmp_param)
             else:
                 tmp_param = name_str_prefix
 
-            print("TMP_PARAM 1: ", tmp_param)
-
             if (name_str_suffix == "Intercept") or (name_str_prefix == self._parent):
-                # print("PASSING HERE")
-                # print("PRIORS: ", self.priors)
-                # print("TMP_PARAM: ", tmp_param)
-                # print(self.priors[tmp_param])
                 if "initval" in self.priors[tmp_param]["Intercept"].args:
-                    # print("PASSING HERE 2")
                     return True
                 else:
-                    # print("PASSING HERE 3")
                     return False
             else:
-                # print("PRIORS: ", self.priors)
-                # print("TMP_PARAM: ", tmp_param)
-                # print("INDEX ERROR: ", self.priors[tmp_param])
                 if "initval" in self.priors[tmp_param].args:
                     return True
                 else:

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -10,7 +10,7 @@ import logging
 from copy import deepcopy
 from inspect import isclass
 from os import PathLike
-from typing import Any, Callable, Literal, Union
+from typing import Any, Callable, Literal
 
 import arviz as az
 import bambi as bmb
@@ -1758,7 +1758,7 @@ class HSSM:
         self,
         name_str: str,
         return_value: bool = False,
-    ) -> Union[bool, float, int, np.ndarray, None]:
+    ) -> bool | float | int | np.ndarray | None:
         """Check if initial value is user-supplied."""
         # The function assumes that the name_str is either raw parameter name
         # or `paramname_Intercept`, because we only really provide special default

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -464,24 +464,29 @@ class HSSM:
             (default), "nuts_numpyro", "nuts_blackjax" or "laplace". An `Approximation`
             object if `"vi"`.
         """
-        if isinstance(initvals, dict):
-            kwargs["initvals"] = initvals
-        else:
-            if isinstance(initvals, str):
-                if initvals == "map":
-                    if self._map_dict is None:
-                        _logger.info(
-                            "initvals='map' but no map estimate precomputed. \n"
-                            "Running map estimation first..."
-                        )
-                        self.find_MAP()
-                        kwargs["initvals"] = self._map_dict
-                    else:
-                        kwargs["initvals"] = self._map_dict
+        # If initvals are None (default)
+        # we skip processing initvals here.
+        if initvals is not None:
+            if isinstance(initvals, dict):
+                kwargs["initvals"] = initvals
             else:
-                raise ValueError(
-                    "initvals must be a dictionary or 'map' to use the MAP estimate."
-                )
+                if isinstance(initvals, str):
+                    if initvals == "map":
+                        if self._map_dict is None:
+                            _logger.info(
+                                "initvals='map' but no map"
+                                "estimate precomputed. \n"
+                                "Running map estimation first..."
+                            )
+                            self.find_MAP()
+                            kwargs["initvals"] = self._map_dict
+                        else:
+                            kwargs["initvals"] = self._map_dict
+                else:
+                    raise ValueError(
+                        "initvals argument must be a dictionary or 'map'"
+                        " to use the MAP estimate."
+                    )
 
         if sampler is None:
             if (

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -413,7 +413,7 @@ class HSSM:
                 vector_only=True,
             )
 
-    def find_MAP(self):
+    def find_MAP(self, **kwargs):
         """Perform Maximum A Posteriori estimation.
 
         Returns
@@ -421,7 +421,7 @@ class HSSM:
         dict
             A dictionary containing the MAP estimates of the model parameters.
         """
-        self._map_dict = pm.find_MAP(model=self.pymc_model)
+        self._map_dict = pm.find_MAP(model=self.pymc_model, **kwargs)
         return self._map_dict
 
     def sample(

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -1753,7 +1753,7 @@ class HSSM:
         self,
         name_str: str,
         return_value: bool = False,
-    ) -> Union[bool, float, int, np.ndarray]:
+    ) -> Union[bool, float, int, np.ndarray, None]:
         """Check if initial value is user-supplied."""
         # The function assumes that the name_str is either raw parameter name
         # or `paramname_Intercept`, because we only really provide special default

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -1694,14 +1694,9 @@ class HSSM:
             self.__jitter_initvals_all(jitter_epsilon)
 
     def __jitter_initvals_vector_only(self, jitter_epsilon: float) -> None:
-        # print("names_vars:", self.pymc_model.named_vars)
         initial_point_dict = self.pymc_model.initial_point()
         for name_, starting_value in initial_point_dict.items():
             name_tmp = name_.replace("_log__", "").replace("_interval__", "")
-            # print(f"name_: {name_}")
-            # print(f"starting_value: {starting_value}")
-            # print(f"starting_value.shape: {starting_value.shape}")
-            # print(f"starting_value.ndim: {starting_value.ndim}")
             if starting_value.ndim != 0 and starting_value.shape[0] != 1:
                 starting_value_tmp = starting_value + np.random.uniform(
                     -jitter_epsilon, jitter_epsilon, starting_value.shape

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -290,7 +290,6 @@ def get_hddm_default_prior(
         # print(param)
         # print(link)
         if link is not None:
-            print("passed")
             prior = generate_prior("Normal")
         else:
             prior = generate_prior(HDDM_MU[param], bounds=bounds)

--- a/tests/test_data_sanity.py
+++ b/tests/test_data_sanity.py
@@ -68,9 +68,15 @@ def test_data_sanity_check(data_ddm, cpn, caplog):
 
     hssm.HSSM(data=data_ddm_miscoded, model="ddm", choices=[1, 2, 3])
 
+    print("THE CAPLOG RECORDS")
+    print([record.msg for record in caplog.records])
+
     assert (
-        caplog.records[-1].msg
-        == "You set choices to be [1, 2, 3], but [3] are missing from your dataset."
+        "You set choices to be [1, 2, 3], but [3] are missing from your dataset."
+        in [
+            record.msg % record.args if record.args else record.msg
+            for record in caplog.records
+        ]
     )
 
     # Case 7: if deadline or missing_data is True, data should contain missing values
@@ -96,8 +102,12 @@ def test_data_sanity_check(data_ddm, cpn, caplog):
     )
 
     assert (
-        caplog.records[-1].msg
-        == "`missing_data` is set to False, but you have missing data in your dataset. Missing data will be dropped."
+        "`missing_data` is set to False, but you have missing data"
+        " in your dataset. Missing data will be dropped."
+        in [
+            record.msg % record.args if record.args else record.msg
+            for record in caplog.records
+        ]
     )
 
     assert model.data.shape[0] == data_ddm.shape[0] - missing_size
@@ -114,8 +124,12 @@ def test_data_sanity_check(data_ddm, cpn, caplog):
         )
 
         assert (
-            caplog.records[-1].msg
-            == "`missing_data` is set to False, but you have missing data in your dataset. Missing data will be dropped."
+            "`missing_data` is set to False, but you have missing data in your dataset."
+            " Missing data will be dropped."
+            in [
+                record.msg % record.args if record.args else record.msg
+                for record in caplog.records
+            ]
         )
 
     data_ddm_missing.loc[missing_indices[0], "rt"] = -10

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -14,15 +14,25 @@ parameter_grid = [
     ("approx_differentiable", "ddm", "nuts_numpyro", "map"),
     ("analytical", "ddm", "nuts_numpyro", "map"),
     ("approx_differentiable", "angle", "nuts_numpyro", "map"),
-    # ("approx_differentiable", "ddm", "mcmc", "map"), # parallel sampling is an issue here
+    (
+        "approx_differentiable",
+        "ddm",
+        "mcmc",
+        "map",
+    ),
     ("analytical", "ddm", "mcmc", "map"),
-    # ("approx_differentiable", "angle", "mcmc", "map"), # parallel sampling is an issue here
+    (
+        "approx_differentiable",
+        "angle",
+        "mcmc",
+        "map",
+    ),
     ("approx_differentiable", "ddm", "nuts_numpyro", "initial_point"),
     ("analytical", "ddm", "nuts_numpyro", "initial_point"),
     ("approx_differentiable", "angle", "nuts_numpyro", "initial_point"),
-    # ("approx_differentiable", "ddm", "mcmc", "initial_point"),
-    # ("analytical", "ddm", "mcmc", "initial_point"), # parallel sampling is an issue
-    # ("approx_differentiable", "angle", "mcmc", "initial_point"),
+    ("approx_differentiable", "ddm", "mcmc", "initial_point"),
+    ("analytical", "ddm", "mcmc", "initial_point"),
+    ("approx_differentiable", "angle", "mcmc", "initial_point"),
 ]
 
 
@@ -49,9 +59,18 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
     initial_point = model_on.initial_point(transformed=True)
 
     if initvals == "initial_point":
-        model_on.sample(sampler=sampler, initvals=initial_point, draws=10, tune=10)
+        model_on.sample(
+            sampler=sampler,
+            initvals=initial_point,
+            chains=1,
+            cores=1,
+            draws=10,
+            tune=10,
+        )
     if initvals == "map":
-        model_on.sample(sampler=sampler, initvals=initvals, draws=10, tune=10)
+        model_on.sample(
+            sampler=sampler, initvals=initvals, chains=1, cores=1, draws=10, tune=10
+        )
 
 
 def _check_initval_defaults_correctness(model) -> None:
@@ -73,7 +92,7 @@ def _check_initval_defaults_correctness(model) -> None:
         # Go through parameters that are specified in the initial value defaults
         # If not specified in there, we won't touch the parameter during post-processing
         # anyways
-        if name_ in hssm.defaults.INITVAL_SETTINGS[param_link_setting].keys():
+        if name_ in hssm.defaults.INITVAL_SETTINGS[param_link_setting]:
             # Figure out if user specified a custom initial value for the parameter
 
             # If yes, we need to check it this custom value successfully overrode our

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -1,0 +1,213 @@
+import numpy as np
+import pytest
+import hssm
+from hssm import HSSM
+from hssm.utils import download_hf
+import logging
+
+hssm.set_floatX("float32", update_jax=True)
+logger = logging.getLogger("hssm")
+
+
+def _check_initval_defaults_correctness(model) -> None:
+    """Check if initial values from default dictionary are correctly applied."""
+    # Consider case where link functions are set to 'log_logit'
+    # or 'None'
+    if model.link_settings not in ["log_logit", None]:
+        return None
+
+    # Set initial values for particular parameters
+    for name_, starting_value in model.initial_point().items():
+        # If the user actively supplies a link function, the user
+        # should also have supplied an initial value insofar it matters.
+        if model.params[model._get_prefix(name_)].is_regression:
+            param_link_setting = model.link_settings
+        else:
+            param_link_setting = None
+
+        # Go through parameters that are specified in the initial value defaults
+        # If not specified in there, we won't touch the parameter during post-processing
+        # anyways
+        if name_ in hssm.defaults.INITVAL_SETTINGS[param_link_setting].keys():
+            # Figure out if user specified a custom initial value for the parameter
+
+            # If yes, we need to check it this custom value successfully overrode our
+            # global defaults
+            # If not, we want to check if our defaults where successfully applied
+            user_initval = model._check_if_initval_user_supplied(
+                name_, return_value=True
+            )
+
+            # print("Is actually in initval default dict...")
+            print(f"testing initial value for {name_}...")
+            # print(f"{user_initval=}")
+
+            if user_initval is not None:
+                # If the user specified custom initial values for anything
+                # in our INITVAL_DEFAULTS dictionary, we need to check if
+                # the user's initial value was successfully applied
+                model_initial_point = model.initial_point()[name_]
+                assert np.allclose(
+                    model_initial_point, user_initval, atol=1e-3
+                ), f"""User supplied initial value for {name_} is {user_initval},
+                    which does not match the initial point set by model,
+                    which is {model_initial_point}"""
+            else:
+                # If the user did not specify custom initial values,
+                # we need to check that our INITVAL_DEFAULTS
+                # were successfully applied
+                model_initial_point = model.initial_point()[name_]
+                default_initial_point = hssm.defaults.INITVAL_SETTINGS[
+                    param_link_setting
+                ][name_]
+
+                assert np.allclose(
+                    model_initial_point,
+                    default_initial_point,
+                    atol=1e-3,
+                ), f"""Initial value for {name_} is supposed to be {default_initial_point},
+                       and does not match the initial point set by model,
+                       which is {model_initial_point}."""
+        else:
+            pass
+
+
+def test_basic_model(caplog):
+    """Test basic model with p_outlier distribution defined."""
+    caplog.set_level(logging.INFO)
+    logger.info("\nTesting most basic model.")
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="ddm",
+        process_initvals=True,
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_basic_model_p_outlier(caplog):
+    """Test basic model with p_outlier distribution defined."""
+    caplog.set_level(logging.INFO)
+    logger.info("\nTesting basic model with p_outlier distribution defined.")
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="ddm",
+        process_initvals=True,
+        p_outlier={"name": "Uniform", "lower": 0.0001, "upper": 0.5},
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_basic_model_p_outlier_initval(caplog):
+    """Test basic model with p_outlier distribution defined."""
+    caplog.set_level(logging.INFO)
+    logger.info(
+        """\nTesting basic model with p_outlier distribution
+                and initval defined."""
+    )
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="ddm",
+        process_initvals=True,
+        p_outlier={"name": "Uniform", "lower": 0.0001, "upper": 0.5, "initval": 0.5},
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_reg_model(caplog):
+    """Test regression model, with regression on all parameters."""
+    caplog.set_level(logging.INFO)
+    logger.info("\nTesting regression model.")
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="ddm",
+        process_initvals=True,
+        include=[
+            {"name": "v", "formula": "v ~ 1 + (1|participant_id)"},
+            {"name": "a", "formula": "a ~ 1 + (1|participant_id)"},
+            {"name": "z", "formula": "z ~ 1 + (1|participant_id)"},
+            {"name": "t", "formula": "t ~ 1 + (1|participant_id)"},
+        ],
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_reg_model_subset(caplog):
+    """Test regression model, with subset of parameters being regressions."""
+    caplog.set_level(logging.INFO)
+    logger.info(
+        "\nTesting regression model with subset of parameters being regressions."
+    )
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="ddm",
+        process_initvals=True,
+        include=[
+            {"name": "v", "formula": "v ~ 1 + (1|participant_id)"},
+            {"name": "a", "formula": "a ~ 1 + (1|participant_id)"},
+        ],
+    )
+
+
+def test_angle_model_reg(caplog):
+    """Test with angle model regression."""
+    caplog.set_level(logging.INFO)
+    logger.info(
+        """\nTesting regression model with subset of parameters being regressions,
+        for angle model."""
+    )
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="angle",
+        process_initvals=True,
+        include=[
+            {"name": "v", "formula": "v ~ 1 + (1|participant_id)"},
+            {"name": "a", "formula": "a ~ 1 + (1|participant_id)"},
+        ],
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_angle_model(caplog):
+    """Test with angle model basic."""
+    caplog.set_level(logging.INFO)
+    logger.info("\nTesting basic angle model.")
+    cav_data = hssm.load_data("cavanagh_theta")
+    model = hssm.HSSM(
+        data=cav_data,
+        model="angle",
+        process_initvals=True,
+    )
+    _check_initval_defaults_correctness(model)
+
+
+def test_process_no_process(caplog):
+    """Test mismatch with and without preprocessing."""
+    caplog.set_level(logging.INFO)
+    logger.info(
+        """\nTesting that turning initval-processing off,
+                doesn't change initial values."""
+    )
+
+    cav_data = hssm.load_data("cavanagh_theta")
+    model_on = hssm.HSSM(
+        data=cav_data,
+        model="angle",
+        process_initvals=True,
+    )
+    init_on = model_on.initial_point(transformed=False)
+
+    model_off = hssm.HSSM(
+        data=cav_data,
+        model="angle",
+        process_initvals=False,
+    )
+    init_off = model_off.initial_point(transformed=False)
+
+    assert init_on != init_off, """Initial values should not be the same when
+    initval processing is turned off vs. turned on."""

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -111,12 +111,6 @@ def test_param_creation_non_regression():
     assert pt.is_fixed
     assert not ptheta.is_truncated
 
-    print("PASSING PARAMETERS TO MODEL: ")
-    print(v)
-    print(a)
-    print(z)
-    print(t)
-
     model_1 = hssm.HSSM(
         model="angle",
         data=hssm.simulate_data(
@@ -559,9 +553,8 @@ def test_param_override_default_priors(cavanagh_test, caplog, param_name, bounds
     )
 
     param_no_common_intercept.override_default_priors(cavanagh_test, {})
-    print(caplog.records)
-    assert "limitation" in caplog.records[-1].msg
 
+    assert "limitation" in caplog.records[-1].msg
     assert "Intercept" not in param_no_common_intercept.prior
     group_intercept_prior = param_no_common_intercept.prior["1|participant_id"]
     group_slope_prior = param_no_common_intercept.prior["theta|participant_id"]

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -111,6 +111,12 @@ def test_param_creation_non_regression():
     assert pt.is_fixed
     assert not ptheta.is_truncated
 
+    print("PASSING PARAMETERS TO MODEL: ")
+    print(v)
+    print(a)
+    print(z)
+    print(t)
+
     model_1 = hssm.HSSM(
         model="angle",
         data=hssm.simulate_data(
@@ -635,7 +641,6 @@ def test_param_override_default_priors_ddm(
     assert intercept_prior.bounds == bounds
     assert intercept_prior.dist is not None
     mu1 = mu.copy()
-    print("hello hello hello")
     print(f"{intercept_prior}=")
     print(f"{mu1}=")
 


### PR DESCRIPTION
- fixes key error bug when going through initial value setters
- make initial value setters optional
- make safe priors the default
- if user supplied initial value to a parameter that we try to overwrite --> skip overwrite
- allow map as starting point in sampler and add `find_MAP()` method.
- fixing some redundant starting value settings