### PR TITLE
668 add lanfactory as optional dependency

### DIFF
--- a/docs/tutorials/jax_callable_contribution_onnx_example.ipynb
+++ b/docs/tutorials/jax_callable_contribution_onnx_example.ipynb
@@ -65,7 +65,9 @@
     "\n",
     "If we have a JAX function with this signature, we will be able to proceed to create a valid PyMC distribution form helper functions provided by `hssm`.\n",
     "\n",
-    "In this particular example, we will reinstantiate a pretrained [LAN](https://elifesciences.org/articles/65074) via utilities from the [`lanfactory`](https://github.com/AlexanderFengler/LANfactory) package. This is not necessary, but illustrates how to make use of the braoder ecosystem around HSSM."
+    "In this particular example, we will reinstantiate a pretrained [LAN](https://elifesciences.org/articles/65074) via utilities from the [`lanfactory`](https://github.com/AlexanderFengler/LANfactory) package. This is not necessary, but illustrates how to make use of the braoder ecosystem around HSSM.\n",
+    "\n",
+    "> **Note:** `lanfactory` is an optional dependency of `hssm` and can be installed using the command `pip install hssm[notebook]`. Alternatively, you can install it directly with `pip install lanfactory`."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,14 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "hddm-wfpt>=0.1.4",
     "huggingface-hub>=0.24.6",
-    "numpy>=1.26.4,<2.0.0",
+        "numpy>=1.26.4,<2.0.0",
     "numpyro>=0.16.0",
     "onnx>=1.16.0",
     "pymc>=5.19.0",
     "seaborn>=0.13.2",
     "ssm-simulators>=0.8.3",
     "tqdm>=4.66.0",
-]
+    ]
 
 [project.optional-dependencies]
 cuda12 = ["jax[cuda12]>=0.4.25"]
@@ -56,6 +56,10 @@ dev = [
     "pytest-xdist>=3.6.1",
     "pytest>=8.3.1",
     "ruff>=0.9.1",
+]
+notebook = [
+    "ipykernel>=6.29.5",
+    "lanfactory>=0.4.4",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This pull request includes updates to documentation and configuration files to improve clarity and functionality. The most important changes include adding a note about optional dependencies in a Jupyter notebook tutorial and updating the `pyproject.toml` file to include a new dependency group.

Documentation updates:

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R60-R63): Added a new dependency group `notebook` with `ipykernel` and `lanfactory` dependencies.

* [`docs/tutorials/jax_callable_contribution_onnx_example.ipynb`](diffhunk://#diff-a469e6baafe0e7f767df6ac2a9e6128c8513be272d1e36548a7413da3a143cbeL68-R70): Added a note about the optional `lanfactory` dependency and how to install it.

