### PR TITLE
Reapply [pymc6 migration] fixed `sample_posterior_predictive`, `sample_prior_predictive`, and `sample_do`

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -966,9 +966,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             _logger.info(
                 "dt=None, we use the traces assigned to the HSSM object as datatree."
             )
-
-        if dt is not None:
-            if "posterior_predictive" in dt.groups():
+        else:
+            if inplace and "posterior_predictive" in dt:
                 del dt["posterior_predictive"]
                 _logger.warning(
                     "pre-existing posterior_predictive group deleted from datatree."
@@ -1002,7 +1001,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             and not np.allclose(draws, dt["posterior"].draw.values)
         ):
             # Reassign posterior to sub-sampled version
-            setattr(dt_copy, "posterior", dt["posterior"].isel(draw=draws))
+            dt_copy["posterior"] = dt["posterior"].isel(draw=draws)
 
         if kind == "response":
             # If we run kind == 'response' we actually run the observation RV
@@ -1014,31 +1013,28 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 posterior_predictive_list = []
                 for samples_tmp in split_draws:
                     tmp_posterior = dt["posterior"].sel(draw=samples_tmp)
-                    setattr(dt_copy, "posterior", tmp_posterior)
+                    dt_copy["posterior"] = tmp_posterior
                     self.model.predict(
                         dt_copy, kind, data, True, include_group_specific
                     )
                     posterior_predictive_list.append(dt_copy["posterior_predictive"])
 
                 if inplace:
