### PR TITLE
[pymc6 migration] Fixed model cartoon plots

### DIFF
--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -24,7 +24,7 @@ from .utils import (
     _get_title,
     # _hdi_to_interval, # TODO: We eventually want to add HDI plotting back in here
     _subset_df,
-    _to_idata_group,
+    _to_dt_group,
     _use_traces_or_sample,
 )
 
@@ -234,17 +234,17 @@ def _plot_model_cartoon_2D(
 
 
 def compute_merge_necessary_deterministics(
-    model, dt, idata_group: Literal["posterior", "prior"] = "posterior"
+    model, dt, dt_group: Literal["posterior", "prior"] = "posterior"
 ):
     """Compute the necessary deterministic variables for the model."""
     # Get the list of deterministic variables
     necessary_params = default_model_config[model.model_name]["list_params"]
     deterministics_list = []
-    group_ds = dt[idata_group].to_dataset()
-    idata_group_keys = list(group_ds.data_vars)
+    group_ds = dt[dt_group].to_dataset()
+    dt_group_keys = list(group_ds.data_vars)
     # Compute the deterministic variables
     for param in necessary_params:
-        if param not in idata_group_keys:
+        if param not in dt_group_keys:
             if param in [
                 deterministic.name for deterministic in model.pymc_model.deterministics
             ]:
@@ -255,12 +255,12 @@ def compute_merge_necessary_deterministics(
                 )
 
     deterministics_idata = xr.merge(deterministics_list)
-    dt[idata_group] = xr.merge([group_ds, deterministics_idata])
+    dt[dt_group] = xr.merge([group_ds, deterministics_idata])
     return dt
 
 
 def attach_trialwise_params_to_df(
-    model, df, dt, idata_group: Literal["posterior", "prior"] = "posterior"
+    model, df, dt, dt_group: Literal["posterior", "prior"] = "posterior"
 ):
     """Attach the trial-wise parameters to the dataframe.
 
@@ -273,7 +273,7 @@ def attach_trialwise_params_to_df(
     necessary_params = default_model_config[model.model_name]["list_params"]
     df[necessary_params] = 0.0
 
-    group_ds = dt[idata_group].to_dataset()
+    group_ds = dt[dt_group].to_dataset()
     for chain_tmp, draw_tmp in {(x[0], x[1]) for x in list(df.index) if x[0] != -1}:
         n_rows = len(df.loc[(chain_tmp, draw_tmp, slice(None))])
         for param in necessary_params:
@@ -323,7 +323,7 @@ def _make_dt_mean_group(
     return dt
 
 
-def _make_idata_mean_posterior(dt: xr.DataTree) -> xr.DataTree:
+def _make_dt_mean_posterior(dt: xr.DataTree) -> xr.DataTree:
     """Create a new DataTree object containing only the posterior mean."""
     return _make_dt_mean_group(dt, "posterior")
 
@@ -474,7 +474,7 @@ def plot_model_cartoon(
 
     Returns
     -------
-    Axes | FacetGrid
+    Axes | FacetGrid | list[FacetGrid]
         The matplotlib `axis` or seaborn `FacetGrid` object containing the plot.
     """
     if not (plot_predictive_mean or plot_predictive_samples):
@@ -513,13 +513,13 @@ def plot_model_cartoon(
     plotting_df_mean = None
     if plot_predictive_mean:
         if predictive_group == "posterior_predictive":
-            idata_mean = _make_idata_mean_posterior(
+            dt_mean = _make_dt_mean_posterior(
                 deepcopy(model.traces if dt is None else dt)
             )
-            idata_mean, _ = _use_traces_or_sample(
+            dt_mean, _ = _use_traces_or_sample(
                 model,
                 data,
-                idata_mean,
+                dt_mean,
                 n_samples=None,
                 predictive_group="posterior_predictive",
             )
@@ -533,11 +533,11 @@ def plot_model_cartoon(
                 predictive_group=predictive_group,
             )
 
-            idata_mean = _make_idata_mean_prior(deepcopy(dt))
+            dt_mean = _make_idata_mean_prior(deepcopy(dt))
             # AF-COMMENT: This is a hack to get the prior predictive mean
             # we should find a better way to do this eventually.
             mean_dt = xr.DataTree.from_dict(
-                {"posterior": idata_mean["prior"].to_dataset()}
+                {"posterior": dt_mean["prior"].to_dataset()}
             )
             idata_mean_tmp = model.predict(
                 **dict(
@@ -547,13 +547,13 @@ def plot_model_cartoon(
                 )
             )
 
-            idata_mean["prior_predictive"] = idata_mean_tmp[
+            dt_mean["prior_predictive"] = idata_mean_tmp[
                 "posterior_predictive"
             ].to_dataset()
 
         # # Get the plotting dataframe by chain and sample
         plotting_df_mean = _get_plotting_df(
-            idata_mean,
+            dt_mean,
             data,
             extra_dims=extra_dims,
             n_samples=None,
@@ -563,15 +563,15 @@ def plot_model_cartoon(
 
         # Get plotting dataframe for predictive mean
         # df by chain and sample
-        idata_mean = compute_merge_necessary_deterministics(
-            model, idata_mean, idata_group=_to_idata_group(predictive_group)
+        dt_mean = compute_merge_necessary_deterministics(
+            model, dt_mean, dt_group=_to_dt_group(predictive_group)
         )
 
         plotting_df_mean = attach_trialwise_params_to_df(
             model,
             plotting_df_mean,
-            idata_mean,
-            idata_group=_to_idata_group(predictive_group),
+            dt_mean,
+            dt_group=_to_dt_group(predictive_group),
         )
 
         # Flip the rt values if necessary
@@ -606,14 +606,14 @@ def plot_model_cartoon(
         dt = compute_merge_necessary_deterministics(
             model,
             dt,
-            idata_group=_to_idata_group(predictive_group),
+            dt_group=_to_dt_group(predictive_group),
         )
 
         plotting_df = attach_trialwise_params_to_df(
             model,
             plotting_df,
             dt,
-            idata_group=_to_idata_group(predictive_group),
+            dt_group=_to_dt_group(predictive_group),
         )
 
         # Flip the rt values if necessary

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -6,15 +6,14 @@ from itertools import product
 from typing import Any, Iterable, Literal, Protocol, cast
 
 import arviz as az
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pymc as pm
-import seaborn as sns
 import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
+from seaborn import FacetGrid
 from ssms.basic_simulators.simulator import simulator
 
 # Original model cartoon plot from gui
@@ -66,7 +65,7 @@ def _plot_model_cartoon_1D(
     xlabel: str | None = "Response Time",
     ylabel: str | None = "",
     **kwargs,
-) -> mpl.axes.Axes:
+) -> Axes:
     """Plot the posterior predictive distribution against the observed data.
 
     Check the `plot_model_cartoon` function below for docstring.
@@ -173,17 +172,17 @@ def _plot_model_cartoon_2D(
     ylabel: str | None = "",
     grid_kwargs: dict | None = None,
     **kwargs,
-) -> sns.FacetGrid:
+) -> FacetGrid:
     """Plot the posterior predictive distribution against the observed data.
 
     Check the function below for docstring.
 
     Returns
     -------
-    sns.FacetGrid
+    FacetGrid
         A seaborn FacetGrid object containing the plot.
     """
-    g = sns.FacetGrid(
+    g = FacetGrid(
         data=data,
         col=col,
         row=row,
@@ -375,7 +374,7 @@ def plot_model_cartoon(
     ylabel: str | None = "",
     grid_kwargs: dict | None = None,
     **kwargs,
-) -> Axes | sns.FacetGrid | list[sns.FacetGrid]:
+) -> Axes | FacetGrid | list[FacetGrid]:
     """Plot the posterior predictive distribution against the observed data.
 
     Parameters
@@ -480,7 +479,7 @@ def plot_model_cartoon(
     ylabel : optional
         The label for the y-axis, by default "Density".
     grid_kwargs : optional
-        Additional keyword arguments are passed to the [`sns.FacetGrid` constructor]
+        Additional keyword arguments are passed to the [`FacetGrid` constructor]
         (https://seaborn.pydata.org/generated/seaborn.FacetGrid.html#seaborn.FacetGrid.__init__)
         when any of row or col is provided. When producing a single plot, these
         arguments are ignored.
@@ -489,7 +488,7 @@ def plot_model_cartoon(
 
     Returns
     -------
-    mpl.axes.Axes | sns.FacetGrid
+    Axes | FacetGrid
         The matplotlib `axis` or seaborn `FacetGrid` object containing the plot.
     """
     if not (plot_predictive_mean or plot_predictive_samples):

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from itertools import product
 from typing import Any, Iterable, Literal, Protocol, cast
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -235,13 +234,14 @@ def _plot_model_cartoon_2D(
 
 
 def compute_merge_necessary_deterministics(
-    model, idata, idata_group: Literal["posterior", "prior"] = "posterior"
+    model, dt, idata_group: Literal["posterior", "prior"] = "posterior"
 ):
     """Compute the necessary deterministic variables for the model."""
     # Get the list of deterministic variables
     necessary_params = default_model_config[model.model_name]["list_params"]
     deterministics_list = []
-    idata_group_keys = list(idata[idata_group].keys())
+    group_ds = dt[idata_group].to_dataset()
+    idata_group_keys = list(group_ds.data_vars)
     # Compute the deterministic variables
     for param in necessary_params:
         if param not in idata_group_keys:
@@ -250,17 +250,17 @@ def compute_merge_necessary_deterministics(
             ]:
                 deterministics_list.append(
                     pm.compute_deterministics(
-                        idata[idata_group], model=model.pymc_model, var_names=[param]
+                        group_ds, model=model.pymc_model, var_names=[param]
                     )
                 )
 
     deterministics_idata = xr.merge(deterministics_list)
-    setattr(idata, idata_group, xr.merge([idata[idata_group], deterministics_idata]))
-    return idata
+    dt[idata_group] = xr.merge([group_ds, deterministics_idata])
+    return dt
 
 
 def attach_trialwise_params_to_df(
-    model, df, idata, idata_group: Literal["posterior", "prior"] = "posterior"
+    model, df, dt, idata_group: Literal["posterior", "prior"] = "posterior"
 ):
     """Attach the trial-wise parameters to the dataframe.
 
@@ -273,12 +273,11 @@ def attach_trialwise_params_to_df(
     necessary_params = default_model_config[model.model_name]["list_params"]
     df[necessary_params] = 0.0
 
+    group_ds = dt[idata_group].to_dataset()
     for chain_tmp, draw_tmp in {(x[0], x[1]) for x in list(df.index) if x[0] != -1}:
         n_rows = len(df.loc[(chain_tmp, draw_tmp, slice(None))])
         for param in necessary_params:
-            values = (
-                idata[idata_group].sel(chain=chain_tmp, draw=draw_tmp)[param].values
-            )
+            values = group_ds.sel(chain=chain_tmp, draw=draw_tmp)[param].values
             # Handle scalar / intercept-only params that don't have the
             # full observation dimension. Bambi >= 0.17 returns shape (1,)
             # for intercept-only deterministics; directly-sampled scalars
@@ -289,67 +288,54 @@ def attach_trialwise_params_to_df(
     return df
 
 
-def _make_idata_mean_posterior(idata: az.InferenceData) -> az.InferenceData:
-    """Create a new InferenceData object containing only the posterior mean.
+def _make_dt_mean_group(
+    dt: xr.DataTree, group: Literal["posterior", "prior"]
+) -> xr.DataTree:
+    """Create a new DataTree containing only the mean of a given group.
 
-    Takes an InferenceData object and computes the mean across chains and draws,
-    then restructures it to have a single chain and draw. Removes posterior
-    predictive samples if present.
-
-    Parameters
-    ----------
-    idata : arviz.InferenceData
-        The InferenceData object to process
-
-    Returns
-    -------
-    arviz.InferenceData
-        A new InferenceData object containing only the posterior mean
-    """
-    setattr(idata, "posterior", idata["posterior"].mean(dim=["chain", "draw"]))
-    setattr(idata, "posterior", idata["posterior"].assign_coords(chain=[0], draw=[0]))
-    for data_var in list(idata["posterior"].data_vars):
-        idata["posterior"][data_var] = idata["posterior"][data_var].expand_dims(
-            dim=["chain", "draw"], axis=[0, 1]
-        )
-
-    if "posterior_predictive" in idata:
-        del idata["posterior_predictive"]
-    return idata
-
-
-def _make_idata_mean_prior(idata: az.InferenceData) -> az.InferenceData:
-    """Create a new InferenceData object containing only the prior mean.
-
-    Takes an InferenceData object and computes the mean across chains and draws,
-    then restructures it to have a single chain and draw. Removes prior
-    predictive samples if present.
+    Takes a DataTree object and computes the mean across chains and draws of the
+    requested group (``"posterior"`` or ``"prior"``), then restructures it to have
+    a single chain and draw. Removes the corresponding predictive samples if present.
 
     Parameters
     ----------
-    idata : arviz.InferenceData
-        The InferenceData object to process
+    dt : xarray.DataTree
+        The DataTree object to process.
+    group : {"posterior", "prior"}
+        The group to reduce to its mean.
 
     Returns
     -------
-    arviz.InferenceData
-        A new InferenceData object containing only the posterior mean
+    xarray.DataTree
+        A new DataTree object containing only the mean of the requested group.
     """
-    setattr(idata, "prior", idata["prior"].mean(dim=["chain", "draw"]))
-    setattr(idata, "prior", idata["prior"].assign_coords(chain=[0], draw=[0]))
-    for data_var in list(idata["prior"].data_vars):
-        idata["prior"][data_var] = idata["prior"][data_var].expand_dims(
+    group_ds = dt[group].to_dataset().mean(dim=["chain", "draw"])
+    group_ds = group_ds.assign_coords(chain=[0], draw=[0])
+    for data_var in list(group_ds.data_vars):
+        group_ds[data_var] = group_ds[data_var].expand_dims(
             dim=["chain", "draw"], axis=[0, 1]
         )
+    dt[group] = group_ds
 
-    if "prior_predictive" in idata:
-        del idata["prior_predictive"]
-    return idata
+    predictive_group = group + "_predictive"
+    if predictive_group in dt:
+        del dt[predictive_group]
+    return dt
+
+
+def _make_idata_mean_posterior(dt: xr.DataTree) -> xr.DataTree:
+    """Create a new DataTree object containing only the posterior mean."""
+    return _make_dt_mean_group(dt, "posterior")
+
+
+def _make_idata_mean_prior(dt: xr.DataTree) -> xr.DataTree:
+    """Create a new DataTree object containing only the prior mean."""
+    return _make_dt_mean_group(dt, "prior")
 
 
 def plot_model_cartoon(
     model,
-    idata: az.InferenceData | None = None,
+    dt: xr.DataTree | None = None,
     data: pd.DataFrame | None = None,
     predictive_group: Literal[
         "posterior_predictive", "prior_predictive"
@@ -381,15 +367,15 @@ def plot_model_cartoon(
     ----------
     model : hssm.HSSM
         A fitted HSSM model.
-    idata : optional
-        The InferenceData object with posterior samples. If not provided, will use the
+    dt : optional
+        The DataTree object with posterior samples. If not provided, will use the
         traces object stored inside the model. If posterior predictive samples are not
         present in this object, will generate posterior predictive samples using the
-        this InferenceData object and the original data.
+        this DataTree object and the original data.
     data : optional
         The observed data.
 
-        - If `data` is provided and the idata object does not contain a
+        - If `data` is provided and the `dt` object does not contain a
         `"posterior_predictive"` group, will generate posterior predictive samples using
         covariate provided in this object. If the group does exist, it is assumed that
         the posterior predictive samples are generated with the covariates provided in
@@ -398,9 +384,9 @@ def plot_model_cartoon(
         "plot_data" is true or not. If `plot_data=True`, the plotting function will use
         the data stored in the `model` object and proceed as the case above. If
         `plot_data=False`, if posterior predictive samples are not present in the
-        `idata` object, the plotting function will generate posterior predictive samples
+        `dt` object, the plotting function will generate posterior predictive samples
         using the data stored in the `model` object. If posterior predictive samples
-        exist in the `idata` object, these samples will be used for plotting, but a
+        exist in the `dt` object, these samples will be used for plotting, but a
         ValueError will be thrown if any of `col` or `row` is not None.
     predictive_group : optional
         The type of predictive distribution to plot, by default "posterior_predictive".
@@ -408,8 +394,8 @@ def plot_model_cartoon(
     plot_data : optional
         Whether to plot the observed data, by default True.
     n_samples : optional
-        When idata is provided, the number or proportion of predictive samples
-        randomly drawn to be used from each chain for plotting. When idata is not
+        When dt is provided, the number or proportion of predictive samples
+        randomly drawn to be used from each chain for plotting. When dt is not
         provided, the number or proportion of posterior/prior
         samples to be used to generate predictive samples.
         The number or proportion are defined as follows:
@@ -514,8 +500,8 @@ def plot_model_cartoon(
         if (
             (not extra_dims)
             and (not plot_data)
-            and (idata is not None)
-            and (predictive_group in idata)
+            and (dt is not None)
+            and (predictive_group in dt)
         ):
             # Allows data to be None only when plot_data=False and no extra_dims
             # and posterior predictive samples are available
@@ -528,7 +514,7 @@ def plot_model_cartoon(
     if plot_predictive_mean:
         if predictive_group == "posterior_predictive":
             idata_mean = _make_idata_mean_posterior(
-                deepcopy(model.traces if idata is None else idata)
+                deepcopy(model.traces if dt is None else dt)
             )
             idata_mean, _ = _use_traces_or_sample(
                 model,
@@ -539,26 +525,31 @@ def plot_model_cartoon(
             )
         else:
             # Need to sample from prior predictive here to get samples from the prior
-            idata, _ = _use_traces_or_sample(
+            dt, _ = _use_traces_or_sample(
                 model,
                 data,
-                idata,
+                dt,
                 n_samples=n_samples_prior,
                 predictive_group=predictive_group,
             )
 
-            idata_mean = _make_idata_mean_prior(deepcopy(idata))
+            idata_mean = _make_idata_mean_prior(deepcopy(dt))
             # AF-COMMENT: This is a hack to get the prior predictive mean
             # we should find a better way to do this eventually.
+            mean_dt = xr.DataTree.from_dict(
+                {"posterior": idata_mean["prior"].to_dataset()}
+            )
             idata_mean_tmp = model.predict(
                 **dict(
-                    idata=az.InferenceData(posterior=idata_mean["prior"]),
+                    idata=mean_dt,
                     kind="response",
                     inplace=False,
                 )
             )
 
-            idata_mean.add_groups(prior_predictive=idata_mean_tmp.posterior_predictive)
+            idata_mean["prior_predictive"] = idata_mean_tmp[
+                "posterior_predictive"
+            ].to_dataset()
 
         # # Get the plotting dataframe by chain and sample
         plotting_df_mean = _get_plotting_df(
@@ -596,13 +587,13 @@ def plot_model_cartoon(
         plotting_df_mean["source"] = predictive_group + "_mean"
 
     if plot_predictive_samples:
-        idata, sampled = _use_traces_or_sample(
-            model, data, idata, n_samples=n_samples, predictive_group=predictive_group
+        dt, sampled = _use_traces_or_sample(
+            model, data, dt, n_samples=n_samples, predictive_group=predictive_group
         )
 
         # Get the plotting dataframe by chain and sample
         plotting_df = _get_plotting_df(
-            idata,
+            dt,
             data,
             extra_dims=extra_dims,
             n_samples=None if sampled else n_samples,
@@ -612,16 +603,16 @@ def plot_model_cartoon(
 
         # Get plotting dataframe for posterior mean
         # df by chain and sample
-        idata = compute_merge_necessary_deterministics(
+        dt = compute_merge_necessary_deterministics(
             model,
-            idata,
+            dt,
             idata_group=_to_idata_group(predictive_group),
         )
 
         plotting_df = attach_trialwise_params_to_df(
             model,
             plotting_df,
-            idata,
+            dt,
             idata_group=_to_idata_group(predictive_group),
         )
 

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -254,8 +254,8 @@ def compute_merge_necessary_deterministics(
                     )
                 )
 
-    deterministics_idata = xr.merge(deterministics_list)
-    dt[dt_group] = xr.merge([group_ds, deterministics_idata])
+    deterministics_dt = xr.merge(deterministics_list)
+    dt[dt_group] = xr.merge([group_ds, deterministics_dt])
     return dt
 
 
@@ -328,7 +328,7 @@ def _make_dt_mean_posterior(dt: xr.DataTree) -> xr.DataTree:
     return _make_dt_mean_group(dt, "posterior")
 
 
-def _make_idata_mean_prior(dt: xr.DataTree) -> xr.DataTree:
+def _make_dt_mean_prior(dt: xr.DataTree) -> xr.DataTree:
     """Create a new DataTree object containing only the prior mean."""
     return _make_dt_mean_group(dt, "prior")
 
@@ -533,21 +533,19 @@ def plot_model_cartoon(
                 predictive_group=predictive_group,
             )
 
-            dt_mean = _make_idata_mean_prior(deepcopy(dt))
+            dt_mean = _make_dt_mean_prior(deepcopy(dt))
             # AF-COMMENT: This is a hack to get the prior predictive mean
             # we should find a better way to do this eventually.
             mean_dt = xr.DataTree.from_dict(
                 {"posterior": dt_mean["prior"].to_dataset()}
             )
-            idata_mean_tmp = model.predict(
-                **dict(
-                    idata=mean_dt,
-                    kind="response",
-                    inplace=False,
-                )
+            dt_mean_tmp = model.predict(
+                idata=mean_dt,  # bambi.Model.predict still uses idata
+                kind="response",
+                inplace=False,
             )
 
-            dt_mean["prior_predictive"] = idata_mean_tmp[
+            dt_mean["prior_predictive"] = dt_mean_tmp[
                 "posterior_predictive"
             ].to_dataset()
 

--- a/src/hssm/plotting/quantile_probability.py
+++ b/src/hssm/plotting/quantile_probability.py
@@ -562,7 +562,10 @@ def plot_quantile_probability(
     Returns
     -------
     Axes | FacetGrid | list[FacetGrid]
-        A seaborn FacetGrid object containing the plot.
+        If neither `row`, `col`, nor `groups` is provided, returns a single Axes object.
+        If `row` or `col` is provided (but not `groups`), returns a FacetGrid object.
+        If `groups` is provided, returns a list of FacetGrid objects, one for each
+        group.
     """
     # TODO: Should provide a few more safeguards to ensure
     # 1. quantile_by dimension is a column(s) of strings

--- a/src/hssm/plotting/utils.py
+++ b/src/hssm/plotting/utils.py
@@ -551,7 +551,7 @@ def _check_sample_size(plotting_df):
         )
 
 
-def _to_idata_group(
+def _to_dt_group(
     predictive_group: Literal["posterior_predictive", "prior_predictive"],
 ) -> Literal["posterior", "prior"]:
     return "posterior" if predictive_group == "posterior_predictive" else "prior"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,7 @@ def intercept_only_ddm_cartoon(cavanagh_test):
         },
         coords={"chain": [0], "draw": [0, 1]},
     )
-    model._inference_obj = az.InferenceData(posterior=posterior)
+    model._inference_obj = xr.DataTree.from_dict({"posterior": posterior})
     return model
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -266,12 +266,7 @@ class TestPlotting:
     @pytest.mark.parametrize(
         "predictive_style",
         [
-            pytest.param(
-                "points",
-                marks=pytest.mark.xfail(
-                    reason="AssertionError: assert 'Density' == 'rt'"
-                ),
-            ),
+            "points",
             "ellipse",
             "both",
         ],

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -68,9 +68,6 @@ def test_plot_model_cartoon_2_choice(
                 n_trajectories=n_trajectories,
             )
     else:
-        pytest.xfail(
-            "Known DataTree compatibility errors in plot_model_cartoon predictive paths"
-        )
         ax = hssm.plotting.plot_model_cartoon(
             cav_model_cartoon,
             n_samples=10,
@@ -97,9 +94,6 @@ def test_plot_model_cartoon_2_choice(
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="TypeError: DataTree.__init__() got an unexpected keyword argument 'posterior'"
-)
 def test_plot_model_cartoon_intercept_only(intercept_only_ddm_cartoon):
     """Test plot_model_cartoon with intercept-only DDM (no regression).
 
@@ -178,9 +172,6 @@ def test_plot_model_cartoon_3_choice(
                 n_trajectories=n_trajectories,
             )
     else:
-        pytest.xfail(
-            "Known DataTree compatibility errors in plot_model_cartoon predictive paths"
-        )
         ax = hssm.plotting.plot_model_cartoon(
             race_model_cartoon,
             n_samples=10,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved posterior predictive compatibility issues in model cartoon plotting.
  * Fixed quantile probability plotting with various parameter combinations.

* **Breaking Changes**
  * `plot_model_cartoon()` now accepts DataTree objects instead of InferenceData.

* **Documentation**
  * Clarified return type descriptions for `plot_quantile_probability()` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->