### PR TITLE
[pymc6 migration] Fixed failed VI tests

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -28,6 +28,7 @@ import xarray as xr
 from bambi.model_components import DistributionalComponent
 from bambi.transformations import transformations_namespace
 from pymc.model.transform.conditioning import do
+from pymc.variational import Approximation
 
 from hssm._types import SupportedModels
 from hssm.data_validator import DataValidatorMixin
@@ -254,7 +255,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         # region ===== Inference Results (initialized to None/empty) =====
         self._inference_obj: az.InferenceData | None = None
-        self._inference_obj_vi: pm.Approximation | None = None
+        self._inference_obj_vi: Approximation | None = None
         self._vi_approx = None
         self._map_dict = None
         # endregion
@@ -515,7 +516,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         initvals: str | dict | None = None,
         include_response_params: bool = False,
         **kwargs,
-    ) -> xr.DataTree | pm.Approximation:
+    ) -> xr.DataTree | Approximation:
         """Perform sampling using the `fit` method via bambi.Model.
 
         Parameters
@@ -550,7 +551,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        xr.DataTree | pm.Approximation
+        xr.DataTree | Approximation
             A reference to the `model.traces` object, which stores the traces of the
             last call to `model.sample()`. `model.traces` is an ArviZ `InferenceData`
             instance if `sampler` is `"pymc"` (default), `"numpyro"`,
@@ -703,7 +704,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return_idata: bool = True,
         ignore_mcmc_start_point_defaults=False,
         **vi_kwargs,
-    ) -> pm.Approximation | az.InferenceData:
+    ) -> Approximation | az.InferenceData:
         """Perform Variational Inference.
 
         Parameters
@@ -722,7 +723,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-            pm.Approximation or az.InferenceData: The mean field approximation object.
+            Approximation or az.InferenceData: The mean field approximation object.
         """
         if self.loglik_kind == "analytical":
             _logger.warning(
@@ -1474,7 +1475,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return pm.model.Point(fn(None), model=self.pymc_model)
 
     def restore_traces(
-        self, traces: az.InferenceData | pm.Approximation | str | PathLike
+        self, traces: az.InferenceData | Approximation | str | PathLike
     ) -> None:
         """Restore traces from an InferenceData object or a .netcdf file.
 
@@ -1483,7 +1484,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         traces
             An InferenceData object or a path to a file containing the traces.
         """
-        if isinstance(traces, pm.Approximation):
+        if isinstance(traces, Approximation):
             self._inference_obj_vi = traces
             return
 
@@ -1492,7 +1493,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         self._inference_obj = cast("az.InferenceData", traces)
 
     def restore_vi_traces(
-        self, traces: az.InferenceData | pm.Approximation | str | PathLike
+        self, traces: az.InferenceData | Approximation | str | PathLike
     ) -> None:
         """Restore VI traces from an InferenceData object or a .netcdf file.
 
@@ -1501,7 +1502,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         traces
             An InferenceData object or a path to a file containing the VI traces.
         """
-        if isinstance(traces, pm.Approximation):
+        if isinstance(traces, Approximation):
             self._inference_obj_vi = traces
             return
 
@@ -1778,7 +1779,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return self.__repr__()
 
     @property
-    def traces(self) -> az.InferenceData | pm.Approximation:
+    def traces(self) -> az.InferenceData | Approximation:
         """Return the trace of the model after sampling.
 
         Raises
@@ -1788,7 +1789,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        az.InferenceData | pm.Approximation
+        az.InferenceData | Approximation
             The trace of the model after the last call to `sample()`.
         """
         if not self._inference_obj:
@@ -1819,7 +1820,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return self._inference_obj_vi
 
     @property
-    def vi_approx(self) -> pm.Approximation:
+    def vi_approx(self) -> Approximation:
         """Return the variational inference approximation object.
 
         Raises
