### PR TITLE
Extract lapse model application

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -419,10 +419,13 @@ def _apply_lapse_model(
         )
 
     out_shape = sims_out.shape[:-1]
+    # Handle array-like p_outlier
     if isinstance(p_outlier, np.ndarray):
-        if p_outlier.shape[-1] == 1:
+        if p_outlier.ndim == 0:  # scalar array
+            p_outlier = float(p_outlier)
+        elif p_outlier.shape[-1] == 1:  # vector with single value
             p_outlier = np.broadcast_to(p_outlier, out_shape)
-        else:
+        else:  # reshape to match output shape
             p_outlier = p_outlier.reshape(out_shape)
     else:  # p_outlier is a float/scalar
         p_outlier = np.full(out_shape, p_outlier)

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -370,45 +370,88 @@ def make_hssm_rv(
                         (*max_shape[:-1], max_shape[-1], n_replicas, obs_dim_int)
                     )
 
-            if p_outlier is not None:
-                assert cls._lapse is not None, (
-                    "You have specified `p_outlier`, the probability of the lapse "
-                    + "distribution but did not specify the distribution."
-                )
-                out_shape = sims_out.shape[:-1]
-                if not np.isscalar(p_outlier) and len(p_outlier.shape) > 0:
-                    if p_outlier.shape[-1] == 1:
-                        p_outlier = np.broadcast_to(p_outlier, out_shape)
-                    else:
-                        p_outlier = p_outlier.reshape(out_shape)
-
-                replace = rng.binomial(n=1, p=p_outlier, size=out_shape).astype(bool)
-                replace_n = int(np.sum(replace, axis=None))
-                if replace_n == 0:
-                    return sims_out
-
-                replace_shape = (*out_shape[:-1], replace_n)
-                replace_mask = np.stack([replace, replace], axis=-1)
-                n_draws = np.prod(replace_shape)
-                lapse_rt = pm.draw(
-                    get_distribution_from_prior(cls._lapse).dist(**cls._lapse.args),
-                    n_draws,
-                    random_seed=rng,
-                ).reshape(replace_shape)
-
-                lapse_response = rng.choice(
-                    choices,
-                    p=1 / len(choices) * np.ones(len(choices)),
-                    size=replace_shape,
-                )
-                lapse_output = np.stack(
-                    [lapse_rt, lapse_response],
-                    axis=-1,
-                )
-                np.putmask(sims_out, replace_mask, lapse_output)
+            sims_out = _apply_lapse_model(
+                sims_out=sims_out,
+                p_outlier=p_outlier,
+                rng=rng,
+                lapse_dist=cls._lapse,
+                choices=choices,
+            )
             return sims_out
 
     return HSSMRV
+
+
+def _apply_lapse_model(
+    sims_out: np.ndarray,
+    p_outlier: np.ndarray | float | None,
+    rng: np.random.Generator,
+    lapse_dist: bmb.Prior | None,
+    choices: list,
+) -> np.ndarray:
+    """Apply lapse model to the simulation output.
+
+    Parameters
+    ----------
+    sims_out : np.ndarray
+        The simulation output to apply lapse model to
+    p_outlier : np.ndarray | float
+        Probability of outlier/lapse for each trial
+    rng : np.random.Generator
+        Random number generator
+    lapse_dist : bmb.Prior
+        The lapse distribution to draw from
+    choices : list
+        List of possible choices
+
+    Returns
+    -------
+    np.ndarray
+        The simulation output with lapse model applied
+    """
+    if p_outlier is None:
+        return sims_out
+
+    if lapse_dist is None:
+        raise ValueError(
+            "You have specified `p_outlier`, the probability of the lapse "
+            "distribution but did not specify the distribution."
+        )
+
+    out_shape = sims_out.shape[:-1]
+    if isinstance(p_outlier, np.ndarray):
+        if p_outlier.shape[-1] == 1:
+            p_outlier = np.broadcast_to(p_outlier, out_shape)
+        else:
+            p_outlier = p_outlier.reshape(out_shape)
+    else:  # p_outlier is a float/scalar
+        p_outlier = np.full(out_shape, p_outlier)
+
+    replace = rng.binomial(n=1, p=p_outlier, size=out_shape).astype(bool)
+    replace_n = int(np.sum(replace, axis=None))
+    if replace_n == 0:
+        return sims_out
+
+    replace_shape = (*out_shape[:-1], replace_n)
+    replace_mask = np.stack([replace, replace], axis=-1)
+    n_draws = np.prod(replace_shape)
+    lapse_rt = pm.draw(
+        get_distribution_from_prior(lapse_dist).dist(**lapse_dist.args),
+        n_draws,
+        random_seed=rng,
+    ).reshape(replace_shape)
+
+    lapse_response = rng.choice(
+        choices,
+        p=1 / len(choices) * np.ones(len(choices)),
+        size=replace_shape,
+    )
+    lapse_output = np.stack(
+        [lapse_rt, lapse_response],
+        axis=-1,
+    )
+    np.putmask(sims_out, replace_mask, lapse_output)
+    return sims_out
 
 
 def make_distribution(

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -419,7 +419,12 @@ def _apply_lapse_model(
         )
 
     out_shape = sims_out.shape[:-1]
-    # Handle array-like p_outlier
+
+    # Handle p_outlier shape/type to ensure consistent shape:
+    # - 0-dim numpy array (scalar array) -> convert to float
+    # - 1-dim array with single value -> broadcast to match output shape
+    # - n-dim array -> reshape to match output shape
+    # - Python scalar (float) -> fill array of output shape
     if isinstance(p_outlier, np.ndarray):
         if p_outlier.ndim == 0:  # scalar array
             p_outlier = float(p_outlier)


### PR DESCRIPTION
This pull request introduces changes to the `src/hssm/distribution_utils/dist.py` file to refactor the lapse model application into a separate function and improve code clarity. The most important changes include the creation of a new function `_apply_lapse_model`, updates to the `rng_fn` function to use this new helper, and minor adjustments to the lapse model application logic.

Refactoring and code clarity improvements:

* [`src/hssm/distribution_utils/dist.py`](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL373-R428): Extracted the lapse model application logic into a new function `_apply_lapse_model` to improve code readability and maintainability.
* [`src/hssm/distribution_utils/dist.py`](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL394-R439): Updated the `rng_fn` function to call the new `_apply_lapse_model` function, streamlining the lapse model application process. [[1]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL394-R439) [[2]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL411-L412)

These changes enhance the structure of the code, making it easier to understand and maintain.