### PR TITLE
Update check notebooks workflow

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -14,16 +14,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.11"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: ./.github/setup-env
-        with:
-          python-version: ${{ matrix.python-version }}
+        run: uv sync --group notebook
 
       - name: Run notebooks
         run: make run-notebooks

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -26,17 +26,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run notebooks
-        run: |
-          echo "Running notebooks with Python ${{ matrix.python-version }}"
-          EXIT_CODE=0
-          for notebook in $(find docs -name "*.ipynb"); do
-            echo "Cleaning $notebook"
-            uv run nb-clean clean -o "$notebook"
-            if ! uv run jupyter nbconvert --ExecutePreprocessor.timeout=10000 --to notebook --execute "$notebook"; then
-              echo "::error::Failed to execute notebook: $notebook"
-              EXIT_CODE=1
-            fi
-          done
-          exit $EXIT_CODE
+        run: make run-notebooks
         env:
           PYTENSOR_FLAGS: ${{ env.PYTENSOR_FLAGS }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+run-notebooks:
+	@echo "Running notebooks with $$(python --version)"
+	@EXIT_CODE=0; \
+	for notebook in $$(find docs -name "*.ipynb"); do \
+		echo "Cleaning $$notebook"; \
+		uv run nb-clean clean -o "$$notebook"; \
+		if ! uv run jupyter nbconvert --ExecutePreprocessor.timeout=10000 --to notebook --execute "$$notebook"; then \
+			echo "Failed to execute notebook: $$notebook"; \
+			EXIT_CODE=1; \
+		fi; \
+	done; \
+	exit $$EXIT_CODE


### PR DESCRIPTION
This pull request updates the workflow for checking notebooks by simplifying the setup process and delegating notebook execution to a `Makefile` target. It also updates the Python version used in the workflow matrix.

Workflow updates:

* [`.github/workflows/check_notebooks.yml`](diffhunk://#diff-3f338ef1568369e46ada472671dc31795e05ea14413f40311e9aca062b227d16L17-R27): Changed the Python version in the matrix from `3.12` to `3.11`. Replaced the `setup-env` action with a `uv sync` command for environment setup. Delegated the notebook execution process to the `make run-notebooks` command for better modularity.

Makefile addition:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R12): Added a new `run-notebooks` target to handle notebook cleaning and execution. This centralizes the notebook-related logic and improves maintainability.