### PR TITLE
Add slow marker to multiple test cases

### DIFF
--- a/tests/test_data_sanity.py
+++ b/tests/test_data_sanity.py
@@ -11,6 +11,7 @@ def cpn():
     return Path(__file__).parent / "fixtures" / "ddm_cpn.onnx"
 
 
+@pytest.mark.slow
 def test_data_sanity_check(data_ddm, cpn, caplog):
     # Case 1: raise error if there are missing fields in data
     with pytest.raises(ValueError, match="Field rt not found in data."):

--- a/tests/test_distribution_utils.py
+++ b/tests/test_distribution_utils.py
@@ -81,6 +81,7 @@ def test_lapse_distribution():
     np.testing.assert_array_equal(random_sample_a, random_sample_b)
 
 
+@pytest.mark.slow
 def test_apply_param_bounds_to_loglik():
     """Tests the function in separation."""
     logp = np.random.normal(size=1000)
@@ -121,6 +122,7 @@ def test_apply_param_bounds_to_loglik():
     )
 
 
+@pytest.mark.slow
 def test_make_distribution():
     def fake_logp_function(data, param1, param2):
         """Make up a fake log likelihood function for this test only."""
@@ -165,6 +167,7 @@ def test_make_distribution():
     )
 
 
+@pytest.mark.slow
 def test_extra_fields(data_ddm):
     ones = np.ones(data_ddm.shape[0])
     x = ones * 0.5
@@ -231,6 +234,7 @@ def test_extra_fields(data_ddm):
     )
 
 
+@pytest.mark.slow
 def test_ensure_positive_ndt():
     data = np.zeros((1000, 2))
     data[:, 0] = np.random.uniform(size=1000)

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -1,6 +1,9 @@
+import pytest
+
 import hssm
 
 
