### PR TITLE
Add absl-py as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "absl-py>=2.3.1",
     "arviz>=0.22.0",
     "bambi>=0.15.0, <0.16.0",
     "cloudpickle>=3.0.0",


### PR DESCRIPTION
This pull request introduces a minor update to the project dependencies in `pyproject.toml`. The change adds a new required package to the list.

* Added `absl-py>=2.3.1` to the `dependencies` array in `pyproject.toml`, ensuring this package will be installed with the project.