### PR TITLE
672 create a supported models class property for hssm

### DIFF
--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -355,6 +355,7 @@ class HSSM:
             # Model config is not provided, but at this point was constructed from
             # defaults.
             if model not in typing.get_args(SupportedModels):
+                # TODO: ideally use self.supported_models above but mypy doesn't like it
                 if choices is not None:
                     self.model_config.update_choices(choices)
                 elif model in ssms_model_config:


### PR DESCRIPTION
This pull request includes several updates to the `docs/tutorials/main_tutorial.ipynb` and `src/hssm/hssm.py` files. The changes primarily focus on improving documentation and adding new functionalities to the HSSM class.

Codebase enhancements:

* Added a `classproperty` decorator to the `HSSM` class in `src/hssm/hssm.py` to allow class-level properties that perform computations or access class-level data. This decorator ensures compatibility across Python versions 3.10 through 3.12.
* Introduced a new `supported_models` class property in the `HSSM` class to return a tuple of all supported model names.

Documentation updates:

* Updated references to model accessors in `docs/tutorials/main_tutorial.ipynb` to reflect the new structure, changing `hssm.defaults.SupportedModels` to `hssm.HSSM.supported_models` and updating the method to check detailed model information. [[1]](diffhunk://#diff-42241a7f990168f1a35b70ab2d4a32adfdb10be2179cadbff729ebbbd6c5dc7dL418-R418) [[2]](diffhunk://#diff-42241a7f990168f1a35b70ab2d4a32adfdb10be2179cadbff729ebbbd6c5dc7dL430-R505) [[3]](diffhunk://#diff-42241a7f990168f1a35b70ab2d4a32adfdb10be2179cadbff729ebbbd6c5dc7dL6674-R6697) [[4]](diffhunk://#diff-42241a7f990168f1a35b70ab2d4a32adfdb10be2179cadbff729ebbbd6c5dc7dL6716-R6739) [[5]](diffhunk://#diff-42241a7f990168f1a35b70ab2d4a32adfdb10be2179cadbff729ebbbd6c5dc7dL7148-R7171)

