### PR TITLE
Add type definitions for HSSM package and refactor imports

### DIFF
--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -1,0 +1,54 @@
+"""Type definitions for the HSSM package."""
+
+from os import PathLike
+from typing import Any, Callable, Literal, Optional, TypedDict, Union
+
+import bambi as bmb
+from pymc import Distribution
+from pytensor.graph.op import Op
+
+LogLik = Union[str, PathLike, Callable, Op, type[Distribution]]
+ParamSpec = Union[float, dict[str, Any], bmb.Prior, None]
+
+SupportedModels = Literal[
+    "ddm",
+    "ddm_sdv",
+    "full_ddm",
+    "angle",
+    "levy",
+    "ornstein",
+    "weibull",
+    "race_no_bias_angle_4",
+    "ddm_seq2_no_bias",
+    "lba3",
+    "lba2",
+]
+
+
+LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
+
+
+class LoglikConfig(TypedDict):
+    """Type for the value of LoglikConfig."""
+
+    loglik: LogLik
+    backend: Optional[Literal["jax", "pytensor"]]
+    default_priors: dict[str, ParamSpec]
+    bounds: dict[str, tuple[float, float]]
+    extra_fields: Optional[list[str]]
+
+
+LoglikConfigs = dict[LoglikKind, LoglikConfig]
+
+
+class DefaultConfig(TypedDict):
+    """Type for the value of DefaultConfig."""
+
+    response: list[str]
+    list_params: list[str]
+    choices: list[int]
+    description: Optional[str]
+    likelihoods: LoglikConfigs
+
+
+DefaultConfigs = dict[SupportedModels, DefaultConfig]

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -9,10 +9,8 @@ from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args
 
 import bambi as bmb
 
+from ._types import LogLik, LoglikKind, SupportedModels
 from .defaults import (
-    LogLik,
-    LoglikKind,
-    SupportedModels,
     default_model_config,
     get_default_model_meta,
 )

--- a/src/hssm/defaults.py
+++ b/src/hssm/defaults.py
@@ -2,13 +2,22 @@
 
 from enum import Enum
 from os import PathLike
-from typing import Any, Callable, Literal, Optional, TypedDict, Union
 
 import bambi as bmb
 import numpy as np
 from pymc import Distribution
 from pytensor.graph.op import Op
 
+from ._types import (
+    Any,
+    Callable,
+    DefaultConfig,
+    DefaultConfigs,
+    LoglikKind,
+    Optional,
+    SupportedModels,
+    Union,
+)
 from .likelihoods.analytical import (
     ddm_bounds,
     ddm_params,
@@ -29,35 +38,6 @@ from .param.utils import _make_default_prior
 LogLik = Union[str, PathLike, Callable, Op, type[Distribution]]
 ParamSpec = Union[float, dict[str, Any], bmb.Prior, None]
 
-SupportedModels = Literal[
-    "ddm",
-    "ddm_sdv",
-    "full_ddm",
-    "angle",
-    "levy",
-    "ornstein",
-    "weibull",
-    "race_no_bias_angle_4",
-    "ddm_seq2_no_bias",
-    "lba3",
-    "lba2",
-]
-
-LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
-
-
-class LoglikConfig(TypedDict):
-    """Type for the value of LoglikConfig."""
-
-    loglik: LogLik
-    backend: Optional[Literal["jax", "pytensor"]]
-    default_priors: dict[str, ParamSpec]
-    bounds: dict[str, tuple[float, float]]
-    extra_fields: Optional[list[str]]
-
-
-LoglikConfigs = dict[LoglikKind, LoglikConfig]
-
 
 class MissingDataNetwork(Enum):
     """Enum for the missing data network."""
@@ -74,19 +54,6 @@ missing_data_networks_suffix = {
     MissingDataNetwork.GONOGO: "_gonogo",
     MissingDataNetwork.OPN: "_opn",
 }
-
-
-class DefaultConfig(TypedDict):
-    """Type for the value of DefaultConfig."""
-
-    response: list[str]
-    list_params: list[str]
-    choices: list[int]
-    description: Optional[str]
-    likelihoods: LoglikConfigs
-
-
-DefaultConfigs = dict[SupportedModels, DefaultConfig]
 
 
 def get_ddm_config() -> DefaultConfig:

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -30,12 +30,11 @@ from bambi.model_components import DistributionalComponent
 from bambi.transformations import transformations_namespace
 from ssms.config import model_config as ssms_model_config
 
+from hssm._types import LoglikKind, SupportedModels
 from hssm.defaults import (
     INITVAL_JITTER_SETTINGS,
     INITVAL_SETTINGS,
-    LoglikKind,
     MissingDataNetwork,
-    SupportedModels,
     missing_data_networks_suffix,
 )
 from hssm.distribution_utils import (

--- a/src/hssm/register.py
+++ b/src/hssm/register.py
@@ -3,7 +3,7 @@
 from pprint import pformat, pp
 from typing import cast
 
-from .defaults import (
+from ._types import (
     DefaultConfig,
     LoglikConfigs,
     SupportedModels,


### PR DESCRIPTION
This pull request includes changes to improve the organization and readability of type definitions in the HSSM package by moving them to a separate `_types.py` file. The most important changes include defining new types and updating import statements across multiple files.

Type definitions:

* [`src/hssm/_types.py`](diffhunk://#diff-75f0d25f3fd331542ba2194c016b2aafdb4290525bf8bcc8fdc8013d9e0b7d72R1-R54): Added type definitions for `LogLik`, `ParamSpec`, `SupportedModels`, `LoglikKind`, `LoglikConfig`, `LoglikConfigs`, `DefaultConfig`, and `DefaultConfigs`.

Import updates:

* [`src/hssm/config.py`](diffhunk://#diff-8ac0c2f5062baeb4cb02855c82b1a3af9743e7fbb6283523bfbcc36bd4097e44R12-L15): Updated import statements to use the new `_types.py` file.
* [`src/hssm/defaults.py`](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeL5-R20): Updated import statements to use the new `_types.py` file and removed the old type definitions. [[1]](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeL5-R20) [[2]](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeL32-L60) [[3]](diffhunk://#diff-92b06a0b2de75d6e43362d4dee22c608dfed8931f8d60d00513571b4bfc83dfeL79-L91)
* [`src/hssm/hssm.py`](diffhunk://#diff-886b4f455536b5c662d101c272845eaf0d7ea4acc0475bc11473cbf11147546eR33-L38): Updated import statements to use the new `_types.py` file.
* [`src/hssm/register.py`](diffhunk://#diff-0e7027907947efb9d812d5cb7a653d7aaf8711d8764d61221f26cca446f41420L6-R6): Updated import statements to use the new `_types.py` file.