### PR TITLE
Load default_model_config_lazily

### DIFF
--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -3,7 +3,6 @@
 # This is necessary to enable forward looking
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
@@ -58,7 +57,7 @@ class Config:
             # approx_differentiable
             for kind in ["analytical", "approx_differentiable", "blackbox"]:
                 model_name = cast(SupportedModels, model_name)
-                default_config = deepcopy(default_model_config()[model_name])
+                default_config = default_model_config()[model_name]
                 if kind in default_config["likelihoods"]:
                     kind = cast(LoglikKind, kind)
                     loglik_config = default_config["likelihoods"][kind]
@@ -88,7 +87,7 @@ class Config:
                 )
             if model_name in default_model_config():
                 model_name = cast(SupportedModels, model_name)
-                default_config = deepcopy(default_model_config()[model_name])
+                default_config = default_model_config()[model_name]
                 if loglik_kind in default_config["likelihoods"]:
                     loglik_config = default_config["likelihoods"][loglik_kind]
                     return Config(

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -50,7 +50,7 @@ class Config:
             The kind of the log-likelihood for the model.
         """
         if loglik_kind is None:
-            if model_name not in default_model_config:
+            if model_name not in default_model_config():
                 raise ValueError(
                     "When using a custom model, please provide a `loglik_kind.`"
                 )
@@ -58,7 +58,7 @@ class Config:
             # approx_differentiable
             for kind in ["analytical", "approx_differentiable", "blackbox"]:
                 model_name = cast(SupportedModels, model_name)
-                default_config = deepcopy(default_model_config[model_name])
+                default_config = deepcopy(default_model_config()[model_name])
                 if kind in default_config["likelihoods"]:
                     kind = cast(LoglikKind, kind)
                     loglik_config = default_config["likelihoods"][kind]
@@ -86,9 +86,9 @@ class Config:
                     "`loglik_kind`, when provided, must be one of "
                     + '"analytical", "approx_differentiable", "blackbox".'
                 )
-            if model_name in default_model_config:
+            if model_name in default_model_config():
                 model_name = cast(SupportedModels, model_name)
-                default_config = deepcopy(default_model_config[model_name])
+                default_config = deepcopy(default_model_config()[model_name])
                 if loglik_kind in default_config["likelihoods"]:
                     loglik_config = default_config["likelihoods"][loglik_kind]
                     return Config(

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -88,287 +88,314 @@ class DefaultConfig(TypedDict):
 
 DefaultConfigs = dict[SupportedModels, DefaultConfig]
 
-default_model_config: DefaultConfigs = {
-    "ddm": {
-        "response": ["rt", "response"],
-        "list_params": ddm_params,
-        "choices": [-1, 1],
-        "description": "The Drift Diffusion Model (DDM)",
-        "likelihoods": {
-            "analytical": {
-                "loglik": logp_ddm,
-                "backend": None,
-                "bounds": ddm_bounds,
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+
+def get_default_model_config() -> DefaultConfigs:
+    """Get the default model configurations.
+
+    Returns
+    -------
+    DefaultConfigs
+        Dictionary containing default configurations for all supported models.
+    """
+    return {
+        "ddm": {
+            "response": ["rt", "response"],
+            "list_params": ddm_params,
+            "choices": [-1, 1],
+            "description": "The Drift Diffusion Model (DDM)",
+            "likelihoods": {
+                "analytical": {
+                    "loglik": logp_ddm,
+                    "backend": None,
+                    "bounds": ddm_bounds,
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
                     },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
-            },
-            "approx_differentiable": {
-                "loglik": "ddm.onnx",
-                "backend": "jax",
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+                "approx_differentiable": {
+                    "loglik": "ddm.onnx",
+                    "backend": "jax",
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
                     },
-                },
-                "bounds": {
-                    "v": (-3.0, 3.0),
-                    "a": (0.3, 2.5),
-                    "z": (0.0, 1.0),
-                    "t": (0.0, 2.0),
-                },
-                "extra_fields": None,
-            },
-            "blackbox": {
-                "loglik": logp_ddm_bbox,
-                "backend": None,
-                "bounds": ddm_bounds,
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+                    "bounds": {
+                        "v": (-3.0, 3.0),
+                        "a": (0.3, 2.5),
+                        "z": (0.0, 1.0),
+                        "t": (0.0, 2.0),
                     },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
-            },
-        },
-    },
-    "ddm_sdv": {
-        "response": ["rt", "response"],
-        "list_params": ddm_sdv_params,
-        "choices": [-1, 1],
-        "description": "The Drift Diffusion Model (DDM) with standard deviation for v",
-        "likelihoods": {
-            "analytical": {
-                "loglik": logp_ddm_sdv,
-                "backend": None,
-                "bounds": ddm_sdv_bounds,
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+                "blackbox": {
+                    "loglik": logp_ddm_bbox,
+                    "backend": None,
+                    "bounds": ddm_bounds,
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
                     },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
             },
-            "approx_differentiable": {
-                "loglik": "ddm_sdv.onnx",
-                "backend": "jax",
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+        },
+        "ddm_sdv": {
+            "response": ["rt", "response"],
+            "list_params": ddm_sdv_params,
+            "choices": [-1, 1],
+            "description": "The Drift Diffusion Model (DDM) with standard deviation for v",
+            "likelihoods": {
+                "analytical": {
+                    "loglik": logp_ddm_sdv,
+                    "backend": None,
+                    "bounds": ddm_sdv_bounds,
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
                     },
+                    "extra_fields": None,
                 },
-                "bounds": {
-                    "v": (-3.0, 3.0),
-                    "a": (0.3, 2.5),
-                    "z": (0.1, 0.9),
-                    "t": (0.0, 2.0),
-                    "sv": (0.0, 1.0),
-                },
-                "extra_fields": None,
-            },
-            "blackbox": {
-                "loglik": logp_ddm_sdv_bbox,
-                "backend": None,
-                "bounds": ddm_sdv_bounds,
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+                "approx_differentiable": {
+                    "loglik": "ddm_sdv.onnx",
+                    "backend": "jax",
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
                     },
-                },
-                "extra_fields": None,
-            },
-        },
-    },
-    "full_ddm": {
-        "response": ["rt", "response"],
-        "list_params": ["v", "a", "z", "t", "sz", "sv", "st"],
-        "choices": [-1, 1],
-        "description": "The full Drift Diffusion Model (DDM)",
-        "likelihoods": {
-            "blackbox": {
-                "loglik": logp_full_ddm,
-                "backend": None,
-                "bounds": ddm_sdv_bounds | {"sz": (0, np.inf), "st": (0, np.inf)},
-                "default_priors": {
-                    "t": {
-                        "name": "HalfNormal",
-                        "sigma": 2.0,
+                    "bounds": {
+                        "v": (-3.0, 3.0),
+                        "a": (0.3, 2.5),
+                        "z": (0.1, 0.9),
+                        "t": (0.0, 2.0),
+                        "sv": (0.0, 1.0),
                     },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
-            }
-        },
-    },
-    "lba2": {
-        "response": ["rt", "response"],
-        "list_params": lba2_params,
-        "choices": [0, 1],
-        "description": "Linear Ballistic Accumulator 2 Choices (LBA2)",
-        "likelihoods": {
-            "analytical": {
-                "loglik": logp_lba2,
-                "backend": None,
-                "default_priors": {},
-                "bounds": lba2_bounds,
-                "extra_fields": None,
-            }
-        },
-    },
-    "lba3": {
-        "response": ["rt", "response"],
-        "list_params": lba3_params,
-        "choices": [0, 1, 2],
-        "description": "Linear Ballistic Accumulator 3 Choices (LBA3)",
-        "likelihoods": {
-            "analytical": {
-                "loglik": logp_lba3,
-                "backend": None,
-                "default_priors": {},
-                "bounds": lba3_bounds,
-                "extra_fields": None,
-            }
-        },
-    },
-    "angle": {
-        "response": ["rt", "response"],
-        "list_params": ["v", "a", "z", "t", "theta"],
-        "choices": [-1, 1],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "angle.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "v": (-3.0, 3.0),
-                    "a": (0.3, 3.0),
-                    "z": (0.1, 0.9),
-                    "t": (0.001, 2.0),
-                    "theta": (-0.1, 1.3),
+                "blackbox": {
+                    "loglik": logp_ddm_sdv_bbox,
+                    "backend": None,
+                    "bounds": ddm_sdv_bounds,
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
+                    },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
             },
         },
-    },
-    "levy": {
-        "response": ["rt", "response"],
-        "list_params": ["v", "a", "z", "alpha", "t"],
-        "choices": [-1, 1],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "levy.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "v": (-3.0, 3.0),
-                    "a": (0.3, 3.0),
-                    "z": (0.1, 0.9),
-                    "alpha": (1.0, 2.0),
-                    "t": (1e-3, 2.0),
-                },
-                "extra_fields": None,
+        "full_ddm": {
+            "response": ["rt", "response"],
+            "list_params": ["v", "a", "z", "t", "sz", "sv", "st"],
+            "choices": [-1, 1],
+            "description": "The full Drift Diffusion Model (DDM)",
+            "likelihoods": {
+                "blackbox": {
+                    "loglik": logp_full_ddm,
+                    "backend": None,
+                    "bounds": ddm_sdv_bounds | {"sz": (0, np.inf), "st": (0, np.inf)},
+                    "default_priors": {
+                        "t": {
+                            "name": "HalfNormal",
+                            "sigma": 2.0,
+                        },
+                    },
+                    "extra_fields": None,
+                }
             },
         },
-    },
-    "ornstein": {
-        "response": ["rt", "response"],
-        "list_params": ["v", "a", "z", "g", "t"],
-        "choices": [-1, 1],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "ornstein.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "v": (-2.0, 2.0),
-                    "a": (0.3, 3.0),
-                    "z": (0.1, 0.9),
-                    "g": (-1.0, 1.0),
-                    "t": (1e-3, 2.0),
-                },
-                "extra_fields": None,
+        "lba2": {
+            "response": ["rt", "response"],
+            "list_params": lba2_params,
+            "choices": [0, 1],
+            "description": "Linear Ballistic Accumulator 2 Choices (LBA2)",
+            "likelihoods": {
+                "analytical": {
+                    "loglik": logp_lba2,
+                    "backend": None,
+                    "default_priors": {},
+                    "bounds": lba2_bounds,
+                    "extra_fields": None,
+                }
             },
         },
-    },
-    "weibull": {
-        "response": ["rt", "response"],
-        "list_params": ["v", "a", "z", "t", "alpha", "beta"],
-        "choices": [-1, 1],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "weibull.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "v": (-2.5, 2.5),
-                    "a": (0.3, 2.5),
-                    "z": (0.2, 0.8),
-                    "t": (1e-3, 2.0),
-                    "alpha": (0.31, 4.99),
-                    "beta": (0.31, 6.99),
-                },
-                "extra_fields": None,
+        "lba3": {
+            "response": ["rt", "response"],
+            "list_params": lba3_params,
+            "choices": [0, 1, 2],
+            "description": "Linear Ballistic Accumulator 3 Choices (LBA3)",
+            "likelihoods": {
+                "analytical": {
+                    "loglik": logp_lba3,
+                    "backend": None,
+                    "default_priors": {},
+                    "bounds": lba3_bounds,
+                    "extra_fields": None,
+                }
             },
         },
-    },
-    "race_no_bias_angle_4": {
-        "response": ["rt", "response"],
-        "list_params": ["v0", "v1", "v2", "v3", "a", "z", "t", "theta"],
-        "choices": [0, 1, 2, 3],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "race_no_bias_angle_4.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "v0": (0.0, 2.5),
-                    "v1": (0.0, 2.5),
-                    "v2": (0.0, 2.5),
-                    "v3": (0.0, 2.5),
-                    "a": (1.0, 3.0),
-                    "z": (0.0, 0.9),
-                    "t": (0.0, 2.0),
-                    "theta": (-0.1, 1.45),
+        "angle": {
+            "response": ["rt", "response"],
+            "list_params": ["v", "a", "z", "t", "theta"],
+            "choices": [-1, 1],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "angle.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "v": (-3.0, 3.0),
+                        "a": (0.3, 3.0),
+                        "z": (0.1, 0.9),
+                        "t": (0.001, 2.0),
+                        "theta": (-0.1, 1.3),
+                    },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
             },
         },
-    },
-    "ddm_seq2_no_bias": {
-        "response": ["rt", "response"],
-        "list_params": ["vh", "vl1", "vl2", "a", "t"],
-        "choices": [0, 1, 2, 3],
-        "description": None,
-        "likelihoods": {
-            "approx_differentiable": {
-                "loglik": "ddm_seq2_no_bias.onnx",
-                "backend": "jax",
-                "default_priors": {},
-                "bounds": {
-                    "vh": (-4.0, 4.0),
-                    "vl1": (-4.0, 4.0),
-                    "vl2": (-4.0, 4.0),
-                    "a": (0.3, 2.5),
-                    "t": (0.0, 2.0),
+        "levy": {
+            "response": ["rt", "response"],
+            "list_params": ["v", "a", "z", "alpha", "t"],
+            "choices": [-1, 1],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "levy.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "v": (-3.0, 3.0),
+                        "a": (0.3, 3.0),
+                        "z": (0.1, 0.9),
+                        "alpha": (1.0, 2.0),
+                        "t": (1e-3, 2.0),
+                    },
+                    "extra_fields": None,
                 },
-                "extra_fields": None,
             },
         },
-    },
-}
+        "ornstein": {
+            "response": ["rt", "response"],
+            "list_params": ["v", "a", "z", "g", "t"],
+            "choices": [-1, 1],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "ornstein.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "v": (-2.0, 2.0),
+                        "a": (0.3, 3.0),
+                        "z": (0.1, 0.9),
+                        "g": (-1.0, 1.0),
+                        "t": (1e-3, 2.0),
+                    },
+                    "extra_fields": None,
+                },
+            },
+        },
+        "weibull": {
+            "response": ["rt", "response"],
+            "list_params": ["v", "a", "z", "t", "alpha", "beta"],
+            "choices": [-1, 1],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "weibull.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "v": (-2.5, 2.5),
+                        "a": (0.3, 2.5),
+                        "z": (0.2, 0.8),
+                        "t": (1e-3, 2.0),
+                        "alpha": (0.31, 4.99),
+                        "beta": (0.31, 6.99),
+                    },
+                    "extra_fields": None,
+                },
+            },
+        },
+        "race_no_bias_angle_4": {
+            "response": ["rt", "response"],
+            "list_params": ["v0", "v1", "v2", "v3", "a", "z", "t", "theta"],
+            "choices": [0, 1, 2, 3],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "race_no_bias_angle_4.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "v0": (0.0, 2.5),
+                        "v1": (0.0, 2.5),
+                        "v2": (0.0, 2.5),
+                        "v3": (0.0, 2.5),
+                        "a": (1.0, 3.0),
+                        "z": (0.0, 0.9),
+                        "t": (0.0, 2.0),
+                        "theta": (-0.1, 1.45),
+                    },
+                    "extra_fields": None,
+                },
+            },
+        },
+        "ddm_seq2_no_bias": {
+            "response": ["rt", "response"],
+            "list_params": ["vh", "vl1", "vl2", "a", "t"],
+            "choices": [0, 1, 2, 3],
+            "description": None,
+            "likelihoods": {
+                "approx_differentiable": {
+                    "loglik": "ddm_seq2_no_bias.onnx",
+                    "backend": "jax",
+                    "default_priors": {},
+                    "bounds": {
+                        "vh": (-4.0, 4.0),
+                        "vl1": (-4.0, 4.0),
+                        "vl2": (-4.0, 4.0),
+                        "a": (0.3, 2.5),
+                        "t": (0.0, 2.0),
+                    },
+                    "extra_fields": None,
+                },
+            },
+        },
+    }
+
+# cache the default model configurations
+_default_model_config: Optional[DefaultConfigs] = None
+
+
+def default_model_config() -> DefaultConfigs:
+    """Get the default model configurations lazily.
+
+    Returns
+    -------
+    DefaultConfigs
+        Dictionary containing default configurations for all supported models.
+    """
+    global _default_model_config
+    if _default_model_config is None:
+        _default_model_config = get_default_model_config()
+    return _default_model_config
+
 
 # TODO: Initval settings could be specified directly in model config as well.
 INITVAL_SETTINGS = {
@@ -418,10 +445,10 @@ def show_defaults(model: SupportedModels, loglik_kind=Optional[LoglikKind]) -> s
     str
         A nicely organized printout for the defaults of provided model.
     """
-    if model not in default_model_config:
+    if model not in default_model_config():
         raise ValueError(f"{model} does not currently have defaults in HSSM.")
 
-    model_config = default_model_config[model]
+    model_config = default_model_config()[model]
 
     output = []
     output.append("Default model config:")
@@ -469,8 +496,8 @@ def _show_defaults_helper(model: SupportedModels, loglik_kind: LoglikKind) -> li
         A list of nicely organized printout for the defaults of provided model.
     """
     output = []
-    params = default_model_config[model]["list_params"]
-    model_defaults = default_model_config[model]["likelihoods"][loglik_kind]
+    params = default_model_config()[model]["list_params"]
+    model_defaults = default_model_config()[model]["likelihoods"][loglik_kind]
 
     output.append(f"Log-likelihood kind: {loglik_kind}")
     output.append(f"Log-likelihood: {model_defaults['loglik']}")

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -151,7 +151,9 @@ def get_default_model_config() -> DefaultConfigs:
             "response": ["rt", "response"],
             "list_params": ddm_sdv_params,
             "choices": [-1, 1],
-            "description": "The Drift Diffusion Model (DDM) with standard deviation for v",
+            "description": (
+                "The Drift Diffusion Model (DDM) with standard deviation for v"
+            ),
             "likelihoods": {
                 "analytical": {
                     "loglik": logp_ddm_sdv,

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -379,6 +379,7 @@ def get_default_model_config() -> DefaultConfigs:
         },
     }
 
+
 # cache the default model configurations
 _default_model_config: Optional[DefaultConfigs] = None
 

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -87,7 +87,7 @@ def _plot_model_cartoon_1D(
     else:
         ax = plt.gca()
 
-    config_tmp = default_model_config[cast(SupportedModels, model_name)]
+    config_tmp = default_model_config()[cast(SupportedModels, model_name)]
     model_params = config_tmp["list_params"]
 
     n_choices = len(config_tmp["choices"])
@@ -229,7 +229,7 @@ def _plot_model_cartoon_2D(
 def compute_merge_necessary_deterministics(model, idata, inplace=True):
     """Compute the necessary deterministic variables for the model."""
     # Get the list of deterministic variables
-    necessary_params = default_model_config[model.model_name]["list_params"]
+    necessary_params = default_model_config()[model.model_name]["list_params"]
     deterministics_list = []
     idata_posterior_keys = list(idata["posterior"].keys())
     # Compute the deterministic variables
@@ -251,7 +251,7 @@ def compute_merge_necessary_deterministics(model, idata, inplace=True):
 
 def attach_trialwise_params_to_df(model, df, idata):
     """Attach the trial-wise parameters to the dataframe."""
-    necessary_params = default_model_config[model.model_name]["list_params"]
+    necessary_params = default_model_config()[model.model_name]["list_params"]
     df[necessary_params] = 0.0
 
     for chain_tmp, draw_tmp in {(x[0], x[1]) for x in list(df.index) if x[0] != -1}:
@@ -1556,7 +1556,7 @@ def plot_func_model_n(
 
     # ADD HISTOGRAMS
     # -------------------------------
-    choices = default_model_config[cast(SupportedModels, model_name)]["choices"]
+    choices = default_model_config()[cast(SupportedModels, model_name)]["choices"]
     cnt_cumul = 0
 
     # POSTERIOR MEAN BASED HISTOGRAM

--- a/src/hssm/register.py
+++ b/src/hssm/register.py
@@ -48,7 +48,7 @@ def register_model(
         If the model name already exists
     """
     # Ensure no collisions with existing models
-    if name in registered_models:
+    if name in registered_models():
         raise ValueError(f"Model '{name}' already exists")
 
     _config = {k: v for k, v in locals().items() if k != "name"}
@@ -57,7 +57,7 @@ def register_model(
     # TODO: validate provided configs?
 
     # Register the model
-    registered_models[name] = config
+    registered_models()[name] = config
 
 
 def list_registered_models() -> None:
@@ -65,7 +65,7 @@ def list_registered_models() -> None:
     pp(
         {
             name: config.get("description") or "No description"
-            for name, config in registered_models.items()
+            for name, config in registered_models().items()
         },
         sort_dicts=True,
     )
@@ -89,8 +89,8 @@ def get_model_info(name: SupportedModels | str) -> None:
     ValueError
         If the model name is not found in the registered models
     """
-    if name not in registered_models:
+    if name not in registered_models():
         raise ValueError(f"Model '{name}' not found")
 
     name = cast(SupportedModels, name)
-    print(f"Model: {name}\n" + pformat(registered_models[name], indent=2))
+    print(f"Model: {name}\n" + pformat(registered_models()[name], indent=2))

--- a/tests/param/test_params.py
+++ b/tests/param/test_params.py
@@ -27,10 +27,10 @@ def create_mock_model(
     prior_settings=None,
 ):
     def mock_config(model: SupportedModels, loglik_kind="analytical"):
-        if model not in default_model_config:
+        if model not in default_model_config():
             return lambda param: (None, None)
 
-        defaults = default_model_config[model]["likelihoods"][loglik_kind]
+        defaults = default_model_config()[model]["likelihoods"][loglik_kind]
 
         priors = defaults["default_priors"]
         bounds = defaults["bounds"]
@@ -51,7 +51,7 @@ def create_mock_model(
     model = Mock(
         model_name=model_name,
         spec=HSSM,
-        list_params=default_model_config[model_name]["list_params"] + ["p_outlier"],
+        list_params=default_model_config()[model_name]["list_params"] + ["p_outlier"],
         has_lapse=True,
         loglik_kind=loglik_kind,
         global_formula=global_formula,
@@ -125,7 +125,7 @@ def test_make_param_from_user_param():
     assert param.prior is None
     assert (
         param.bounds
-        == default_model_config["ddm"]["likelihoods"]["analytical"]["bounds"]["a"]
+        == default_model_config()["ddm"]["likelihoods"]["analytical"]["bounds"]["a"]
     )
     assert param.link is None
     assert param.user_param is reg_user_param
@@ -168,7 +168,7 @@ def test_make_param_from_user_param():
     assert param.prior is None
     assert (
         param.bounds
-        == default_model_config["ddm"]["likelihoods"]["analytical"]["bounds"]["a"]
+        == default_model_config()["ddm"]["likelihoods"]["analytical"]["bounds"]["a"]
     )
     assert param.link == "log"
     assert param.user_param is reg_user_param

--- a/tests/param/test_regression_param.py
+++ b/tests/param/test_regression_param.py
@@ -195,16 +195,16 @@ def test_validate():
     assert v.link.bounds == (0.0, 1.0)
 
 
-angle_params = default_model_config["angle"]["list_params"]
-angle_bounds = default_model_config["angle"]["likelihoods"]["approx_differentiable"][
+angle_params = default_model_config()["angle"]["list_params"]
+angle_bounds = default_model_config()["angle"]["likelihoods"]["approx_differentiable"][
     "bounds"
 ].values()
 param_and_bounds_angle = list(
     zip(angle_params, angle_bounds, [False] * len(angle_params))
 )
 
-ddm_params = default_model_config["full_ddm"]["list_params"]
-ddm_bounds = default_model_config["full_ddm"]["likelihoods"]["blackbox"][
+ddm_params = default_model_config()["full_ddm"]["list_params"]
+ddm_bounds = default_model_config()["full_ddm"]["likelihoods"]["blackbox"][
     "bounds"
 ].values()
 param_and_bounds_ddm = list(zip(ddm_params, ddm_bounds, [True] * len(ddm_params)))

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -17,14 +17,14 @@ def test_register_model():
     # Test data for registration
     name = "custom_model"
     # get some model metadata for testing purposes
-    config = registered_models["ddm"]
+    config = registered_models()["ddm"]
 
     # Register the model
     register_model(name=name, **config)
 
     # Test listing models
     list_registered_models()
-    assert name in registered_models
+    assert name in registered_models()
 
     # Verify model can be instantiated
     data = hssm.load_data("cavanagh_theta")


### PR DESCRIPTION
This pull request introduces changes to lazily load default model configurations and registered models. The main changes involve replacing direct dictionary access with function calls to improve performance and maintainability.

Key changes include:

### Configuration Management:
* Introduced `get_default_model_config` and `default_model_config` functions to lazily load and cache default model configurations in `src/hssm/defaults.py`. [[1]](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeL91-R100) [[2]](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeR382-R399)

### Code Refactoring:
* Updated various functions to use the `default_model_config` function instead of directly accessing the `default_model_config` dictionary in `src/hssm/config.py`, `src/hssm/plotting/model_cartoon.py`, and `tests/param/test_params.py`. [[1]](diffhunk://#diff-8ac0c2f5062baeb4cb02855c82b1a3af9743e7fbb6283523bfbcc36bd4097e44L53-R61) [[2]](diffhunk://#diff-8ac0c2f5062baeb4cb02855c82b1a3af9743e7fbb6283523bfbcc36bd4097e44L89-R91) [[3]](diffhunk://#diff-082c1eddd8d91d9778b3f01c4c5986a95d327f78e98e5699b34883cd083aafceL90-R90) [[4]](diffhunk://#diff-082c1eddd8d91d9778b3f01c4c5986a95d327f78e98e5699b34883cd083aafceL232-R232) [[5]](diffhunk://#diff-af4f29afdd850d30e745f2ba6859ea1c3f6bf17e7f896bf679e554407a027da0L30-R33) [[6]](diffhunk://#diff-af4f29afdd850d30e745f2ba6859ea1c3f6bf17e7f896bf679e554407a027da0L54-R54) [[7]](diffhunk://#diff-af4f29afdd850d30e745f2ba6859ea1c3f6bf17e7f896bf679e554407a027da0L128-R128) [[8]](diffhunk://#diff-af4f29afdd850d30e745f2ba6859ea1c3f6bf17e7f896bf679e554407a027da0L171-R171) [[9]](diffhunk://#diff-e2135bb5ce77046a36c3b1f4720a0bd5c5f120f402b8995195d6a061002341edL198-R207)

### Model Registration:
* Updated functions to use the `registered_models` function instead of directly accessing the `registered_models` dictionary in `src/hssm/register.py` and `tests/test_register.py`. [[1]](diffhunk://#diff-0e7027907947efb9d812d5cb7a653d7aaf8711d8764d61221f26cca446f41420L51-R51) [[2]](diffhunk://#diff-0e7027907947efb9d812d5cb7a653d7aaf8711d8764d61221f26cca446f41420L60-R68) [[3]](diffhunk://#diff-0e7027907947efb9d812d5cb7a653d7aaf8711d8764d61221f26cca446f41420L92-R96) [[4]](diffhunk://#diff-4682147ca75340613cbb9d69a15bab4961497d49b9e56be0a456ff30ba33f46bL20-R27)