### PR TITLE
[pymc6 migration] Fix IO for traces and models

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1024,8 +1024,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 if inplace:
                     dt.add_groups(
                         posterior_predictive=xr.concat(
-                            posterior_predictive_list, dim="draw"
-                        )  # type: ignore[arg-type]
+                            posterior_predictive_list,  # type: ignore[arg-type]
+                            dim="draw",
+                        )
                     )
                     # for inplace, we don't return anything
                     return None
@@ -1036,8 +1037,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     del dt_copy["posterior_predictive"]
                     dt_copy.add_groups(
                         posterior_predictive=xr.concat(
-                            posterior_predictive_list, dim="draw"
-                        )  # type: ignore[arg-type]
+                            posterior_predictive_list,  # type: ignore[arg-type]
+                            dim="draw",
+                        )
                     )
                     return dt_copy
             else:

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -25,6 +25,7 @@ import pymc as pm
 import pytensor
 import seaborn as sns
 import xarray as xr
+from arviz import DataTree
 from bambi.model_components import DistributionalComponent
 from bambi.transformations import transformations_namespace
 from pymc.model.transform.conditioning import do
@@ -255,7 +256,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         self.additional_namespace = additional_namespace
 
         # region ===== Inference Results (initialized to None/empty) =====
-        self._inference_obj: az.InferenceData | None = None
+        self._inference_obj: DataTree | None = None
         self._inference_obj_vi: Approximation | None = None
         self._vi_approx = None
         self._map_dict = None
@@ -517,7 +518,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         initvals: str | dict | None = None,
         include_response_params: bool = False,
         **kwargs,
-    ) -> xr.DataTree | Approximation:
+    ) -> DataTree | Approximation:
         """Perform sampling using the `fit` method via bambi.Model.
 
         Parameters
@@ -552,9 +553,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        xr.DataTree | Approximation
+        DataTree | Approximation
             A reference to the `model.traces` object, which stores the traces of the
-            last call to `model.sample()`. `model.traces` is an ArviZ `InferenceData`
+            last call to `model.sample()`. `model.traces` is a `DataTree`
             instance if `sampler` is `"pymc"` (default), `"numpyro"`,
             `"blackjax"` or "`laplace".
         """
@@ -705,7 +706,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return_idata: bool = True,
         ignore_mcmc_start_point_defaults=False,
         **vi_kwargs,
-    ) -> Approximation | az.InferenceData:
+    ) -> Approximation | DataTree:
         """Perform Variational Inference.
 
         Parameters
@@ -719,12 +720,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             The number of samples to draw from the posterior distribution.
             Defaults to 1000.
         return_idata : bool
-            If True, returns an InferenceData object. Otherwise, returns the
+            If True, returns an DataTree object. Otherwise, returns the
             approximation object directly. Defaults to True.
 
         Returns
         -------
-            Approximation or az.InferenceData: The mean field approximation object.
+            Approximation or DataTree: The mean field approximation object.
         """
         if self.loglik_kind == "analytical":
             _logger.warning(
@@ -752,18 +753,18 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         # Post-processing
         self._clean_posterior_group(dt=self._inference_obj_vi)
 
-        # Return the InferenceData object if return_idata is True
+        # Return the DataTree object if return_idata is True
         if return_idata:
             return self._inference_obj_vi
         # Otherwise return the appromation object directly
         return self.vi_approx
 
-    def _clean_posterior_group(self, dt: xr.DataTree | None = None):
-        """Clean up the posterior group of the InferenceData object.
+    def _clean_posterior_group(self, dt: DataTree | None = None):
+        """Clean up the posterior group of the DataTree object.
 
         Parameters
         ----------
-        dt : xr.DataTree | None
+        dt : DataTree | None
             The DataTree object to clean up. If None, the last DataTree object
             will be used.
         """
@@ -802,120 +803,122 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     def log_likelihood(
         self,
-        idata: az.InferenceData | None = None,
+        dt: DataTree | None = None,
         data: pd.DataFrame | None = None,
         inplace: bool = True,
         keep_likelihood_params: bool = False,
-    ) -> az.InferenceData | None:
+    ) -> DataTree | None:
         """Compute the log likelihood of the model.
 
         Parameters
         ----------
-        idata : optional
-            The `InferenceData` object returned by `HSSM.sample()`. If not provided,
+        dt : optional
+            The trace object returned by `HSSM.sample()`. If not provided,
         data : optional
             A pandas DataFrame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.
         inplace : optional
-            If `True` will modify idata in-place and append a `log_likelihood` group to
-            `idata`. Otherwise, it will return a copy of idata with the predictions
+            If `True` will modify dt in-place and append a `log_likelihood` group to
+            `dt`. Otherwise, it will return a copy of dt with the predictions
             added, by default True.
         keep_likelihood_params : optional
             If `True`, the trial wise likelihood parameters that are computed
-            on route to getting the log likelihood are kept in the `idata` object.
-            Defaults to False. See also the method `add_likelihood_parameters_to_idata`.
+            on route to getting the log likelihood are kept in the `dt` object.
+            Defaults to False. See also the method
+            `add_likelihood_parameters_to_datatree`.
 
         Returns
         -------
-        az.InferenceData | None
-            InferenceData or None
+        DataTree | None
+            The DataTree object with the log likelihood computed and added to it, or
+            None if inplace is True.
         """
-        if self._inference_obj is None and idata is None:
+        if self._inference_obj is None and dt is None:
             raise ValueError(
                 "Neither has the model been sampled yet nor"
-                + " an idata object has been provided."
+                + " a DataTree object has been provided."
             )
 
-        if idata is None:
+        if dt is None:
             if self._inference_obj is None:
                 raise ValueError(
                     "The model has not been sampled yet. "
-                    + "Please provide an idata object."
+                    + "Please provide a DataTree object."
                 )
             else:
-                idata = self._inference_obj
+                dt = self._inference_obj
 
         # Actual likelihood computation
-        idata = _compute_log_likelihood(self.model, idata, data, inplace)
+        dt = _compute_log_likelihood(self.model, dt, data, inplace)
 
         # clean up posterior:
         if not keep_likelihood_params:
-            self._clean_posterior_group(dt=idata)
+            self._clean_posterior_group(dt=dt)
 
         if inplace:
             return None
         else:
-            return idata
+            return dt
 
-    def add_likelihood_parameters_to_idata(
+    def add_likelihood_parameters_to_datatree(
         self,
-        idata: az.InferenceData | None = None,
+        dt: DataTree | None = None,
         inplace: bool = False,
-    ) -> az.InferenceData | None:
-        """Add likelihood parameters to the InferenceData object.
+    ) -> DataTree | None:
+        """Add likelihood parameters to the DataTree object.
 
         Parameters
         ----------
-        idata : az.InferenceData
-            The InferenceData object returned by HSSM.sample().
+        dt : DataTree
+            The trace object returned by HSSM.sample().
         inplace : bool
-            If True, the likelihood parameters are added to idata in-place. Otherwise,
-            a copy of idata with the likelihood parameters added is returned.
-            Defaults to False.
+            If True, the likelihood parameters are added to datatree in-place.
+            Otherwise, a copy of datatree with the likelihood parameters added is
+            returned. Defaults to False.
 
         Returns
         -------
-        az.InferenceData | None
-            InferenceData or None
+        DataTree | None
+            DataTree object with likelihood parameters added or None if inplace is True.
         """
