### PR TITLE
only include src/hssm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,14 @@ markers = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "docs/**",            # remove all docs content from the source tarball
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/hssm"]  # keep as-is so only package code goes into the wheel
+
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"


### PR DESCRIPTION
Getting pypi complains about file size. 
In general makes sense to slim down the actual build?