@@ -1829,7 +1830,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        pm.Approximation
+        Approximation
             The variational inference approximation object.
         """
         if not self._vi_approx:

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -743,9 +743,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         with self.pymc_model:
             self._vi_approx = pm.fit(n=niter, method=method, **vi_kwargs)
 
-        # Sample from the approximate posterior
-        if self._vi_approx is not None:
-            self._inference_obj_vi = self._vi_approx.sample(draws)
+            # Sample from the approximate posterior
+            if self._vi_approx is not None:
+                self._inference_obj_vi = self._vi_approx.sample(draws)
 
         # Post-processing
         self._clean_posterior_group(dt=self._inference_obj_vi)

--- a/tests/slow/test_missing_data_and_deadline_vi.py
+++ b/tests/slow/test_missing_data_and_deadline_vi.py
@@ -1,8 +1,8 @@
 import pytest
 
-import arviz as az
 import hssm
 import numpy as np
+import xarray as xr
 
 from hssm.utils import _rearrange_data
 
@@ -56,13 +56,12 @@ def run_vi(model, method, expected):
     import pymc as pm
 
     if expected == True:
-        pytest.xfail("TypeError: No model on context stack.")
-        model.vi(method, niter=1000)
-        assert isinstance(model.vi_idata, az.InferenceData)
-        assert isinstance(model.vi_approx, pm.Approximation)
+        model.vi(method, niter=1000, progressbar=False)
+        assert isinstance(model.vi_idata, xr.DataTree)
+        assert isinstance(model.vi_approx, pm.variational.Approximation)
     else:
         with pytest.raises(expected):
-            model.vi(method, niter=1000)
+            model.vi(method, niter=1000, progressbar=False)
 
 
 @pytest.mark.slow

--- a/tests/slow/test_missing_data_vi.py
+++ b/tests/slow/test_missing_data_vi.py
@@ -1,8 +1,8 @@
 import pytest
 
-import arviz as az
 import hssm
 import numpy as np
+import xarray as xr
 
 from hssm.utils import _rearrange_data
 
@@ -79,18 +79,16 @@ def run_vi(model, method, expected):
     import pymc as pm
 
     if expected == True:
-        pytest.xfail("TypeError: No model on context stack.")
-        model.vi(method, niter=100)
-        assert isinstance(model.vi_idata, az.InferenceData)
-        assert isinstance(model.vi_approx, pm.Approximation)
+        model.vi(method, niter=100, progressbar=False)
+        assert isinstance(model.vi_idata, xr.DataTree)
+        assert isinstance(model.vi_approx, pm.variational.Approximation)
     else:
         with pytest.raises(expected):
-            model.vi(method, niter=100)
+            model.vi(method, niter=100, progressbar=False)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
-# @pytest.mark.xfail(reason="Needs to be reactivated, CPN logic needs to be revised")
 def test_simple_models_missing_data(
     data_ddm_missing, loglik_kind, backend, method, expected, cpn
 ):
@@ -107,7 +105,6 @@ def test_simple_models_missing_data(
 
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
-# @pytest.mark.xfail(reason="Needs to be reactivated, CPN logic needs to be revised")
 def test_reg_models_missing_data(
     data_ddm_reg_missing, loglik_kind, backend, method, expected, cpn
 ):

--- a/tests/slow/test_vi.py
+++ b/tests/slow/test_vi.py
@@ -1,8 +1,8 @@
 import pytest
 
-import arviz as az
 import hssm
 import pymc as pm
+import xarray as xr
 
 hssm.set_floatX("float32", update_jax=True)
 
@@ -24,13 +24,12 @@ PARAMETER_GRID = [
 
 def run_vi(model, method, expected):
     if expected == True:
-        pytest.xfail("TypeError: No model on context stack.")
-        model.vi(method, niter=100)
-        assert isinstance(model.vi_idata, az.InferenceData)
-        assert isinstance(model.vi_approx, pm.Approximation)
+        model.vi(method, niter=100, progressbar=False)
+        assert isinstance(model.vi_idata, xr.DataTree)
+        assert isinstance(model.vi_approx, pm.variational.Approximation)
     else:
         with pytest.raises(expected):
-            model.vi(method, niter=100)
+            model.vi(method, niter=100, progressbar=False)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Turns out that there was a bug in the vi methods. Once these are fixed, `No model on context stack` errors are fixed

Other fixes:
1. In tests, disabled progress bars for cleaner outputs
2. use `xr.DataTree` instead of `az.InferenceData` and `pm.variational.Approximation` instead of `pm.Approximation`
3. Updated `base.py` with `pm.variational.Approximation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations for variational inference methods to enhance consistency and type safety across the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->