### PR TITLE
[pymc6 migration] Basic errors in slow MCMC tests

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -636,20 +636,21 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             else:
                 init = "auto"
 
+        # TODO: add back jitter after knowing what to do
         # If sampler is finally `numpyro` make sure
         # the jitter argument is set to False
-        if sampler == "numpyro":
-            if "nuts_sampler_kwargs" in kwargs:
-                if kwargs["nuts_sampler_kwargs"].get("jitter"):
-                    _logger.warning(
-                        "The jitter argument is set to True. "
-                        + "This argument is not supported "
-                        + "by the numpyro backend. "
-                        + "The jitter argument will be set to False."
-                    )
-                kwargs["nuts_sampler_kwargs"]["jitter"] = False
-            else:
-                kwargs["nuts_sampler_kwargs"] = {"jitter": False}
+        # if sampler == "numpyro":
+        #     if "nuts" in kwargs:
+        #         if kwargs["nuts"].get("jitter"):
+        #             _logger.warning(
+        #                 "The jitter argument is set to True. "
+        #                 + "This argument is not supported "
+        #                 + "by the numpyro backend. "
+        #                 + "The jitter argument will be set to False."
+        #             )
+        #         kwargs["nuts"]["jitter"] = False
+        #     else:
+        #         kwargs["nuts"] = {"jitter": False}
 
         if sampler != "pymc" and "step" in kwargs:
             raise ValueError(

--- a/tests/slow/test_choice_only.py
+++ b/tests/slow/test_choice_only.py
@@ -17,16 +17,7 @@ PARAMETER_GRID = [
     ("analytical", None, None, "jax", True),  # Defaults should work
     ("analytical", "pymc", None, "jax", True),
     ("analytical", "pymc", "slice", "jax", True),
-    pytest.param(
-        "analytical",
-        "numpyro",
-        None,
-        "jax",
-        True,
-        marks=pytest.mark.xfail(
-            reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-        ),
-    ),
+    ("analytical", "numpyro", None, "jax", True),
     ("analytical", "numpyro", None, "pytensor", ValueError),
     ("analytical", "numpyro", "slice", "jax", ValueError),
 ]
@@ -67,17 +58,14 @@ def test_choice_only_default_params(
                 chains=1,
                 tune=10,
                 draws=10,
+                progressbar=False,
             )
 
         return
 
     if step is None:
         idata = model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
     else:
         idata = model.sample(
@@ -87,6 +75,7 @@ def test_choice_only_default_params(
             chains=1,
             tune=10,
             draws=10,
+            progressbar=False,
         )
 
     assert isinstance(idata, az.InferenceData)
@@ -121,17 +110,14 @@ def test_choice_only_beta_reg(
                 chains=1,
                 tune=10,
                 draws=10,
+                progressbar=False,
             )
 
         return
 
     if step is None:
         idata = model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
     else:
         idata = model.sample(
@@ -141,6 +127,7 @@ def test_choice_only_beta_reg(
             chains=1,
             tune=10,
             draws=10,
+            progressbar=False,
         )
 
     assert isinstance(idata, az.InferenceData)
@@ -175,17 +162,14 @@ def test_choice_only_logit_reg(
                 chains=1,
                 tune=10,
                 draws=10,
+                progressbar=False,
             )
 
         return
 
     if step is None:
         idata = model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
     else:
         idata = model.sample(
@@ -195,6 +179,7 @@ def test_choice_only_logit_reg(
             chains=1,
             tune=10,
             draws=10,
+            progressbar=False,
         )
 
     assert isinstance(idata, az.InferenceData)
@@ -236,17 +221,14 @@ def test_choice_only_multiple_reg(
                 chains=1,
                 tune=10,
                 draws=10,
+                progressbar=False,
             )
 
         return
 
     if step is None:
         idata = model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
     else:
         idata = model.sample(
@@ -256,6 +238,7 @@ def test_choice_only_multiple_reg(
             chains=1,
             tune=10,
             draws=10,
+            progressbar=False,
         )
 
     assert isinstance(idata, az.InferenceData)

--- a/tests/slow/test_choice_only.py
+++ b/tests/slow/test_choice_only.py
@@ -5,6 +5,7 @@ import hssm
 import numpy as np
 import pandas as pd
 import pymc as pm
+import xarray as xr
 
 
 hssm.set_floatX("float32", update_jax=True)
@@ -78,7 +79,7 @@ def test_choice_only_default_params(
             progressbar=False,
         )
 
-    assert isinstance(idata, az.InferenceData)
+    assert isinstance(idata, xr.DataTree)
 
 
 @pytest.mark.slow
@@ -130,7 +131,7 @@ def test_choice_only_beta_reg(
             progressbar=False,
         )
 
-    assert isinstance(idata, az.InferenceData)
+    assert isinstance(idata, xr.DataTree)
 
 
 @pytest.mark.slow
@@ -182,7 +183,7 @@ def test_choice_only_logit_reg(
             progressbar=False,
         )
 
-    assert isinstance(idata, az.InferenceData)
+    assert isinstance(idata, xr.DataTree)
 
 
 @pytest.mark.slow
@@ -241,4 +242,4 @@ def test_choice_only_multiple_reg(
             progressbar=False,
         )
 
-    assert isinstance(idata, az.InferenceData)
+    assert isinstance(idata, xr.DataTree)

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -48,6 +48,7 @@ def sample(model, sampler, step):
             tune=10,
             draws=10,
             step=pm.Slice(model=model.pymc_model),
+            progressbar=False,
         )
     else:
         model.sample(
@@ -56,16 +57,13 @@ def sample(model, sampler, step):
             chains=1,
             tune=10,
             draws=10,
+            progressbar=False,
         )
 
 
 def run_sample(model, sampler, step, expected):
     """Run the sample function and check if the expected error is raised."""
     if expected is True:
-        if sampler == "numpyro":
-            pytest.xfail(
-                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-            )
         sample(model, sampler, step)
         assert isinstance(model.traces, xr.DataTree)
 
@@ -87,9 +85,6 @@ def run_sample(model, sampler, step, expected):
 
 # Basic tests for LBA likelihood
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-)
 def test_lba_sampling():
     """Test if sampling works for available lba models."""
     lba2_data_out = hssm.simulate_data(
@@ -182,7 +177,7 @@ def test_reg_models(data_ddm_reg, loglik_kind, backend, sampler, step, expected)
         summary = model.summary()
         assert summary.shape[0] == 6
 
-        model.plot_trace(show=False)
+        az.plot_trace_dist(model.traces)
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 6
 
@@ -252,18 +247,18 @@ def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, sampler, step, ex
         summary = model.summary(var_names=["~a", "~t"])
         assert summary.shape[0] == 7
 
-        model.plot_trace(show=False)
+        az.plot_trace_dist(model.traces)
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 8
 
-        model.plot_trace(show=False, var_names=["~a"])
+        az.plot_trace_dist(model.traces, var_names=["~a"])
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 8
 
-        model.plot_trace(show=False, var_names=["~t"])
+        az.plot_trace_dist(model.traces, var_names=["~t"])
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 7
 
-        model.plot_trace(show=False, var_names=["~a", "~t"])
+        az.plot_trace_dist(model.traces, var_names=["~a", "~t"])
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 7

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -102,8 +102,8 @@ def test_lba_sampling():
     traces_2 = lba2_model.sample(sampler="numpyro", draws=10, tune=10, chains=1)
     traces_3 = lba3_model.sample(sampler="numpyro", draws=10, tune=10, chains=1)
 
-    assert isinstance(traces_2, az.InferenceData)
-    assert isinstance(traces_3, az.InferenceData)
+    assert isinstance(traces_2, xr.DataTree)
+    assert isinstance(traces_3, xr.DataTree)
 
 
 @pytest.mark.slow

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -66,9 +66,8 @@ def run_sample(model, sampler, step, expected):
             pytest.xfail(
                 "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
             )
-        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
-        assert isinstance(model.traces, az.InferenceData)
+        assert isinstance(model.traces, xr.DataTree)
 
         # make sure log_likelihood computations check out
         traces_copy = deepcopy(model.traces)
@@ -76,9 +75,9 @@ def run_sample(model, sampler, step, expected):
 
         # recomputing log-likelihood yields same results?
         model.log_likelihood(traces_copy, inplace=True)
-        assert isinstance(traces_copy, az.InferenceData)
-        assert "log_likelihood" in traces_copy.groups()
-        for group_ in traces_copy.groups():
+        assert isinstance(traces_copy, xr.DataTree)
+        assert "log_likelihood" in traces_copy
+        for group_ in traces_copy:
             xr.testing.assert_equal(traces_copy[group_], model.traces[group_])
 
     else:
@@ -142,7 +141,7 @@ def test_simple_models(data_ddm, loglik_kind, backend, sampler, step, expected):
         summary = model.summary()
         assert summary.shape[0] == 4
 
-        model.plot_trace(show=False)
+        az.plot_trace_dist(model.traces)
         fig = plt.gcf()
         assert len(fig.axes) // 2 == 4
 

--- a/tests/slow/test_missing_data_and_deadline_mcmc.py
+++ b/tests/slow/test_missing_data_and_deadline_mcmc.py
@@ -97,34 +97,26 @@ def sample(model, sampler, step):
             tune=10,
             draws=10,
             step=pm.Slice(model=model.pymc_model),
+            progressbar=False,
         )
     else:
         model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
 
 
 def run_sample(model, sampler, step, expected):
     if expected is True:
-        if sampler == "numpyro":
-            pytest.xfail(
-                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-            )
-        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
-        assert isinstance(model.traces, az.InferenceData)
+        assert isinstance(model.traces, xr.DataTree)
 
         traces_copy = deepcopy(model.traces)
         del traces_copy["log_likelihood"]
 
         model.log_likelihood(traces_copy, inplace=True)
-        assert isinstance(traces_copy, az.InferenceData)
-        assert "log_likelihood" in traces_copy.groups()
-        for group_ in traces_copy.groups():
+        assert isinstance(traces_copy, xr.DataTree)
+        assert "log_likelihood" in traces_copy
+        for group_ in traces_copy:
             xr.testing.assert_equal(traces_copy[group_], model.traces[group_])
     else:
         with pytest.raises(expected):

--- a/tests/slow/test_missing_data_mcmc.py
+++ b/tests/slow/test_missing_data_mcmc.py
@@ -87,8 +87,7 @@ def sample(model, sampler, step):
 def run_sample(model, sampler, step, expected):
     if expected is True:
         sample(model, sampler, step)
-        assert isinstance(model.traces, az.InferenceData)
-
+        assert isinstance(model.traces, xr.DataTree)
         traces_copy = deepcopy(model.traces)
         del traces_copy["log_likelihood"]
 

--- a/tests/slow/test_missing_data_mcmc.py
+++ b/tests/slow/test_missing_data_mcmc.py
@@ -92,7 +92,7 @@ def run_sample(model, sampler, step, expected):
         del traces_copy["log_likelihood"]
 
         model.log_likelihood(traces_copy, inplace=True)
-        assert isinstance(traces_copy, az.InferenceData)
+        assert isinstance(traces_copy, xr.DataTree)
         assert "log_likelihood" in traces_copy
         for group_ in traces_copy:
             xr.testing.assert_equal(traces_copy[group_], model.traces[group_])

--- a/tests/slow/test_missing_data_mcmc.py
+++ b/tests/slow/test_missing_data_mcmc.py
@@ -76,24 +76,16 @@ def sample(model, sampler, step):
             tune=10,
             draws=10,
             step=pm.Slice(model=model.pymc_model),
+            progressbar=False,
         )
     else:
         model.sample(
-            sampler=sampler,
-            cores=1,
-            chains=1,
-            tune=10,
-            draws=10,
+            sampler=sampler, cores=1, chains=1, tune=10, draws=10, progressbar=False
         )
 
 
 def run_sample(model, sampler, step, expected):
     if expected is True:
-        if sampler == "numpyro":
-            pytest.xfail(
-                "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-            )
-        pytest.xfail("TypeError: 'tuple' object is not callable")
         sample(model, sampler, step)
         assert isinstance(model.traces, az.InferenceData)
 
@@ -102,8 +94,8 @@ def run_sample(model, sampler, step, expected):
 
         model.log_likelihood(traces_copy, inplace=True)
         assert isinstance(traces_copy, az.InferenceData)
-        assert "log_likelihood" in traces_copy.groups()
-        for group_ in traces_copy.groups():
+        assert "log_likelihood" in traces_copy
+        for group_ in traces_copy:
             xr.testing.assert_equal(traces_copy[group_], model.traces[group_])
     else:
         with pytest.raises(expected):
@@ -113,7 +105,6 @@ def run_sample(model, sampler, step, expected):
 # AF-TODO: CPN / GONOGO part has to be rethought
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
-# @pytest.mark.xfail(reason="Needs to be reactivated, CPN logic needs to be revised")
 def test_simple_models_missing_data(
     data_ddm_missing, loglik_kind, backend, sampler, step, expected, cpn
 ):
@@ -133,7 +124,6 @@ def test_simple_models_missing_data(
 
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
-# @pytest.mark.xfail(reason="Needs to be reactivated, CPN logic needs to be revised")
 def test_reg_models_missing_data(
     data_ddm_reg_missing, loglik_kind, backend, sampler, step, expected, cpn
 ):


### PR DESCRIPTION
All slow tests in `tests/slow/test_*_mcmc.py are now passing.

Fixes implemented:
1. replaced `model.plot_trace` with `az.plot_trace_dist`. `model.plot_trace` and `model.summary` wrapper method for their arviz equivalents will be removed in a future PR. These wrappers are not necessary and may break when arviz is updated. Users are will be recommended to use the arviz methods directly.
2. added `progressbar=False` to all sample methods to suppress progress bar outputs in tests
3. All calls to `InferenceData.groups()` is now done through dictionary-like methods. e.g. `if __ in idata.groups()` is now `if __ in dt` following changes to xr.DataTree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed forced override of NUTS jitter settings for the numpyro sampler, allowing users full control over jitter configuration.

* **Tests**
  * Updated test validation logic to handle new trace container types.
  * Removed expected-failure markers from previously failing test configurations that should now pass.
  * Updated trace visualization methods in test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->