### PR TITLE
tests: add xfail tests for float lapse_dist bugs in _apply_lapse_model

### DIFF
--- a/tests/distribution_utils/test_distribution_utils.py
+++ b/tests/distribution_utils/test_distribution_utils.py
@@ -12,6 +12,7 @@ from hssm.distribution_utils.dist import (
     ensure_positive_ndt,
     make_distribution,
     make_distribution_for_supported_model,
+    _apply_lapse_model,
     _create_arg_arrays,
     _extract_size,
     _get_p_outlier,
@@ -420,3 +421,65 @@ class TestGetPOutlier:
 
         assert p_outlier is None
         assert new_arg_arrays is arg_arrays
+
+
+# ---------------------------------------------------------------------------
+# Tests for _apply_lapse_model with float lapse_dist (choice-only models)
+# ---------------------------------------------------------------------------
+# Both tests are expected to fail with the current implementation because:
+#   Bug 1: `lapse_dist.args` is called on a float → AttributeError
+#   Bug 2: `np.stack([replace, replace], axis=-1)` creates a 2-column mask,
+#          but choice-only sims_out has only 1 column, corrupting the output.
+# Once the float-lapse branch is added to _apply_lapse_model these should pass.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Float lapse_dist crashes: `lapse_dist.args` raises AttributeError on float. "
+        "Fix: add isinstance(lapse_dist, float) branch in _apply_lapse_model."
+    ),
+)
+def test_apply_lapse_model_float_lapse_1d_does_not_crash():
+    """Float lapse_dist with 1-D sims_out (choice-only) must not crash."""
+    rng = np.random.default_rng(0)
+    choices = [0, 1]
+    # 1-D input: shape (n_obs,) — pure choice-only output from ssms_rng_fn
+    sims_out = np.array([0, 1, 0, 1, 0], dtype=float)
+    # p_outlier=1.0 forces every trial to be replaced, guaranteeing replace_n > 0
+    # and that the lapse branch is reached every time.
+    result = _apply_lapse_model(
+        sims_out=sims_out,
+        p_outlier=1.0,
+        rng=rng,
+        lapse_dist=0.5,  # float — 1/n_choices for a 2-choice model
+        choices=choices,
+    )
+    assert result.shape == sims_out.shape
+    assert set(result).issubset(set(choices))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Float lapse_dist with 2-D sims_out: shape mismatch from "
+        "`np.stack([replace, replace], axis=-1)` producing a 2-column mask for "
+        "a 1-column array.  Fix: add isinstance(lapse_dist, float) branch."
+    ),
+)
+def test_apply_lapse_model_float_lapse_2d_correct_shape():
+    """Float lapse_dist with 2-D (n_obs, 1) sims_out must return same shape."""
+    rng = np.random.default_rng(0)
+    choices = [0, 1]
+    # 2-D input: shape (n_obs, 1) — choice column only
+    sims_out = np.array([[0], [1], [0], [1], [0]], dtype=float)
+    result = _apply_lapse_model(
+        sims_out=sims_out,
+        p_outlier=1.0,
+        rng=rng,
+        lapse_dist=0.5,
+        choices=choices,
+    )
+    assert result.shape == sims_out.shape
+    assert set(result[:, -1]).issubset(set(choices))


### PR DESCRIPTION
@AlexanderFengler @digicosmos86 Would it be sensible to address this?

**Summary**

Adds two `xfail(strict=True)` tests that document two latent bugs in `_apply_lapse_model` (in dist.py). The tests are currently expected to fail and will flip to passing once a fix is added.

---

**Background**

For choice-only models (e.g. `softmax_inv_temperature_2`), `_check_lapse` sets `self.lapse = 1 / n_choices` — a plain `float`. This float is stored as `HSSMRV._lapse` and passed to `_apply_lapse_model(lapse_dist=...)` during prior/posterior predictive sampling. The existing code assumes `lapse_dist` is always a `bmb.Prior` object, so two things go wrong.

---

**Bug 1 — `AttributeError` on `lapse_dist.args`**

`_apply_lapse_model` always executes:

```python
lapse_rt = pm.draw(
    get_distribution_from_prior(lapse_dist).dist(**lapse_dist.args), ...
)
```

When `lapse_dist` is `0.5` (a `float`), `lapse_dist.args` raises:

```
AttributeError: 'float' object has no attribute 'args'
```

**Trigger:** any call to `model.sample_prior_predictive()` or `model.sample_posterior_predictive()` on a choice-only model that has `p_outlier != 0`.

---

**Bug 2 — 2-column replace mask for a 1-column output**

Even if Bug 1 were somehow bypassed, the replacement mask is always built as:

```python
replace_mask = np.stack([replace, replace], axis=-1)  # always 2 columns
```

Choice-only simulation output has only **1 column** (response; no RT). The 2-column mask either silently corrupts the array via `np.putmask` broadcasting or raises a shape error depending on input dimensions.

**Trigger:** same as Bug 1.

---

**Current status**

Both bugs are latent on the `add-choice-only-rlssm-model-to-registry` branch. For RLSSM models `ssms_rng_fn` raises before reaching `_apply_lapse_model` (ssm_simulators does not support `2AB_RescorlaWagner_Softmax`), so neither bug is reachable through the RLSSM path today. They would be reachable for any other choice-only model supported by ssm_simulators (e.g. `softmax_inv_temperature_2`) the moment a user passes `p_outlier != 0`.

---

**Fix (tracked separately)**

Add an `isinstance(lapse_dist, float)` branch in `_apply_lapse_model` that:
- skips RT sampling (there is no RT column)
- samples replacement responses uniformly over `choices`
- handles both 1-D `(n_obs,)` and 2-D `(n_obs, 1)` `sims_out`

The type annotation of `make_hssm_rv`'s `lapse` parameter should also be updated from `bmb.Prior | None` to `bmb.Prior | float | None`.