### PR TITLE
Mark expected failures

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/tests/rl/test_rl_likelihood_builder.py
+++ b/tests/rl/test_rl_likelihood_builder.py
@@ -746,6 +746,9 @@ class TestRldmLikelihoodBuilder:
         assert result.shape[0] == rldm_setup.total_trials
         np.testing.assert_almost_equal(result.sum(), -6879.15, decimal=DECIMAL)
 
+    @pytest.mark.xfail(
+        reason="TypeError: can't unbox array from PyObject into native value.  The object maybe of a different type"
+    )
     def test_make_rl_logp_op(
         self, rldm_setup, rldm_data, model_config, param_arrays, annotated_ssm_logp_func
     ):

--- a/tests/slow/test_choice_only.py
+++ b/tests/slow/test_choice_only.py
@@ -17,7 +17,16 @@ PARAMETER_GRID = [
     ("analytical", None, None, "jax", True),  # Defaults should work
     ("analytical", "pymc", None, "jax", True),
     ("analytical", "pymc", "slice", "jax", True),
-    ("analytical", "numpyro", None, "jax", True),
+    pytest.param(
+        "analytical",
+        "numpyro",
+        None,
+        "jax",
+        True,
+        marks=pytest.mark.xfail(
+            reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+        ),
+    ),
     ("analytical", "numpyro", None, "pytensor", ValueError),
     ("analytical", "numpyro", "slice", "jax", ValueError),
 ]

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -83,6 +83,9 @@ def run_sample(model, sampler, step, expected):
 
 # Basic tests for LBA likelihood
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+)
 def test_lba_sampling():
     """Test if sampling works for available lba models."""
     lba2_data_out = hssm.simulate_data(

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -62,6 +62,11 @@ def sample(model, sampler, step):
 def run_sample(model, sampler, step, expected):
     """Run the sample function and check if the expected error is raised."""
     if expected is True:
+        if sampler == "numpyro":
+            pytest.xfail(
+                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+            )
+        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
         assert isinstance(model.traces, az.InferenceData)
 

--- a/tests/slow/test_missing_data_and_deadline_mcmc.py
+++ b/tests/slow/test_missing_data_and_deadline_mcmc.py
@@ -110,6 +110,11 @@ def sample(model, sampler, step):
 
 def run_sample(model, sampler, step, expected):
     if expected is True:
+        if sampler == "numpyro":
+            pytest.xfail(
+                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+            )
+        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
         assert isinstance(model.traces, az.InferenceData)
 

--- a/tests/slow/test_missing_data_and_deadline_vi.py
+++ b/tests/slow/test_missing_data_and_deadline_vi.py
@@ -56,6 +56,7 @@ def run_vi(model, method, expected):
     import pymc as pm
 
     if expected == True:
+        pytest.xfail("TypeError: No model on context stack.")
         model.vi(method, niter=1000)
         assert isinstance(model.vi_idata, az.InferenceData)
         assert isinstance(model.vi_approx, pm.Approximation)

--- a/tests/slow/test_missing_data_mcmc.py
+++ b/tests/slow/test_missing_data_mcmc.py
@@ -89,6 +89,11 @@ def sample(model, sampler, step):
 
 def run_sample(model, sampler, step, expected):
     if expected is True:
+        if sampler == "numpyro":
+            pytest.xfail(
+                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+            )
+        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
         assert isinstance(model.traces, az.InferenceData)
 

--- a/tests/slow/test_missing_data_vi.py
+++ b/tests/slow/test_missing_data_vi.py
@@ -79,6 +79,7 @@ def run_vi(model, method, expected):
     import pymc as pm
 
     if expected == True:
+        pytest.xfail("TypeError: No model on context stack.")
         model.vi(method, niter=100)
         assert isinstance(model.vi_idata, az.InferenceData)
         assert isinstance(model.vi_approx, pm.Approximation)

--- a/tests/slow/test_vi.py
+++ b/tests/slow/test_vi.py
@@ -24,6 +24,7 @@ PARAMETER_GRID = [
 
 def run_vi(model, method, expected):
     if expected == True:
+        pytest.xfail("TypeError: No model on context stack.")
         model.vi(method, niter=100)
         assert isinstance(model.vi_idata, az.InferenceData)
         assert isinstance(model.vi_approx, pm.Approximation)

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -149,6 +149,9 @@ def test_model_definition_outside_include(data_ddm):
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="AttributeError: 'DataTree' object has no attribute 'add_groups'"
+)
 def test_sample_prior_predictive(data_ddm_reg):
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
 
@@ -417,6 +420,7 @@ class TestFixedVectorParams:
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(reason="TypeError: 'tuple' object is not callable")
 def test_sample_do(data_ddm):
     model = HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -54,6 +54,11 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
         process_initvals=True,
     )
 
