### PR TITLE
Mark plotting tests as slow

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -81,7 +81,7 @@ class TestPlotting:
         """Test _get_posterior_samples."""
         if expected == "error":
             with pytest.raises(ValueError):
-                df = _xarray_to_df(posterior, n_samples=n_samples)
+                _xarray_to_df(posterior, n_samples=n_samples)
         else:
             df = _xarray_to_df(posterior, n_samples=n_samples)
             if n_samples and n_samples > posterior.draw.size:


### PR DESCRIPTION
This pull request refactors the plotting test suite in `tests/test_plotting.py` to improve organization and maintainability by grouping all plotting-related tests into a single `TestPlotting` class. This change also converts previously standalone test functions into methods within this class, making the test structure more consistent and easier to extend. Minor code cleanups and formatting improvements are included as part of this refactor.

Test suite restructuring:

* All plotting-related test functions have been grouped into a single `TestPlotting` class, marked as slow with `@pytest.mark.slow`, improving organization and clarity of the test suite.
* Standalone test functions have been converted into methods of the `TestPlotting` class, with appropriate changes to indentation and method signatures. [[1]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL63-R80) [[2]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL82-R108) [[3]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL113-R131) [[4]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL128-R145) [[5]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL152-R168) [[6]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL231-R246) [[7]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL253-L278) [[8]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL290-L302) [[9]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL328-L340) [[10]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL358-R346) [[11]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL405-R393) [[12]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL434-R421) [[13]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL504-R492) [[14]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL517-R503) [[15]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL604-R591) [[16]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL671-R659) [[17]](diffhunk://#diff-b8aa68d38b59341f74e2277bc6fde44b917d597363ebfd7bf613743d7098a7caL738-R727)
