### PR TITLE
Refactor test_analytical_gradient function to use parameterization

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -166,7 +166,7 @@ def make_ssm_rv(
         # to get around the support checking in PyMC that would result in error
         ndim_supp: int = 1
 
-        ndims_params: list[int] = [0 for _ in list_params]
+        ndims_params: list[int] = [0 for _ in list_params]  # type: ignore
         dtype: str = "floatX"
         _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params


### PR DESCRIPTION
This pull request refactors the `test_analytical_gradient` function to use parameterization.

Adding helper functions `generate_test_data`, `compute_gradient`, and  `generate_dvectors` functions, the `test_analytical_gradient` function is now parameterized making it more modular and extensible.