+    if sampler == "numpyro":
+        pytest.xfail(
+            "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+        )
+
     initial_point = model_on.initial_point(transformed=True)
 
     if initvals == "initial_point":

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -96,6 +96,9 @@ class TestPlotting:
             assert np.all(obs_n.value_counts() == expected // 500)
             assert df.columns[0] == "rt"
 
+    @pytest.mark.xfail(
+        reason="TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior_predictive'"
+    )
     def test__get_plotting_df(self, posterior, cavanagh_test):
         """Test _get_plotting_df."""
 
@@ -165,6 +168,9 @@ class TestPlotting:
         assert len(g2.figure.axes) == 5 * 2
         assert len(g2.figure.axes[0].get_lines()) == 1
 
+    @pytest.mark.xfail(
+        reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
+    )
     def test_plot_predictive(self, cav_idata, cavanagh_test):
         # Mock model object
         model = hssm.HSSM(
@@ -264,7 +270,19 @@ class TestPlotting:
         with pytest.raises(ValueError):
             _process_df_for_qp_plot(df=df, q=6, cond=1, correct=None)
 
-    @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
+    @pytest.mark.parametrize(
+        "predictive_style",
+        [
+            pytest.param(
+                "points",
+                marks=pytest.mark.xfail(
+                    reason="AssertionError: assert 'Density' == 'rt'"
+                ),
+            ),
+            "ellipse",
+            "both",
+        ],
+    )
     def test__plot_quantile_probability_1D(
         self, cav_idata, cavanagh_test, predictive_style
     ):
@@ -316,6 +334,9 @@ class TestPlotting:
         )
         assert len(g.figure.axes) == 5 * 4
 
+    @pytest.mark.xfail(
+        reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
+    )
     @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
     def test_plot_quantile_probability(
         self, cav_idata, cavanagh_test, predictive_style

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -94,6 +94,9 @@ def test_plot_model_cartoon_2_choice(
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior'"
+)
 def test_plot_model_cartoon_intercept_only(intercept_only_ddm_cartoon):
     """Test plot_model_cartoon with intercept-only DDM (no regression).
 

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -68,6 +68,9 @@ def test_plot_model_cartoon_2_choice(
                 n_trajectories=n_trajectories,
             )
     else:
+        pytest.xfail(
+            "Known DataTree compatibility errors in plot_model_cartoon predictive paths"
+        )
         ax = hssm.plotting.plot_model_cartoon(
             cav_model_cartoon,
             n_samples=10,
@@ -175,6 +178,9 @@ def test_plot_model_cartoon_3_choice(
                 n_trajectories=n_trajectories,
             )
     else:
+        pytest.xfail(
+            "Known DataTree compatibility errors in plot_model_cartoon predictive paths"
+        )
         ax = hssm.plotting.plot_model_cartoon(
             race_model_cartoon,
             n_samples=10,

--- a/tests/test_rlssm.py
+++ b/tests/test_rlssm.py
@@ -293,6 +293,9 @@ def test_rlssm_pymc_model(rldm_data, rlssm_config) -> None:
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+)
 def test_rlssm_sample_smoke(rldm_data, rlssm_config) -> None:
     """Minimal sampling run should return an InferenceData object."""
     model = RLSSM(data=rldm_data, model_config=rlssm_config)

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -30,6 +30,9 @@ PARAMETER_GRID = [
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
+)
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(
     cav_idata, cavanagh_test, draws, safe_mode, inplace

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -32,6 +32,9 @@ def test_save_load_model_only(basic_hssm_model, tmp_path):
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
+)
 def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     # Sample to attach vi and mcmc traces to model
     # Using minimal parameters since we only need traces to exist, not be accurate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -139,6 +139,9 @@ def assertions(caplog, obj, n_samples, expected):
             assert "n_samples > n_draws" in caplog.text
 
 
+@pytest.mark.xfail(
+    reason="cav_idata fixture requires optional xarray NetCDF backends not installed",
+)
 @pytest.mark.parametrize(
     ["n_samples", "expected"],
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,6 +230,9 @@ def test_check_data_for_rl():
     assert n_trials == 2
 
 
+@pytest.mark.xfail(
+    reason="TypeError when accessing idata.groups(): 'tuple' object is not callable"
+)
 def test_predictive_idata_to_dataframe(data_ddm):
     model = hssm.HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)


### PR DESCRIPTION


Click to expand
<details>
<summary>Slow tests failing</summary>

```console
===================================== short test summary info =====================================
FAILED tests/slow/test_choice_only.py::test_choice_only_default_params[analytical-numpyro-None-jax-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_choice_only.py::test_choice_only_beta_reg[analytical-numpyro-None-jax-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_choice_only.py::test_choice_only_logit_reg[analytical-numpyro-None-jax-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_choice_only.py::test_choice_only_multiple_reg[analytical-numpyro-None-jax-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_lba_sampling - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_simple_models[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_simple_models[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_simple_models[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_mcmc.py::test_reg_models_v_a[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_simple_models_deadline[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_mcmc.py::test_reg_models_deadline[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_simple_models_deadline[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_simple_models_deadline[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_simple_models_deadline[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_simple_models_deadline[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_reg_models_deadline[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_reg_models_deadline[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_reg_models_deadline[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_and_deadline_vi.py::test_reg_models_deadline[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_simple_models_missing_data[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[analytical-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[analytical-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[analytical-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[analytical-None-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-pytensor-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-pytensor-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-pytensor-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-pytensor-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-jax-None-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-jax-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-jax-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[approx_differentiable-jax-numpyro-None-True] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[blackbox-None-None-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[blackbox-None-pymc-None-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_mcmc.py::test_reg_models_missing_data[blackbox-None-pymc-slice-True] - TypeError: 'tuple' object is not callable
FAILED tests/slow/test_missing_data_vi.py::test_simple_models_missing_data[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_simple_models_missing_data[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_simple_models_missing_data[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_simple_models_missing_data[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_reg_models_missing_data[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_reg_models_missing_data[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_reg_models_missing_data[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_missing_data_vi.py::test_reg_models_missing_data[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_simple_models[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_simple_models[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_simple_models[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_simple_models[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models_v_a[approx_differentiable-pytensor-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models_v_a[approx_differentiable-pytensor-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models_v_a[approx_differentiable-jax-advi-True] - TypeError: No model on context stack.
FAILED tests/slow/test_vi.py::test_reg_models_v_a[approx_differentiable-jax-fullrank_advi-True] - TypeError: No model on context stack.
FAILED tests/test_hssm.py::test_sample_prior_predictive - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_hssm.py::test_sample_do - TypeError: 'tuple' object is not callable
FAILED tests/test_initvals.py::test_sample_map[approx_differentiable-ddm-numpyro-map] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_initvals.py::test_sample_map[analytical-ddm-numpyro-map] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_initvals.py::test_sample_map[approx_differentiable-angle-numpyro-map] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_initvals.py::test_sample_map[approx_differentiable-ddm-numpyro-initial_point] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_initvals.py::test_sample_map[analytical-ddm-numpyro-initial_point] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_initvals.py::test_sample_map[approx_differentiable-angle-numpyro-initial_point] - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_plotting.py::TestPlotting::test__get_plotting_df - TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior_predictive'
FAILED tests/test_plotting.py::TestPlotting::test_plot_predictive - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_plotting.py::TestPlotting::test__plot_quantile_probability_1D[points] - AssertionError: assert 'Density' == 'rt'
FAILED tests/test_plotting.py::TestPlotting::test_plot_quantile_probability[points] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_plotting.py::TestPlotting::test_plot_quantile_probability[ellipse] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_plotting.py::TestPlotting::test_plot_quantile_probability[both] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-True-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-False-True-posterior_predictive-participant_id-stim] - TypeError: 'tuple' object is not callable
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-False-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[0-None-False-True-posterior_predictive-participant_id-stim] - TypeError: 'tuple' object is not callable
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[0-None-False-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[0-None-True-False-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[0-None-True-False-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-groups10-True-True-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-groups11-True-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-posterior_predictive-participant_id-None] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-prior_predictive-participant_id-None] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-posterior_predictive-None-None] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_2_choice[2-None-True-False-prior_predictive-None-None] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-True-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-False-True-posterior_predictive-participant_id-stim] - TypeError: 'tuple' object is not callable
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-False-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[0-None-False-True-posterior_predictive-participant_id-stim] - TypeError: 'tuple' object is not callable
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[0-None-False-True-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[0-None-True-False-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[0-None-True-False-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-posterior_predictive-participant_id-None] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-prior_predictive-participant_id-None] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-posterior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-prior_predictive-participant_id-stim] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-posterior_predictive-None-None] - AttributeError: 'DataTree' object has no attribute 'assign_coords'
FAILED tests/test_plotting_cartoon.py::test_plot_model_cartoon_3_choice[2-None-True-False-prior_predictive-None-None] - AttributeError: 'DataTree' object has no attribute 'add_groups'
FAILED tests/test_rlssm.py::test_rlssm_sample_smoke - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[1-False-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[1-True-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[None-True-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[50-True-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws4-True-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[1-False-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[1-True-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[None-True-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[50-False-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[50-True-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws10-False-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws11-True-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws12-False-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws13-True-False] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws14-False-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_sample_posterior_predictive.py::test_sample_posterior_predictive[draws15-True-True] - AttributeError: 'DataTree' object has no attribute 'posterior_predictive'
FAILED tests/test_save_load.py::test_save_load_vi_mcmc - TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'
ERROR tests/test_plotting_cartoon.py::test_plot_model_cartoon_intercept_only - TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior'
```

</details>