### PR TITLE
Use `jaxonnxruntime` for onnx model conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "hddm-wfpt>=0.1.5",
     "huggingface-hub>=0.34.0",
+    "jaxonnxruntime>=0.3.0",
     "numpyro>=0.19",
     "onnx>=1.16.0",
     "pymc>=5.25.0",
@@ -56,6 +57,8 @@ dev = [
     "pyarrow>=20.0.0",
     "lanfactory>=0.5.3",
     "HSSM[test]",
+    "bayeux-ml==0.1.15",
+    "flowmc==0.3.4",
 ]
 
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,6 @@ dev = [
     "pyarrow>=20.0.0",
     "lanfactory>=0.5.3",
     "HSSM[test]",
-    "bayeux-ml==0.1.15",
-    "flowmc==0.3.4",
 ]
 
 test = [

--- a/src/hssm/distribution_utils/onnx.py
+++ b/src/hssm/distribution_utils/onnx.py
@@ -104,7 +104,7 @@ def make_jax_logp_funcs_from_onnx(
                 param_vector = param_vector.squeeze(axis=-1)
             input_vector = jnp.concatenate((param_vector, data))
 
-        return jax_func(input_vector)[0].squeeze()
+        return jax_func(input_vector)
 
     if params_only and scalars_only:
         logp_vec = lambda *inputs: logp(*inputs).reshape((1,))
@@ -218,6 +218,6 @@ def make_jax_matrix_logp_funcs_from_onnx(
         jnp.ndarray
             The element-wise log-likelihoods.
         """
-        return jax_func(input_matrix)[0].squeeze()
+        return jax_func(input_matrix)
 
     return logp

--- a/src/hssm/distribution_utils/onnx.py
+++ b/src/hssm/distribution_utils/onnx.py
@@ -17,8 +17,8 @@ from numpy.typing import ArrayLike
 from .._types import LogLikeFunc, LogLikeGrad
 from .jax import make_vmap_func
 from .onnx_utils.model import load_onnx_model
+from .onnx_utils.onnx2jax import make_jax_func
 from .onnx_utils.onnx2pt import pt_interpret_onnx
-from .onnx_utils.onnx2xla import interpret_onnx
 
 
 @overload
@@ -74,6 +74,7 @@ def make_jax_logp_funcs_from_onnx(
     """
     model_onnx = load_onnx_model(model)
     scalars_only = all(not is_reg for is_reg in params_is_reg)
+    jax_func = make_jax_func(model_onnx)
 
     def logp(*inputs) -> np.ndarray:
         """Compute the log-likelihood.
@@ -103,7 +104,7 @@ def make_jax_logp_funcs_from_onnx(
                 param_vector = param_vector.squeeze(axis=-1)
             input_vector = jnp.concatenate((param_vector, data))
 
-        return interpret_onnx(model_onnx.graph, input_vector)[0].squeeze()
+        return jax_func(input_vector)[0].squeeze()
 
     if params_only and scalars_only:
         logp_vec = lambda *inputs: logp(*inputs).reshape((1,))
@@ -198,6 +199,7 @@ def make_jax_matrix_logp_funcs_from_onnx(
         log-likelihoods.
     """
     model_onnx = load_onnx_model(model)
+    jax_func = make_jax_func(model_onnx)
 
     def logp(input_matrix) -> np.ndarray:
         """Compute the log-likelihood.
@@ -216,6 +218,6 @@ def make_jax_matrix_logp_funcs_from_onnx(
         jnp.ndarray
             The element-wise log-likelihoods.
         """
-        return interpret_onnx(model_onnx.graph, input_matrix)[0].squeeze()
+        return jax_func(input_matrix)[0].squeeze()
 
     return logp

--- a/src/hssm/distribution_utils/onnx_utils/onnx2jax.py
+++ b/src/hssm/distribution_utils/onnx_utils/onnx2jax.py
@@ -1,0 +1,41 @@
+"""Use jaxonnxruntime to convert ONNX models to JAX functions."""
+
+from typing import Callable
+
+import jax
+import numpy as np
+import onnx
+from jaxonnxruntime import call_onnx
+
+
+def make_jax_func(onnx_model: onnx.ModelProto) -> Callable:
+    """Convert an ONNX model to a JAX function using jaxonnxruntime.
+
+    Parameters
+    ----------
+    onnx_model : onnx.ModelProto
+        The ONNX model to be converted.
+
+    Returns
+    -------
+    Callable
+        A JAX function that represents the ONNX model.
+    """
+    model_graph = onnx_model.graph
+
+    # Get the input name and shape from the ONNX model to create a dummy input for
+    # initialization.
+    input_name = model_graph.input[0].name
+    input_dims = tuple(
+        dim.dim_value if (dim.dim_value > 0) else 1
+        for dim in model_graph.input[0].type.tensor_type.shape.dim
+    )
+    model_func, model_weights = call_onnx.call_onnx_model(
+        onnx_model, {input_name: np.ones(input_dims)}
+    )
+
+    # Create a JAX function that takes the input and applies the ONNX model.
+    run_func = jax.tree_util.Partial(model_func, model_weights)
+    jax_func = lambda x: run_func({input_name: x})
+
+    return jax_func

--- a/src/hssm/distribution_utils/onnx_utils/onnx2jax.py
+++ b/src/hssm/distribution_utils/onnx_utils/onnx2jax.py
@@ -36,6 +36,6 @@ def make_jax_func(onnx_model: onnx.ModelProto) -> Callable:
 
     # Create a JAX function that takes the input and applies the ONNX model.
     run_func = jax.tree_util.Partial(model_func, model_weights)
-    jax_func = lambda x: run_func({input_name: x})
+    jax_func = lambda x: run_func({input_name: x})[0].squeeze()
 
     return jax_func


### PR DESCRIPTION
`jaxonnxruntime` is a package maintained by Google that converts most onnx `op`s to JAX functions way beyond what we support right now. This PR creates a drop-in replacement to the `interpret_onnx` function that we had for JAX model conversion and all downstream tasks