### PR TITLE
[pymc6 migration] fix posterior predictive plots

### DIFF
--- a/src/hssm/plotting/predictive.py
+++ b/src/hssm/plotting/predictive.py
@@ -5,7 +5,6 @@ from itertools import product
 from typing import Iterable, Literal, cast, overload
 
 import arviz as az
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -47,14 +46,14 @@ def _plot_predictive_1D(
     xlabel: str | None = "Response Time",
     ylabel: str | None = "Density",
     **kwargs,
-) -> mpl.axes.Axes:
+) -> Axes:
     """Plot the posterior predictive distribution against the observed data.
 
     Check the `plot_predictive` function below for docstring.
 
     Returns
     -------
-    mpl.Axes
+    Axes
         A matplotlib Axes object containing the plot.
     """
     if "color" in kwargs:
@@ -445,7 +444,7 @@ def plot_predictive(
 
     Returns
     -------
-    mpl.axes.Axes | sns.FacetGrid
+    Axes | sns.FacetGrid
         The matplotlib `axis` or seaborn `FacetGrid` object containing the plot.
     """
     # Process hdi

--- a/src/hssm/plotting/predictive.py
+++ b/src/hssm/plotting/predictive.py
@@ -4,11 +4,11 @@ import logging
 from itertools import product
 from typing import Iterable, Literal, cast, overload
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+import xarray as xr
 from matplotlib.axes import Axes
 
 from .utils import (
@@ -299,7 +299,7 @@ def _process_lines(
 
 def plot_predictive(
     model,
-    idata: az.InferenceData | None = None,
+    dt: xr.DataTree | None = None,
     data: pd.DataFrame | None = None,
     predictive_group: Literal[
         "posterior_predictive", "prior_predictive"
@@ -330,15 +330,15 @@ def plot_predictive(
     ----------
     model : hssm.HSSM
         A fitted HSSM model.
-    idata : optional
-        The InferenceData object with posterior samples. If not provided, will use the
+    dt : optional
+        The DataTree object with posterior samples. If not provided, will use the
         traces object stored inside the model. If posterior predictive samples are not
         present in this object, will generate posterior predictive samples using the
-        this InferenceData object and the original data.
+        this DataTree object and the original data.
     data : optional
         The observed data.
 
-        - If `data` is provided and the idata object does not contain a
+        - If `data` is provided and the `dt` object does not contain a
         `"posterior_predictive"` group, will generate posterior predictive samples using
         covariate provided in this object. If the group does exist, it is assumed that
         the posterior predictive samples are generated with the covariates provided in
@@ -347,9 +347,9 @@ def plot_predictive(
         "plot_data" is true or not. If `plot_data=True`, the plotting function will use
         the data stored in the `model` object and proceed as the case above. If
         `plot_data=False`, if posterior predictive samples are not present in the
-        `idata` object, the plotting function will generate posterior predictive samples
+        `dt` object, the plotting function will generate posterior predictive samples
         using the data stored in the `model` object. If posterior predictive samples
-        exist in the `idata` object, these samples will be used for plotting, but a
+        exist in the `dt` object, these samples will be used for plotting, but a
         ValueError will be thrown if any of `col` or `row` is not None.
     predictive_group : optional
         The type of predictive distribution to plot, by default "posterior_predictive".
@@ -357,8 +357,8 @@ def plot_predictive(
     plot_data : optional
         Whether to plot the observed data, by default True.
     n_samples : optional
-        When idata is provided, the number or proportion of posterior predictive samples
-        randomly drawn to be used from each chain for plotting. When idata is not
+        When `dt` is provided, the number or proportion of posterior predictive samples
+        randomly drawn to be used from each chain for plotting. When `dt` is not
         provided, the number or proportion of posterior samples to be used to generate
         posterior predictive samples. The number or proportion are defined as follows:
 
@@ -467,8 +467,8 @@ def plot_predictive(
         if (
             (not extra_dims)
             and (not plot_data)
-            and (idata is not None)
-            and ("posterior_predictive" in idata)
+            and (dt is not None)
+            and ("posterior_predictive" in dt)
         ):
             # Allows data to be None only when plot_data=False and no extra_dims
             # and posterior predictive samples are available
@@ -476,12 +476,12 @@ def plot_predictive(
         else:
             data = model.data
 
-    idata, sampled = _use_traces_or_sample(
-        model, data, idata, n_samples=n_samples, predictive_group=predictive_group
+    dt, sampled = _use_traces_or_sample(
+        model, data, dt, n_samples=n_samples, predictive_group=predictive_group
     )
 
     plotting_df = _get_plotting_df(
-        idata,
+        dt,
         data,
         extra_dims=extra_dims,
         n_samples=None if sampled else n_samples,

--- a/src/hssm/plotting/predictive.py
+++ b/src/hssm/plotting/predictive.py
@@ -444,7 +444,7 @@ def plot_predictive(
 
     Returns
     -------
-    Axes | sns.FacetGrid
+    Axes | sns.FacetGrid | list[sns.FacetGrid]
         The matplotlib `axis` or seaborn `FacetGrid` object containing the plot.
     """
     # Process hdi

--- a/src/hssm/plotting/predictive.py
+++ b/src/hssm/plotting/predictive.py
@@ -25,7 +25,7 @@ from .utils import (
 _logger = logging.getLogger("hssm")
 
 
-def _histogram(a: np.ndarray, bins: int | np.ndarray | str | None = 100) -> np.ndarray:
+def _histogram(a: np.ndarray, bins: int | np.ndarray | str | None = 100) -> pd.Series:
     return pd.Series(
         np.histogram(a, bins=bins, density=True)[0],  # type: ignore
         name="bin_n",

--- a/src/hssm/plotting/predictive.py
+++ b/src/hssm/plotting/predictive.py
@@ -333,7 +333,7 @@ def plot_predictive(
     dt : optional
         The DataTree object with posterior samples. If not provided, will use the
         traces object stored inside the model. If posterior predictive samples are not
-        present in this object, will generate posterior predictive samples using the
+        present in this object, will generate posterior predictive samples using
         this DataTree object and the original data.
     data : optional
         The observed data.

--- a/src/hssm/plotting/utils.py
+++ b/src/hssm/plotting/utils.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Any, Iterable, Literal, cast
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -133,7 +132,7 @@ def _hdi_to_interval(hdi: str | float | tuple[float, float]) -> tuple[float, flo
 
 
 def _get_plotting_df(
-    idata: az.InferenceData | None = None,
+    dt: xr.DataTree | None = None,
     data: pd.DataFrame | None = None,
     extra_dims: list[str] | None = None,
     quantile_by_dims: list[str] | str | None = None,
@@ -147,14 +146,14 @@ def _get_plotting_df(
 
     Parameters
     ----------
-    idata : optional
-        An InferenceData object. If not provided, the function will only return the
+    dt : optional
+        A DataTree object. If not provided, the function will only return the
         processed original data.
     data: optional
         A dataframe with the original data. If not provided, the function will only
         return the posterior samples without appending the observed data.
     extra_dims, optional
-        Extra dimensions to be added to the dataframe from `idata`, by default None
+        Extra dimensions to be added to the dataframe from `dt`, by default None
     quantile_by_dims, optional
         Extra dimensions to be used for quantiles.
     n_samples, optional
@@ -184,19 +183,19 @@ def _get_plotting_df(
                     "`quantile_by_dims` and `extra_dims` must not have any overlap."
                 )
 
-    if idata is None and data is None:
-        raise ValueError("Either idata or data must be provided.")
+    if dt is None and data is None:
+        raise ValueError("Either dt or data must be provided.")
 
     extra_dims = [] if extra_dims is None else extra_dims
 
-    if idata is None:
+    if dt is None:
         data = _process_data(data, extra_dims, quantile_by_dims)
 
         data.insert(0, "observed", "observed")
         return data
 
     # get the posterior samples
-    idata_predictive = idata[predictive_group][response_str]
+    idata_predictive = cast("xr.DataArray", dt[predictive_group][response_str])
     predictive = _xarray_to_df(idata_predictive, n_samples=n_samples)
 
     if data is None:
@@ -485,47 +484,47 @@ def _check_groups_and_groups_order(
 def _use_traces_or_sample(
     model,
     data: pd.DataFrame | None,
-    idata: az.InferenceData | None,
+    dt: xr.DataTree | None,
     n_samples: int | float | None,
     predictive_group: Literal[
         "posterior_predictive", "prior_predictive"
     ] = "posterior_predictive",
-) -> tuple[az.InferenceData, bool]:
-    """Check if idata is provided, otherwise use traces.
+) -> tuple[xr.DataTree, bool]:
+    """Check if dt is provided, otherwise use traces.
 
     Also, if posterior predictive samples are not contained in traces, sample from
     the model.
     """
     # First, determine whether posterior predictive samples are available
     # If not, we need to sample from the posterior
-    if idata is None:
+    if dt is None:
         if model.traces is None:
             raise ValueError(
-                "No InferenceData object provided. Please provide an InferenceData "
+                "No DataTree object provided. Please provide a DataTree "
                 + "object or sample the model first using model.sample()."
             )
-        idata = model.traces
+        dt = model.traces
 
     sampled = False
 
-    if predictive_group not in idata:
+    if predictive_group not in dt:
         _logger.info(
             "No %s samples found. Generating %s samples using the provided "
-            "InferenceData object and the original data. "
-            "This will modify the provided InferenceData object, "
+            "DataTree object and the original data. "
+            "This will modify the provided DataTree object, "
             "or if not provided, the traces object stored inside the model.",
             predictive_group,
             predictive_group,
         )
         if predictive_group == "posterior_predictive":
             model.sample_posterior_predictive(
-                idata=idata,
+                dt=dt,
                 data=data,
                 inplace=True,
                 draws=n_samples,
             )
         elif predictive_group == "prior_predictive":
-            idata = model.sample_prior_predictive(
+            dt = model.sample_prior_predictive(
                 draws=n_samples,
                 omit_offsets=False,
             )
@@ -534,7 +533,7 @@ def _use_traces_or_sample(
         # AF-TODO: 'sampled' logic needs to be re-examined
         sampled = True
 
-    return cast("az.InferenceData", idata), sampled
+    return cast("xr.DataTree", dt), sampled
 
 
 def _check_sample_size(plotting_df):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -96,15 +95,12 @@ class TestPlotting:
             assert np.all(obs_n.value_counts() == expected // 500)
             assert df.columns[0] == "rt"
 
-    @pytest.mark.xfail(
-        reason="TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior_predictive'"
-    )
     def test__get_plotting_df(self, posterior, cavanagh_test):
         """Test _get_plotting_df."""
 
-        # Makes a mock InferenceData object
+        # Makes a mock DataTree object
         posterior_dataset = xr.Dataset(data_vars={"rt,response": posterior})
-        idata = az.InferenceData(posterior_predictive=posterior_dataset)
+        idata = xr.DataTree.from_dict({"posterior_predictive": posterior_dataset})
 
         df = _get_plotting_df(
             idata, cavanagh_test, extra_dims=["participant_id", "conf"]
@@ -168,9 +164,6 @@ class TestPlotting:
         assert len(g2.figure.axes) == 5 * 2
         assert len(g2.figure.axes[0].get_lines()) == 1
 
-    @pytest.mark.xfail(
-        reason="AttributeError: 'DataTree' object has no attribute 'posterior_predictive'"
-    )
     def test_plot_predictive(self, cav_idata, cavanagh_test):
         # Mock model object
         model = hssm.HSSM(
@@ -195,14 +188,14 @@ class TestPlotting:
         ax1 = plot_predictive(model, ax=ax1)  # Should work directly
         assert len(ax1.get_lines()) == 2
 
-        delattr(model.traces, "posterior_predictive")
+        del model.traces["posterior_predictive"]
         _, ax2 = plt.subplots()
         ax2 = plot_predictive(
             model, ax=ax2, n_samples=2
         )  # Should sample posterior predictive
         assert len(ax2.get_lines()) == 2
         assert "posterior_predictive" in model.traces
-        assert model.traces.posterior_predictive.draw.size == 2
+        assert model.traces["posterior_predictive"].draw.size == 2
 
         with pytest.raises(ValueError):
             plot_predictive(model, groups="participant_id")


### PR DESCRIPTION
This PR updates plotting/predictive.py to use DataTree instead of InferenceData

Changes implemented:
1. all `idata` arguments are now `dt`, and types are changed to `xr.DataTree`
2. all access to the internals of the `dt` object is now updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Updated `plot_predictive()` function: `idata` parameter replaced with `dt` parameter for improved data structure compatibility.
  * Posterior predictive sampling is now integrated directly into the plotting workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->