### PR TITLE
667 add zeus as optional dependency

### DIFF
--- a/docs/tutorials/compile_logp.ipynb
+++ b/docs/tutorials/compile_logp.ipynb
@@ -258,7 +258,9 @@
     "### Using the compiled log-likelihood function\n",
     "\n",
     "For illustration, we use our compile log-likelihood function with a different MCMC sampler, using the \n",
-    "[`zeus`](https://github.com/minaskar/zeus) package."
+    "[`zeus`](https://github.com/minaskar/zeus) package.\n",
+    "\n",
+    "> **Note:** `zeus` is an optional dependency of `hssm` and can be installed using the command `pip install hssm[notebook]`. Alternatively, you can install it directly with `pip install zeus-mcmc`."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ dev = [
     "pytest>=8.3.1",
     "ruff>=0.9.1",
 ]
+notebook = [
+    "ipykernel>=6.29.5",
+    "zeus-mcmc>=2.5.4",
+]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration files to improve the user experience and ensure necessary dependencies are included.

Configuration updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R60-R63): Added a new `notebook` group to the `dev` dependencies section, including `ipykernel` and `zeus-mcmc` to ensure all necessary dependencies are installed for notebook usage. #668 

Documentation updates:

* [`docs/tutorials/compile_logp.ipynb`](diffhunk://#diff-0d65bd44de80e8b06e410e7342fcb5f40763a12dd5f6a51a1aedd85f4a2a2f7bL261-R263): Added a note to inform users that `zeus` is an optional dependency and provided installation instructions.