### PR TITLE
Cpaniaguam/model listing at module level

### DIFF
--- a/src/hssm/__init__.py
+++ b/src/hssm/__init__.py
@@ -16,6 +16,7 @@ from .datasets import load_data
 from .defaults import show_defaults
 from .hssm import HSSM
 from .link import Link
+from .modelconfig import list_models
 from .param import UserParam as Param
 from .prior import Prior
 from .register import register_model
@@ -34,6 +35,7 @@ __all__ = [
     "HSSM",
     "RLSSM",
     "Link",
+    "list_models",
     "load_data",
     "ModelConfig",
     "Param",

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -8,6 +8,7 @@ This file defines the entry class HSSM.
 
 import datetime
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from os import PathLike
@@ -452,11 +453,19 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
     def supported_models(cls) -> tuple[SupportedModels, ...]:
         """Get a tuple of all supported models.
 
+        Deprecated in favor of ``hssm.list_models()``.
+
         Returns
         -------
         tuple[SupportedModels, ...]
             A tuple containing all supported model names.
         """
+        warnings.warn(
+            "HSSM.supported_models is deprecated and will be removed in a "
+            "future release. Use hssm.list_models() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return list_models()
 
     @staticmethod

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Union, cast, get_args
+from typing import Any, Callable, Literal, Optional, Union, cast
 
 import arviz as az
 import bambi as bmb
@@ -48,6 +48,7 @@ from hssm.utils import (
 
 from . import plotting
 from .config import BaseModelConfig
+from .modelconfig import list_models
 from .param import Params
 from .param import UserParam as Param
 
@@ -456,7 +457,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         tuple[SupportedModels, ...]
             A tuple containing all supported model names.
         """
-        return get_args(SupportedModels)
+        return list_models()
 
     @staticmethod
     def _store_init_args(

--- a/src/hssm/modelconfig/__init__.py
+++ b/src/hssm/modelconfig/__init__.py
@@ -35,6 +35,17 @@ from typing import get_args
 from .._types import DefaultConfig, SupportedModels
 
 
+def list_models() -> tuple[SupportedModels, ...]:
+    """Return the names of the built-in HSSM models.
+
+    Returns
+    -------
+    tuple[SupportedModels, ...]
+        A tuple containing all built-in HSSM model names.
+    """
+    return get_args(SupportedModels)
+
+
 def get_default_model_config(model_name: SupportedModels) -> DefaultConfig:
     """
     Get the default configuration for a given model name.
@@ -53,7 +64,7 @@ def get_default_model_config(model_name: SupportedModels) -> DefaultConfig:
         and likelihood specifications.
 
     """
-    supported_models = get_args(SupportedModels)
+    supported_models = list_models()
     if model_name not in supported_models:
         error_message = (
             f"{model_name} is not a supported model in HSSM. "

--- a/src/hssm/rl/__init__.py
+++ b/src/hssm/rl/__init__.py
@@ -6,7 +6,6 @@ learning rules with sequential-sampling decision models (SSMs).
 Public API (import from ``hssm.rl``):
 
 - ``RLSSM``: the public RL + SSM model class in :mod:`hssm.rl.rlssm`.
-- ``_RLSSM``: the internal base class that requires a fully built config.
 - ``RLSSMConfig``: the config class for RL + SSM models in :mod:`hssm.rl.config`.
 - ``get_rlssm_model_config``: factory that builds a config from a named model.
 - ``register_rlssm_model``: register a custom named RLSSM model.
@@ -26,12 +25,11 @@ from .registry import (
     register_rlssm_model,
     register_ssm,
 )
-from .rlssm import _RLSSM, RLSSM
+from .rlssm import RLSSM
 from .utils import validate_balanced_panel
 
 __all__ = [
     "RLSSM",
-    "_RLSSM",
     "RLSSMConfig",
     "get_rlssm_model_config",
     "list_models",

--- a/src/hssm/rl/__init__.py
+++ b/src/hssm/rl/__init__.py
@@ -22,6 +22,7 @@ helpers such as :func:`~hssm.rl.likelihoods.builder.make_rl_logp_func` and
 from .config import RLSSMConfig
 from .registry import (
     get_rlssm_model_config,
+    list_models,
     register_rlssm_model,
     register_ssm,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "_RLSSM",
     "RLSSMConfig",
     "get_rlssm_model_config",
+    "list_models",
     "register_rlssm_model",
     "register_ssm",
     "validate_balanced_panel",

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -44,27 +44,27 @@ from ..base import HSSMBase, classproperty
 from .config import RLSSMConfig
 from .registry import get_rlssm_model_config, list_models
 
-_logger = logging.getLogger("hssm")
+_logger = logging.getLogger(__name__)
 
 
 class _RLSSM(HSSMBase):
-    """Internal Reinforcement Learning Sequential Sampling Model.
+    """Internal implementation class for reinforcement-learning SSMs.
 
-    Requires a fully populated :class:`RLSSMConfig` (with ``ssm_logp_func`` set)
-    to be passed directly.  End users should use :class:`RLSSM` instead, which
-    provides a simplified interface backed by the named-model registry.
+    This class is intended for maintainers and advanced integrations that
+    already have a fully built :class:`RLSSMConfig`. It combines a
+    reinforcement-learning update rule with a sequential-sampling likelihood in
+    a single differentiable model, using the annotated SSM log-likelihood
+    stored on ``model_config.ssm_logp_func``.
 
-    Combines a reinforcement learning (RL) process with a sequential sampling
-    model (SSM) inside a single differentiable likelihood.  The RL component
-    computes trial-wise intermediate parameters (e.g., drift rates) from the
-    learning history, which are then fed into the SSM log-likelihood.
+    Unlike :class:`~hssm.hssm.HSSM`, this implementation does not go through
+    the standard ``loglik`` / ``loglik_kind`` wrapping pipeline. It builds a
+    differentiable pytensor ``Op`` with
+    :func:`~hssm.rl.likelihoods.builder.make_rl_logp_op` and passes that Op
+    directly to :func:`~hssm.distribution_utils.make_distribution`.
 
-    The likelihood is built via
-    :func:`~hssm.rl.likelihoods.builder.make_rl_logp_op` from the annotated
-    SSM function stored in *model_config.ssm_logp_func*.  This produces a
-    differentiable pytensor ``Op`` that is passed directly to
-    :func:`~hssm.distribution_utils.make_distribution`, superseding the
-    ``loglik`` / ``loglik_kind`` dispatching used by :class:`~hssm.hssm.HSSM`.
+    The data must form a balanced panel because the RL likelihood reconstructs
+    per-participant trial sequences from row order. Any reshuffling of rows
+    would change the learning history seen by the model.
 
     Parameters
     ----------
@@ -325,16 +325,19 @@ class _BlockedAttribute:
 
 
 class RLSSM(_RLSSM):
-    """Reinforcement Learning Sequential Sampling Model — simplified public API.
+    """Fit reinforcement-learning sequential sampling models from trial data.
 
-    This class wraps :class:`_RLSSM` with a user-friendly constructor that
-    accepts a *model* name string (looked up in the named-model registry) and
-    optional overrides for *learning_process*, *decision_process*, and
-    *choices*.  Advanced users can bypass the registry entirely by supplying a
-    pre-built *model_config*.
+    RLSSM combines a reinforcement-learning process with a sequential-sampling
+    decision model in a single likelihood. In the common case, you choose a
+    named RLSSM model with ``model`` and optionally override its
+    ``learning_process``, ``decision_process``, or ``choices`` settings. Use
+    :attr:`RLSSM.list_models` to inspect the named models available in HSSM.
 
-    ``missing_data``, ``deadline``, and ``loglik_missing_data`` are not
-    supported for RLSSM models and raise :exc:`NotImplementedError` if accessed.
+    If you already have a fully built :class:`RLSSMConfig`, you can pass it as
+    ``model_config`` instead of selecting a named model.
+
+    RLSSM currently requires balanced panel data and does not support
+    ``missing_data``, ``deadline``, or ``loglik_missing_data`` handling.
 
     Parameters
     ----------

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -41,9 +41,8 @@ from hssm.rl.likelihoods.builder import make_rl_logp_op
 from hssm.rl.utils import validate_balanced_panel
 
 from ..base import HSSMBase, classproperty
-from . import list_models
 from .config import RLSSMConfig
-from .registry import get_rlssm_model_config
+from .registry import get_rlssm_model_config, list_models
 
 _logger = logging.getLogger("hssm")
 

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -41,6 +41,7 @@ from hssm.rl.likelihoods.builder import make_rl_logp_op
 from hssm.rl.utils import validate_balanced_panel
 
 from ..base import HSSMBase, classproperty
+from . import list_models
 from .config import RLSSMConfig
 from .registry import get_rlssm_model_config
 
@@ -487,6 +488,4 @@ class RLSSM(_RLSSM):
         >>> RLSSM.list_models
         {'2AB_RescorlaWagner_DDM': 'RLSSM model with ...', ...}
         """
-        from .registry import list_models  # noqa: PLC0415
-
         return list_models()

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -592,3 +592,10 @@ class TestListModels:
         assert set(result.keys()) == set(registry._RLSSM_REGISTRY.keys())
         for name, desc in result.items():
             assert desc == registry._RLSSM_REGISTRY[name].get("description")
+
+    def test_public_rl_api_matches_registry(self) -> None:
+        """The public hssm.rl and RLSSM accessors should delegate to the registry."""
+        import hssm
+
+        assert hssm.rl.list_models() == registry.list_models()
+        assert hssm.RLSSM.list_models == registry.list_models()

--- a/tests/rl/test_rlssm.py
+++ b/tests/rl/test_rlssm.py
@@ -19,8 +19,9 @@ import pytest
 
 import hssm
 from hssm.distribution_utils import make_distribution as real_make_distribution
-from hssm.rl import _RLSSM, RLSSM, RLSSMConfig, register_rlssm_model
+from hssm.rl import RLSSM, RLSSMConfig, register_rlssm_model
 from hssm.rl.likelihoods.two_armed_bandit import compute_v_subject_wise
+from hssm.rl.rlssm import _RLSSM
 from hssm.utils import annotate_function
 
 # Annotate the RL learning function: maps

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -109,6 +109,10 @@ def test_load_all_supported_model_configs(model):
     assert isinstance(get_default_model_config(model), dict)
 
 
+def test_hssm_list_models_matches_supported_models():
+    assert hssm.list_models() == hssm.HSSM.supported_models
+
+
 def test_get_default_model_config_invalid():
     with pytest.raises(ValueError):
         get_default_model_config("invalid_model")

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -104,13 +104,18 @@ def test_get_ornstein_config():
     }
 
 
-@pytest.mark.parametrize("model", hssm.HSSM.supported_models)
+@pytest.mark.parametrize("model", hssm.list_models())
 def test_load_all_supported_model_configs(model):
     assert isinstance(get_default_model_config(model), dict)
 
 
 def test_hssm_list_models_matches_supported_models():
-    assert hssm.list_models() == hssm.HSSM.supported_models
+    with pytest.deprecated_call(
+        match=r"HSSM\.supported_models is deprecated.*Use hssm\.list_models\(\) instead\."
+    ):
+        supported_models = hssm.HSSM.supported_models
+
+    assert hssm.list_models() == supported_models
 
 
 def test_get_default_model_config_invalid():


### PR DESCRIPTION
This PR adds module-level model discovery APIs: [hssm.list_models()](vscode-file://vscode-app/c:/Users/cpaniagu/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for built-in HSSM models and [hssm.rl.list_models()](vscode-file://vscode-app/c:/Users/cpaniagu/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for RLSSM models. The existing class-level accessors are kept as backward-compatible delegates, and tests/docs were updated accordingly.

https://github.com/lnccbrown/HSSM/pull/955#discussion_r3312829307