### PR TITLE
improve naming to make logic clearer

### DIFF
--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -719,8 +719,15 @@ def make_likelihood_callable(
         A list of boolean values indicating whether the parameters are regression
         parameters. Defaults to None.
     params_only : Optional
-        Whether the missing data likelihood is takes its first argument as the data.
-        Defaults to None.
+        Controls the expected signature of the ``loglik`` callable.
+        If False (the default when None), the callable signature is
+        ``f(data, *params)``, where ``data`` is a 2-column array of
+        [rt, choice].  This is the standard case for LANs and other
+        likelihoods that condition on observed data.
+        If True, the callable signature is ``f(*params)`` with no data
+        argument.  This is used for Choice Probability Networks (CPNs)
+        and Outcome Probability Networks (OPNs).
+        Defaults to None (treated as False).
     """
     if isinstance(loglik, pytensor.graph.Op):
         return loglik

--- a/src/hssm/distribution_utils/onnx.py
+++ b/src/hssm/distribution_utils/onnx.py
@@ -53,7 +53,14 @@ def make_jax_logp_funcs_from_onnx(
         Parameters that are regressions will not be vectorized in likelihood
         calculations.
     params_only:
-        If True, the log-likelihood function will only take parameters as input.
+        Controls the expected signature of the ``logp`` callable.
+        If False (default), the callable signature is ``f(data, *params)``,
+        where ``data`` is a 2-column array of [rt, choice].  This is the
+        standard case for LANs and other likelihoods that condition on
+        observed data.
+        If True, the callable signature is ``f(*params)`` with no data
+        argument.  This is used for Choice Probability Networks (CPNs)
+        and Outcome Probability Networks (OPNs).
     return_jit
         If `True`, the function will return a JIT-compiled version of the vectorized
         logp function, its VJP, and the non-jitted version of the logp function.


### PR DESCRIPTION
The way params_only was used before was highly confusing as it propagated through the function calls. It had one meaning and then suddenly flipped it's meaning conceptually. 

This rename should make it clearer what it is actually doing at the level of the jax function constructors.