### PR TITLE
Refactor ellipse visual test to use temporary directory for output

### DIFF
--- a/tests/test_ellipse_qp.py
+++ b/tests/test_ellipse_qp.py
@@ -1,14 +1,13 @@
 """Quick test of the ellipse plotting functionality for quantile probability plots."""
 
+import tempfile
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import pytest
 
-# Import the helper functions
-import sys
-
-sys.path.insert(0, "src")
 
 from hssm.plotting.quantile_probability import (
     _confidence_to_n_std,
@@ -182,8 +181,10 @@ def test_ellipse_visual():
         ax.grid(True, alpha=0.3)
 
     plt.tight_layout()
-    plt.savefig("test_ellipse_output.png", dpi=100, bbox_inches="tight")
-    print("  ✓ Visual test saved to test_ellipse_output.png")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "test_ellipse_output.png"
+        plt.savefig(output_path, dpi=100, bbox_inches="tight")
+        print(f"  ✓ Visual test saved to {output_path}")
     plt.close()
 
 


### PR DESCRIPTION
This pull request makes small improvements to the `test_ellipse_qp.py` test file, specifically updating how test output files are handled to avoid polluting the working directory.

- Test output management:
  * Changed the visual test in `test_ellipse_qp.py` to save the output image in a temporary directory using Python's `tempfile` and `pathlib` modules, rather than saving directly to the project directory. This helps keep the workspace clean and ensures test artifacts are properly managed. [[1]](diffhunk://#diff-82e2772da30fab354a020ac72d445d88407028c84de221cc171ad27d9338d5ceR3-L11) [[2]](diffhunk://#diff-82e2772da30fab354a020ac72d445d88407028c84de221cc171ad27d9338d5ceL185-R187)