### PR TITLE
Update pymc dependency to version 5.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<=3.12"
-pymc = ">=5.16.2,<5.17.0"
+pymc = "^5.19"
 arviz = "^0.19.0"
 onnx = "^1.16.0"
 ssm-simulators = "^0.7.5"


### PR DESCRIPTION
This pull request includes updates to dependencies in the `pyproject.toml` file. Namely, it updates of the `pymc` dependency to a newer version. 

Dependency updates:

* `pyproject.toml`: Updated the `pymc` dependency from ">=5.16.2,<5.17.0" to "^5.19".

The goal is to ensure this version is compatible with `hssm` and further investigate #608.