### PR TITLE
fix: flaky test in test_data_validator 

### DIFF
--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -1,4 +1,3 @@
-import random
 from typing import Callable
 
 import pytest
@@ -140,12 +139,12 @@ def test_post_check_data_sanity_valid(base_data):
         n_choices=3,
     )
 
-    invalid_response = random.choice(range(3, 100))
-    dv_instance_no_missing.data.iloc[0, 1] = invalid_response
+    invalid_response = max(dv_instance_no_missing.choices) + 1
+    dv_instance_no_missing.data.loc[0, "response"] = invalid_response
     with pytest.raises(ValueError, match=f"Invalid responses found in your dataset: "):
         dv_instance_no_missing._post_check_data_sanity()
 
-    dv_instance_no_missing.data.iloc[0, 1] = 1  # Reset to valid response
+    dv_instance_no_missing.data.loc[0, "response"] = 1  # Reset to valid response
     with pytest.warns(
         UserWarning,
         match=(r"missing from your dataset"),


### PR DESCRIPTION
…range

The test sets choices=[0, 1, 2] but picks a supposedly invalid response from range(2, 100). When random.choice returns 2, the response is actually valid and no ValueError is raised, causing a flaky failure. Changed to range(3, 100) to guarantee an invalid choice.
