### PR TITLE
Fixed badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/HSSM?link=https%3A%2F%2Fpypi.org%2Fproject%2Fhssm%2F)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hssm)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/HSSM)
-[![CI](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml/badge.svg?branch=main)](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml)
+[![CI](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml/badge.svg)](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![codecov](https://codecov.io/gh/lnccbrown/HSSM/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/HSSM)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,14 @@ authors = [
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
-repository = "https://github.com/lnccbrown/HSSM"
 keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
 requires-python = ">=3.11,<3.13"
 classifiers = [
-  "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -37,6 +36,11 @@ dependencies = [
     "ssm-simulators>=0.11.1",
     "tqdm>=4.66.0",
 ]
+
+[project.urls]
+homepage = "https://lnccbrown.github.io/HSSM/"
+documentation = "https://lnccbrown.github.io/HSSM/"
+repository = "https://github.com/lnccbrown/HSSM"
 
 [project.optional-dependencies]
 cuda12 = ["jax[cuda12]>=0.5.2"]
@@ -217,11 +221,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
-  "docs/**",            # remove all docs content from the source tarball
+    "docs/**", # remove all docs content from the source tarball
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/hssm"]  # keep as-is so only package code goes into the wheel
+packages = ["src/hssm"] # keep as-is so only package code goes into the wheel
 
 [[tool.uv.index]]
 name = "pypi"


### PR DESCRIPTION
I updated the package metadata (mainly just took out the `repository` definition which should not be there (could be a remnant of poetry), which helped the `classifiers` section to show up on test pypi. This should correct the python version badge (won't know until we push a new version to pypi, which I didn't do for this PR. We shouldn't push a new version just to update metadata)

I also updated the badge for our test workflow. It is working now

<img width="278" height="835" alt="image" src="https://github.com/user-attachments/assets/a361159d-12f2-45c9-a9d0-0046f9c97def" />
