### PR TITLE
Added functionalities to save and load models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ mkdocs = "^1.6.0"
 mkdocs-material = "^9.5.21"
 mkdocstrings-python = "^1.10.0"
 mkdocs-jupyter = "^0.24.8"
+pyarrow = "^17.0.0"
 
 [tool.poetry.extras]
 cuda12 = ["jax"]

--- a/src/hssm/__init__.py
+++ b/src/hssm/__init__.py
@@ -15,6 +15,7 @@ from .config import ModelConfig
 from .datasets import load_data
 from .defaults import show_defaults
 from .hssm import HSSM
+from .io import _load_model as load_model
 from .link import Link
 from .param import UserParam as Param
 from .prior import Prior
@@ -32,6 +33,7 @@ __all__ = [
     "HSSM",
     "Link",
     "load_data",
+    "load_model",
     "ModelConfig",
     "Param",
     "Prior",

--- a/src/hssm/distribution_utils/__init__.py
+++ b/src/hssm/distribution_utils/__init__.py
@@ -1,6 +1,5 @@
 """Utility functions for dynamically building pm.Distributions."""
 
-from ..utils import download_hf
 from .dist import (
     assemble_callables,
     make_blackbox_op,
@@ -10,6 +9,7 @@ from .dist import (
     make_missing_data_callable,
     make_ssm_rv,
 )
+from .utils import download_hf
 
 __all__ = [
     "assemble_callables",

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -22,13 +22,13 @@ from pytensor.tensor.random.op import RandomVariable
 from ssms.basic_simulators.simulator import simulator
 from ssms.config import model_config as ssms_model_config
 
-from ..utils import download_hf
 from .blackbox import make_blackbox_op
 from .onnx import (
     make_jax_logp_funcs_from_onnx,
     make_jax_logp_ops,
     make_pytensor_logp,
 )
+from .utils import download_hf
 
 LogLikeFunc = Callable[..., ArrayLike]
 LogLikeGrad = Callable[..., ArrayLike]

--- a/src/hssm/distribution_utils/utils.py
+++ b/src/hssm/distribution_utils/utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for likelihoods."""
+
+from huggingface_hub import hf_hub_download
+
+REPO_ID = "franklab/HSSM"
+
+
+def download_hf(path: str):
+    """
+    Download a file from a HuggingFace repository.
+
+    Parameters
+    ----------
+    path : str
+        The path of the file to download in the repository.
+
+    Returns
+    -------
+    str
+        The local path where the file is downloaded.
+
+    Notes
+    -----
+    The repository is specified by the REPO_ID constant,
+    which should be a valid HuggingFace.co repository ID.
+    The file is downloaded using the HuggingFace Hub's
+     hf_hub_download function.
+    """
+    return hf_hub_download(repo_id=REPO_ID, filename=path)

--- a/src/hssm/io.py
+++ b/src/hssm/io.py
@@ -1,0 +1,262 @@
+"""Model loading and saving functions."""
+
+import json
+import logging
+import pickle
+from io import BytesIO
+from os import PathLike
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Any, Literal
+from zipfile import ZipFile
+
+import arviz as az
+import pandas as pd
+
+from hssm.config import ModelConfig
+from hssm.param.user_param import UserParam
+from hssm.param.utils import deserialize_prior, serialize_prior
+
+if TYPE_CHECKING:
+    from . import HSSM
+
+_logger = logging.getLogger("hssm")
+
+SERIALIZABLE_ATTRS = [
+    "model_name",
+    "choices",
+    "loglik_kind",
+    "global_formula",
+    "link_settings",
+    "prior_settings",
+    "missing_data",
+    "deadline",
+]
+
+
+def _save_model(
+    model: "HSSM",
+    path: str | PathLike,
+    save_data: bool = True,
+    save_data_format: Literal["csv", "parquet"] = "csv",
+) -> None:
+    """Save the model to a file.
+
+    Parameters
+    ----------
+    model
+        The model to save.
+    path
+        The path to save the model to.
+    save_data
+        Whether to save the data along with model specifications. Set to false if you
+        do not want the data to be saved. Defaults to True.
+    save_data_format
+        The format to save the data in. Either "csv" or "parquet". The "csv" format
+        provides more compatibility, but the "parquet" format provides faster loading
+        and smaller file size. When "parquet", `pyarrow` is required. Defaults to "csv".
+    """
+    if save_data:
+        if save_data_format not in ["csv", "parquet"]:
+            raise ValueError("save_data_format must be either 'csv' or 'parquet'.")
+
+        if save_data_format == "parquet":
+            _check_pyarrow()
+
+    # First, save all the attributes that are serializable (str, int, float, etc.)
+    attrs_dict = {
+        attr: value
+        for attr in SERIALIZABLE_ATTRS
+        if (value := getattr(model, attr)) is not None
+    }
+
+    # Save all user-specified parameters
+    attrs_dict["include"] = model.params.serialize_user_params()
+
+    if model.has_lapse:
+        attrs_dict["lapse"] = serialize_prior(model.lapse)
+
+    # Save the user-specified attributes
+    user_attrs = model.user_spec.copy()
+    if (model_config := model.user_spec.get("model_config")) is not None:
+        user_attrs["model_config"] = model_config.serialize()
+
+    with ZipFile(path, "w") as zipf:
+        if "loglik" in user_attrs and not isinstance(user_attrs["loglik"], str):
+            _write_pickle(zipf, "loglik", user_attrs.pop("loglik"), check_none=False)
+
+        if "loglik_missing_data" in user_attrs and not isinstance(
+            user_attrs["loglik_missing_data"], str
+        ):
+            _write_pickle(
+                zipf,
+                "loglik_missing_data",
+                user_attrs.pop("loglik_missing_data"),
+                check_none=False,
+            )
+
+        attrs_dict |= user_attrs
+
+        # Save the model into JSON
+        zipf.writestr("model.json", json.dumps(attrs_dict))
+
+        # Save data
+        if save_data:
+            dataIO = BytesIO()
+
+            if save_data_format == "csv":
+                model.data.to_csv(dataIO)
+                zipf.writestr("data.csv", dataIO.getvalue())
+            else:
+                model.data.to_parquet(dataIO)
+                zipf.writestr("data.parquet", dataIO.getvalue())
+
+        # Save the traces to a netcdf file
+        if model._inference_obj is not None:
+            with NamedTemporaryFile(delete=True) as tmpfile:
+                model._inference_obj.to_netcdf(tmpfile.name)
+                zipf.write(tmpfile.name, "traces.nc")
+
+        _write_pickle(zipf, "traces_vi", model._inference_obj_vi)
+        _write_pickle(zipf, "vi_approx", model._vi_approx)
+        _write_pickle(zipf, "map_dict", model._map_dict)
+
+    _logger.info("Model saved.")
+
+
+def _load_model(path: str | PathLike, data: pd.DataFrame | None = None) -> "HSSM":
+    """Load a model from a .hssm file.
+
+    Parameters
+    ----------
+    path
+        The path to the saved model file.
+    data
+        The data to be used. If None, the data will be loaded from the saved model file.
+        An error will be raised if the data is not found in the saved model file.
+    """
+    with ZipFile(path, "r") as zipf:
+        if data is None:
+            if "data.csv" in zipf.namelist():
+                with zipf.open("data.csv") as f:
+                    data = pd.read_csv(f, index_col=0)
+            elif "data.parquet" in zipf.namelist():
+                _check_pyarrow()
+                with zipf.open("data.parquet") as f:
+                    data = pd.read_parquet(f)
+            else:
+                raise ValueError(
+                    "Data not found in the saved model file. "
+                    "Please provide the data as an argument."
+                )
+
+        with zipf.open("model.json") as f:
+            model_dict = json.load(f)
+
+        model_dict["data"] = data
+        # Because "model" is the keyword argument for HSSM, we change `model_name` to
+        # `model` here.
+        model_dict["model"] = model_dict.pop("model_name")
+
+        # If "p_outlier" is in the dict saved in `include`, that means a p_outlier
+        # parameter was included in the model. We need to deal with it separately.
+        include_dict = model_dict.pop("include", None)
+
+        if include_dict is not None:
+            if "p_outlier" in include_dict:
+                p_outlier = UserParam.deserialize(include_dict.pop("p_outlier"))
+                model_dict["p_outlier"] = p_outlier.prior
+
+        if "lapse" in model_dict:
+            model_dict["lapse"] = deserialize_prior(model_dict["lapse"])
+
+        if "model_config" in model_dict:
+            model_config = model_dict.pop("model_config")
+            model_config = ModelConfig.deserialize(model_config)
+
+            # If the model has a p_outlier parameter, we need to remove it from the
+            # list of parameters.
+            if hasattr(model_config, "list_params"):
+                list_params = model_config.list_params
+                if "p_outlier" in list_params:
+                    list_params.remove("p_outlier")
+            model_dict["model_config"] = model_config
+
+        model_dict["include"] = [
+            UserParam.deserialize(param) for param in include_dict.values()
+        ]
+
+        model_dict["loglik"] = _load_pickle(zipf, "loglik")
+        model_dict["loglik_missing_data"] = _load_pickle(zipf, "loglik_missing_data")
+
+        kwargs = model_dict.pop("kwargs", {})
+        model_dict.update(kwargs)
+
+        # Importing in function to avoid circular imports
+        from . import HSSM
+
+        model = HSSM(**model_dict)
+
+        # Load the traces if exist
+        if "traces.nc" in zipf.namelist():
+            with NamedTemporaryFile(delete=True) as tmpfile:
+                with zipf.open("traces.nc") as f:
+                    tmpfile.write(f.read())
+                model._inference_obj = az.from_netcdf(tmpfile.name)
+
+        # Load additional objects
+        for attr in ["traces_vi", "vi_approx", "map_dict"]:
+            setattr(model, f"_{attr}", _load_pickle(zipf, attr))
+
+    return model
+
+
+def _write_pickle(zipf: ZipFile, name: str, obj: Any, check_none: bool = True) -> None:
+    """Write an object to a ZipFile.
+
+    Parameters
+    ----------
+    zipf
+        The open ZipFile object to write to.
+    name
+        The name of the object in the ZipFile.
+    obj
+        The object to pickle.
+    check_none
+        Whether to check if the object is None before pickling.
+    """
+    if check_none and obj is None:
+        return
+
+    zipf.writestr(name, pickle.dumps(obj))
+
+
+def _load_pickle(zipf: ZipFile, obj_name: str) -> Any | None:
+    """Load a picked object from a ZipFile.
+
+    Parameters
+    ----------
+    zipf
+        The open ZipFile object to read from.
+    obj_name
+        The name of the object in the ZipFile.
+
+    Returns
+    -------
+        The unpickled object.
+    """
+    if obj_name in zipf.namelist():
+        with zipf.open(obj_name, "r") as f:
+            return pickle.load(f)
+
+    return None
+
+
+def _check_pyarrow():
+    """Check if pyarrow is installed."""
+    try:
+        import pyarrow  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "The pyarrow package is required to save models. "
+            "Please install it using `pip install pyarrow`."
+        )

--- a/src/hssm/param/param.py
+++ b/src/hssm/param/param.py
@@ -1,5 +1,6 @@
 """The parent class for all parameters in the model."""
 
+from abc import abstractmethod
 from typing import Any
 
 import bambi as bmb
@@ -153,13 +154,15 @@ class Param:
             if getattr(self, key) is None:
                 setattr(self, key, value)
 
+    @abstractmethod
     def validate(self) -> None:
         """Validate the parameter."""
-        raise NotImplementedError("This method is to be implemented in subclasses.")
+        ...
 
+    @abstractmethod
     def process_prior(self) -> None:
         """Process the prior specification."""
-        raise NotImplementedError("This method is to be implemented in subclasses.")
+        ...
 
     def parse_bambi(
         self,

--- a/src/hssm/param/params.py
+++ b/src/hssm/param/params.py
@@ -174,6 +174,17 @@ class Params(UserDict[str, Param]):
         params = "\n".join(repr(param) for _, param in self.items())
         return "Parameters:\n" f"{params}"
 
+    def serialize_user_params(self) -> dict[str, Any]:
+        """Serialize the Params object to a dictionary.
+
+        Returns
+        -------
+        dict[str, dict[str, Any]]
+            A dictionary with the parameter names as keys and dictionaries with the
+            parameter attributes as values.
+        """
+        return save_user_params(self)
+
 
 def collect_user_params(
     model: HSSM,
@@ -351,3 +362,25 @@ def make_param_from_defaults(model: HSSM, name: str) -> Param:
         param = DefaultParam.from_defaults(name, default_prior, default_bounds)
 
     return param
+
+
+def save_user_params(params: Params) -> dict[str, dict[str, Any]]:
+    """Serialize the Params object to a dictionary.
+
+    Parameters
+    ----------
+    params
+        The Params object.
+
+    Returns
+    -------
+    dict[str, dict[str, Any]]
+        A dictionary with the parameter names as keys and dictionaries with the
+        parameter attributes as values.
+    """
+    result: dict[str, Any] = {}
+    for param_name, param in params.items():
+        if (user_param := param.user_param) is not None:
+            result[param_name] = user_param.serialize()
+
+    return result

--- a/src/hssm/param/regression_param.py
+++ b/src/hssm/param/regression_param.py
@@ -13,6 +13,7 @@ from ..link import Link
 from ..prior import get_default_prior, get_hddm_default_prior
 from .param import Param
 from .user_param import UserParam
+from .utils import _make_prior_dict
 
 _logger = logging.getLogger("hssm")
 
@@ -350,57 +351,3 @@ class RegressionParam(Param):
             f"    Priors:\n{priors}\n"
             f"    Link: {link}"
         )
-
-
-def _make_prior_dict(
-    prior: dict[str, float | dict[dict, Any] | bmb.Prior],
-) -> dict[str, float | bmb.Prior]:
-    """Make bambi priors from a ``dict`` of priors for the regression case.
-
-    Parameters
-    ----------
-    prior
-        A dictionary where each key is the name of a parameter in a regression
-        and each value is the prior specification for that parameter.
-
-    Returns
-    -------
-    dict[str, float | bmb.Prior]
-        A dictionary where each key is the name of a parameter in a regression and each
-        value is either a float or a bmb.Prior object.
-    """
-    priors = {
-        # Convert dict to bmb.Prior if a dict is passed
-        param: _make_priors_recursive(cast(dict[str, Any], prior))
-        if isinstance(prior, dict)
-        else prior
-        for param, prior in prior.items()
-    }
-
-    return priors
-
-
-def _make_priors_recursive(
-    prior: dict[str, float | dict[str, Any] | bmb.Prior],
-) -> bmb.Prior:
-    """Make `bmb.Prior` objects from ``dict``s.
-
-    Helper function that recursively converts a dict that might have some fields that
-    have a parameter definitions as dicts to bmb.Prior objects.
-
-    Parameters
-    ----------
-    prior
-        A dictionary that contains parameter specifications.
-
-    Returns
-    -------
-    bmb.Prior
-        A bmb.Prior object with fields that can be converted to bmb.Prior objects also
-        converted.
-    """
-    for k, v in prior.items():
-        if isinstance(v, dict) and "name" in v:
-            prior[k] = _make_priors_recursive(v)
-
-    return bmb.Prior(**prior)

--- a/src/hssm/param/utils.py
+++ b/src/hssm/param/utils.py
@@ -1,7 +1,20 @@
 """Utility functions for the parameter classes."""
 
+from typing import Any, Literal, TypedDict, Union, cast
+
 import bambi as bmb
 import numpy as np
+
+from ..prior import deserialize_prior_obj, serialize_prior_obj
+
+
+class SerializedPrior(TypedDict):
+    """A dictionary that represents a serialized prior."""
+
+    type: Literal["constant", "array", "prior", "simple", "regression"]
+    value: Union[
+        int, float, str, dict[str, Any], dict[str, "SerializedPrior"], "SerializedPrior"
+    ]
 
 
 def validate_bounds(bounds: tuple[float, float]) -> None:
@@ -41,3 +54,163 @@ def _make_default_prior(bounds: tuple[float, float] | None) -> bmb.Prior:
         prior = bmb.Prior(name="Uniform", lower=lower, upper=upper)
 
     return prior
+
+
+def _make_prior_dict(
+    prior: dict[str, float | dict[dict, Any] | bmb.Prior],
+) -> dict[str, float | bmb.Prior]:
+    """Make bambi priors from a ``dict`` of priors for the regression case.
+
+    Parameters
+    ----------
+    prior
+        A dictionary where each key is the name of a parameter in a regression
+        and each value is the prior specification for that parameter.
+
+    Returns
+    -------
+    dict[str, float | bmb.Prior]
+        A dictionary where each key is the name of a parameter in a regression and each
+        value is either a float or a bmb.Prior object.
+    """
+    priors = {
+        # Convert dict to bmb.Prior if a dict is passed
+        param: _make_priors_recursive(cast(dict[str, Any], prior))
+        if isinstance(prior, dict)
+        else prior
+        for param, prior in prior.items()
+    }
+
+    return priors
+
+
+def _make_priors_recursive(
+    prior: dict[str, float | dict[str, Any] | bmb.Prior],
+) -> bmb.Prior:
+    """Make `bmb.Prior` objects from ``dict``s.
+
+    Helper function that recursively converts a dict that might have some fields that
+    have a parameter definitions as dicts to bmb.Prior objects.
+
+    Parameters
+    ----------
+    prior
+        A dictionary that contains parameter specifications.
+
+    Returns
+    -------
+    bmb.Prior
+        A bmb.Prior object with fields that can be converted to bmb.Prior objects also
+        converted.
+    """
+    for k, v in prior.items():
+        if isinstance(v, dict) and "name" in v:
+            prior[k] = _make_priors_recursive(v)
+
+    return bmb.Prior(**prior)
+
+
+def serialize_prior(
+    prior: float | np.ndarray | dict[str, Any] | bmb.Prior,
+) -> SerializedPrior:
+    """Serialize a dictionary of priors to a dictionary.
+
+    Parameters
+    ----------
+    prior
+        A dictionary of priors.
+
+    Returns
+    -------
+    dict
+        A dictionary of serialized priors.
+    """
+    if isinstance(prior, (int, float)):
+        return {"type": "constant", "value": prior}
+    if isinstance(prior, np.ndarray):
+        return {"type": "array", "value": array_to_str(prior)}
+    if isinstance(prior, bmb.Prior):
+        return {"type": "prior", "value": serialize_prior_obj(prior)}
+    if "name" in prior:
+        return {"type": "simple", "value": prior}
+
+    regression_prior: dict[str, SerializedPrior] = {}
+    for key, value in prior.items():
+        regression_prior[key] = serialize_prior(value)
+
+    return {"type": "regression", "value": regression_prior}
+
+
+def deserialize_prior(
+    serialized_prior: SerializedPrior,
+) -> float | np.ndarray | dict[str, Any] | bmb.Prior:
+    """Deserialize a serialized prior.
+
+    Parameters
+    ----------
+    serialized_prior
+        A dictionary of serialized priors.
+
+    Returns
+    -------
+    float | np.ndarray | dict[str, Any] | bmb.Prior
+        The deserialized prior.
+    """
+    prior_type = serialized_prior["type"]
+    prior_value = serialized_prior["value"]
+
+    match prior_type:
+        case "constant":
+            return prior_value
+        case "array":
+            prior_value = cast(str, prior_value)
+            return str_to_array(prior_value)
+        case "prior":
+            prior_value = cast(dict[str, Any], prior_value)
+            return deserialize_prior_obj(prior_value)
+        case "simple":
+            return prior_value
+        case "regression":
+            prior_value = cast(dict[str, SerializedPrior], prior_value)
+            regression_prior: dict[str, Any] = {}
+            for key, value in prior_value.items():
+                regression_prior[key] = deserialize_prior(value)
+
+    return regression_prior
+
+
+def array_to_str(array: np.ndarray) -> str:
+    """Convert a numpy array to a string.
+
+    Parameters
+    ----------
+    array
+        The numpy array to convert.
+
+    Returns
+    -------
+    str
+        The string representation of the numpy array.
+    """
+    # generate an array with strings
+    array_str = np.char.mod("%f", array)
+    # combine to a string
+    return ",".join(array_str)
+
+
+def str_to_array(array_str: str) -> np.ndarray:
+    """Convert a string to a numpy array.
+
+    Parameters
+    ----------
+    array_str
+        The string representation of the numpy array.
+
+    Returns
+    -------
+    np.ndarray
+        The numpy array.
+    """
+    if array_str == "":
+        return np.array([])
+    return np.array(array_str.split(",")).astype(float)

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -9,14 +9,15 @@ these representations in Bambi-compatible formats through convenience function
 _parse_bambi().
 """
 
+from __future__ import annotations
+
 import contextlib
 import itertools
 import logging
 import os
 from copy import deepcopy
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
-import arviz as az
 import bambi as bmb
 import jax
 import numpy as np
@@ -27,38 +28,25 @@ import pytensor.tensor as pt
 import xarray as xr
 from bambi.terms import CommonTerm, GroupSpecificTerm, HSGPTerm, OffsetTerm
 from bambi.utils import get_aliased_name, response_evaluate_new_data
-from huggingface_hub import hf_hub_download
 from tqdm import tqdm
 
-from .param.param import Param
+if TYPE_CHECKING:
+    import arviz as az
+
+    from .param.param import Param
 
 _logger = logging.getLogger("hssm")
 
-REPO_ID = "franklab/HSSM"
-
-
-def download_hf(path: str):
-    """
-    Download a file from a HuggingFace repository.
-
-    Parameters
-    ----------
-    path : str
-        The path of the file to download in the repository.
-
-    Returns
-    -------
-    str
-        The local path where the file is downloaded.
-
-    Notes
-    -----
-    The repository is specified by the REPO_ID constant,
-    which should be a valid HuggingFace.co repository ID.
-    The file is downloaded using the HuggingFace Hub's
-     hf_hub_download function.
-    """
-    return hf_hub_download(repo_id=REPO_ID, filename=path)
+SERIALIZABLE_ATTRS = [
+    "model_name",
+    "choices",
+    "loglik_kind",
+    "global_formula",
+    "link_settings",
+    "prior_settings",
+    "missing_data",
+    "deadline",
+]
 
 
 def make_alias_dict_from_parent(parent: Param) -> dict[str, str]:

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -37,17 +37,6 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger("hssm")
 
-SERIALIZABLE_ATTRS = [
-    "model_name",
-    "choices",
-    "loglik_kind",
-    "global_formula",
-    "link_settings",
-    "prior_settings",
-    "missing_data",
-    "deadline",
-]
-
 
 def make_alias_dict_from_parent(parent: Param) -> dict[str, str]:
     """Make aliases from the parent parameter.

--- a/tests/param/test_param.py
+++ b/tests/param/test_param.py
@@ -83,12 +83,3 @@ def test_fill_defaults():
     assert param.link == "identity"
     assert param.bounds == (0, 1)
     assert param.user_param is None
-
-
-def test_unimplemented_methods():
-    """Test that the unimplemented methods raise NotImplementedError."""
-    param = Param(name="test", prior=0)
-    with pytest.raises(NotImplementedError):
-        param.validate()
-    with pytest.raises(NotImplementedError):
-        param.process_prior()

--- a/tests/param/test_regression_param.py
+++ b/tests/param/test_regression_param.py
@@ -1,6 +1,5 @@
 import bambi as bmb
 import numpy as np
-import pandas as pd
 import pytest
 
 import hssm
@@ -8,9 +7,8 @@ from hssm import Prior
 from hssm.defaults import default_model_config
 from hssm.link import Link
 from hssm.param import UserParam
-from hssm.param.regression_param import RegressionParam, _make_priors_recursive
-from hssm.prior import HSSM_SETTINGS_DISTRIBUTIONS, HDDM_SETTINGS_GROUP
-
+from hssm.param.regression_param import RegressionParam
+from hssm.param.utils import _make_priors_recursive
 
 v_reg = UserParam(
     name="v",

--- a/tests/param/test_user_param.py
+++ b/tests/param/test_user_param.py
@@ -1,13 +1,19 @@
+import re
+import bambi as bmb
+import numpy as np
 import pytest
 
-from hssm.param import UserParam
+from hssm.param.user_param import UserParam
+from hssm.param.utils import deserialize_prior
+
+from tests.param.test_utils import test_cases_deserialize, test_cases_serialize
 
 
 def test_bounds_validation():
     """Test that the bounds are validated correctly."""
-    with pytest.raises(ValueError, match="Invalid bounds: \(0, 0, 1\)"):
+    with pytest.raises(ValueError, match=re.escape("Invalid bounds: (0, 0, 1)")):
         UserParam(name="test", prior=0, bounds=(0, 0, 1))
-    with pytest.raises(ValueError, match="Invalid bounds: \(1, 0\)"):
+    with pytest.raises(ValueError, match=re.escape("Invalid bounds: (1, 0)")):
         UserParam(name="test", prior=0, bounds=(1, 0))
 
 
@@ -71,3 +77,49 @@ def test_to_dict():
         "prior": 0,
         "bounds": (0, 1),
     }
+
+
+def _check_equivalence(user_param, d):
+    """Check that the user_param and dictionary are equivalent."""
+    for attr in ["name", "formula", "link", "bounds"]:
+        if attr in d:
+            assert getattr(user_param, attr) == d[attr]
+        else:
+            assert getattr(user_param, attr) is None
+
+    if "prior" in d:
+        if isinstance(user_param.prior, np.ndarray):
+            assert np.allclose(user_param.prior, deserialize_prior(d["prior"]))
+        else:
+            assert user_param.prior == deserialize_prior(d["prior"])
+
+
+@pytest.mark.parametrize("prior", test_cases_serialize)
+def test_serialize(prior):
+    """Test that the UserParam object can be serialized and deserialized."""
+    user_param = UserParam(name="test", prior=prior, link="identity", bounds=(0, 1))
+    d = user_param.serialize()
+    _check_equivalence(user_param, d)
+
+
+def test_serialize_link_obj():
+    """Test that the UserParam object can be serialized and deserialized."""
+    user_param = UserParam(name="test", prior=0, link=bmb.Link("identity"))
+    with pytest.raises(
+        ValueError, match="Cannot serialize link object for parameter test"
+    ):
+        user_param.serialize()
+
+
+@pytest.mark.parametrize("prior", test_cases_deserialize)
+def test_deserialize(prior):
+    """Test that the UserParam object can be serialized and deserialized."""
+    d = {
+        "name": "test",
+        "prior": prior,
+        "link": "identity",
+        "bounds": (0, 1),
+    }
+    user_param = UserParam.deserialize(d.copy())
+
+    _check_equivalence(user_param, d)

--- a/tests/param/test_utils.py
+++ b/tests/param/test_utils.py
@@ -1,0 +1,150 @@
+import bambi as bmb
+import numpy as np
+import pytest
+
+from hssm import Prior
+from hssm.param.utils import (
+    deserialize_prior,
+    serialize_prior,
+    str_to_array,
+    array_to_str,
+)
+
+normal_prior = bmb.Prior("Normal", mu=0.0, sigma=1.0)
+half_normal_prior = bmb.Prior("HalfNormal", sigma=1.0)
+nested_prior = bmb.Prior(
+    "Normal",
+    mu=bmb.Prior("Normal", mu=0.0, sigma=1.0),
+    sigma=bmb.Prior("HalfNormal", sigma=1.0),
+)
+
+normal_prior_dict = {
+    "name": "Normal",
+    "mu": 0.0,
+    "sigma": 1.0,
+    "auto_scale": True,
+}
+half_normal_prior_dict = {
+    "name": "HalfNormal",
+    "sigma": 1.0,
+    "auto_scale": True,
+}
+nested_prior_dict = {
+    "name": "Normal",
+    "mu": normal_prior_dict,
+    "sigma": half_normal_prior_dict,
+    "auto_scale": True,
+}
+
+test_cases_serialize = [
+    1.0,  # constant
+    np.array([1.0, 2.0]),  # array
+    normal_prior_dict,  # dictionary
+    Prior.from_bambi(normal_prior, bounds=(0.0, 1.0)),  # hssm.Prior
+    nested_prior,  # Nested Prior
+    {
+        "Intercept": normal_prior_dict,
+        "x": normal_prior_dict,
+    },  # nested dictionary
+    {
+        "Intercept": normal_prior,
+        "x": half_normal_prior,
+    },  # dictionary with bmb.Prior
+]
+
+test_cases_deserialize = [
+    {"type": "constant", "value": 1.0},  # constant
+    {"type": "array", "value": "1.000000,2.000000"},  # array
+    {
+        "type": "simple",
+        "value": normal_prior_dict,
+    },  # dictionary
+    {
+        "type": "prior",
+        "value": normal_prior_dict | {"bounds": (0.0, 1.0)},
+    },  # hssm.Prior
+    {
+        "type": "prior",
+        "value": nested_prior_dict,
+    },
+    {
+        "type": "regression",
+        "value": {
+            "Intercept": {
+                "type": "simple",
+                "value": normal_prior_dict,
+            },
+            "x": {
+                "type": "simple",
+                "value": normal_prior_dict,
+            },
+        },
+    },
+    {
+        "type": "regression",
+        "value": {
+            "Intercept": {
+                "type": "prior",
+                "value": normal_prior_dict,
+            },
+            "x": {
+                "type": "prior",
+                "value": half_normal_prior_dict,
+            },
+        },
+    },
+]
+
+
+def test_array_to_str():
+    """Test that the array_to_str function works correctly."""
+    assert array_to_str(np.array([1.0, 2.0])) == "1.000000,2.000000"
+    assert array_to_str(np.array([1.0])) == "1.000000"
+    assert array_to_str(np.array([])) == ""
+
+
+def test_str_to_array():
+    """Test that the str_to_array function works correctly."""
+    assert np.allclose(str_to_array("1.0,2.0"), np.array([1.0, 2.0]))
+    assert np.allclose(str_to_array("1.0"), np.array([1.0]))
+    assert np.allclose(str_to_array(""), np.array([]))
+
+
+@pytest.mark.parametrize(
+    "prior,expected", zip(test_cases_serialize, test_cases_deserialize)
+)
+def test_serialize_prior(prior, expected):
+    """Test that the serialize_prior function works correctly."""
+    serialized_prior = serialize_prior(prior)
+
+    assert serialized_prior == expected
+
+
+@pytest.mark.parametrize(
+    "serialized_prior,expected", zip(test_cases_deserialize, test_cases_serialize)
+)
+def test_deserialize_prior(serialized_prior, expected):
+    """Test that the deserialize_prior function works correctly."""
+    deserialized_prior = deserialize_prior(serialized_prior)
+
+    prior_type = serialized_prior["type"]
+
+    match prior_type:
+        case "constant":
+            assert deserialized_prior == expected
+        case "array":
+            assert np.allclose(deserialized_prior, expected)
+        case _:
+            assert deserialized_prior == expected
+
+
+@pytest.mark.parametrize("prior", test_cases_serialize)
+def test_equivalence_before_and_after_serialization(prior):
+    """Test that the serialized and deserialized priors are equivalent."""
+    serialized_prior = serialize_prior(prior)
+    deserialized_prior = deserialize_prior(serialized_prior)
+
+    if isinstance(prior, np.ndarray):
+        assert np.allclose(prior, deserialized_prior)
+    else:
+        assert prior == deserialized_prior

--- a/tests/test_data_sanity.py
+++ b/tests/test_data_sanity.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -46,7 +47,7 @@ def test_data_sanity_check(data_ddm, cpn, caplog):
 
     with pytest.raises(
         ValueError,
-        match=r"Invalid responses found in your dataset: \[0, 2\]",
+        match=re.escape("Invalid responses found in your dataset: [0]"),
     ):
         data_ddm_miscoded = data_ddm.copy()
         data_ddm_miscoded["response"] = np.random.choice([0, 1, 2], data_ddm.shape[0])

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -1,9 +1,6 @@
-from re import T
 import numpy as np
 import pytest
 import hssm
-from hssm import HSSM
-from hssm.utils import download_hf
 import logging
 
 hssm.set_floatX("float32", update_jax=True)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,204 @@
+import json
+import pickle
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from zipfile import ZipFile
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pytest
+
+import hssm
+from hssm.io import (
+    SERIALIZABLE_ATTRS,
+    _load_model,
+    _save_model,
+)
+from hssm.likelihoods.analytical import logp_ddm
+
+
+def _check_seriaizable_attrs(obj, d):
+    for attr in SERIALIZABLE_ATTRS:
+        if attr in d:
+            assert getattr(obj, attr) == d[attr]
+
+
+def test__save_model(data_ddm, cav_idata):
+    basic_model = hssm.HSSM(data=data_ddm)
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(basic_model, tmp.name)
+
+        with ZipFile(tmp.name, "r") as zip_ref:
+            assert "model.json" in zip_ref.namelist()
+
+            with zip_ref.open("model.json") as f:
+                model_dict = json.load(f)
+                _check_seriaizable_attrs(basic_model, model_dict)
+
+                assert len(model_dict["include"]) == 1
+                assert "p_outlier" in model_dict["include"]
+
+            assert "loglik" not in zip_ref.namelist()
+            assert "loglik_missing_data" not in zip_ref.namelist()
+            assert "data.csv" in zip_ref.namelist()
+
+            with zip_ref.open("data.csv") as f:
+                data = pd.read_csv(f)
+                assert np.all(pd.Series(["rt", "response"]).isin(data.columns))
+
+            assert "traces.nc" not in zip_ref.namelist()
+
+    basic_model.restore_traces(cav_idata)
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(basic_model, tmp.name)
+
+        with ZipFile(tmp.name, "r") as zip_ref:
+            assert "model.json" in zip_ref.namelist()
+            assert "traces.nc" in zip_ref.namelist()
+
+            with TemporaryDirectory() as tmp_dir:
+                zip_ref.extract("traces.nc", path=tmp_dir)
+                idata = az.from_netcdf(f"{tmp_dir}/traces.nc")
+
+                assert np.all(idata.posterior == cav_idata.posterior)
+
+    model_with_loglik = hssm.HSSM(
+        data=data_ddm,
+        loglik=logp_ddm,
+        include=[
+            {
+                "name": "v",
+                "prior": {
+                    "Intercept": {"name": "Uniform", "lower": -3.0, "upper": 3.0}
+                },
+                "formula": "v ~ 1",
+                "link": "identity",
+            }
+        ],
+    )
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(model_with_loglik, tmp.name, save_data_format="parquet")
+
+        with ZipFile(tmp.name, "r") as zip_ref:
+            assert "loglik" in zip_ref.namelist()
+
+            with zip_ref.open("model.json") as f:
+                model_dict = json.load(f)
+                _check_seriaizable_attrs(basic_model, model_dict)
+
+                assert len(model_dict["include"]) == 2
+                assert "v" in model_dict["include"]
+
+            assert "data.parquet" in zip_ref.namelist()
+
+            with zip_ref.open("data.parquet") as f:
+                data = pd.read_parquet(f)
+                assert np.all(pd.Series(["rt", "response"]).isin(data.columns))
+
+            with zip_ref.open("loglik") as f:
+                loglik = pickle.load(f)
+                assert loglik == logp_ddm
+
+
+user_attrs = [
+    "model_config",
+    "process_initvals",
+    "initval_jitter",
+    "extra_namespace",
+]
+
+
+def check_attr(attr, obj_a, obj_b):
+    attr_value_a = getattr(obj_a, attr)
+    attr_value_b = getattr(obj_b, attr)
+
+    if attr_value_a is None:
+        assert attr_value_b is None
+    else:
+        assert attr_value_a == attr_value_b
+
+
+def check_user_attr(attr, obj_a, obj_b):
+    attr_a = obj_a.user_spec.get(attr, None)
+
+    if not attr_a:
+        assert not obj_b.user_spec.get(attr, None)
+    else:
+        attr_b = obj_b.user_spec[attr]
+        assert attr_a == attr_b
+
+
+def test__load_model(data_ddm, cav_idata):
+    basic_model = hssm.HSSM(data=data_ddm)
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(basic_model, tmp.name)
+
+        loaded_model = _load_model(tmp.name)
+
+    for attr in SERIALIZABLE_ATTRS:
+        check_attr(attr, basic_model, loaded_model)
+
+    assert "p_outlier" in loaded_model.params
+    check_attr("lapse", basic_model, loaded_model)
+
+    for attr in user_attrs:
+        check_user_attr(attr, basic_model, loaded_model)
+
+    assert np.allclose(basic_model.data.values, loaded_model.data.values)
+
+    assert loaded_model._inference_obj is None
+
+    basic_model.restore_traces(cav_idata)
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(basic_model, tmp.name)
+
+        loaded_model = _load_model(tmp.name)
+
+    assert loaded_model._inference_obj is not None
+
+    basic_model = hssm.HSSM(data=data_ddm)
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(basic_model, tmp.name, save_data_format="parquet")
+
+        loaded_model = _load_model(tmp.name)
+
+    assert np.allclose(basic_model.data.values, loaded_model.data.values)
+
+    model_with_loglik = hssm.HSSM(
+        data=data_ddm,
+        loglik=logp_ddm,
+        include=[
+            {
+                "name": "v",
+                "prior": {
+                    "Intercept": {"name": "Uniform", "lower": -3.0, "upper": 3.0}
+                },
+                "formula": "v ~ 1",
+                "link": "identity",
+            }
+        ],
+    )
+
+    with NamedTemporaryFile() as tmp:
+        _save_model(model_with_loglik, tmp.name)
+
+        loaded_model = _load_model(tmp.name)
+
+    assert loaded_model.user_spec["loglik"] is not None
+    assert "v" in loaded_model.params
+
+    with pytest.raises(
+        ValueError,
+        match="Data not found in the saved model file. "
+        + "Please provide the data as an argument.",
+    ):
+        with NamedTemporaryFile() as tmp:
+            _save_model(basic_model, tmp.name, save_data=False)
+
+            _load_model(tmp.name)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,12 +1,86 @@
+from typing import Any
+
 import pytest
 
 import bambi as bmb
 import numpy as np
 
 import hssm
-from hssm import Prior
+from hssm.prior import Prior, serialize_prior_obj, deserialize_prior_obj
 
 hssm.set_floatX("float32")
+
+
+def _check_prior_dict_equivalence(prior: bmb.Prior, prior_dict: dict[str, Any]):
+    prior_dict = prior_dict.copy()
+    assert prior.name == prior_dict.pop("name")
+    if auto_scale := prior_dict.pop("auto_scale", None):
+        assert prior.auto_scale == auto_scale
+    if bounds := prior_dict.pop("bounds", None):
+        assert isinstance(prior, Prior)
+        assert prior.bounds == bounds
+        assert prior.is_truncated
+
+    args = (
+        prior._args if isinstance(prior, Prior) and prior.is_truncated else prior.args
+    )
+
+    for key, value in args.items():
+        if isinstance(value, bmb.Prior):
+            _check_prior_dict_equivalence(value, prior_dict.pop(key))
+        else:
+            assert value == prior_dict.pop(key)
+
+
+@pytest.fixture(scope="function")
+def flat_prior_dict():
+    return {
+        "name": "Normal",
+        "bounds": (-1.0, 1.0),
+        "auto_scale": True,
+        "mu": 0,
+        "sigma": 1,
+    }
+
+
+@pytest.fixture(scope="function")
+def flat_prior():
+    return Prior(
+        "Normal", auto_scale=True, dist=None, bounds=(-1.0, 1.0), mu=0, sigma=1
+    )
+
+
+@pytest.fixture(scope="function")
+def nested_prior_dict():
+    return {
+        "name": "Normal",
+        "bounds": (-1.0, 1.0),
+        "auto_scale": True,
+        "mu": {
+            "name": "Normal",
+            "auto_scale": False,
+            "mu": 0,
+            "sigma": 1,
+        },
+        "sigma": {
+            "name": "Normal",
+            "auto_scale": False,
+            "mu": 0,
+            "sigma": 1,
+        },
+    }
+
+
+@pytest.fixture(scope="function")
+def nested_prior():
+    return Prior(
+        "Normal",
+        auto_scale=True,
+        dist=None,
+        bounds=(-1.0, 1.0),
+        mu=Prior("Normal", auto_scale=False, mu=0, sigma=1),
+        sigma=bmb.Prior("Normal", auto_scale=False, mu=0, sigma=1),
+    )
 
 
 def test_truncation():
@@ -24,7 +98,7 @@ def test_truncation():
     assert not prior2.is_truncated
     assert prior2.dist is None
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         bounded_prior_err = Prior(
             "Uniform", lower=0.0, upper=1.0, bounds=(0.2, 0.8), dist=lambda x: x
         )
@@ -60,3 +134,45 @@ def test_eq():
     assert hssm_prior == bounded_prior2
 
     assert dist_hssm_prior == dist_bmb_prior
+
+
+def test_serialize_prior_obj(flat_prior, nested_prior):
+    _check_prior_dict_equivalence(flat_prior, serialize_prior_obj(flat_prior))
+    _check_prior_dict_equivalence(nested_prior, serialize_prior_obj(nested_prior))
+
+
+def test_deserialize_prior_obj(flat_prior_dict, nested_prior_dict):
+    _check_prior_dict_equivalence(
+        deserialize_prior_obj(flat_prior_dict), flat_prior_dict
+    )
+    _check_prior_dict_equivalence(
+        deserialize_prior_obj(nested_prior_dict), nested_prior_dict
+    )
+
+
+def test_to_dict(flat_prior, nested_prior):
+    _check_prior_dict_equivalence(flat_prior, flat_prior.to_dict())
+    _check_prior_dict_equivalence(nested_prior, nested_prior.to_dict())
+
+
+def test_from_dict(flat_prior_dict, nested_prior_dict):
+    _check_prior_dict_equivalence(Prior.from_dict(flat_prior_dict), flat_prior_dict)
+    _check_prior_dict_equivalence(Prior.from_dict(nested_prior_dict), nested_prior_dict)
+
+
+def test_equivalence_before_and_after_serialization(flat_prior, nested_prior):
+    assert flat_prior == deserialize_prior_obj(serialize_prior_obj(flat_prior))
+    assert nested_prior == deserialize_prior_obj(serialize_prior_obj(nested_prior))
+
+
+def test_from_bambi():
+    bambi_prior = bmb.Prior("Normal", auto_scale=True, dist=None, mu=0, sigma=1)
+    prior_from_bambi_unbounded = Prior.from_bambi(bambi_prior)
+
+    _check_prior_dict_equivalence(bambi_prior, prior_from_bambi_unbounded.to_dict())
+
+    prior_from_bambi_bounded = Prior.from_bambi(bambi_prior, bounds=(-1.0, 1.0))
+    assert prior_from_bambi_bounded.is_truncated
+    assert prior_from_bambi_bounded.bounds == (-1.0, 1.0)
+    assert prior_from_bambi_bounded.dist is not None
+    assert prior_from_bambi_bounded._args == prior_from_bambi_unbounded.args


### PR DESCRIPTION
This PR adds the functionalities to save and load models. These are mainly achieved by serializing settings saved in the HSSM object into a `json` file in a zip archive. It is also possible to save the data (optional) and `InferenceData` into the same zip archive by saving them into `csv` (or parquet) format and `netcdf`.

To that end, serialization and deserialization methods are added to multiple objects (`UserParam`, `Params`, `Config`, etc) so they can be turned into `dict`s and eventually `JSON`s. Some objects, such as the `vi_approx` objects, will be saved as pickles.

The reason why this implementation is favored over one single `pickle` file is that `pickle` files are not secure. They can contain arbitrary code that can be executed without the users' knowledge. The users can also pickle the object themselves if they so choose.

The disadvantage of this is that many objects might not be able to be serialized into `JSON` formats, especially when the models are highly customized with custom Link functions, custom distributions, etc.. Unfortunately not even the `pickling` could solve the problem with this level of customization. This method should work 90% percent of the time.