### PR TITLE
Fix posterior predictive sampling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,19 @@ keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
-pymc = "~5.16"
+pymc = ">=5.16.2,<5.17.0"
 arviz = "^0.18.0"
 onnx = "^1.16.0"
 ssm-simulators = "^0.7.2"
 huggingface-hub = "^0.23.0"
-bambi = "~0.14"
+bambi = ">=0.14.0,<0.15.0"
 numpyro = "^0.15.0"
 hddm-wfpt = "^0.1.4"
 seaborn = "^0.13.2"
 jax = { version = "^0.4.25", extras = ["cuda12"], optional = true }
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.2.2"
+pytest = "^8.3.1"
 mypy = "^1.10.1"
 pre-commit = "^2.20.0"
 jupyterlab = "^4.2.3"

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -404,7 +404,8 @@ class HSSM:
             self.model, self._parent_param, self.response_c, self.response_str
         )
         self.set_alias(self._aliases)
-        # _logger.info(self.pymc_model.initial_point())
+        self.model.build()
+        _logger.info(self.pymc_model.initial_point())
 
         if process_initvals:
             self._postprocess_initvals_deterministic(initval_settings=INITVAL_SETTINGS)
@@ -1077,10 +1078,9 @@ class HSSM:
         for param in self.params.values():
             if param.name == "p_outlier":
                 continue
-            name = self.response_c if param.is_parent else param.name
             output.append(f"{param.name}:")
 
-            component = self.model.components[name]
+            component = self.model.components[param.name]
 
             # Regression case:
             if param.is_regression:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,7 +64,8 @@ def test_get_alias_dict():
 
     assert alias_default["c(rt, response)"] == "rt,response"
     assert alias_default["Intercept"] == "v"
-    assert alias_default["a"] == "a"
+    assert alias_default["v"] == "v_mean"
+    assert "a" not in alias_default
 
     assert alias_regression["c(rt, response)"] == "rt,response"
     assert alias_regression["Intercept"] == "v_Intercept"


### PR DESCRIPTION
In Bambi 0.14.0, the `kind` argument for `model.predict()` went from `"pps"` and `"mean"` to `"response"` and `"response_params"`. We need to update bambi code to accommodate for that