### PR TITLE
Wire ddm_hierarchical_tutorial into docs nav, skip build-time execution

### DIFF
--- a/docs/tutorials/ddm_hierarchical_tutorial.ipynb
+++ b/docs/tutorials/ddm_hierarchical_tutorial.ipynb
@@ -732,7 +732,7 @@
   {
    "cell_type": "code",
    "execution_count": 84,
-   "id": "A-build",
+   "id": "174406d3",
    "metadata": {},
    "outputs": [
     {
@@ -6942,8 +6942,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
           - hssm.plotting: api/plotting.md
   - Tutorials:
       - Main tutorial: tutorials/main_tutorial.ipynb
+      - Hierarchical DDM: tutorials/ddm_hierarchical_tutorial.ipynb
       - Choice-only models: tutorials/choice_only_models.ipynb
       - Understanding likelihood functions in HSSM: tutorials/likelihoods.ipynb
       - Plotting: tutorials/plotting.ipynb
@@ -77,6 +78,7 @@ plugins:
         - getting_started/getting_started.ipynb
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
+        - tutorials/ddm_hierarchical_tutorial.ipynb
         - tutorials/choice_only_models.ipynb
         - tutorials/likelihoods.ipynb
         - tutorials/variational_inference.ipynb


### PR DESCRIPTION
Move ddm_hierarchical_tutorial.ipynb into docs/tutorials/, add it to the Tutorials nav and to mkdocs-jupyter execute_ignore so it renders from saved outputs without being re-run at docs build. Clean notebook (nb-clean) to dedupe cell ids while preserving outputs and execution counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new hierarchical tutorial notebook to the documentation, now available in the Tutorials section of the site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->