### PR TITLE
Refactor test_no_inf_values to use parametrize for all parameters

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -166,7 +166,7 @@ def make_ssm_rv(
         # to get around the support checking in PyMC that would result in error
         ndim_supp: int = 1
 
-        ndims_params: list[int] = [0 for _ in list_params]
+        ndims_params: list[int] = [0 for _ in list_params]  # type: ignore
         dtype: str = "floatX"
         _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -59,31 +59,21 @@ def shared_params():
     }
 
 
-def test_no_inf_values_a(data_ddm, shared_params):
-    for a in np.arange(2.5, 5.1, 0.5):
-        params = {**shared_params, "a": a}
+@pytest.mark.parametrize(
+    "param_name, param_values",
+    [
+        ("a", np.arange(2.5, 5.1, 0.5)),
+        ("t", np.arange(3.0, 5.1, 0.5)),
+        ("v", np.arange(3.0, 5.1, 0.5)),
+    ],
+)
+def test_no_inf_values(data_ddm, shared_params, param_name, param_values):
+    for value in param_values:
+        params = shared_params | {param_name: value}
         logp = logp_ddm_sdv(data_ddm, **params)
         assert np.all(
             np.isfinite(logp.eval())
-        ), f"log_pdf_sv() returned non-finite values for a = {a}."
-
-
-def test_no_inf_values_t(data_ddm, shared_params):
-    for t in np.arange(3.0, 5.1, 0.5):
-        params = {**shared_params, "t": t}
-        logp = logp_ddm_sdv(data_ddm, **params)
-        assert np.all(
-            np.isfinite(logp.eval())
-        ), f"log_pdf_sv() returned non-finite values for t = {t}."
-
-
-def test_no_inf_values_v(data_ddm, shared_params):
-    for v in np.arange(3.0, 5.1, 0.5):
-        params = {**shared_params, "v": v}
-        logp = logp_ddm_sdv(data_ddm, **params)
-        assert np.all(
-            np.isfinite(logp.eval())
-        ), f"log_pdf_sv() returned non-finite values for v = {v}."
+        ), f"log_pdf_sv() returned non-finite values for {param_name} = {value}."
 
 
 def test_bbox(data_ddm):


### PR DESCRIPTION
This pull request refactors the `test_no_inf_values_x` functions to use the `parametrize` decorator in pytest for all parameters. This improves code readability and reduces code duplication.