-                    dt.add_groups(
-                        posterior_predictive=xr.concat(
-                            posterior_predictive_list,  # type: ignore[arg-type]
-                            dim="draw",
-                        )
+                    dt["posterior_predictive"] = xr.concat(
+                        posterior_predictive_list,  # type: ignore[arg-type]
+                        dim="draw",
                     )
                     # for inplace, we don't return anything
                     return None
                 else:
                     # Reassign original posterior to dt_copy
-                    setattr(dt_copy, "posterior", dt["posterior"])
+                    dt_copy["posterior"] = dt["posterior"]
                     # Add new posterior predictive group to dt_copy
-                    del dt_copy["posterior_predictive"]
-                    dt_copy.add_groups(
-                        posterior_predictive=xr.concat(
-                            posterior_predictive_list,  # type: ignore[arg-type]
-                            dim="draw",
-                        )
+                    if "posterior_predictive" in dt_copy:
+                        del dt_copy["posterior_predictive"]
+                    dt_copy["posterior_predictive"] = xr.concat(
+                        posterior_predictive_list,  # type: ignore[arg-type]
+                        dim="draw",
                     )
                     return dt_copy
             else:
@@ -1054,7 +1050,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     )
 
                     # posterior predictive group added to dt
-                    dt.add_groups(posterior_predictive=dt_copy["posterior_predictive"])
+                    dt["posterior_predictive"] = dt_copy["posterior_predictive"]
                     # don't return anything if inplace
                     return None
                 else:
@@ -1122,20 +1118,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         # rename otherwise inconsistent dims and coords
         if "rt,response_extra_dim_0" in do_dt["prior_predictive"].dims:
-            setattr(
-                do_dt,
-                "prior_predictive",
-                do_dt["prior_predictive"].rename_dims(
-                    {"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            do_dt["prior_predictive"] = do_dt["prior_predictive"].ds.rename_dims(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
         if "rt,response_extra_dim_0" in do_dt["prior_predictive"].coords:
-            setattr(
-                do_dt,
-                "prior_predictive",
-                do_dt["prior_predictive"].rename_vars(
-                    name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            do_dt["prior_predictive"] = do_dt["prior_predictive"].ds.rename_vars(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
 
         if return_model:
@@ -1178,38 +1166,33 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         # AF-COMMENT: Not sure if necessary to include the
         # mean prior here (which adds deterministics that
         # could be recomputed elsewhere)
-        prior_predictive.add_groups(posterior=prior_predictive.prior)
+        prior_predictive["posterior"] = prior_predictive["prior"]
         # Bambi >= 0.17 renamed kind="mean" to kind="response_params".
         self.model.predict(prior_predictive, kind="response_params", inplace=True)
 
         # clean
-        setattr(prior_predictive, "prior", prior_predictive["posterior"])
+        prior_predictive["prior"] = prior_predictive["posterior"]
         del prior_predictive["posterior"]
 
         if self._inference_obj is None:
             self._inference_obj = prior_predictive
         else:
-            self._inference_obj.extend(prior_predictive)
+            for group_name in list(prior_predictive.groups):
+                if group_name == "/":
+                    continue
+                self._inference_obj[group_name] = prior_predictive[group_name]
 
         # clean up `rt,response_mean` to `v`
         dt = self._drop_parent_str_from_datatree(dt=self._inference_obj)
 
         # rename otherwise inconsistent dims and coords
         if "rt,response_extra_dim_0" in dt["prior_predictive"].dims:
-            setattr(
-                dt,
-                "prior_predictive",
-                dt["prior_predictive"].rename_dims(
-                    {"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            dt["prior_predictive"] = dt["prior_predictive"].ds.rename_dims(
+                {"rt,response_extra_dim_0": "rt,response_dim"}
             )
         if "rt,response_extra_dim_0" in dt["prior_predictive"].coords:
-            setattr(
-                dt,
-                "prior_predictive",
-                dt["prior_predictive"].rename_vars(
-                    name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
-                ),
+            dt["prior_predictive"] = dt["prior_predictive"].ds.rename_vars(
+                name_dict={"rt,response_extra_dim_0": "rt,response_dim"}
             )
 
         # Update self._inference_obj to match the cleaned datatree
@@ -1876,15 +1859,13 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         if dt is None:
             raise ValueError("Please provide a DataTree (traces) object.")
         else:
-            for group in dt.groups():
+            for group in dt.groups:
+                if group == "/":
+                    continue
                 if ("rt,response_mean" in dt[group].data_vars) and (
                     self._parent not in dt[group].data_vars
                 ):
-                    setattr(
-                        dt,
-                        group,
-                        dt[group].rename({"rt,response_mean": self._parent}),
-                    )
+                    dt[group] = dt[group].ds.rename({"rt,response_mean": self._parent})
             return dt
 
     def _postprocess_initvals_deterministic(

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -533,7 +533,7 @@ def check_data_for_rl(
     return sorted_data, n_participants, n_trials
 
 
-def predictive_idata_to_dataframe(
+def predictive_dt_to_dataframe(
     dt: xr.DataTree,
     predictive_group: Literal[
         "posterior_predictive", "prior_predictive"

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -16,7 +16,6 @@ import logging
 import os
 from typing import Any, Callable, Literal, cast
 
-import arviz as az
 import bambi as bmb
 import jax
 import numpy as np
@@ -535,19 +534,19 @@ def check_data_for_rl(
 
 
 def predictive_idata_to_dataframe(
-    idata: az.InferenceData,
+    dt: xr.DataTree,
     predictive_group: Literal[
         "posterior_predictive", "prior_predictive"
     ] = "posterior_predictive",
     response_str: str = "rt,response",
     response_dim: str = "rt,response_dim",
 ) -> pd.DataFrame:
-    """Convert a predictive InferenceData object to a dataframe.
+    """Convert a predictive DataTree object to a dataframe.
 
     Parameters
     ----------
-    idata : az.InferenceData
-        The InferenceData object to convert.
+    dt : xr.DataTree
+        The DataTree object to convert.
     predictive_group : Literal["posterior_predictive", "prior_predictive"]
         The predictive group to convert.
 
@@ -556,7 +555,7 @@ def predictive_idata_to_dataframe(
     pd.DataFrame:
         A dataframe with the predictive samples.
     """
-    df = idata[predictive_group].to_dataframe().reset_index(drop=False)
+    df = dt[predictive_group].ds.to_dataframe().reset_index(drop=False)
     df_wide = df.pivot_table(
         index=["chain", "draw", "__obs__"], columns=response_dim, values=response_str
     ).reset_index()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def data_ddm_reg_va():
 
 
 @pytest.fixture
-def cav_idata():
+def cav_dt():
     return az.from_netcdf("tests/fixtures/cavanagh_idata.nc")
 
 

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -149,9 +149,6 @@ def test_model_definition_outside_include(data_ddm):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="AttributeError: 'DataTree' object has no attribute 'add_groups'"
-)
 def test_sample_prior_predictive(data_ddm_reg):
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
 
@@ -228,10 +225,10 @@ def test_override_default_link(caplog, data_ddm_reg):
 @pytest.mark.slow
 def test_resampling(data_ddm):
     model = HSSM(data=data_ddm)
-    sample_1 = model.sample(draws=10, chains=1, tune=0)
+    sample_1 = model.sample(draws=10, chains=1, tune=0, progressbar=False)
     assert sample_1 is model.traces
 
-    sample_2 = model.sample(draws=10, chains=1, tune=0)
+    sample_2 = model.sample(draws=10, chains=1, tune=0, progressbar=False)
     assert sample_2 is model.traces
 
     assert sample_1 is not sample_2
@@ -241,7 +238,7 @@ def test_resampling(data_ddm):
 def test_add_likelihood_parameters_to_data(data_ddm):
     """Test if the likelihood parameters are added to the DataTree object."""
     model = HSSM(data=data_ddm)
-    sample_1 = model.sample(draws=10, chains=1, tune=10)
+    sample_1 = model.sample(draws=10, chains=1, tune=10, progressbar=False)
     sample_1_copy = deepcopy(sample_1)
     model.add_likelihood_parameters_to_datatree(inplace=True)
 
@@ -388,7 +385,7 @@ class TestFixedVectorParams:
             model="ddm",
             include=[{"name": "v", "prior": v_fixed}],
         )
-        idata = model.sample(draws=10, chains=1, tune=10)
+        idata = model.sample(draws=10, chains=1, tune=10, progressbar=False)
 
         # v must not appear in the posterior (it's a constant, not sampled)
         assert "v" not in idata.posterior.data_vars
@@ -409,7 +406,7 @@ class TestFixedVectorParams:
                 {"name": "t", "prior": t_fixed},
             ],
         )
-        idata = model.sample(draws=10, chains=1, tune=10)
+        idata = model.sample(draws=10, chains=1, tune=10, progressbar=False)
 
         # Both fixed params excluded from posterior
         assert "v" not in idata.posterior.data_vars
@@ -420,7 +417,6 @@ class TestFixedVectorParams:
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(reason="TypeError: 'tuple' object is not callable")
 def test_sample_do(data_ddm):
     model = HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -54,11 +54,6 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
         process_initvals=True,
     )
 
-    if sampler == "numpyro":
-        pytest.xfail(
-            "TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'"
-        )
-
     initial_point = model_on.initial_point(transformed=True)
 
     if initvals == "initial_point":
@@ -69,10 +64,17 @@ def test_sample_map(caplog, loglik_kind, model, sampler, initvals):
             cores=1,
             draws=10,
             tune=10,
+            progressbar=False,
         )
     if initvals == "map":
         model_on.sample(
-            sampler=sampler, initvals=initvals, chains=1, cores=1, draws=10, tune=10
+            sampler=sampler,
+            initvals=initvals,
+            chains=1,
+            cores=1,
+            draws=10,
+            tune=10,
+            progressbar=False,
         )
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -131,9 +131,9 @@ class TestPlotting:
         with pytest.raises(ValueError):
             _get_plotting_df(idata, data=None, extra_dims=["participant_id", "conf"])
 
-    def test__plot_predictive_1D(self, cav_idata, cavanagh_test):
+    def test__plot_predictive_1D(self, cav_dt, cavanagh_test):
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
         df["Response Time"] = df["rt"] * np.where(df["response"] == 0, -1, 1)
 
@@ -145,9 +145,9 @@ class TestPlotting:
         ax2 = _plot_predictive_1D(df, plot_data=False, ax=ax2)
         assert len(ax2.get_lines()) == 1
 
-    def test__plot_predictive_2D(self, cav_idata, cavanagh_test):
+    def test__plot_predictive_2D(self, cav_dt, cavanagh_test):
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
         df["Response Time"] = df["rt"] * np.where(df["response"] == 0, -1, 1)
 
@@ -171,7 +171,7 @@ class TestPlotting:
     @pytest.mark.xfail(
         reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
     )
-    def test_plot_predictive(self, cav_idata, cavanagh_test):
+    def test_plot_predictive(self, cav_dt, cavanagh_test):
         # Mock model object
         model = hssm.HSSM(
             data=cavanagh_test,
@@ -190,7 +190,7 @@ class TestPlotting:
         with pytest.raises(ValueError):
             plot_predictive(model)
 
-        model._inference_obj = cav_idata.copy()
+        model._inference_obj = cav_dt.copy()
         _, ax1 = plt.subplots()
         ax1 = plot_predictive(model, ax=ax1)  # Should work directly
         assert len(ax1.get_lines()) == 2
@@ -249,9 +249,9 @@ class TestPlotting:
             cavanagh_test[cavanagh_test["conf"] == "LC"].groupby(["conf", "dbs"])
         )
 
-    def test__process_df_for_qp_plot(self, cav_idata, cavanagh_test):
+    def test__process_df_for_qp_plot(self, cav_dt, cavanagh_test):
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
 
         processed_df = _process_df_for_qp_plot(df=df, q=6, cond="conf", correct=None)
@@ -284,14 +284,14 @@ class TestPlotting:
         ],
     )
     def test__plot_quantile_probability_1D(
-        self, cav_idata, cavanagh_test, predictive_style
+        self, cav_dt, cavanagh_test, predictive_style
     ):
         """Tests the _plot_quantile_probability_1D function.
 
         Tests that the function correctly creates a 1D quantile probability plot with the
         specified predictive style and verifies the plot attributes.
         """
-        df = _get_plotting_df(cav_idata, cavanagh_test, extra_dims=["stim"])
+        df = _get_plotting_df(cav_dt, cavanagh_test, extra_dims=["stim"])
         ax = _plot_quantile_probability_1D(
             df, cond="stim", predictive_style=predictive_style
         )
@@ -303,7 +303,7 @@ class TestPlotting:
 
     @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
     def test__plot_quantile_probability_2D(
-        self, cav_idata, cavanagh_test, predictive_style
+        self, cav_dt, cavanagh_test, predictive_style
     ):
         """Tests the _plot_quantile_probability_2D function.
 
@@ -311,7 +311,7 @@ class TestPlotting:
         specified predictive style and verifies the plot grid dimensions.
         """
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "stim"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "stim"]
         )
         g = _plot_quantile_probability_2D(
             df,
@@ -323,7 +323,7 @@ class TestPlotting:
         assert len(g.figure.axes) == 10
 
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "stim", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "stim", "conf"]
         )
         g = _plot_quantile_probability_2D(
             df,
@@ -338,9 +338,7 @@ class TestPlotting:
         reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
     )
     @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
-    def test_plot_quantile_probability(
-        self, cav_idata, cavanagh_test, predictive_style
-    ):
+    def test_plot_quantile_probability(self, cav_dt, cavanagh_test, predictive_style):
         """Tests the plot_quantile_probability function.
 
         Tests the main plotting function for quantile probability plots, including error cases,
@@ -366,7 +364,7 @@ class TestPlotting:
                 model, cond="stim", predictive_style=predictive_style
             )
 
-        model._inference_obj = cav_idata.copy()
+        model._inference_obj = cav_dt.copy()
         ax1 = plot_quantile_probability(
             model, cond="stim", data=cavanagh_test, predictive_style=predictive_style
         )  # Should work directly
@@ -439,7 +437,7 @@ class TestPlotting:
         # Should only have lines for observed data, no predictive samples
         # The exact number depends on how many quantiles and conditions there are
 
-    def test__process_df_for_qp_plot_with_quantile_by(self, cav_idata, cavanagh_test):
+    def test__process_df_for_qp_plot_with_quantile_by(self, cav_dt, cavanagh_test):
         """Test _process_df_for_qp_plot with quantile_by parameter.
 
         This tests the functionality where quantiles are first computed for each
@@ -447,7 +445,7 @@ class TestPlotting:
         """
         # Get plotting dataframe with participant_id as extra dimension
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
 
         # Test 1: Without quantile_by (original behavior)
@@ -521,7 +519,7 @@ class TestPlotting:
         # Might be less due to some groups having no data for certain quantiles
         assert processed_df_single.shape[0] == processed_df_no_grouping.shape[0]
 
-    def test_plot_quantile_probability_with_quantile_by(self, cav_idata, cavanagh_test):
+    def test_plot_quantile_probability_with_quantile_by(self, cav_dt, cavanagh_test):
         """Test plot_quantile_probability with quantile_by parameter.
 
         This tests the full plotting pipeline with the quantile_by functionality,
@@ -543,7 +541,7 @@ class TestPlotting:
                 },
             ],
         )
-        model._inference_obj = cav_idata.copy()
+        model._inference_obj = cav_dt.copy()
 
         # Test 1: Single plot with quantile_by as string
         ax1 = plot_quantile_probability(
@@ -608,7 +606,7 @@ class TestPlotting:
             assert ax is not None
 
     def test__process_df_for_qp_plot_quantile_by_edge_cases(
-        self, cav_idata, cavanagh_test
+        self, cav_dt, cavanagh_test
     ):
         """Test edge cases for quantile_by parameter.
 
@@ -616,7 +614,7 @@ class TestPlotting:
         functionality.
         """
         df = _get_plotting_df(
-            cav_idata, cavanagh_test, extra_dims=["participant_id", "conf"]
+            cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
 
         # Test 1: Empty list for quantile_by (should behave like None)
@@ -675,14 +673,12 @@ class TestPlotting:
         assert all(col in result2.columns for col in base_cols)
         assert all(col in result3.columns for col in base_cols)
 
-    def test__get_plotting_df_quantile_by_dims_validation(
-        self, cav_idata, cavanagh_test
-    ):
+    def test__get_plotting_df_quantile_by_dims_validation(self, cav_dt, cavanagh_test):
         """Test _get_plotting_df with various quantile_by_dims inputs for validation coverage."""
 
         # Test 0: quantile_by_dims as None (should be None)
         df_none = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=["conf"],
             quantile_by_dims=None,  # None input
@@ -691,7 +687,7 @@ class TestPlotting:
 
         # Test 1: quantile_by_dims as string (should convert to list)
         df_string = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=["conf"],
             quantile_by_dims="participant_id",  # String input
@@ -702,7 +698,7 @@ class TestPlotting:
 
         # Test 2: quantile_by_dims as list (normal case)
         df_list = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=["conf"],
             quantile_by_dims=["participant_id"],  # List input
@@ -714,7 +710,7 @@ class TestPlotting:
             ValueError, match="`quantile_by_dims` must be a non-empty list of strings."
         ):
             _get_plotting_df(
-                cav_idata,
+                cav_dt,
                 cavanagh_test,
                 extra_dims=["conf"],
                 quantile_by_dims=[],  # Empty list
@@ -725,7 +721,7 @@ class TestPlotting:
             ValueError, match="All elements in `quantile_by_dims` must be strings."
         ):
             _get_plotting_df(
-                cav_idata,
+                cav_dt,
                 cavanagh_test,
                 extra_dims=["conf"],
                 quantile_by_dims=[1, 2],  # Non-string elements
@@ -737,20 +733,18 @@ class TestPlotting:
             match="`quantile_by_dims` and `extra_dims` must not have any overlap.",
         ):
             _get_plotting_df(
-                cav_idata,
+                cav_dt,
                 cavanagh_test,
                 extra_dims=["conf", "participant_id"],
                 quantile_by_dims=["participant_id"],  # Overlaps with extra_dims
             )
 
-    def test__get_plotting_df_quantile_by_dims_edge_cases(
-        self, cav_idata, cavanagh_test
-    ):
+    def test__get_plotting_df_quantile_by_dims_edge_cases(self, cav_dt, cavanagh_test):
         """Test additional edge cases for quantile_by_dims to ensure full coverage."""
 
         # Test 1: quantile_by_dims provided but extra_dims is None
         df1 = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=None,  # No extra_dims
             quantile_by_dims=["participant_id"],
@@ -761,7 +755,7 @@ class TestPlotting:
 
         # Test 2: Both provided but NO overlap (normal successful case)
         df2 = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=["conf"],  # Different from quantile_by_dims
             quantile_by_dims=["participant_id"],  # No overlap
@@ -772,7 +766,7 @@ class TestPlotting:
 
         # Test 3: Valid list of multiple quantile_by_dims (covers elif branch with valid list)
         df3 = _get_plotting_df(
-            cav_idata,
+            cav_dt,
             cavanagh_test,
             extra_dims=["conf"],
             quantile_by_dims=["participant_id", "dbs"],  # Multiple items, all valid

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -30,9 +30,6 @@ PARAMETER_GRID = [
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
-)
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(
     cav_idata, cavanagh_test, draws, safe_mode, inplace
@@ -53,7 +50,8 @@ def test_sample_posterior_predictive(
             },
         ],
     )  # Doesn't matter what model or data we use here
-    delattr(cav_idata, "posterior_predictive")
+    if "posterior_predictive" in cav_idata:
+        del cav_idata["posterior_predictive"]
     cav_idata_copy = cav_idata.copy()
 
     posterior_predictive = model.sample_posterior_predictive(

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -31,9 +31,7 @@ PARAMETER_GRID = [
 
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
-def test_sample_posterior_predictive(
-    cav_idata, cavanagh_test, draws, safe_mode, inplace
-):
+def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, inplace):
     """Test sample_posterior_predictive method."""
 
     model = hssm.HSSM(
@@ -50,12 +48,12 @@ def test_sample_posterior_predictive(
             },
         ],
     )  # Doesn't matter what model or data we use here
-    if "posterior_predictive" in cav_idata:
-        del cav_idata["posterior_predictive"]
-    cav_idata_copy = cav_idata.copy()
+    if "posterior_predictive" in cav_dt:
+        del cav_dt["posterior_predictive"]
+    cav_dt_copy = cav_dt.copy()
 
     posterior_predictive = model.sample_posterior_predictive(
-        dt=cav_idata_copy, draws=draws, safe_mode=safe_mode, inplace=inplace
+        dt=cav_dt_copy, draws=draws, safe_mode=safe_mode, inplace=inplace
     )
 
     if draws is None:
@@ -71,11 +69,11 @@ def test_sample_posterior_predictive(
 
     try:
         if inplace:
-            assert "posterior_predictive" in cav_idata_copy
-            assert cav_idata_copy.posterior_predictive.draw.size == size
+            assert "posterior_predictive" in cav_dt_copy
+            assert cav_dt_copy.posterior_predictive.draw.size == size
         else:
             assert posterior_predictive is not None
-            assert "posterior_predictive" not in cav_idata_copy
+            assert "posterior_predictive" not in cav_dt_copy
             assert posterior_predictive.posterior_predictive.draw.size == size
     except AssertionError:
         raise

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytensor
 import pytest
+import xarray as xr
 from ssms.basic_simulators.simulator import simulator
 from jax import config
 
@@ -155,12 +156,12 @@ def assertions(caplog, obj, n_samples, expected):
 )
 def test__random_sample(
     caplog,
-    cav_idata,
+    cav_dt,
     n_samples,
     expected,
 ):
-    posterior = cav_idata["posterior"]
-    posterior_predictive = cav_idata["posterior_predictive"]
+    posterior = cav_dt["posterior"]
+    posterior_predictive = cav_dt["posterior_predictive"]
 
     assertions(caplog, posterior, n_samples, expected)
     assertions(caplog, posterior_predictive, n_samples, expected)
@@ -233,7 +234,8 @@ def test_check_data_for_rl():
 def test_predictive_idata_to_dataframe(data_ddm):
     model = hssm.HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)
-    df = hssm.utils.predictive_idata_to_dataframe(
+    assert isinstance(sample_do, xr.DataTree)
+    df = hssm.utils.predictive_dt_to_dataframe(
         sample_do, predictive_group="prior_predictive"
     )
     assert df is not None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -139,9 +139,6 @@ def assertions(caplog, obj, n_samples, expected):
             assert "n_samples > n_draws" in caplog.text
 
 
-@pytest.mark.xfail(
-    reason="cav_idata fixture requires optional xarray NetCDF backends not installed",
-)
 @pytest.mark.parametrize(
     ["n_samples", "expected"],
     [
@@ -162,8 +159,8 @@ def test__random_sample(
     n_samples,
     expected,
 ):
-    posterior = cav_idata.posterior
-    posterior_predictive = cav_idata.posterior_predictive
+    posterior = cav_idata["posterior"]
+    posterior_predictive = cav_idata["posterior_predictive"]
 
     assertions(caplog, posterior, n_samples, expected)
     assertions(caplog, posterior_predictive, n_samples, expected)
@@ -233,9 +230,6 @@ def test_check_data_for_rl():
     assert n_trials == 2
 
 
-@pytest.mark.xfail(
-    reason="TypeError when accessing idata.groups(): 'tuple' object is not callable"
-)
 def test_predictive_idata_to_dataframe(data_ddm):
     model = hssm.HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)


### PR DESCRIPTION
#991 was merged by accident. This reapplies the changes in that PR. Please see the PR for notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed posterior predictive sampling functionality
* Fixed prior predictive sampling
* Fixed sampling with NumPyro sampler using MAP initialization
* Improved handling of inference data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->