-        if idata is None:
+        if dt is None:
             if self._inference_obj is None:
-                raise ValueError("No idata provided and model not yet sampled!")
+                raise ValueError("No datatree provided and model not yet sampled!")
             else:
-                idata = self.model._compute_likelihood_params(  # pylint: disable=protected-access
+                dt = self.model._compute_likelihood_params(  # pylint: disable=protected-access
                     deepcopy(self._inference_obj)
                     if not inplace
                     else self._inference_obj
                 )
         else:
-            idata = self.model._compute_likelihood_params(  # pylint: disable=protected-access
-                deepcopy(idata) if not inplace else idata
+            dt = self.model._compute_likelihood_params(  # pylint: disable=protected-access
+                deepcopy(dt) if not inplace else dt
             )
-        return idata
+        return dt
 
     def sample_posterior_predictive(
         self,
-        idata: az.InferenceData | None = None,
+        dt: DataTree | None = None,
         data: pd.DataFrame | None = None,
         inplace: bool = True,
         include_group_specific: bool = True,
         kind: Literal["response", "response_params"] = "response",
         draws: int | float | list[int] | np.ndarray | None = None,
         safe_mode: bool = True,
-    ) -> az.InferenceData | None:
+    ) -> DataTree | None:
         """Perform posterior predictive sampling from the HSSM model.
 
         Parameters
         ----------
-        idata : optional
-            The `InferenceData` object returned by `HSSM.sample()`. If not provided,
-            the `InferenceData` from the last time `sample()` is called will be used.
+        dt : optional
+            The `DataTree` object returned by `HSSM.sample()`. If not provided,
+            the `DataTree` from the last time `sample()` is called will be used.
         data : optional
             An optional data frame with values for the predictors that are used to
             obtain out-of-sample predictions. If omitted, the original dataset is used.
         inplace : optional
-            If `True` will modify idata in-place and append a `posterior_predictive`
-            group to `idata`. Otherwise, it will return a copy of idata with the
+            If `True` will modify datatree in-place and append a `posterior_predictive`
+            group to `datatree`. Otherwise, it will return a copy of datatree with the
             predictions added, by default True.
         include_group_specific : optional
             If `True` will make predictions including the group specific effects.
@@ -946,29 +949,30 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         Raises
         ------
         ValueError
-            If the model has not been sampled yet and idata is not provided.
+            If the model has not been sampled yet and datatree is not provided.
 
         Returns
         -------
-        az.InferenceData | None
-            InferenceData or None
+        DataTree | None
+            A DataTree object with the posterior predictive samples added,
+            or None if inplace is True.
         """
-        if idata is None:
+        if dt is None:
             if self._inference_obj is None:
                 raise ValueError(
                     "The model has not been sampled yet. "
-                    + "Please either provide an idata object or sample the model first."
+                    "Please either provide a datatree object or sample the model first."
                 )
-            idata = self._inference_obj
+            dt = self._inference_obj
             _logger.info(
-                "idata=None, we use the traces assigned to the HSSM object as idata."
+                "dt=None, we use the traces assigned to the HSSM object as datatree."
             )
 
-        if idata is not None:
-            if "posterior_predictive" in idata.groups():
-                del idata["posterior_predictive"]
+        if dt is not None:
+            if "posterior_predictive" in dt.groups():
+                del dt["posterior_predictive"]
                 _logger.warning(
-                    "pre-existing posterior_predictive group deleted from idata. \n"
+                    "pre-existing posterior_predictive group deleted from datatree."
                 )
 
         if self._check_extra_fields(data):
@@ -981,7 +985,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         elif isinstance(draws, int | float):
             draws = np.arange(int(draws))
         elif draws is None:
-            draws = idata["posterior"].draw.values
+            draws = dt["posterior"].draw.values
         else:
             raise ValueError(
                 "draws must be an integer, " + "a list of integers, or a numpy array."
@@ -989,38 +993,36 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         assert isinstance(draws, np.ndarray)
 
-        # Make a copy of idata, set the `posterior` group to be a random sub-sample
+        # Make a copy of dt, set the `posterior` group to be a random sub-sample
         # of the original (draw dimension gets sub-sampled)
 
-        idata_copy = idata.copy()
+        dt_copy = dt.copy()
 
-        if (draws.shape != idata["posterior"].draw.values.shape) or (
-            (draws.shape == idata["posterior"].draw.values.shape)
-            and not np.allclose(draws, idata["posterior"].draw.values)
+        if (draws.shape != dt["posterior"].draw.values.shape) or (
+            (draws.shape == dt["posterior"].draw.values.shape)
+            and not np.allclose(draws, dt["posterior"].draw.values)
         ):
             # Reassign posterior to sub-sampled version
-            setattr(idata_copy, "posterior", idata["posterior"].isel(draw=draws))
+            setattr(dt_copy, "posterior", dt["posterior"].isel(draw=draws))
 
         if kind == "response":
             # If we run kind == 'response' we actually run the observation RV
             if safe_mode:
                 # safe mode splits the draws into chunks of 10 to avoid
                 # memory issues (TODO: Figure out the source of memory issues)
-                split_draws = _split_array(
-                    idata_copy["posterior"].draw.values, divisor=10
-                )
+                split_draws = _split_array(dt_copy["posterior"].draw.values, divisor=10)
 
                 posterior_predictive_list = []
                 for samples_tmp in split_draws:
-                    tmp_posterior = idata["posterior"].sel(draw=samples_tmp)
-                    setattr(idata_copy, "posterior", tmp_posterior)
+                    tmp_posterior = dt["posterior"].sel(draw=samples_tmp)
+                    setattr(dt_copy, "posterior", tmp_posterior)
                     self.model.predict(
-                        idata_copy, kind, data, True, include_group_specific
+                        dt_copy, kind, data, True, include_group_specific
                     )
-                    posterior_predictive_list.append(idata_copy["posterior_predictive"])
+                    posterior_predictive_list.append(dt_copy["posterior_predictive"])
 
                 if inplace:
-                    idata.add_groups(
+                    dt.add_groups(
                         posterior_predictive=xr.concat(
                             posterior_predictive_list, dim="draw"
                         )
@@ -1028,41 +1030,39 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     # for inplace, we don't return anything
                     return None
                 else:
-                    # Reassign original posterior to idata_copy
-                    setattr(idata_copy, "posterior", idata["posterior"])
-                    # Add new posterior predictive group to idata_copy
-                    del idata_copy["posterior_predictive"]
-                    idata_copy.add_groups(
+                    # Reassign original posterior to dt_copy
+                    setattr(dt_copy, "posterior", dt["posterior"])
+                    # Add new posterior predictive group to dt_copy
+                    del dt_copy["posterior_predictive"]
+                    dt_copy.add_groups(
                         posterior_predictive=xr.concat(
                             posterior_predictive_list, dim="draw"
                         )
                     )
-                    return idata_copy
+                    return dt_copy
             else:
                 if inplace:
                     # If not safe-mode
                     # We call .predict() directly without any
                     # chunking of data.
 
-                    # .predict() is called on the copy of idata
+                    # .predict() is called on the copy of dt
                     # since we still subsampled (or assigned) the draws
                     self.model.predict(
-                        idata_copy, kind, data, True, include_group_specific
+                        dt_copy, kind, data, True, include_group_specific
                     )
 
-                    # posterior predictive group added to idata
-                    idata.add_groups(
-                        posterior_predictive=idata_copy["posterior_predictive"]
-                    )
+                    # posterior predictive group added to dt
+                    dt.add_groups(posterior_predictive=dt_copy["posterior_predictive"])
                     # don't return anything if inplace
                     return None
                 else:
                     # Not safe mode and not inplace
                     # Function acts as very thin wrapper around
                     # .predict(). It just operates on the
-                    # idata_copy object
+                    # dt_copy object
                     return self.model.predict(
-                        idata_copy, kind, data, False, include_group_specific
+                        dt_copy, kind, data, False, include_group_specific
                     )
         elif kind == "response_params":
             # If kind == 'response_params', we don't need to run the RV directly,
@@ -1073,9 +1073,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 "The kind argument is set to 'mean', but 'draws' argument "
                 + "is not None: The draws argument will be ignored!"
             )
-            return self.model.predict(
-                idata, kind, data, inplace, include_group_specific
-            )
+            return self.model.predict(dt, kind, data, inplace, include_group_specific)
         else:
             raise ValueError("`kind` must be either 'response' or 'response_params'.")
 
@@ -1107,41 +1105,41 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         """
         return plotting.plot_quantile_probability(self, **kwargs)
 
-    def predict(self, **kwargs) -> az.InferenceData:
+    def predict(self, **kwargs) -> DataTree:
         """Generate samples from the predictive distribution."""
         return self.model.predict(**kwargs)
 
     def sample_do(
         self, params: dict[str, Any], draws: int = 100, return_model=False, **kwargs
-    ) -> az.InferenceData | tuple[az.InferenceData, pm.Model]:
+    ) -> DataTree | tuple[DataTree, pm.Model]:
         """Generate samples from the predictive distribution using the `do-operator`."""
         do_model = do(self.pymc_model, params)
-        do_idata = pm.sample_prior_predictive(model=do_model, draws=draws, **kwargs)
+        do_dt = pm.sample_prior_predictive(model=do_model, draws=draws, **kwargs)
 
         # clean up `rt,response_mean` to `v`
-        do_idata = self._drop_parent_str_from_idata(idata=do_idata)
+        do_dt = self._drop_parent_str_from_datatree(dt=do_dt)
 
         # rename otherwise inconsistent dims and coords
-        if "rt,response_extra_dim_0" in do_idata["prior_predictive"].dims:
+        if "rt,response_extra_dim_0" in do_dt["prior_predictive"].dims:
             setattr(
-                do_idata,
+                do_dt,
                 "prior_predictive",
-                do_idata["prior_predictive"].rename_dims(
+                do_dt["prior_predictive"].rename_dims(
                     {"rt,response_extra_dim_0": "rt,response_dim"}
                 ),
             )
-        if "rt,response_extra_dim_0" in do_idata["prior_predictive"].coords:
+        if "rt,response_extra_dim_0" in do_dt["prior_predictive"].coords:
             setattr(
-                do_idata,
+                do_dt,
                 "prior_predictive",
-                do_idata["prior_predictive"].rename_vars(
+                do_dt["prior_predictive"].rename_vars(
                     name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
                 ),
             )
 
         if return_model:
-            return do_idata, do_model
-        return do_idata
+            return do_dt, do_model
+        return do_dt
 
     def sample_prior_predictive(
         self,
@@ -1149,7 +1147,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         var_names: str | list[str] | None = None,
         omit_offsets: bool = True,
         random_seed: np.random.Generator | None = None,
-    ) -> az.InferenceData:
+    ) -> DataTree:
         """Generate samples from the prior predictive distribution.
 
         Parameters
@@ -1159,18 +1157,18 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             to 500.
         var_names
             A list of names of variables for which to compute the prior predictive
-            distribution. Defaults to ``None`` which means both observed and unobserved
+            distribution. Defaults to `None` which means both observed and unobserved
             RVs.
         omit_offsets
-            Whether to omit offset terms. Defaults to ``True``.
+            Whether to omit offset terms. Defaults to `True`.
         random_seed
             Seed for the random number generator.
 
         Returns
         -------
-        az.InferenceData
-            ``InferenceData`` object with the groups ``prior``, ``prior_predictive`` and
-            ``observed_data``.
+        DataTree
+            `DataTree` object with the groups `prior`, `prior_predictive` and
+            `observed_data`.
         """
         prior_predictive = self.model.prior_predictive(
             draws, var_names, omit_offsets, random_seed
@@ -1193,28 +1191,28 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             self._inference_obj.extend(prior_predictive)
 
         # clean up `rt,response_mean` to `v`
-        idata = self._drop_parent_str_from_idata(idata=self._inference_obj)
+        dt = self._drop_parent_str_from_datatree(dt=self._inference_obj)
 
         # rename otherwise inconsistent dims and coords
-        if "rt,response_extra_dim_0" in idata["prior_predictive"].dims:
+        if "rt,response_extra_dim_0" in dt["prior_predictive"].dims:
             setattr(
-                idata,
+                dt,
                 "prior_predictive",
-                idata["prior_predictive"].rename_dims(
+                dt["prior_predictive"].rename_dims(
                     {"rt,response_extra_dim_0": "rt,response_dim"}
                 ),
             )
-        if "rt,response_extra_dim_0" in idata["prior_predictive"].coords:
+        if "rt,response_extra_dim_0" in dt["prior_predictive"].coords:
             setattr(
-                idata,
+                dt,
                 "prior_predictive",
-                idata["prior_predictive"].rename_vars(
+                dt["prior_predictive"].rename_vars(
                     name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
                 ),
             )
 
-        # Update self._inference_obj to match the cleaned idata
-        self._inference_obj = idata
+        # Update self._inference_obj to match the cleaned datatree
+        self._inference_obj = dt
         return deepcopy(self._inference_obj)
 
     @property
@@ -1348,7 +1346,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     def plot_trace(
         self,
-        data: az.InferenceData | None = None,
+        data: DataTree | None = None,
         include_deterministic: bool = False,
         tight_layout: bool = True,
         **kwargs,
@@ -1364,7 +1362,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         Parameters
         ----------
         data : optional
-            An ArviZ InferenceData object. If None, the traces stored in the model will
+            An DataTree object. If None, the traces stored in the model will
             be used.
         include_deterministic : optional
             Whether to include deterministic variables in the plot. Defaults to False.
@@ -1376,8 +1374,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             Whether to call plt.tight_layout() after plotting. Defaults to True.
         """
         data = data or self.traces
-        if not isinstance(data, az.InferenceData):
-            raise TypeError("data must be an InferenceData object.")
+        if not isinstance(data, DataTree):
+            raise TypeError("data must be an DataTree object.")
 
         if not include_deterministic:
             var_names = list(
@@ -1411,7 +1409,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     def summary(
         self,
-        data: az.InferenceData | None = None,
+        data: DataTree | None = None,
         include_deterministic: bool = False,
         **kwargs,
     ) -> pd.DataFrame | xr.Dataset:
@@ -1426,7 +1424,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         Parameters
         ----------
         data
-            An ArviZ InferenceData object. If None, the traces stored in the model will
+            An ArviZ DataTree object. If None, the traces stored in the model will
             be used.
         include_deterministic : optional
             Whether to include deterministic variables in the plot. Defaults to False.
@@ -1441,8 +1439,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             A pandas DataFrame or xarray Dataset containing the summary statistics.
         """
         data = data or self.traces
-        if not isinstance(data, az.InferenceData):
-            raise TypeError("data must be an InferenceData object.")
+        if not isinstance(data, DataTree):
+            raise TypeError("data must be an DataTree object.")
 
         if not include_deterministic:
             var_names = list(
@@ -1476,15 +1474,13 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return pm.model.Point(fn(None), model=self.pymc_model)
 
     @_requires_io_backends
-    def restore_traces(
-        self, traces: az.InferenceData | Approximation | str | PathLike
-    ) -> None:
-        """Restore traces from an InferenceData object or a .netcdf file.
+    def restore_traces(self, traces: DataTree | Approximation | str | PathLike) -> None:
+        """Restore traces from an DataTree object or a .netcdf file.
 
         Parameters
         ----------
         traces
-            An InferenceData object or a path to a file containing the traces.
+            An DataTree object or a path to a file containing the traces.
         """
         if isinstance(traces, Approximation):
             self._inference_obj_vi = traces
@@ -1492,18 +1488,18 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         if isinstance(traces, (str, PathLike)):
             traces = az.from_netcdf(traces)
-        self._inference_obj = cast("az.InferenceData", traces)
+        self._inference_obj = cast("DataTree", traces)
 
     @_requires_io_backends
     def restore_vi_traces(
-        self, traces: az.InferenceData | Approximation | str | PathLike
+        self, traces: DataTree | Approximation | str | PathLike
     ) -> None:
-        """Restore VI traces from an InferenceData object or a .netcdf file.
+        """Restore VI traces from a DataTree object or a .netcdf file.
 
         Parameters
         ----------
         traces
-            An InferenceData object or a path to a file containing the VI traces.
+            A DataTree object or a path to a file containing the VI traces.
         """
         if isinstance(traces, Approximation):
             self._inference_obj_vi = traces
@@ -1511,7 +1507,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         if isinstance(traces, (str, PathLike)):
             traces = az.from_netcdf(traces)
-        self._inference_obj_vi = cast("az.InferenceData", traces)
+        self._inference_obj_vi = cast("DataTree", traces)
 
     @_requires_io_backends
     def save_model(
@@ -1519,7 +1515,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         model_name: str | None = None,
         allow_absolute_base_path: bool = False,
         base_path: str | Path = "hssm_models",
-        save_idata_only: bool = False,
+        save_traces_only: bool = False,
     ) -> None:
         """Save a HSSM model instance and its inference results to disk.
 
@@ -1535,7 +1531,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             Base directory to save model files in.
             Must be relative path if allow_absolute_base_path=False.
             Defaults to "hssm_models".
-        save_idata_only : bool
+        save_traces_only : bool
             If True, only saves inference data (traces), not the model pickle.
             Defaults to False (saves both model and traces).
 
@@ -1564,7 +1560,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         model_path.mkdir(parents=True, exist_ok=True)
 
         # Save model to pickle file
-        if not save_idata_only:
+        if not save_traces_only:
             with open(model_path.joinpath("model.pkl"), "wb") as f:
                 cpickle.dump(self, f)
 
@@ -1579,7 +1575,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
     @classmethod
     def load_model(
         cls, path: Union[str, Path]
-    ) -> Union["HSSMBase", dict[str, Optional[az.InferenceData]]]:
+    ) -> Union["HSSMBase", dict[str, Optional[DataTree]]]:
         """Load a HSSM model instance and its inference results from disk.
 
         Parameters
@@ -1590,9 +1586,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        HSSMBase or dict[str, az.InferenceData | None]
+        HSSMBase or dict[str, DataTree | None]
             The loaded model instance (with inference results attached if available),
-            or a dictionary of traces-only InferenceData objects when no model.pkl is
+            or a dictionary of traces-only DataTree objects when no model.pkl is
             found.
         """
         # Convert path to Path object
@@ -1622,8 +1618,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             ):
                 raise FileNotFoundError(f"No traces found in {model_dir}.")
             else:
-                idata_dict = cls.load_model_idata(model_dir)
-                return idata_dict
+                dt_dict = cls.load_model_traces(model_dir)
+                return dt_dict
         else:
             # Load model from pickle file
             with open(model_path, "rb") as f:
@@ -1642,7 +1638,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     @classmethod
     @_requires_io_backends
-    def load_model_idata(cls, path: str | Path) -> dict[str, az.InferenceData | None]:
+    def load_model_traces(cls, path: str | Path) -> dict[str, DataTree | None]:
         """Load the traces from a model directory.
 
         Parameters
@@ -1652,12 +1648,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        dict[str, az.InferenceData | None]
+        dict[str, DataTree | None]
             A dictionary with keys "idata_mcmc" and "idata_vi" containing the traces
             from the model directory. If the traces do not exist, the corresponding
             value will be None.
         """
-        idata_dict: dict[str, az.InferenceData | None] = {}
+        dt_dict: dict[str, DataTree | None] = {}
         model_dir = Path(path)
         # check if path exists
         if not model_dir.exists():
@@ -1667,19 +1663,19 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         traces_path = model_dir.joinpath("traces.nc")
         if not traces_path.exists():
             _logger.warning(f"traces.nc file does not exist in {model_dir}.")
-            idata_dict["idata_mcmc"] = None
+            dt_dict["idata_mcmc"] = None
         else:
-            idata_dict["idata_mcmc"] = az.from_netcdf(traces_path)
+            dt_dict["idata_mcmc"] = az.from_netcdf(traces_path)
 
         # check if vi_traces.nc exists
         vi_traces_path = model_dir.joinpath("vi_traces.nc")
         if not vi_traces_path.exists():
             _logger.warning(f"vi_traces.nc file does not exist in {model_dir}.")
-            idata_dict["idata_vi"] = None
+            dt_dict["idata_vi"] = None
         else:
-            idata_dict["idata_vi"] = az.from_netcdf(vi_traces_path)
+            dt_dict["idata_vi"] = az.from_netcdf(vi_traces_path)
 
-        return idata_dict
+        return dt_dict
 
     def __getstate__(self):
         """Get the state of the model for pickling.
@@ -1784,7 +1780,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return self.__repr__()
 
     @property
-    def traces(self) -> az.InferenceData | Approximation:
+    def traces(self) -> DataTree | Approximation:
         """Return the trace of the model after sampling.
 
         Raises
@@ -1794,7 +1790,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        az.InferenceData | Approximation
+        DataTree | Approximation
             The trace of the model after the last call to `sample()`.
         """
         if not self._inference_obj:
@@ -1803,7 +1799,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return self._inference_obj
 
     @property
-    def vi_idata(self) -> az.InferenceData:
+    def vi_idata(self) -> DataTree:
         """Return the variational inference approximation object.
 
         Raises
@@ -1813,7 +1809,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         Returns
         -------
-        az.InferenceData
+        DataTree
             The variational inference approximation object.
         """
         if not self._inference_obj_vi:
@@ -1909,7 +1905,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             )
         self.lapse = None
 
-    def _get_deterministic_var_names(self, idata) -> list[str]:
+    def _get_deterministic_var_names(self, dt) -> list[str]:
         """Filter out the deterministic variables in var_names."""
         var_names = [
             f"~{param_name}"
@@ -1917,48 +1913,46 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             if (param.is_regression)
         ]
 
-        if f"{self._parent}_mean" in idata["posterior"].data_vars:
+        if f"{self._parent}_mean" in dt["posterior"].data_vars:
             var_names.append(f"~{self._parent}_mean")
 
         # Parent parameters (always regression implicitly)
         # which don't have a formula attached
         # should be dropped from var_names, since the actual
         # parent name shows up as a regression.
-        if f"{self._parent}" in idata["posterior"].data_vars:
+        if f"{self._parent}" in dt["posterior"].data_vars:
             if self.params[self._parent].formula is None:
                 # Drop from var_names
                 var_names = [var for var in var_names if var != f"~{self._parent}"]
 
         return var_names
 
-    def _drop_parent_str_from_idata(
-        self, idata: az.InferenceData | None
-    ) -> az.InferenceData:
-        """Drop the parent_str variable from an InferenceData object.
+    def _drop_parent_str_from_datatree(self, dt: DataTree | None) -> DataTree:
+        """Drop the parent_str variable from an DataTree object.
 
         Parameters
         ----------
-        idata
-            The InferenceData object to be modified.
+        dt
+            The DataTree object to be modified.
 
         Returns
         -------
         xr.Dataset
-            The modified InferenceData object.
+            The modified DataTree object.
         """
-        if idata is None:
-            raise ValueError("Please provide an InferenceData object.")
+        if dt is None:
+            raise ValueError("Please provide an DataTree (traces) object.")
         else:
-            for group in idata.groups():
-                if ("rt,response_mean" in idata[group].data_vars) and (
-                    self._parent not in idata[group].data_vars
+            for group in dt.groups():
+                if ("rt,response_mean" in dt[group].data_vars) and (
+                    self._parent not in dt[group].data_vars
                 ):
                     setattr(
-                        idata,
+                        dt,
                         group,
-                        idata[group].rename({"rt,response_mean": self._parent}),
+                        dt[group].rename({"rt,response_mean": self._parent}),
                     )
-            return idata
+            return dt
 
     def _postprocess_initvals_deterministic(
         self, initval_settings: dict = INITVAL_SETTINGS

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -44,6 +44,7 @@ from hssm.utils import (
     _compute_log_likelihood,
     _get_alias_dict,
     _print_prior,
+    _requires_io_backends,
     _split_array,
 )
 
@@ -1474,6 +1475,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         )
         return pm.model.Point(fn(None), model=self.pymc_model)
 
+    @_requires_io_backends
     def restore_traces(
         self, traces: az.InferenceData | Approximation | str | PathLike
     ) -> None:
@@ -1492,6 +1494,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             traces = az.from_netcdf(traces)
         self._inference_obj = cast("az.InferenceData", traces)
 
+    @_requires_io_backends
     def restore_vi_traces(
         self, traces: az.InferenceData | Approximation | str | PathLike
     ) -> None:
@@ -1510,6 +1513,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             traces = az.from_netcdf(traces)
         self._inference_obj_vi = cast("az.InferenceData", traces)
 
+    @_requires_io_backends
     def save_model(
         self,
         model_name: str | None = None,
@@ -1637,6 +1641,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return model
 
     @classmethod
+    @_requires_io_backends
     def load_model_idata(cls, path: str | Path) -> dict[str, az.InferenceData | None]:
         """Load the traces from a model directory.
 

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1025,7 +1025,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     dt.add_groups(
                         posterior_predictive=xr.concat(
                             posterior_predictive_list, dim="draw"
-                        )
+                        )  # type: ignore[arg-type]
                     )
                     # for inplace, we don't return anything
                     return None
@@ -1037,7 +1037,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     dt_copy.add_groups(
                         posterior_predictive=xr.concat(
                             posterior_predictive_list, dim="draw"
-                        )
+                        )  # type: ignore[arg-type]
                     )
                     return dt_copy
             else:

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1943,7 +1943,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             The modified DataTree object.
         """
         if dt is None:
-            raise ValueError("Please provide an DataTree (traces) object.")
+            raise ValueError("Please provide a DataTree (traces) object.")
         else:
             for group in dt.groups():
                 if ("rt,response_mean" in dt[group].data_vars) and (

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -720,7 +720,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             The number of samples to draw from the posterior distribution.
             Defaults to 1000.
         return_idata : bool
-            If True, returns an DataTree object. Otherwise, returns the
+            If True, returns a DataTree object. Otherwise, returns the
             approximation object directly. Defaults to True.
 
         Returns
@@ -1364,7 +1364,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         Parameters
         ----------
         data : optional
-            An DataTree object. If None, the traces stored in the model will
+            A DataTree object. If None, the traces stored in the model will
             be used.
         include_deterministic : optional
             Whether to include deterministic variables in the plot. Defaults to False.
@@ -1377,7 +1377,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         """
         data = data or self.traces
         if not isinstance(data, DataTree):
-            raise TypeError("data must be an DataTree object.")
+            raise TypeError("data must be a DataTree object.")
 
         if not include_deterministic:
             var_names = list(
@@ -1442,7 +1442,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         """
         data = data or self.traces
         if not isinstance(data, DataTree):
-            raise TypeError("data must be an DataTree object.")
+            raise TypeError("data must be a DataTree object.")
 
         if not include_deterministic:
             var_names = list(
@@ -1477,12 +1477,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     @_requires_io_backends
     def restore_traces(self, traces: DataTree | Approximation | str | PathLike) -> None:
-        """Restore traces from an DataTree object or a .netcdf file.
+        """Restore traces from a DataTree object or a .netcdf file.
 
         Parameters
         ----------
         traces
-            An DataTree object or a path to a file containing the traces.
+            A DataTree object or a path to a file containing the traces.
         """
         if isinstance(traces, Approximation):
             self._inference_obj_vi = traces
@@ -1930,7 +1930,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return var_names
 
     def _drop_parent_str_from_datatree(self, dt: DataTree | None) -> DataTree:
-        """Drop the parent_str variable from a DataTree object."""
+        """Drop the parent_str variable from a DataTree object.
 
         Parameters
         ----------

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1930,7 +1930,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return var_names
 
     def _drop_parent_str_from_datatree(self, dt: DataTree | None) -> DataTree:
-        """Drop the parent_str variable from an DataTree object.
+        """Drop the parent_str variable from a DataTree object."""
 
         Parameters
         ----------

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -25,11 +25,11 @@ import pymc as pm
 import pytensor
 import seaborn as sns
 import xarray as xr
-from arviz import DataTree
 from bambi.model_components import DistributionalComponent
 from bambi.transformations import transformations_namespace
 from pymc.model.transform.conditioning import do
 from pymc.variational import Approximation
+from xarray import DataTree
 
 from hssm._types import SupportedModels
 from hssm.data_validator import DataValidatorMixin

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -648,19 +648,19 @@ def _requires_io_backends(func: Callable) -> Callable:
     Callable
         The wrapped function.
     """
-    try:
-        import h5netcdf  # noqa: F401
-        import h5py  # noqa: F401
-    except ImportError as exc:
-        raise ImportError(
-            "h5py and h5netcdf are required for I/O operations for model traces. "
-            'Please install hssm with the "io" extra: '
-            "`pip install hssm[io]` "
-            'or `uv add "hssm[io]"` if using uv.'
-        ) from exc
-
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+        try:
+            import h5netcdf  # noqa: F401
+            import h5py  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "h5py and h5netcdf are required for I/O operations for model traces. "
+                'Please install hssm with the "io" extra: '
+                "`pip install hssm[io]` "
+                'or `uv add "hssm[io]"` if using uv.'
+            ) from exc
+
         return func(*args, **kwargs)
 
     return wrapper

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -630,3 +630,37 @@ def annotate_function(**kwargs):
         return wrapper
 
     return decorator
+
+
+def _requires_io_backends(func: Callable) -> Callable:
+    """Decorate a function to require h5py and h5netcdf.
+
+    If h5py or h5netcdf is not installed, raise an ImportError instructing
+    the user to install hssm with the "io" extra.
+
+    Parameters
+    ----------
+    func : Callable
+        The function to wrap.
+
+    Returns
+    -------
+    Callable
+        The wrapped function.
+    """
+    try:
+        import h5netcdf  # noqa: F401
+        import h5py  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "h5py and h5netcdf are required for I/O operations for model traces. "
+            'Please install hssm with the "io" extra: '
+            "`pip install hssm[io]` "
+            'or `uv add "hssm[io]"` if using uv.'
+        ) from exc
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -648,6 +648,7 @@ def _requires_io_backends(func: Callable) -> Callable:
     Callable
         The wrapped function.
     """
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -243,7 +243,7 @@ def test_add_likelihood_parameters_to_data(data_ddm):
     model = HSSM(data=data_ddm)
     sample_1 = model.sample(draws=10, chains=1, tune=10)
     sample_1_copy = deepcopy(sample_1)
-    model.add_likelihood_parameters_to_idata(inplace=True)
+    model.add_likelihood_parameters_to_datatree(inplace=True)
 
     # Get distributional components (make sure to take the right aliases)
     distributional_component_names = [

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -239,7 +239,7 @@ def test_resampling(data_ddm):
 
 @pytest.mark.slow
 def test_add_likelihood_parameters_to_data(data_ddm):
-    """Test if the likelihood parameters are added to the InferenceData object."""
+    """Test if the likelihood parameters are added to the DataTree object."""
     model = HSSM(data=data_ddm)
     sample_1 = model.sample(draws=10, chains=1, tune=10)
     sample_1_copy = deepcopy(sample_1)
@@ -252,7 +252,7 @@ def test_add_likelihood_parameters_to_data(data_ddm):
     ]
 
     # Check that after computing the likelihood parameters
-    # all respective parameters appear in the InferenceData object
+    # all respective parameters appear in the DataTree object
     assert np.all(
         [
             component_ in model.traces.posterior.data_vars

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -57,7 +57,7 @@ def test_sample_posterior_predictive(
     cav_idata_copy = cav_idata.copy()
 
     posterior_predictive = model.sample_posterior_predictive(
-        idata=cav_idata_copy, draws=draws, safe_mode=safe_mode, inplace=inplace
+        dt=cav_idata_copy, draws=draws, safe_mode=safe_mode, inplace=inplace
     )
 
     if draws is None:

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import xarray as xr
 
 import hssm
 
@@ -32,9 +33,6 @@ def test_save_load_model_only(basic_hssm_model, tmp_path):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-)
 def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     # Sample to attach vi and mcmc traces to model
     # Using minimal parameters since we only need traces to exist, not be accurate
@@ -49,6 +47,7 @@ def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
         model_name=tmp_model_name_1, base_path=tmp_path, allow_absolute_base_path=True
     )
     loaded_model = hssm.HSSM.load_model(path=tmp_path / tmp_model_name_1)
+    assert isinstance(loaded_model, hssm.HSSM)
 
     # Check that idata is attached to loaded model
     compare_hssm_class_attributes(basic_hssm_model, loaded_model)
@@ -65,6 +64,7 @@ def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     )
 
     loaded_model = hssm.HSSM.load_model(path=tmp_path / tmp_model_name_2)
+    assert isinstance(loaded_model, hssm.HSSM)
 
     # Check that idata is attached to loaded model
     assert loaded_model._inference_obj is not None
@@ -84,7 +84,7 @@ def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     loaded_idata = hssm.HSSM.load_model(path=tmp_path / tmp_model_name_3)
 
     # Check that idata is attached to loaded model
-    assert isinstance(loaded_idata, dict)
+    assert isinstance(loaded_idata, xr.DataTree)
     assert loaded_idata["idata_mcmc"] is not None
     assert loaded_idata["idata_vi"] is not None
 
@@ -99,6 +99,7 @@ def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     loaded_model = hssm.HSSM.load_model(path=tmp_path / tmp_model_name_4)
 
     # Check that vi traces are not attached to loaded model
+    assert isinstance(loaded_model, hssm.HSSM)
     assert loaded_model._inference_obj_vi is None
     assert loaded_model._inference_obj is not None
     compare_hssm_class_attributes(basic_hssm_model, loaded_model)


### PR DESCRIPTION
Decorated all io functions with a decorator that throws an error if io packages (`h5py`, `h5netcdf`) are not installed.

Also fixed all references to az.InferenceData to xr.DataTree with some exceptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `predict()` method for convenience model predictions.
  * Added `load_model_traces()` classmethod to load saved inference traces.

* **Breaking Changes**
  * Likelihood and predictive methods now use updated parameter names.
  * Inference and sampling method return types updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->