### PR TITLE
Refactor test_bbox function to use parameterized tests

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -166,7 +166,7 @@ def make_ssm_rv(
         # to get around the support checking in PyMC that would result in error
         ndim_supp: int = 1
 
-        ndims_params: list[int] = [0 for _ in list_params]
+        ndims_params: list[int] = [0 for _ in list_params]  # type: ignore
         dtype: str = "floatX"
         _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -86,20 +86,25 @@ def test_no_inf_values_v(data_ddm, shared_params):
         ), f"log_pdf_sv() returned non-finite values for v = {v}."
 
 
-def test_bbox(data_ddm):
-    true_values = (0.5, 1.5, 0.5, 0.5)
-    true_values_sdv = (0.5, 1.5, 0.5, 0.5, 0)
+true_values = (0.5, 1.5, 0.5, 0.5)
+true_values_sdv = true_values + (0,)
+standard = (logp_ddm, logp_ddm_bbox, true_values)
+svd = (logp_ddm_sdv, logp_ddm_sdv_bbox, true_values_sdv)
+
+
+@pytest.mark.parametrize(
+    "logp_func, logp_bbox_func, true_values",
+    [
+        standard,
+        svd,
+    ],
+)
+def test_bbox(data_ddm, logp_func, logp_bbox_func, true_values):
     data = data_ddm.values
 
     np.testing.assert_almost_equal(
-        logp_ddm(data, *true_values).eval(),
-        logp_ddm_bbox(data, *true_values),
-        decimal=4,
-    )
-
-    np.testing.assert_almost_equal(
-        logp_ddm_sdv(data, *true_values_sdv).eval(),
-        logp_ddm_sdv_bbox(data, *true_values_sdv),
+        logp_func(data, *true_values).eval(),
+        logp_bbox_func(data, *true_values),
         decimal=4,
     )
 


### PR DESCRIPTION
This pull request refactors the `test_bbox` function in the `test_likelihoods.py` file to use parameterized tests. This change improves the readability and maintainability of the test code by reducing duplication and making it easier to add new test cases.