### PR TITLE
Quick fixes of some unit tests

### DIFF
--- a/src/hssm/data_validator.py
+++ b/src/hssm/data_validator.py
@@ -97,7 +97,7 @@ class DataValidator:
 
         if len(unique_responses) != self.n_choices:
             missing_responses = sorted(
-                np.setdiff1d(self.choices, unique_responses).to_list()
+                np.setdiff1d(self.choices, unique_responses).tolist()
             )
             warnings.warn(
                 (

--- a/src/hssm/data_validator.py
+++ b/src/hssm/data_validator.py
@@ -89,14 +89,16 @@ class DataValidator:
 
         if np.any(~np.isin(unique_responses, self.choices)):
             invalid_responses = sorted(
-                unique_responses[~np.isin(unique_responses, self.choices)]
+                unique_responses[~np.isin(unique_responses, self.choices)].tolist()
             )
             raise ValueError(
                 f"Invalid responses found in your dataset: {invalid_responses}"
             )
 
         if len(unique_responses) != self.n_choices:
-            missing_responses = sorted(np.setdiff1d(self.choices, unique_responses))
+            missing_responses = sorted(
+                np.setdiff1d(self.choices, unique_responses).to_list()
+            )
             warnings.warn(
                 (
                     f"You set choices to be {self.choices}, but {missing_responses} "

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -23,7 +23,7 @@ pymc_dist_args = ["rng", "initval", "dims", "observed", "total_size", "transform
 
 
 # mypy: disable-error-code="has-type"
-class Prior(bmb.Prior):
+class Prior(bmb.Prior):  # noqa: PLW1641
     """Abstract specification of a prior.
 
     Parameters

--- a/tests/param/test_param.py
+++ b/tests/param/test_param.py
@@ -7,9 +7,9 @@ from hssm.param.param import Param
 
 def test_bounds_validation():
     """Test that the bounds are validated correctly."""
-    with pytest.raises(ValueError, match="Invalid bounds: \(0, 0, 1\)"):
+    with pytest.raises(ValueError, match=r"Invalid bounds: \(0, 0, 1\)"):
         Param(name="test", prior=0, bounds=(0, 0, 1))
-    with pytest.raises(ValueError, match="Invalid bounds: \(1, 0\)"):
+    with pytest.raises(ValueError, match=r"Invalid bounds: \(1, 0\)"):
         Param(name="test", prior=0, bounds=(1, 0))
 
 

--- a/tests/param/test_user_param.py
+++ b/tests/param/test_user_param.py
@@ -5,9 +5,9 @@ from hssm.param import UserParam
 
 def test_bounds_validation():
     """Test that the bounds are validated correctly."""
-    with pytest.raises(ValueError, match="Invalid bounds: \(0, 0, 1\)"):
+    with pytest.raises(ValueError, match=r"Invalid bounds: \(0, 0, 1\)"):
         UserParam(name="test", prior=0, bounds=(0, 0, 1))
-    with pytest.raises(ValueError, match="Invalid bounds: \(1, 0\)"):
+    with pytest.raises(ValueError, match=r"Invalid bounds: \(1, 0\)"):
         UserParam(name="test", prior=0, bounds=(1, 0))
 
 


### PR DESCRIPTION
One unit test starts to fail possibly because of how the new numpy handles print output. This PR fixes this and suppresses a few DeprecationWarnings that will become SyntaxErrors in Python 3.12