### PR TITLE
Cpaniaguam/add rlssm model registry

### DIFF
--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -1,0 +1,449 @@
+"""Registry for named RLSSM models and SSM base log-likelihood functions.
+
+This module provides:
+
+- :data:`_SSM_REGISTRY` — maps SSM names (e.g. ``"angle"``) to their base
+  annotated JAX log-likelihood functions and parameter metadata.
+- :data:`_RLSSM_REGISTRY` — maps named RLSSM model strings (e.g. ``"rldm"``)
+  to their default decision process, learning process, and parameter info.
+- :func:`get_rlssm_model_config` — builds a :class:`~hssm.rl.config.RLSSMConfig`
+  from a named model string with optional overrides.
+- :func:`register_rlssm_model` — register a custom named RLSSM model.
+- :func:`register_ssm` — register a custom SSM base logp function.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
+from hssm.rl.likelihoods.two_armed_bandit import compute_v_subject_wise
+from hssm.utils import annotate_function
+
+from .config import RLSSMConfig
+
+_logger = logging.getLogger("hssm")
+
+# ---------------------------------------------------------------------------
+# Default annotated Rescorla-Wagner learning function
+# ---------------------------------------------------------------------------
+
+_compute_v_annotated = annotate_function(
+    inputs=["rl_alpha", "scaler", "response", "feedback"],
+    outputs=["v"],
+)(compute_v_subject_wise)
+
+# ---------------------------------------------------------------------------
+# SSM base log-likelihood registry
+# ---------------------------------------------------------------------------
+# Each entry provides:
+#   ssm_base_logp_func  - annotated JAX function (inputs + outputs, no computed)
+#   list_params_ssm     - ordered SSM parameter names (including computed ones)
+#   bounds_ssm          - bounds for non-computed SSM params
+#   params_default_ssm  - default values aligned with list_params_ssm
+#   response            - data column names
+
+
+def _make_angle_base_logp() -> Any:
+    """Build the annotated angle SSM base logp function from its ONNX file."""
+    _raw = make_jax_matrix_logp_funcs_from_onnx(model="angle.onnx")
+    return annotate_function(
+        inputs=["v", "a", "z", "t", "theta", "rt", "response"],
+        outputs=["logp"],
+    )(_raw)
+
+
+_SSM_REGISTRY: dict[str, dict[str, Any]] = {
+    "angle": {
+        # Factory callable — invoked lazily on first use via _get_ssm_logp().
+        # Storing a callable (not the result) avoids loading angle.onnx at
+        # import time (which would trigger hf_hub_download in offline envs).
+        "ssm_base_logp_func_factory": _make_angle_base_logp,
+        # All SSM params in the order the SSM expects them (includes computed).
+        "list_params_ssm": ["v", "a", "z", "t", "theta"],
+        # Bounds only for params that will be *sampled* (not RL-computed).
+        "bounds_ssm": {
+            "a": (0.3, 3.0),
+            "z": (0.1, 0.9),
+            "t": (0.001, 2.0),
+            "theta": (-0.1, 1.3),
+        },
+        # Defaults aligned with list_params_ssm: v, a, z, t, theta
+        "params_default_ssm": [0.0, 1.5, 0.5, 0.5, 0.0],
+        "response": ["rt", "response"],
+    },
+}
+
+# Cache for resolved SSM base logp functions (populated on first use by
+# _get_ssm_logp, or immediately by register_ssm when a pre-built func is
+# supplied by the caller).
+_SSM_LOGP_CACHE: dict[str, Any] = {}
+
+
+def _get_ssm_logp(name: str) -> Any:
+    """Return the annotated SSM base logp function, building it on first use.
+
+    For built-in SSMs the ONNX model is downloaded / loaded only when this
+    function is first called (lazy initialisation).  Subsequent calls return
+    the cached object without any I/O.
+    """
+    if name not in _SSM_LOGP_CACHE:
+        if name not in _SSM_REGISTRY:
+            raise KeyError(
+                f"SSM '{name}' not found in the SSM registry. "
+                f"Available: {list(_SSM_REGISTRY.keys())}. "
+                "Use register_ssm() to add it."
+            )
+        entry = _SSM_REGISTRY[name]
+        if "ssm_base_logp_func_factory" in entry:
+            _SSM_LOGP_CACHE[name] = entry["ssm_base_logp_func_factory"]()
+        else:
+            # Pre-built function registered via register_ssm().
+            _SSM_LOGP_CACHE[name] = entry["ssm_base_logp_func"]
+    return _SSM_LOGP_CACHE[name]
+
+
+# ---------------------------------------------------------------------------
+# RLSSM named model registry
+# ---------------------------------------------------------------------------
+# Each entry provides:
+#   decision_process            - key into _SSM_REGISTRY
+#   learning_process            - {param: annotated_func}
+#   rl_params                   - ordered list of sampled RL parameter names
+#   rl_bounds                   - {param: (lo, hi)} for RL params
+#   rl_params_default           - default values aligned with rl_params
+#   extra_fields                - extra data column names required by LP
+#   choices                     - response choice values
+#   description                 - human-readable description
+#   decision_process_loglik_kind
+#   learning_process_kind
+
+_RLSSM_REGISTRY: dict[str, dict[str, Any]] = {
+    "rldm": {
+        "decision_process": "angle",
+        "learning_process": {"v": _compute_v_annotated},
+        "rl_params": ["rl_alpha", "scaler"],
+        "rl_bounds": {
+            "rl_alpha": (0.0, 1.0),
+            "scaler": (0.0, 10.0),
+        },
+        "rl_params_default": [0.1, 1.0],
+        "extra_fields": ["feedback"],
+        "choices": [0, 1],
+        "description": (
+            "RLSSM model with Rescorla-Wagner Q-learning and a "
+            "collapsing-bound DDM (angle model) as decision process."
+        ),
+        "decision_process_loglik_kind": "approx_differentiable",
+        "learning_process_kind": "blackbox",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_ssm_logp_func(ssm_base_logp_func: Any, learning_process: dict) -> Any:
+    """Re-annotate *ssm_base_logp_func* adding ``computed=learning_process``.
+
+    Creates a new wrapper that carries the same ``.inputs`` and ``.outputs`` as
+    the base function but adds the ``computed`` dict so that
+    :func:`~hssm.rl.likelihoods.builder.make_rl_logp_op` can resolve which
+    parameters are produced by the RL learning rule at runtime.
+    """
+    existing = getattr(ssm_base_logp_func, "computed", None)
+    if existing:
+        raise ValueError(
+            "ssm_base_logp_func already has a non-empty .computed attribute. "
+            "Pass the raw (base) annotated function without .computed instead."
+        )
+    return annotate_function(
+        inputs=ssm_base_logp_func.inputs,
+        outputs=ssm_base_logp_func.outputs,
+        computed=learning_process,
+    )(ssm_base_logp_func)
+
+
+def _derive_rl_params(
+    learning_process: dict[str, Any],
+    response: list[str],
+    extra_fields: list[str],
+) -> list[str]:
+    """Return sampled RL parameter names inferred from *learning_process*.
+
+    Iterates over each LP function's ``.inputs`` and collects names that are
+    neither response columns nor extra fields.
+    """
+    exclude = set(response) | set(extra_fields)
+    rl_params: list[str] = []
+    seen: set[str] = set()
+    for param_name, lp_func in learning_process.items():
+        if not hasattr(lp_func, "inputs"):
+            _logger.warning(
+                "Learning process function for '%s' has no .inputs attribute; "
+                "cannot derive RL parameters from it. "
+                "Ensure it is decorated with @annotate_function.",
+                param_name,
+            )
+            continue
+        for inp in lp_func.inputs:
+            if inp not in exclude and inp not in seen:
+                rl_params.append(inp)
+                seen.add(inp)
+    return rl_params
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+
+def get_rlssm_model_config(
+    model: str = "rldm",
+    choices: list[int] | None = None,
+    learning_process: dict[str, Any] | None = None,
+    decision_process: str | None = None,
+) -> RLSSMConfig:
+    """Build an :class:`~hssm.rl.config.RLSSMConfig` from a named model.
+
+    Parameters
+    ----------
+    model:
+        Name of a registered RLSSM model (e.g. ``"rldm"``).
+    choices:
+        Override the response choice values stored in the registry.
+    learning_process:
+        Override the learning process dict stored in the registry.
+    decision_process:
+        Override the SSM name stored in the registry.
+
+    Returns
+    -------
+    RLSSMConfig
+        Fully populated configuration ready to be passed to :class:`_RLSSM`.
+
+    Raises
+    ------
+    ValueError
+        If *model* or the resolved *decision_process* is not registered.
+    """
+    if model not in _RLSSM_REGISTRY:
+        available = list(_RLSSM_REGISTRY.keys())
+        raise ValueError(
+            f"Model '{model}' not found in the RLSSM registry. "
+            f"Available models: {available}. "
+            "To add a custom model, use register_rlssm_model() "
+            "(and register_ssm() for custom decision processes), "
+            "or pass 'model_config=' directly to RLSSM()."
+        )
+
+    # Shallow-copy so overrides don't mutate the registry entry.
+    entry = dict(_RLSSM_REGISTRY[model])
+
+    if learning_process is not None:
+        entry["learning_process"] = learning_process
+    if decision_process is not None:
+        entry["decision_process"] = decision_process
+    if choices is not None:
+        entry["choices"] = choices
+
+    dp: str = entry["decision_process"]
+    if dp not in _SSM_REGISTRY:
+        available_ssms = list(_SSM_REGISTRY.keys())
+        raise ValueError(
+            f"Decision process '{dp}' not found in the SSM registry. "
+            f"Available: {available_ssms}. Use register_ssm() to add it."
+        )
+
+    ssm_entry = _SSM_REGISTRY[dp]
+    ssm_base = _get_ssm_logp(dp)
+    lp: dict[str, Any] = entry["learning_process"]
+
+    # Compose the full ssm_logp_func with .computed = learning_process.
+    ssm_logp_func = _build_ssm_logp_func(ssm_base, lp)
+
+    # list_params = [sampled RL params] + [sampled SSM params (non-computed)]
+    computed_set = set(lp.keys())
+    ssm_sampled = [p for p in ssm_entry["list_params_ssm"] if p not in computed_set]
+
+    # Defensive copy of response to prevent downstream mutation of registry.
+    response = list(ssm_entry["response"])
+
+    # Use `is None` checks so that explicitly empty containers ([], {}) are
+    # respected as valid "no RL params" configuration and not overridden by
+    # the fallback derivation logic.
+    _rl_params = entry.get("rl_params")
+    rl_params: list[str] = (
+        _derive_rl_params(lp, response, entry.get("extra_fields") or [])
+        if _rl_params is None
+        else _rl_params
+    )
+    list_params = rl_params + ssm_sampled
+
+    # bounds: RL bounds ∪ SSM sampled bounds
+    _rl_bounds = entry.get("rl_bounds")
+    bounds: dict[str, tuple[float, float]] = dict(
+        _rl_bounds if _rl_bounds is not None else {}
+    )
+    for p in ssm_sampled:
+        if p in ssm_entry["bounds_ssm"]:
+            bounds[p] = ssm_entry["bounds_ssm"][p]
+
+    # params_default aligned with list_params
+    _rl_defaults = entry.get("rl_params_default")
+    rl_defaults: list[float] = list(_rl_defaults if _rl_defaults is not None else [])
+    ssm_all_defaults: list[float] = list(ssm_entry["params_default_ssm"])
+    ssm_sampled_defaults = [
+        ssm_all_defaults[i]
+        for i, p in enumerate(ssm_entry["list_params_ssm"])
+        if p not in computed_set
+    ]
+    params_default = rl_defaults + ssm_sampled_defaults
+
+    return RLSSMConfig(
+        model_name=entry.get("model_name", model),
+        description=entry.get("description"),
+        decision_process=dp,
+        decision_process_loglik_kind=entry["decision_process_loglik_kind"],
+        learning_process_kind=entry["learning_process_kind"],
+        learning_process=lp,
+        ssm_logp_func=ssm_logp_func,
+        list_params=list_params,
+        bounds=bounds,
+        params_default=params_default,
+        response=response,
+        choices=entry["choices"],
+        extra_fields=entry.get("extra_fields"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public registration helpers
+# ---------------------------------------------------------------------------
+
+
+def register_rlssm_model(
+    name: str,
+    decision_process: str,
+    learning_process: dict[str, Any],
+    rl_params: list[str],
+    rl_bounds: dict[str, tuple[float, float]],
+    rl_params_default: list[float],
+    extra_fields: list[str] | None = None,
+    choices: list[int] | None = None,
+    description: str | None = None,
+    decision_process_loglik_kind: str = "approx_differentiable",
+    learning_process_kind: str = "blackbox",
+) -> None:
+    """Register a named RLSSM model in the global registry.
+
+    Parameters
+    ----------
+    name:
+        Registry key (e.g. ``"my_rldm"``).
+    decision_process:
+        Name of the SSM to use (must already be in the SSM registry).
+    learning_process:
+        Dict mapping computed parameter name → annotated learning function.
+    rl_params:
+        Ordered list of sampled RL parameter names.
+    rl_bounds:
+        Parameter bounds for the RL parameters.
+    rl_params_default:
+        Default values aligned with *rl_params*.
+    extra_fields:
+        Data column names required by the learning process (e.g. ``["feedback"]``).
+    choices:
+        Response choice values. Defaults to ``[0, 1]``.
+    description:
+        Optional human-readable description.
+    decision_process_loglik_kind:
+        Loglik kind tag. Defaults to ``"approx_differentiable"``.
+    learning_process_kind:
+        Learning process kind tag. Defaults to ``"blackbox"``.
+    """
+    if name in _RLSSM_REGISTRY:
+        _logger.warning(
+            "Model '%s' is already in the RLSSM registry and will be overwritten.",
+            name,
+        )
+    _RLSSM_REGISTRY[name] = {
+        "decision_process": decision_process,
+        # Shallow-copy all mutable caller-supplied collections so that later
+        # mutations of the originals do not silently corrupt the registry entry.
+        "learning_process": dict(learning_process),
+        "rl_params": list(rl_params),
+        "rl_bounds": dict(rl_bounds),
+        "rl_params_default": list(rl_params_default),
+        "extra_fields": list(extra_fields) if extra_fields is not None else [],
+        "choices": list(choices) if choices is not None else [0, 1],
+        "description": description,
+        "decision_process_loglik_kind": decision_process_loglik_kind,
+        "learning_process_kind": learning_process_kind,
+    }
+
+
+def register_ssm(
+    name: str,
+    ssm_base_logp_func: Any,
+    list_params_ssm: list[str],
+    bounds_ssm: dict[str, tuple[float, float]],
+    params_default_ssm: list[float],
+    response: list[str] | None = None,
+) -> None:
+    """Register an SSM base log-likelihood function in the SSM registry.
+
+    Parameters
+    ----------
+    name:
+        Registry key (e.g. ``"ddm"``).
+    ssm_base_logp_func:
+        An annotated JAX function (created with ``@annotate_function``) that
+        computes the SSM log-likelihood from a parameter matrix.  Must carry
+        ``.inputs`` and ``.outputs`` attributes but should **not** have a
+        ``.computed`` key — that is injected by the factory at config-build time.
+    list_params_ssm:
+        Ordered list of all SSM parameter names (including any that will be
+        computed by the learning process).
+    bounds_ssm:
+        Bounds for the non-computed SSM parameters.
+    params_default_ssm:
+        Default values aligned with *list_params_ssm*.
+    response:
+        Data column names. Defaults to ``["rt", "response"]``.
+    """
+    if not callable(ssm_base_logp_func):
+        raise ValueError(
+            f"ssm_base_logp_func must be callable, got {type(ssm_base_logp_func)!r}."
+        )
+    if not hasattr(ssm_base_logp_func, "inputs") or not hasattr(
+        ssm_base_logp_func, "outputs"
+    ):
+        raise ValueError(
+            "ssm_base_logp_func must be decorated with @annotate_function "
+            "(missing .inputs or .outputs attribute)."
+        )
+    existing_computed = getattr(ssm_base_logp_func, "computed", None)
+    if existing_computed:
+        raise ValueError(
+            "ssm_base_logp_func should not have a non-empty .computed attribute "
+            "at registration time. The .computed dict is injected later by "
+            "get_rlssm_model_config() when composing the learning process. "
+            "Pass the raw base function instead."
+        )
+    if name in _SSM_REGISTRY:
+        _logger.warning(
+            "SSM '%s' is already in the SSM registry and will be overwritten.", name
+        )
+    _SSM_REGISTRY[name] = {
+        "ssm_base_logp_func": ssm_base_logp_func,
+        "list_params_ssm": list(list_params_ssm),
+        "bounds_ssm": dict(bounds_ssm),
+        "params_default_ssm": list(params_default_ssm),
+        "response": list(response) if response is not None else ["rt", "response"],
+    }
+    # Pre-built: cache immediately so _get_ssm_logp never calls a factory.
+    _SSM_LOGP_CACHE[name] = ssm_base_logp_func

--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -15,6 +15,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import Any
 
 from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
@@ -81,6 +82,25 @@ _SSM_REGISTRY: dict[str, dict[str, Any]] = {
 _SSM_LOGP_CACHE: dict[str, Any] = {}
 
 
+def _get_decision_process_spec(
+    decision_process: str | dict[str, Any],
+) -> dict[str, Any]:
+    """Return a defensive copy of a registered decision-process specification."""
+    if isinstance(decision_process, dict):
+        return deepcopy(decision_process)
+
+    if decision_process not in _SSM_REGISTRY:
+        available_ssms = list(_SSM_REGISTRY.keys())
+        raise ValueError(
+            f"Decision process '{decision_process}' not found in the SSM registry. "
+            f"Available: {available_ssms}. Use register_ssm() to add it."
+        )
+
+    spec = deepcopy(_SSM_REGISTRY[decision_process])
+    spec["name"] = decision_process
+    return spec
+
+
 def _get_ssm_logp(name: str) -> Any:
     """Return the annotated SSM base logp function, building it on first use.
 
