### PR TITLE
[pymc6 migration] fixed `sample_posterior_predictive`, `sample_prior_predictive`, and `sample_do`

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1119,20 +1119,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         # rename otherwise inconsistent dims and coords
         if "rt,response_extra_dim_0" in do_dt["prior_predictive"].dims:
-            setattr(
-                do_dt,
-                "prior_predictive",
-                do_dt["prior_predictive"].rename_dims(
-                    {"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            do_dt["prior_predictive"] = do_dt["prior_predictive"].ds.rename_dims(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
         if "rt,response_extra_dim_0" in do_dt["prior_predictive"].coords:
-            setattr(
-                do_dt,
-                "prior_predictive",
-                do_dt["prior_predictive"].rename_vars(
-                    name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            do_dt["prior_predictive"] = do_dt["prior_predictive"].ds.rename_vars(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
 
         if return_model:
@@ -1175,38 +1167,33 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         # AF-COMMENT: Not sure if necessary to include the
         # mean prior here (which adds deterministics that
         # could be recomputed elsewhere)
-        prior_predictive.add_groups(posterior=prior_predictive.prior)
+        prior_predictive["posterior"] = prior_predictive["prior"]
         # Bambi >= 0.17 renamed kind="mean" to kind="response_params".
         self.model.predict(prior_predictive, kind="response_params", inplace=True)
 
         # clean
-        setattr(prior_predictive, "prior", prior_predictive["posterior"])
+        prior_predictive["prior"] = prior_predictive["posterior"]
         del prior_predictive["posterior"]
 
         if self._inference_obj is None:
             self._inference_obj = prior_predictive
         else:
-            self._inference_obj.extend(prior_predictive)
+            for group_name in list(prior_predictive.groups):
+                if group_name == "/":
+                    continue
+                self._inference_obj[group_name] = prior_predictive[group_name]
 
         # clean up `rt,response_mean` to `v`
         dt = self._drop_parent_str_from_datatree(dt=self._inference_obj)
 
         # rename otherwise inconsistent dims and coords
         if "rt,response_extra_dim_0" in dt["prior_predictive"].dims:
-            setattr(
-                dt,
-                "prior_predictive",
-                dt["prior_predictive"].rename_dims(
-                    {"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            dt["prior_predictive"] = dt["prior_predictive"].ds.rename_dims(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
         if "rt,response_extra_dim_0" in dt["prior_predictive"].coords:
-            setattr(
-                dt,
-                "prior_predictive",
-                dt["prior_predictive"].rename_vars(
-                    name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            dt["prior_predictive"] = dt["prior_predictive"].ds.rename_vars(
+                name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
             )
 
         # Update self._inference_obj to match the cleaned datatree
@@ -1873,15 +1860,13 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         if dt is None:
             raise ValueError("Please provide a DataTree (traces) object.")
         else:
-            for group in dt.groups():
+            for group in dt.groups:
+                if group == "/":
+                    continue
                 if ("rt,response_mean" in dt[group].data_vars) and (
                     self._parent not in dt[group].data_vars
                 ):
-                    setattr(
-                        dt,
-                        group,
-                        dt[group].rename({"rt,response_mean": self._parent}),
-                    )
+                    dt[group] = dt[group].ds.rename({"rt,response_mean": self._parent})
             return dt
 
     def _postprocess_initvals_deterministic(

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -966,9 +966,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             _logger.info(
                 "dt=None, we use the traces assigned to the HSSM object as datatree."
             )
-
-        if dt is not None:
-            if "posterior_predictive" in dt:
+        else:
+            if inplace and "posterior_predictive" in dt:
                 del dt["posterior_predictive"]
                 _logger.warning(
                     "pre-existing posterior_predictive group deleted from datatree."

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -968,7 +968,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             )
 
         if dt is not None:
-            if "posterior_predictive" in dt.groups():
+            if "posterior_predictive" in dt:
                 del dt["posterior_predictive"]
                 _logger.warning(
                     "pre-existing posterior_predictive group deleted from datatree."
@@ -1002,7 +1002,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             and not np.allclose(draws, dt["posterior"].draw.values)
         ):
             # Reassign posterior to sub-sampled version
-            setattr(dt_copy, "posterior", dt["posterior"].isel(draw=draws))
+            dt_copy["posterior"] = dt["posterior"].isel(draw=draws)
 
         if kind == "response":
             # If we run kind == 'response' we actually run the observation RV
@@ -1014,31 +1014,28 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 posterior_predictive_list = []
                 for samples_tmp in split_draws:
                     tmp_posterior = dt["posterior"].sel(draw=samples_tmp)
-                    setattr(dt_copy, "posterior", tmp_posterior)
+                    dt_copy["posterior"] = tmp_posterior
                     self.model.predict(
                         dt_copy, kind, data, True, include_group_specific
                     )
                     posterior_predictive_list.append(dt_copy["posterior_predictive"])
 
                 if inplace:
-                    dt.add_groups(
-                        posterior_predictive=xr.concat(
-                            posterior_predictive_list,  # type: ignore[arg-type]
-                            dim="draw",
-                        )
+                    dt["posterior_predictive"] = xr.concat(
+                        posterior_predictive_list,  # type: ignore[arg-type]
+                        dim="draw",
                     )
                     # for inplace, we don't return anything
                     return None
                 else:
                     # Reassign original posterior to dt_copy
-                    setattr(dt_copy, "posterior", dt["posterior"])
+                    dt_copy["posterior"] = dt["posterior"]
                     # Add new posterior predictive group to dt_copy
-                    del dt_copy["posterior_predictive"]
-                    dt_copy.add_groups(
-                        posterior_predictive=xr.concat(
-                            posterior_predictive_list,  # type: ignore[arg-type]
-                            dim="draw",
-                        )
+                    if "posterior_predictive" in dt_copy:
+                        del dt_copy["posterior_predictive"]
+                    dt_copy["posterior_predictive"] = xr.concat(
+                        posterior_predictive_list,  # type: ignore[arg-type]
+                        dim="draw",
                     )
                     return dt_copy
             else:
@@ -1054,7 +1051,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     )
 
                     # posterior predictive group added to dt
-                    dt.add_groups(posterior_predictive=dt_copy["posterior_predictive"])
+                    dt["posterior_predictive"] = dt_copy["posterior_predictive"]
                     # don't return anything if inplace
                     return None
                 else:

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -149,9 +149,6 @@ def test_model_definition_outside_include(data_ddm):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="AttributeError: 'DataTree' object has no attribute 'add_groups'"
-)
 def test_sample_prior_predictive(data_ddm_reg):
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
 
@@ -228,10 +225,10 @@ def test_override_default_link(caplog, data_ddm_reg):
 @pytest.mark.slow
 def test_resampling(data_ddm):
     model = HSSM(data=data_ddm)
-    sample_1 = model.sample(draws=10, chains=1, tune=0)
+    sample_1 = model.sample(draws=10, chains=1, tune=0, progressbar=False)
     assert sample_1 is model.traces
 
-    sample_2 = model.sample(draws=10, chains=1, tune=0)
+    sample_2 = model.sample(draws=10, chains=1, tune=0, progressbar=False)
     assert sample_2 is model.traces
 
     assert sample_1 is not sample_2
@@ -241,7 +238,7 @@ def test_resampling(data_ddm):
 def test_add_likelihood_parameters_to_data(data_ddm):
     """Test if the likelihood parameters are added to the DataTree object."""
     model = HSSM(data=data_ddm)
-    sample_1 = model.sample(draws=10, chains=1, tune=10)
+    sample_1 = model.sample(draws=10, chains=1, tune=10, progressbar=False)
     sample_1_copy = deepcopy(sample_1)
     model.add_likelihood_parameters_to_datatree(inplace=True)
 
@@ -388,7 +385,7 @@ class TestFixedVectorParams:
             model="ddm",
             include=[{"name": "v", "prior": v_fixed}],
         )
-        idata = model.sample(draws=10, chains=1, tune=10)
+        idata = model.sample(draws=10, chains=1, tune=10, progressbar=False)
 
         # v must not appear in the posterior (it's a constant, not sampled)
         assert "v" not in idata.posterior.data_vars
@@ -409,7 +406,7 @@ class TestFixedVectorParams:
                 {"name": "t", "prior": t_fixed},
             ],
         )
-        idata = model.sample(draws=10, chains=1, tune=10)
+        idata = model.sample(draws=10, chains=1, tune=10, progressbar=False)
 
         # Both fixed params excluded from posterior
         assert "v" not in idata.posterior.data_vars
@@ -420,7 +417,6 @@ class TestFixedVectorParams:
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(reason="TypeError: 'tuple' object is not callable")
 def test_sample_do(data_ddm):
     model = HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -54,11 +54,6 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
         process_initvals=True,
     )
 
-    if sampler == "numpyro":
-        pytest.xfail(
-            "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-        )
-
     initial_point = model_on.initial_point(transformed=True)
 
     if initvals == "initial_point":
@@ -69,10 +64,17 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
             cores=1,
             draws=10,
             tune=10,
+            progressbar=False,
         )
     if initvals == "map":
         model_on.sample(
-            sampler=sampler, initvals=initvals, chains=1, cores=1, draws=10, tune=10
+            sampler=sampler,
+            initvals=initvals,
+            chains=1,
+            cores=1,
+            draws=10,
+            tune=10,
+            progressbar=False,
         )
 
 

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -30,9 +30,6 @@ PARAMETER_GRID = [
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
-)
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(
     cav_idata, cavanagh_test, draws, safe_mode, inplace
@@ -53,7 +50,8 @@ def test_sample_posterior_predictive(
             },
         ],
     )  # Doesn't matter what model or data we use here
-    delattr(cav_idata, "posterior_predictive")
+    if "posterior_predictive" in cav_idata:
+        del cav_idata["posterior_predictive"]
     cav_idata_copy = cav_idata.copy()
 
     posterior_predictive = model.sample_posterior_predictive(


### PR DESCRIPTION
Closes #990 

Mainly just changed code that edit `az.InferenceData` into `xr.DataTree`.
Tests were also updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed posterior predictive sampling functionality
  * Fixed prior predictive sampling functionality
  * Corrected do() operator sampling behavior

* **Improvements**
  * Enhanced control over progress bar display during sampling operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->