+@pytest.mark.slow
 def test_simple_graphing(data_ddm):
     model = hssm.HSSM(data=data_ddm, model="ddm")
     graph = model.graph()

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -22,6 +22,7 @@ param_v = {
 param_a = param_v | dict(name="a", formula="a ~ 1 + x + y")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "include, should_raise_exception",
     [
@@ -80,6 +81,7 @@ def test_transform_params_general(data_ddm_reg, include, should_raise_exception)
         assert len(model.params) == 5
 
 
+@pytest.mark.slow
 def test_custom_model(data_ddm):
     with pytest.raises(
         ValueError, match="When using a custom model, please provide a `loglik_kind.`"
@@ -132,6 +134,7 @@ def test_custom_model(data_ddm):
     assert model.list_params == ["v", "a", "z", "t", "p_outlier"]
 
 
+@pytest.mark.slow
 def test_model_definition_outside_include(data_ddm):
     model_with_one_param_fixed = HSSM(data_ddm, a=0.5)
 
@@ -151,6 +154,7 @@ def test_model_definition_outside_include(data_ddm):
         HSSM(data_ddm, include=[{"name": "a", "prior": 0.5}], a=0.5)
 
 
+@pytest.mark.slow
 def test_sample_prior_predictive(data_ddm_reg):
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
 
@@ -195,6 +199,7 @@ def test_sample_prior_predictive(data_ddm_reg):
     )
 
 
+@pytest.mark.slow
 def test_override_default_link(caplog, data_ddm_reg):
     param_v = {
         "name": "v",
@@ -225,6 +230,7 @@ def test_override_default_link(caplog, data_ddm_reg):
     assert "strange" in caplog.records[0].message
 
 
+@pytest.mark.slow
 def test_resampling(data_ddm):
     model = HSSM(data=data_ddm)
     sample_1 = model.sample(draws=10, chains=1, tune=0)
@@ -236,6 +242,7 @@ def test_resampling(data_ddm):
     assert sample_1 is not sample_2
 
 
+@pytest.mark.slow
 def test_add_likelihood_parameters_to_data(data_ddm):
     """Test if the likelihood parameters are added to the InferenceData object."""
     model = HSSM(data=data_ddm)
@@ -271,6 +278,7 @@ def test_add_likelihood_parameters_to_data(data_ddm):
 
 
 # Setting any parameter to a fixed value should work:
+@pytest.mark.slow
 def test_model_creation_constant_parameter(data_ddm):
     for param_name in ["v", "a", "z", "t"]:
         model = HSSM(data=data_ddm, **{param_name: 1.0})
@@ -279,6 +287,7 @@ def test_model_creation_constant_parameter(data_ddm):
 
 
 # Setting any single parameter to a regression should respect the default bounds:
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "param_name, dist_name",
     [("v", "Normal"), ("a", "Gamma"), ("z", "Beta"), ("t", "Gamma")],
@@ -299,6 +308,7 @@ def test_model_creation_all_parameters_constant(data_ddm):
 
 
 # Prior settings
+@pytest.mark.slow
 def test_prior_settings_basic(cavanagh_test):
     model_1 = HSSM(
         data=cavanagh_test,
@@ -321,6 +331,7 @@ def test_prior_settings_basic(cavanagh_test):
     )
 
 
+@pytest.mark.slow
 def test_compile_logp(cavanagh_test):
     model_1 = HSSM(
         data=cavanagh_test,

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -36,6 +36,7 @@ parameter_grid = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(parameter_names, parameter_grid)
 def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
     """Test sampling from MAP starting point."""
@@ -136,6 +137,7 @@ def _check_initval_defaults_correctness(model) -> None:
             pass
 
 
+@pytest.mark.slow
 def test_basic_model(caplog):
     """Test basic model with p_outlier distribution defined."""
     caplog.set_level(logging.INFO)
@@ -149,6 +151,7 @@ def test_basic_model(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_basic_model_p_outlier(caplog):
     """Test basic model with p_outlier distribution defined."""
     caplog.set_level(logging.INFO)
@@ -163,6 +166,7 @@ def test_basic_model_p_outlier(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_basic_model_p_outlier_initval(caplog):
     """Test basic model with p_outlier distribution defined."""
     caplog.set_level(logging.INFO)
@@ -180,6 +184,7 @@ def test_basic_model_p_outlier_initval(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_reg_model(caplog):
     """Test regression model, with regression on all parameters."""
     caplog.set_level(logging.INFO)
@@ -199,6 +204,7 @@ def test_reg_model(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_reg_model_subset(caplog):
     """Test regression model, with subset of parameters being regressions."""
     caplog.set_level(logging.INFO)
@@ -217,6 +223,7 @@ def test_reg_model_subset(caplog):
     )
 
 
+@pytest.mark.slow
 def test_angle_model_reg(caplog):
     """Test with angle model regression."""
     caplog.set_level(logging.INFO)
@@ -237,6 +244,7 @@ def test_angle_model_reg(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_angle_model(caplog):
     """Test with angle model basic."""
     caplog.set_level(logging.INFO)
@@ -250,6 +258,7 @@ def test_angle_model(caplog):
     _check_initval_defaults_correctness(model)
 
 
+@pytest.mark.slow
 def test_process_no_process(caplog):
     """Test mismatch with and without preprocessing."""
     caplog.set_level(logging.INFO)

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -64,6 +64,7 @@ values = [2.5, 3.0, 3.0]
 parameters = [(name, np.arange(value, 5.1, 0.5)) for name, value in zip(names, values)]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("param_name, param_values", parameters)
 def test_no_inf_values(data_ddm, shared_params, param_name, param_values):
     for value in param_values:
@@ -82,6 +83,7 @@ svd = (logp_ddm_sdv, logp_ddm_sdv_bbox, true_values_sdv)
 parameters = [standard, svd]  # type: ignore
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("logp_func, logp_bbox_func, true_values", parameters)
 def test_bbox(data_ddm, logp_func, logp_bbox_func, true_values):
     data = data_ddm.values
@@ -101,6 +103,7 @@ param_matrix = product(
 nan_guard_mode = NanGuardMode(nan_is_error=True, inf_is_error=True, big_is_error=False)
 
 
+@pytest.mark.slow
 def test_analytical_gradient():
     v = pt.dvector()
     a = pt.dvector()
@@ -145,6 +148,7 @@ def test_analytical_gradient():
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("p_outlier, loglik_kind", param_matrix)
 def test_lapse_distribution_cav(p_outlier, loglik_kind):
     true_values = (1.5, 0.5, 0.5)

--- a/tests/test_likelihoods_lba.py
+++ b/tests/test_likelihoods_lba.py
@@ -59,6 +59,7 @@ theta_lba2 = dict(A=0.2, b=0.5, v0=1.0, v1=1.0)
 theta_lba3 = theta_lba2 | {"v2": 1.0}
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "logp_func, model, theta",
     [(logp_lba2, "lba2", theta_lba2), (logp_lba3, "lba3", theta_lba3)],

--- a/tests/test_missing_and_deadline.py
+++ b/tests/test_missing_and_deadline.py
@@ -36,6 +36,7 @@ def data():
 cases = product(["cpn", "opn"], [True, False])
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("cpn, is_vector", cases)
 def test_make_missing_data_callable(data, fixture_path, cpn, is_vector):
     is_cpn = cpn == "cpn"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -28,6 +28,7 @@ def onnx_session(fixture_path):
     )
 
 
+@pytest.mark.slow
 def test_interpret_onnx(onnx_session, fixture_path):
     """Tests whether both versions of interpret_onnx return similar values as does the
     ONNX runtime.
@@ -100,6 +101,7 @@ def test_make_jax_logp_funcs_from_onnx(fixture_path):
     )
 
 
+@pytest.mark.slow
 def test_make_jax_logp_ops(fixture_path):
     """Tests whether the logp Op returned from make_jax_logp_ops with different backends
     work the same way.

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -151,6 +151,7 @@ def test__plot_posterior_predictive_2D(cav_idata, cavanagh_test):
     assert len(g2.figure.axes[0].get_lines()) == 1
 
 
+@pytest.mark.slow
 def test_plot_posterior_predictive(cav_idata, cavanagh_test):
     # Mock model object
     model = hssm.HSSM(
@@ -289,6 +290,7 @@ def test__plot_quantile_probability_2D(cav_idata, cavanagh_test):
     assert len(g.figure.axes) == 5 * 4
 
 
+@pytest.mark.slow
 def test_plot_quantile_probability(cav_idata, cavanagh_test):
     # Mock model object
     model = hssm.HSSM(

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -10,6 +10,7 @@ hssm.set_floatX("float32")
 
 
 # I want to parameter
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ["n_trajectories", "groups", "plot_pp_mean", "plot_pp_samples", "row", "col"],
     [
@@ -66,6 +67,7 @@ def test_plot_model_cartoon_2_choice(
             assert len(ax) == len(cav_model_cartoon.data[groups[0]].unique())
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ["n_trajectories", "groups", "plot_pp_mean", "plot_pp_samples", "row", "col"],
     [

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -10,6 +10,7 @@ from hssm.defaults import (
 )
 
 
+@pytest.mark.slow
 def test_register_model():
     """Test registering a custom model"""
 

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -29,6 +29,7 @@ PARAMETER_GRID = [
 ]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(
     cav_idata, cavanagh_test, draws, safe_mode, inplace

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,6 +1,9 @@
 import numpy as np
 import shutil
 from pathlib import Path
+
+import pytest
+
 import hssm
 
 
@@ -19,6 +22,7 @@ def compare_hssm_class_attributes(model_a, model_b):
     ], "Basic RVs not the same"
 
 
+@pytest.mark.slow
 def test_save_load_model_only(basic_hssm_model):
     tmp_folder_name = "models_pytest"
     tmp_model_name = "hssm_model_pytest"
@@ -32,6 +36,7 @@ def test_save_load_model_only(basic_hssm_model):
     shutil.rmtree(tmp_folder_name)
 
 
+@pytest.mark.slow
 def test_save_load_vi_mcmc(basic_hssm_model):
     tmp_folder_name = "models_pytest"
     tmp_model_name = "hssm_model_pytest"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from hssm.utils import (
 hssm.set_floatX("float32")
 
 
+@pytest.mark.slow
 def test_get_alias_dict():
     # Simulate some data:
     v_true, a_true, z_true, t_true = [0.5, 1.5, 0.5, 0.5]


### PR DESCRIPTION
This pull request introduces the `@pytest.mark.slow` decorator to multiple test functions across various test files. This change helps categorize tests that are expected to take a longer time to run, allowing for better test management and execution control.

Criterion: Test file takes longer than ~5 seconds to run.

To exclude any test marked as slow use `-m "not slow"` option in the `pytest` command.

* [`tests/test_data_sanity.py`](diffhunk://#diff-599d988e92fbbe94680aef502dec6c71b29a6fc18d255d23a3d9462e78f8e8b8R14): Added `@pytest.mark.slow` to `test_data_sanity_check`.
* [`tests/test_distribution_utils.py`](diffhunk://#diff-a4c7e63825e98b51a2f399dc3cfe082be5ba64a133a38e9f080a423f2c5d1c32R84): Added `@pytest.mark.slow` to multiple test functions including `test_lapse_distribution`, `test_apply_param_bounds_to_loglik`, `test_make_distribution`, `test_extra_fields`, and `test_ensure_positive_ndt`. [[1]](diffhunk://#diff-a4c7e63825e98b51a2f399dc3cfe082be5ba64a133a38e9f080a423f2c5d1c32R84) [[2]](diffhunk://#diff-a4c7e63825e98b51a2f399dc3cfe082be5ba64a133a38e9f080a423f2c5d1c32R125) [[3]](diffhunk://#diff-a4c7e63825e98b51a2f399dc3cfe082be5ba64a133a38e9f080a423f2c5d1c32R170) [[4]](diffhunk://#diff-a4c7e63825e98b51a2f399dc3cfe082be5ba64a133a38e9f080a423f2c5d1c32R237)
* [`tests/test_hssm.py`](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R25): Added `@pytest.mark.slow` to various test functions such as `test_transform_params_general`, `test_custom_model`, `test_model_definition_outside_include`, `test_sample_prior_predictive`, `test_override_default_link`, `test_resampling`, `test_add_likelihood_parameters_to_data`, `test_model_creation_constant_parameter`, `test_prior_settings_basic`, and `test_compile_logp`. [[1]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R25) [[2]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R84) [[3]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R137) [[4]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R157) [[5]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R202) [[6]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R233) [[7]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R245) [[8]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R281) [[9]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R311) [[10]](diffhunk://#diff-19a7aa3cce0c461d18f967d0ebb6a12458a1156c9f63ff9e84bd36a0af0a93c1R334)
* [`tests/test_initvals.py`](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R39): Added `@pytest.mark.slow` to test functions including `test_sample_map`, `test_basic_model`, `test_basic_model_p_outlier`, `test_basic_model_p_outlier_initval`, `test_reg_model`, `test_reg_model_subset`, `test_angle_model_reg`, `test_angle_model`, and `test_process_no_process`. [[1]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R39) [[2]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R140) [[3]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R154) [[4]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R169) [[5]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R187) [[6]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R207) [[7]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R226) [[8]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R247) [[9]](diffhunk://#diff-72c1147ca713c5785fce4b00500a42c5630c6a03fd0759b24c08a7a8f5465179R261)
* [`tests/test_likelihoods.py`](diffhunk://#diff-b90c0fb80d86b59ff2cf6d51ebeafaf45d1ed08f9155850441829df93a3ea337R67): Added `@pytest.mark.slow` to `test_no_inf_values`, `test_bbox`, `test_analytical_gradient`, and `test_lapse_distribution_cav`. [[1]](diffhunk://#diff-b90c0fb80d86b59ff2cf6d51ebeafaf45d1ed08f9155850441829df93a3ea337R67) [[2]](diffhunk://#diff-b90c0fb80d86b59ff2cf6d51ebeafaf45d1ed08f9155850441829df93a3ea337R86) [[3]](diffhunk://#diff-b90c0fb80d86b59ff2cf6d51ebeafaf45d1ed08f9155850441829df93a3ea337R106) [[4]](diffhunk://#diff-b90c0fb80d86b59ff2cf6d51ebeafaf45d1ed08f9155850441829df93a3ea337R151)
* [`tests/test_likelihoods_lba.py`](diffhunk://#diff-b8473f02dd068ecc9e8c38166f0b5d77ca2a70472e7a06847076e4f58864243fR62): Added `@pytest.mark.slow` to `test_make_missing_data_callable`.
* [`tests/test_onnx.py`](diffhunk://#diff-5cd6ac8322dfce63a84995dd91b5195ca9cbbb43cc651296dd1ba67e07eb1499R31): Added `@pytest.mark.slow` to `test_interpret_onnx` and `test_make_jax_logp_ops`. [[1]](diffhunk://#diff-5cd6ac8322dfce63a84995dd91b5195ca9cbbb43cc651296dd1ba67e07eb1499R31) [[2]](diffhunk://#diff-5cd6ac8322dfce63a84995dd91b5195ca9cbbb43cc651296dd1ba67e07eb1499R104)
* [`tests/test_plotting.py`](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caR154): Added `@pytest.mark.slow` to `test_plot_posterior_predictive` and `test_plot_quantile_probability`. [[1]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caR154) [[2]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caR293)
* [`tests/test_plotting_cartoon.py`](diffhunk://#diff-10ee255df09bc2bfb6b8203646e34e54e41a0ab608ee3d85b87f05006999e053R13): Added `@pytest.mark.slow` to parameterized tests. [[1]](diffhunk://#diff-10ee255df09bc2bfb6b8203646e34e54e41a0ab608ee3d85b87f05006999e053R13) [[2]](diffhunk://#diff-10ee255df09bc2bfb6b8203646e34e54e41a0ab608ee3d85b87f05006999e053R70)
* [`tests/test_register.py`](diffhunk://#diff-4682147ca75340613cbb9d69a15bab4961497d49b9e56be0a456ff30ba33f46bR13): Added `@pytest.mark.slow` to `test_register_model`.
* [`tests/test_sample_posterior_predictive.py`](diffhunk://#diff-d0cff945d4ea462343e04dd4be31400115809d946c8f0149995f11f44eefb083R32): Added `@pytest.mark.slow` to `test_sample_posterior_predictive`.
* [`tests/test_save_load.py`](diffhunk://#diff-f5690fd26a7ac571eb0e8d97f4e145c62c1ff8c6eb6e5b116553c0e307adb1c4R25): Added `@pytest.mark.slow` to `test_save_load_model_only`.