@@ -121,7 +141,7 @@ def _get_ssm_logp(name: str) -> Any:
 
 _RLSSM_REGISTRY: dict[str, dict[str, Any]] = {
     "rldm": {
-        "decision_process": "angle",
+        "decision_process": _get_decision_process_spec("angle"),
         "learning_process": {"v": _compute_v_annotated},
         "rl_params": ["rl_alpha", "scaler"],
         "rl_bounds": {
@@ -246,19 +266,12 @@ def get_rlssm_model_config(
     if learning_process is not None:
         entry["learning_process"] = learning_process
     if decision_process is not None:
-        entry["decision_process"] = decision_process
+        entry["decision_process"] = _get_decision_process_spec(decision_process)
     if choices is not None:
         entry["choices"] = choices
 
-    dp: str = entry["decision_process"]
-    if dp not in _SSM_REGISTRY:
-        available_ssms = list(_SSM_REGISTRY.keys())
-        raise ValueError(
-            f"Decision process '{dp}' not found in the SSM registry. "
-            f"Available: {available_ssms}. Use register_ssm() to add it."
-        )
-
-    ssm_entry = _SSM_REGISTRY[dp]
+    ssm_entry = _get_decision_process_spec(entry["decision_process"])
+    dp: str = ssm_entry["name"]
     ssm_base = _get_ssm_logp(dp)
     lp: dict[str, Any] = entry["learning_process"]
 
@@ -371,7 +384,7 @@ def register_rlssm_model(
             name,
         )
     _RLSSM_REGISTRY[name] = {
-        "decision_process": decision_process,
+        "decision_process": _get_decision_process_spec(decision_process),
         # Shallow-copy all mutable caller-supplied collections so that later
         # mutations of the originals do not silently corrupt the registry entry.
         "learning_process": dict(learning_process),

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -7,6 +7,7 @@ composition, and registration validation are caught at the module boundary.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -19,9 +20,9 @@ from hssm.utils import annotate_function
 @pytest.fixture(autouse=True)
 def isolated_registries(monkeypatch: pytest.MonkeyPatch) -> None:
     """Isolate global registries so tests do not leak state."""
-    monkeypatch.setattr(registry, "_SSM_REGISTRY", dict(registry._SSM_REGISTRY))
-    monkeypatch.setattr(registry, "_RLSSM_REGISTRY", dict(registry._RLSSM_REGISTRY))
-    monkeypatch.setattr(registry, "_SSM_LOGP_CACHE", {})
+    monkeypatch.setattr(registry, "_SSM_REGISTRY", deepcopy(registry._SSM_REGISTRY))
+    monkeypatch.setattr(registry, "_RLSSM_REGISTRY", deepcopy(registry._RLSSM_REGISTRY))
+    monkeypatch.setattr(registry, "_SSM_LOGP_CACHE", dict(registry._SSM_LOGP_CACHE))
 
 
 @pytest.fixture
@@ -186,10 +187,13 @@ def test_register_rlssm_model_copies_mutable_inputs(
     rl_defaults.append(1.0)
     extra_fields.append("trial")
     choices.append(2)
+    registry._SSM_REGISTRY["angle"]["response"].append("deadline")
     learning_process["other"] = next(iter(learning_process.values()))
 
     stored = registry._RLSSM_REGISTRY["copy_test_model"]
 
+    assert stored["decision_process"]["name"] == "angle"
+    assert stored["decision_process"]["response"] == ["rt", "response"]
     assert stored["rl_params"] == ["rl_alpha"]
     assert stored["rl_bounds"] == {"rl_alpha": (0.0, 1.0)}
     assert stored["rl_params_default"] == [0.2]

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -1,0 +1,241 @@
+"""Unit tests for the RL registry helpers.
+
+These tests exercise the registry module directly without constructing full
+RLSSM model instances, so regressions in lazy SSM resolution, config
+composition, and registration validation are caught at the module boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hssm.rl import registry
+from hssm.rl.config import RLSSMConfig
+from hssm.utils import annotate_function
+
+
+@pytest.fixture(autouse=True)
+def isolated_registries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate global registries so tests do not leak state."""
+    monkeypatch.setattr(registry, "_SSM_REGISTRY", dict(registry._SSM_REGISTRY))
+    monkeypatch.setattr(registry, "_RLSSM_REGISTRY", dict(registry._RLSSM_REGISTRY))
+    monkeypatch.setattr(registry, "_SSM_LOGP_CACHE", {})
+
+
+@pytest.fixture
+def learning_process() -> dict[str, Any]:
+    """Return an annotated RL learning rule for test models."""
+
+    @annotate_function(
+        inputs=["rl_alpha", "response", "feedback"],
+        outputs=["v"],
+    )
+    def compute_v(rl_alpha, response, feedback):
+        return rl_alpha
+
+    return {"v": compute_v}
+
+
+@pytest.fixture
+def annotated_ssm_base_logp() -> Any:
+    """Return an annotated SSM base log-likelihood function."""
+
+    @annotate_function(
+        inputs=["v", "a", "rt", "response"],
+        outputs=["logp"],
+    )
+    def base_logp(v, a, rt, response):
+        return a
+
+    return base_logp
+
+
+def test_get_ssm_logp_builds_lazy_factory_once(annotated_ssm_base_logp: Any) -> None:
+    """Lazy SSM factories should only build and cache one function instance."""
+    call_count = 0
+
+    def factory() -> Any:
+        nonlocal call_count
+        call_count += 1
+        return annotated_ssm_base_logp
+
+    registry._SSM_REGISTRY["lazy_unit_test_ssm"] = {
+        "ssm_base_logp_func_factory": factory,
+        "list_params_ssm": ["v", "a"],
+        "bounds_ssm": {"a": (0.3, 3.0)},
+        "params_default_ssm": [0.0, 1.5],
+        "response": ["rt", "response"],
+    }
+
+    first = registry._get_ssm_logp("lazy_unit_test_ssm")
+    second = registry._get_ssm_logp("lazy_unit_test_ssm")
+
+    assert first is annotated_ssm_base_logp
+    assert second is first
+    assert call_count == 1
+
+
+def test_derive_rl_params_excludes_response_and_extra_fields(
+    learning_process: dict[str, Any],
+) -> None:
+    """Derived RL params should ignore response columns and extra fields."""
+    derived = registry._derive_rl_params(
+        learning_process=learning_process,
+        response=["rt", "response"],
+        extra_fields=["feedback"],
+    )
+
+    assert derived == ["rl_alpha"]
+
+
+def test_get_rlssm_model_config_builds_expected_config(
+    annotated_ssm_base_logp: Any,
+    learning_process: dict[str, Any],
+) -> None:
+    """Registry config composition should exclude computed SSM params."""
+    registry.register_ssm(
+        name="unit_test_ssm",
+        ssm_base_logp_func=annotated_ssm_base_logp,
+        list_params_ssm=["v", "a"],
+        bounds_ssm={"a": (0.3, 3.0)},
+        params_default_ssm=[0.0, 1.5],
+        response=["rt", "response"],
+    )
+    registry.register_rlssm_model(
+        name="unit_test_model",
+        decision_process="unit_test_ssm",
+        learning_process=learning_process,
+        rl_params=["rl_alpha"],
+        rl_bounds={"rl_alpha": (0.0, 1.0)},
+        rl_params_default=[0.2],
+        extra_fields=["feedback"],
+        choices=[0, 1],
+    )
+
+    config = registry.get_rlssm_model_config("unit_test_model")
+
+    assert isinstance(config, RLSSMConfig)
+    assert config.list_params == ["rl_alpha", "a"]
+    assert config.bounds == {"rl_alpha": (0.0, 1.0), "a": (0.3, 3.0)}
+    assert config.params_default == [0.2, 1.5]
+    assert config.response == ["rt", "response"]
+    assert config.ssm_logp_func.computed == learning_process
+
+    config.response.append("mutated")
+    assert registry._SSM_REGISTRY["unit_test_ssm"]["response"] == ["rt", "response"]
+
+
+def test_get_rlssm_model_config_respects_explicit_empty_rl_fields(
+    annotated_ssm_base_logp: Any,
+    learning_process: dict[str, Any],
+) -> None:
+    """Explicit empty RL collections must not trigger fallback derivation."""
+    registry.register_ssm(
+        name="empty_rl_ssm",
+        ssm_base_logp_func=annotated_ssm_base_logp,
+        list_params_ssm=["v", "a"],
+        bounds_ssm={"a": (0.3, 3.0)},
+        params_default_ssm=[0.0, 1.5],
+        response=["rt", "response"],
+    )
+    registry._RLSSM_REGISTRY["empty_rl_model"] = {
+        "decision_process": "empty_rl_ssm",
+        "learning_process": learning_process,
+        "rl_params": [],
+        "rl_bounds": {},
+        "rl_params_default": [],
+        "extra_fields": ["feedback"],
+        "choices": [0, 1],
+        "description": "test model",
+        "decision_process_loglik_kind": "approx_differentiable",
+        "learning_process_kind": "blackbox",
+    }
+
+    config = registry.get_rlssm_model_config("empty_rl_model")
+
+    assert config.list_params == ["a"]
+    assert config.bounds == {"a": (0.3, 3.0)}
+    assert config.params_default == [1.5]
+
+
+def test_register_rlssm_model_copies_mutable_inputs(
+    learning_process: dict[str, Any],
+) -> None:
+    """Caller mutations after registration must not alter the stored model."""
+    rl_params = ["rl_alpha"]
+    rl_bounds = {"rl_alpha": (0.0, 1.0)}
+    rl_defaults = [0.2]
+    extra_fields = ["feedback"]
+    choices = [0, 1]
+
+    registry.register_rlssm_model(
+        name="copy_test_model",
+        decision_process="angle",
+        learning_process=learning_process,
+        rl_params=rl_params,
+        rl_bounds=rl_bounds,
+        rl_params_default=rl_defaults,
+        extra_fields=extra_fields,
+        choices=choices,
+    )
+
+    rl_params.append("scaler")
+    rl_bounds["scaler"] = (0.0, 10.0)
+    rl_defaults.append(1.0)
+    extra_fields.append("trial")
+    choices.append(2)
+    learning_process["other"] = next(iter(learning_process.values()))
+
+    stored = registry._RLSSM_REGISTRY["copy_test_model"]
+
+    assert stored["rl_params"] == ["rl_alpha"]
+    assert stored["rl_bounds"] == {"rl_alpha": (0.0, 1.0)}
+    assert stored["rl_params_default"] == [0.2]
+    assert stored["extra_fields"] == ["feedback"]
+    assert stored["choices"] == [0, 1]
+    assert list(stored["learning_process"]) == ["v"]
+
+
+def test_register_ssm_caches_prebuilt_function(
+    annotated_ssm_base_logp: Any,
+) -> None:
+    """Registering a pre-built SSM should populate the cache immediately."""
+    registry.register_ssm(
+        name="cached_ssm",
+        ssm_base_logp_func=annotated_ssm_base_logp,
+        list_params_ssm=["v", "a"],
+        bounds_ssm={"a": (0.3, 3.0)},
+        params_default_ssm=[0.0, 1.5],
+    )
+
+    assert registry._SSM_LOGP_CACHE["cached_ssm"] is annotated_ssm_base_logp
+    assert registry._SSM_REGISTRY["cached_ssm"]["response"] == ["rt", "response"]
+
+
+def test_register_ssm_rejects_precomputed_function(
+    annotated_ssm_base_logp: Any,
+    learning_process: dict[str, Any],
+) -> None:
+    """SSM registration should reject functions that already carry computed params."""
+    precomputed_logp = annotate_function(
+        inputs=annotated_ssm_base_logp.inputs,
+        outputs=annotated_ssm_base_logp.outputs,
+        computed=learning_process,
+    )(annotated_ssm_base_logp)
+
+    with pytest.raises(ValueError, match="should not have a non-empty .computed"):
+        registry.register_ssm(
+            name="invalid_ssm",
+            ssm_base_logp_func=precomputed_logp,
+            list_params_ssm=["v", "a"],
+            bounds_ssm={"a": (0.3, 3.0)},
+            params_default_ssm=[0.0, 1.5],
+        )
+
+
+def test_get_rlssm_model_config_unknown_model_raises() -> None:
+    """Unknown RLSSM model names should fail with a clear error."""
+    with pytest.raises(ValueError, match="not found in the RLSSM registry"):
+        registry.get_rlssm_model_config("does_not_exist")


### PR DESCRIPTION
```mermaid
flowchart TD
    A[register_rlssm_model] --> B[REGISTERED_RL_MODELS]

    subgraph Registry
      B["REGISTERED_RL_MODELS\nname -> RLSSM spec"]
    end

    subgraph Stored_Spec
      C["decision_process spec\nname, lazy ssm logp factory,\nparams, bounds, defaults, response"]
      D["learning_process"]
      E["rl_params / rl_bounds /\nrl_params_default"]
      F["choices / extra_fields /\ndescription"]
    end

    B --> C
    B --> D
    B --> E
    B --> F

    G[get_rlssm_model_config] --> B
    G --> H[copy named spec]
    H --> I[resolve lazy SSM logp]
    I --> J[compose computed SSM logp]
    J --> K[merge RL and SSM metadata]
    K --> L[build fresh RLSSMConfig]

    style B fill:#1f2937,stroke:#cbd5e1,stroke-width:2px,color:#f9fafb
    style C fill:#0f766e,stroke:#ccfbf1,stroke-width:2px,color:#f9fafb
    style D fill:#0f766e,stroke:#ccfbf1,stroke-width:2px,color:#f9fafb
    style E fill:#0f766e,stroke:#ccfbf1,stroke-width:2px,color:#f9fafb
    style F fill:#0f766e,stroke:#ccfbf1,stroke-width:2px,color:#f9fafb
    style A fill:#7c2d12,stroke:#fed7aa,stroke-width:2px,color:#f9fafb
    style G fill:#7c2d12,stroke:#fed7aa,stroke-width:2px,color:#f9fafb
    style H fill:#1d4ed8,stroke:#bfdbfe,stroke-width:2px,color:#f9fafb
    style I fill:#1d4ed8,stroke:#bfdbfe,stroke-width:2px,color:#f9fafb
    style J fill:#1d4ed8,stroke:#bfdbfe,stroke-width:2px,color:#f9fafb
    style K fill:#1d4ed8,stroke:#bfdbfe,stroke-width:2px,color:#f9fafb
    style L fill:#166534,stroke:#bbf7d0,stroke-width:2px,color:#f9fafb
```

Registry for RLSSM model specs.