### PR TITLE
Add exclusion of docs directory in sdist build configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,9 @@ markers = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.sdist]
+exclude = ["docs"]
+
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"


### PR DESCRIPTION
This pull request introduces a configuration update to the Python project build process by modifying the `pyproject.toml` file. The main change is the exclusion of the `docs` directory from the source distribution build, which helps keep distribution packages smaller and more focused.

Build process improvements:

* Updated `[tool.hatch.build.targets.sdist]` in `pyproject.toml` to exclude the `docs` directory from source distributions.