### PR TITLE
Review + Refine choice-only RL

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -347,6 +347,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         self._post_check_data_sanity()
 
+        # Remap response labels to internal 0..N-1 action indices where the model
+        # requires it (no-op by default; see `_remap_choice_only_responses`). Runs
+        # AFTER sanity validation (which reports against the declared labels) and
+        # BEFORE the distribution / bmb.Model is built from `self.data`.
+        self._remap_choice_only_responses()
+
         self.model_distribution = self._make_model_distribution()
 
         self.family = make_family(
@@ -396,6 +402,15 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             {key_: None for key_ in self.pymc_model.rvs_to_initial_values.keys()}
         )
         _logger.info("Model initialized successfully.")
+
+    def _remap_choice_only_responses(self) -> None:
+        """Remap response labels to internal 0..N-1 action indices.
+
+        No-op on the base class. Subclasses whose likelihood consumes the
+        response column purely as an action index (e.g. the choice-only softmax
+        RLSSM) override this to support arbitrary integer ``choices`` labels.
+        """
+        return
 
     @abstractmethod
     def _make_model_distribution(self) -> type[pm.Distribution]:

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -190,7 +190,7 @@ def _get_p_outlier(cls: _RandomVariable, arg_arrays):
 def make_hssm_rv(
     simulator_fun: Callable | str,
     list_params: list[str],
-    lapse: bmb.Prior | None = None,
+    lapse: bmb.Prior | float | None = None,
     is_choice_only: bool = False,
 ) -> type[RandomVariable]:
     """Build a RandomVariable Op according to the list of parameters.
@@ -202,7 +202,8 @@ def make_hssm_rv(
     list_params
         A list of str of all parameters for this `RandomVariable`.
     lapse : optional
-        A bmb.Prior object representing the lapse distribution.
+        A bmb.Prior object representing the lapse distribution, or a ``float``
+        for choice-only models (the uniform choice probability ``1 / n_choices``).
     is_choice_only : bool
         Whether the model is a choice-only model.
 
@@ -312,7 +313,7 @@ def _apply_lapse_model(
     sims_out: np.ndarray,
     p_outlier: np.ndarray | float | None,
     rng: np.random.Generator,
-    lapse_dist: bmb.Prior | None,
+    lapse_dist: bmb.Prior | float | None,
     choices: list,
 ) -> np.ndarray:
     """Apply lapse model to the simulation output.
@@ -325,8 +326,11 @@ def _apply_lapse_model(
         Probability of outlier/lapse for each trial
     rng : np.random.Generator
         Random number generator
-    lapse_dist : bmb.Prior
-        The lapse distribution to draw from
+    lapse_dist : bmb.Prior | float
+        The lapse distribution to draw from. For choice-only models this is a
+        ``float`` (the uniform choice probability ``1 / n_choices``); there is
+        no RT distribution, so lapsed trials are replaced by a uniform draw over
+        ``choices``.
     choices : list
         List of possible choices
 
@@ -343,6 +347,27 @@ def _apply_lapse_model(
             "You have specified `p_outlier`, the probability of the lapse "
             "distribution but did not specify the distribution."
         )
+
+    # Choice-only models pass a float `lapse_dist` (the uniform choice
+    # probability 1/n_choices). `sims_out` then holds the choice column only,
+    # as either (n_obs,) or (n_obs, 1) — there is no RT to draw. Replace lapsed
+    # trials with a uniform draw over `choices`. The float lapse value itself is
+    # consumed as a log-probability in the logp path; here only `p_outlier`
+    # decides which trials lapse.
+    if isinstance(lapse_dist, float):
+        flat = sims_out.reshape(-1).copy()
+        n_obs = flat.shape[0]
+        if isinstance(p_outlier, np.ndarray):
+            p_vec = np.broadcast_to(
+                np.asarray(p_outlier, dtype=float).reshape(-1), (n_obs,)
+            )
+        else:
+            p_vec = np.full(n_obs, float(p_outlier))
+        replace = rng.binomial(n=1, p=p_vec, size=n_obs).astype(bool)
+        if not replace.any():
+            return sims_out
+        flat[replace] = rng.choice(choices, size=int(replace.sum()))
+        return flat.reshape(sims_out.shape)
 
     out_shape = sims_out.shape[:-1]
 

--- a/src/hssm/missing_data_mixin.py
+++ b/src/hssm/missing_data_mixin.py
@@ -141,29 +141,25 @@ class MissingDataMixin:
             Optional custom likelihood function for missing data. If not None,
             must be used only when missing_data or deadline is True.
         """
-        # Choice-only models have no "rt" column, so missing_data handling does
-        # not apply.  Deadline is still supported.
+        # Choice-only models have no "rt" column, so neither missing-data nor
+        # deadline handling applies. Reject both explicitly (a deadline censors
+        # RTs, which choice-only data does not have) and set the flags to their
+        # disabled state.
         if self.is_choice_only:  # type: ignore[attr-defined]
             if missing_data is not False:
                 raise ValueError("Choice-only models cannot have missing data.")
+            if deadline is not False:
+                raise ValueError("Choice-only models cannot have a deadline.")
+            if loglik_missing_data is not None:
+                raise ValueError(
+                    "loglik_missing_data function specified, but choice-only "
+                    "models do not support missing data or deadlines."
+                )
             self.missing_data = False
             self.missing_data_network = MissingDataNetwork.NONE
-            self.deadline = True if isinstance(deadline, str) else deadline
-            self.deadline_name = deadline if isinstance(deadline, str) else "deadline"
-            self.loglik_missing_data = loglik_missing_data
-            if not self.deadline and loglik_missing_data is not None:
-                raise ValueError(
-                    "loglik_missing_data function specified, but you have not"
-                    " set the missing_data or deadline flag to True."
-                )
-            if self.deadline and self.response is not None:  # type: ignore[attr-defined]
-                if self.deadline_name not in self.data.columns:  # type: ignore[attr-defined]
-                    raise ValueError(
-                        "You have specified that your data has deadline, but "
-                        f"`{self.deadline_name}` is not found in your dataset."
-                    )
-                if self.deadline_name not in self.response:  # type: ignore[attr-defined]
-                    self.response.append(self.deadline_name)  # type: ignore[attr-defined]
+            self.deadline = False
+            self.deadline_name = "deadline"
+            self.loglik_missing_data = None
             return
 
         if isinstance(missing_data, float):

--- a/src/hssm/rl/likelihoods/builder.py
+++ b/src/hssm/rl/likelihoods/builder.py
@@ -551,15 +551,19 @@ def make_rl_logp_func(
     list_params = list_params or []
     extra_fields = extra_fields or []
 
-    # Pre-compute vmapped versions of all compute functions
-    vmapped_compute_funcs = (
-        {
-            param_name: jax.vmap(compute_func, in_axes=0)
-            for param_name, compute_func in ssm_logp_func.computed.items()
-        }
+    # Pre-compute vmapped versions of each DISTINCT compute function, keyed by
+    # function identity. A single compute function may produce several outputs
+    # (e.g. a Q-value scan emitting q0, q1, ... for an N-action softmax); it is
+    # then registered under multiple names in `computed` and must run only once,
+    # not once per output.
+    _distinct_compute_funcs = (
+        {id(f): f for f in ssm_logp_func.computed.values()}
         if hasattr(ssm_logp_func, "computed") and ssm_logp_func.computed
         else {}
     )
+    vmapped_compute_funcs = {
+        fid: jax.vmap(f, in_axes=0) for fid, f in _distinct_compute_funcs.items()
+    }
 
     def _prepare_subj_trials(
         compute_func: AnnotatedFunction, data: np.ndarray, args: tuple
@@ -585,21 +589,20 @@ def make_rl_logp_func(
         subj_trials = jnp.stack(cols_data, axis=1)
         return subj_trials.reshape(n_participants, n_trials, -1)
 
-    def compute_parameter(
-        param_name: str, data: np.ndarray, args: tuple
+    def compute_block(
+        compute_func: AnnotatedFunction, data: np.ndarray, args: tuple
     ) -> jnp.ndarray:
-        """Compute a single parameter."""
-        compute_func = ssm_logp_func.computed[param_name]
-        vmapped_func = vmapped_compute_funcs[param_name]
+        """Run one compute function once, returning (n_total_trials, n_outputs).
 
-        # Prepare data for computation
+        Single-output learning rules (e.g. drift rate ``v``) return one column;
+        multi-output rules (e.g. an N-action Q-value scan emitting
+        ``q0..q_{N-1}``) return one column per declared output. The caller slices
+        the block into the named output columns.
+        """
         subj_trials = _prepare_subj_trials(compute_func, data, args)
-
-        # Apply pre-vmapped function to compute parameter values
-        computed_values = vmapped_func(subj_trials)
-
-        # Reshape back to 2D (total_trials, 1) for concatenation
-        return computed_values.reshape((-1, 1))
+        computed_values = vmapped_compute_funcs[id(compute_func)](subj_trials)
+        n_out = len(compute_func.outputs)
+        return computed_values.reshape((-1, n_out))
 
     def logp(data, *args) -> Array:
         """Compute the log-likelihood for the RLDM model for each trial.
@@ -650,14 +653,35 @@ def make_rl_logp_func(
         # Validate that all computed parameters have compute functions
         _validate_computed_parameters(ssm_logp_func, ssm_logp_func_colidxs.computed)
 
-        computed_param_values = (
-            {
-                param_name: compute_parameter(param_name, data, args)
-                for param_name in ssm_logp_func_colidxs.computed
+        # Run each DISTINCT compute function once and slice its (n, n_out) block
+        # into the named output columns it produces. Grouping by function
+        # identity avoids re-running a multi-output learning rule (e.g. the
+        # softmax Q-value scan) once per action.
+        needed = ssm_logp_func_colidxs.computed
+        computed_param_values: dict[str, Array] = {}
+        if needed:
+            distinct_needed_funcs = {
+                id(ssm_logp_func.computed[name]): ssm_logp_func.computed[name]
+                for name in needed
             }
-            if hasattr(ssm_logp_func, "computed") and ssm_logp_func.computed
-            else {}
-        )
+            for compute_func in distinct_needed_funcs.values():
+                outputs = getattr(compute_func, "outputs", None)
+                if not outputs:
+                    raise ValueError(
+                        "Compute functions for computed parameters must be "
+                        "annotated with a non-empty `outputs` list; "
+                        f"got {outputs!r}."
+                    )
+                block = compute_block(compute_func, data, args)
+                if block.shape[1] != len(outputs):
+                    raise ValueError(
+                        f"Compute function produced {block.shape[1]} output "
+                        f"column(s) but its `.outputs` declares {len(outputs)} "
+                        f"({outputs})."
+                    )
+                for col, out_name in enumerate(outputs):
+                    if out_name in needed:
+                        computed_param_values[out_name] = block[:, col : col + 1]
 
         # Extract non-computed parameters
         non_computed_args = _collect_cols_arrays(

--- a/src/hssm/rl/likelihoods/softmax.py
+++ b/src/hssm/rl/likelihoods/softmax.py
@@ -2,12 +2,18 @@
 
 This module provides:
 - Q-value learning functions (Rescorla-Wagner update, no scaler)
-- A JAX softmax log-likelihood function for 2-alternative forced choice tasks
+- A JAX softmax log-likelihood function for N-alternative choice tasks
 
 Unlike the DDM-based learning functions in ``two_armed_bandit.py``, these
 functions operate on choice-only data (no RT column) and compute the
 log-probability of observed choices under a softmax decision rule.
+
+The Q-value scan emits the full per-action Q-value array in a single pass and a
+single generic softmax consumes it, so the same code supports any number of
+actions (responses are 0-based action indices ``0..n_actions-1``).
 """
+
+from collections.abc import Callable
 
 import jax.numpy as jnp
 from jax import nn as jax_nn
@@ -26,7 +32,7 @@ def compute_q_values_trial_wise(
     Parameters
     ----------
     q_val
-        A length-2 array of current Q-values for the two alternatives.
+        A length-``n_actions`` array of current Q-values for the alternatives.
         Carried forward across trials.
     inputs
         A 1D array of ``[rl_alpha, action, reward]`` for the current trial.
@@ -34,7 +40,7 @@ def compute_q_values_trial_wise(
     Returns
     -------
     tuple
-        Updated Q-values and the computed action values ``[Q[0], Q[1]]``.
+        Updated Q-values and the computed action values ``[Q[0], ..., Q[N-1]]``.
     """
     rl_alpha, action, reward = inputs
     action = jnp.astype(action, jnp.int32)
@@ -48,49 +54,60 @@ def compute_q_values_trial_wise(
     return q_val, computed_q_values
 
 
-def _compute_q_values_subject_wise(subj_trials: jnp.ndarray) -> jnp.ndarray:
-    """Compute trial-wise Q-values for one subject.
+def make_compute_q_values_subject_wise(
+    n_actions: int,
+) -> Callable[[jnp.ndarray], jnp.ndarray]:
+    """Build the subject-wise Q-value scan for ``n_actions`` alternatives.
+
+    The returned function maps one subject's ``(n_trials, 3)`` input array with
+    columns ``[rl_alpha, response, feedback]`` to its ``(n_trials, n_actions)``
+    trajectory of pre-update Q-values. The Rescorla-Wagner scan runs **once** and
+    emits all per-action values, so the builder computes every ``q_i`` column in a
+    single pass (it is registered for ``q0..q_{n_actions-1}`` under one function).
 
     Parameters
     ----------
-    subj_trials
-        Array of shape ``(n_trials, 3)`` with columns
-        ``[rl_alpha, response, feedback]``.
+    n_actions
+        Number of choice alternatives (length of the Q-value carrier).
 
     Returns
     -------
-    jnp.ndarray
-        Action values for each trial, shape ``(n_trials, 2)``.
+    Callable
+        ``subj_trials -> q_values`` of shape ``(n_trials, n_actions)``.
     """
-    _, q_values = scan(
-        compute_q_values_trial_wise,
-        jnp.ones(2) * 0.5,  # uniform initial Q-values
-        subj_trials,
-    )
-    return q_values
 
+    def compute_q_values_subject_wise(subj_trials: jnp.ndarray) -> jnp.ndarray:
+        # Build the initial carrier inside the traced function so its dtype
+        # matches the active floatX (the scan carry input and output dtypes must
+        # agree); building it at factory time would freeze the import-time dtype.
+        initial_q_values = jnp.ones(n_actions) * 0.5  # uniform initial Q-values
+        _, q_values = scan(
+            compute_q_values_trial_wise,
+            initial_q_values,
+            subj_trials,
+        )
+        return q_values
 
-def compute_q0_subject_wise(subj_trials: jnp.ndarray) -> jnp.ndarray:
-    """Compute the first action's trial-wise Q-values for one subject."""
-    return _compute_q_values_subject_wise(subj_trials)[:, 0]
-
-
-def compute_q1_subject_wise(subj_trials: jnp.ndarray) -> jnp.ndarray:
-    """Compute the second action's trial-wise Q-values for one subject."""
-    return _compute_q_values_subject_wise(subj_trials)[:, 1]
+    return compute_q_values_subject_wise
 
 
 def softmax_logp_func(params_matrix: jnp.ndarray) -> jnp.ndarray:
-    """Compute the softmax log-likelihood for 2AFC choice-only data.
+    """Compute the softmax log-likelihood for N-alternative choice-only data.
 
-    Inputs (columns of ``params_matrix``) are resolved by the builder from
-    the ``.inputs`` annotation: ``["beta", "q0", "q1", "response"]``.
+    Inputs (columns of ``params_matrix``) are resolved by the builder from the
+    ``.inputs`` annotation ``["beta", "q0", "q1", ..., "q_{N-1}", "response"]``;
+    the number of actions ``N`` is inferred from the width (the Q-value columns
+    are everything between ``beta`` and ``response``).
+
+    The decision rule is ``logits = beta * q`` followed by a softmax over actions,
+    so the chosen action's log-probability is ``logit[response] - logsumexp(logits)``.
 
     Parameters
     ----------
     params_matrix
-        Array of shape ``(n_trials, 4)`` with columns
-        ``[beta, q0, q1, response]``.
+        Array of shape ``(n_trials, N + 2)`` with columns
+        ``[beta, q0, ..., q_{N-1}, response]``. ``response`` holds 0-based action
+        indices.
 
     Returns
     -------
@@ -98,11 +115,10 @@ def softmax_logp_func(params_matrix: jnp.ndarray) -> jnp.ndarray:
         Log-probability of each observed choice, shape ``(n_trials,)``.
     """
     beta = params_matrix[:, 0]
-    q0 = params_matrix[:, 1]
-    q1 = params_matrix[:, 2]
-    response = params_matrix[:, 3]
+    q_values = params_matrix[:, 1:-1]  # (n_trials, n_actions)
+    response = params_matrix[:, -1]
 
-    logits = jnp.stack((beta * q0, beta * q1), axis=1)
-    chosen_logits = logits[:, 1] * (response == 1) + logits[:, 0] * (response == 0)
-    logp = chosen_logits - jax_nn.logsumexp(logits, axis=1)
-    return logp
+    logits = beta[:, None] * q_values  # (n_trials, n_actions)
+    chosen = jnp.astype(response, jnp.int32)
+    chosen_logits = logits[jnp.arange(logits.shape[0]), chosen]
+    return chosen_logits - jax_nn.logsumexp(logits, axis=1)

--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -20,6 +20,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from inspect import signature
@@ -27,8 +28,7 @@ from typing import Any
 
 from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
 from hssm.rl.likelihoods.softmax import (
-    compute_q0_subject_wise,
-    compute_q1_subject_wise,
+    make_compute_q_values_subject_wise,
     softmax_logp_func,
 )
 from hssm.rl.likelihoods.two_armed_bandit import compute_v_subject_wise
@@ -152,20 +152,42 @@ _compute_v_annotated = annotate_function(
     outputs=["v"],
 )(compute_v_subject_wise)
 
-_compute_q0_annotated = annotate_function(
-    inputs=["rl_alpha", "response", "feedback"],
-    outputs=["q0"],
-)(compute_q0_subject_wise)
 
-_compute_q1_annotated = annotate_function(
-    inputs=["rl_alpha", "response", "feedback"],
-    outputs=["q1"],
-)(compute_q1_subject_wise)
+def _make_compute_q_annotated(n_actions: int) -> Any:
+    """Annotate the single N-action Q-value scan.
 
-_softmax_logp_annotated = annotate_function(
-    inputs=["beta", "q0", "q1", "response"],
-    outputs=["logp"],
-)(softmax_logp_func)
+    The function emits one output column per action (``q0..q_{n_actions-1}``)
+    from a single Rescorla-Wagner scan; it is registered for every ``q_i`` under
+    this one object so the builder computes them in a single pass.
+    """
+    return annotate_function(
+        inputs=["rl_alpha", "response", "feedback"],
+        outputs=[f"q{i}" for i in range(n_actions)],
+    )(make_compute_q_values_subject_wise(n_actions))
+
+
+def _make_softmax_logp_annotated(n_actions: int) -> Any:
+    """Annotate the generic softmax logp for an N-action choice-only model."""
+    q_names = [f"q{i}" for i in range(n_actions)]
+    return annotate_function(
+        inputs=["beta", *q_names, "response"],
+        outputs=["logp"],
+    )(softmax_logp_func)
+
+
+def _softmax_n_actions(decision_process: str) -> int | None:
+    """Return N for a built-in softmax decision process ``softmax_<N>AB``.
+
+    Returns ``None`` when *decision_process* is not a built-in softmax name, so
+    callers fall through to the custom-SSM / modelconfig resolution.
+    """
+    match = re.fullmatch(r"softmax_(\d+)AB", decision_process)
+    return int(match.group(1)) if match else None
+
+
+# Built-in two-alternative softmax logp, kept module-level for the default
+# `softmax_2AB` decision process and for tests that reference it.
+_softmax_logp_annotated = _make_softmax_logp_annotated(2)
 
 # ---------------------------------------------------------------------------
 # SSM base log-likelihood registry
@@ -273,8 +295,9 @@ def _get_decision_process_spec(
         spec["name"] = decision_process
         return spec
 
-    if decision_process == "softmax_2AB":
-        return _build_softmax_2ab_spec()
+    n_actions = _softmax_n_actions(decision_process)
+    if n_actions is not None:
+        return _build_softmax_spec(n_actions)
 
     return _build_ssm_spec_from_modelconfig(decision_process)
 
@@ -296,8 +319,9 @@ def _get_ssm_logp(name: str) -> Any:
             _SSM_LOGP_CACHE[name] = entry["ssm_base_logp_func"]
         return _SSM_LOGP_CACHE[name]
 
-    if name == "softmax_2AB":
-        _SSM_LOGP_CACHE[name] = _softmax_logp_annotated
+    n_actions = _softmax_n_actions(name)
+    if n_actions is not None:
+        _SSM_LOGP_CACHE[name] = _make_softmax_logp_annotated(n_actions)
         return _SSM_LOGP_CACHE[name]
 
     spec = _build_ssm_spec_from_modelconfig(name)
@@ -328,10 +352,19 @@ def _make_rescorla_wagner_learning_metadata() -> LearningProcessMetadata:
     )
 
 
-def _make_rescorla_wagner_softmax_learning_metadata() -> LearningProcessMetadata:
-    """Return learning metadata for the built-in choice-only softmax RLSSM."""
+def _make_rescorla_wagner_softmax_learning_metadata(
+    n_actions: int = 2,
+) -> LearningProcessMetadata:
+    """Return learning metadata for the built-in choice-only softmax RLSSM.
+
+    Every per-action Q-value (``q0..q_{n_actions-1}``) is produced by the *same*
+    annotated scan function, so the builder runs the Rescorla-Wagner scan once
+    and slices out all action values.
+    """
+    compute_q = _make_compute_q_annotated(n_actions)
+    q_names = [f"q{i}" for i in range(n_actions)]
     return LearningProcessMetadata(
-        learning_process={"q0": _compute_q0_annotated, "q1": _compute_q1_annotated},
+        learning_process={name: compute_q for name in q_names},
         sampled_params=["rl_alpha"],
         bounds={"rl_alpha": (0.0, 1.0)},
         defaults=[0.1],
@@ -340,15 +373,16 @@ def _make_rescorla_wagner_softmax_learning_metadata() -> LearningProcessMetadata
     )
 
 
-def _build_softmax_2ab_spec() -> dict[str, Any]:
-    """Return the built-in choice-only softmax decision-process specification."""
+def _build_softmax_spec(n_actions: int) -> dict[str, Any]:
+    """Return the built-in choice-only softmax decision-process spec for N actions."""
+    q_names = [f"q{i}" for i in range(n_actions)]
     return {
-        "ssm_base_logp_func": _softmax_logp_annotated,
-        "list_params_ssm": ["beta", "q0", "q1"],
+        "ssm_base_logp_func": _make_softmax_logp_annotated(n_actions),
+        "list_params_ssm": ["beta", *q_names],
         "bounds_ssm": {"beta": (0.0, 10.0)},
-        "params_default_ssm": [1.0, 0.5, 0.5],
+        "params_default_ssm": [1.0] + [0.5] * n_actions,
         "response": ["response"],
-        "name": "softmax_2AB",
+        "name": f"softmax_{n_actions}AB",
     }
 
 
@@ -385,11 +419,21 @@ _RLSSM_REGISTRY: dict[str, RLSSMRegistryEntry] = {
     ),
     "2AB_RescorlaWagner_Softmax": RLSSMRegistryEntry(
         decision_process="softmax_2AB",
-        learning_process_metadata=_make_rescorla_wagner_softmax_learning_metadata(),
+        learning_process_metadata=_make_rescorla_wagner_softmax_learning_metadata(2),
         choices=[0, 1],
         description=(
             "RLSSM model with Rescorla-Wagner Q-learning and a "
             "choice-only softmax decision process."
+        ),
+        decision_process_loglik_kind="approx_differentiable",
+    ),
+    "3AB_RescorlaWagner_Softmax": RLSSMRegistryEntry(
+        decision_process="softmax_3AB",
+        learning_process_metadata=_make_rescorla_wagner_softmax_learning_metadata(3),
+        choices=[0, 1, 2],
+        description=(
+            "RLSSM model with Rescorla-Wagner Q-learning and a choice-only "
+            "softmax decision process over three alternatives."
         ),
         decision_process_loglik_kind="approx_differentiable",
     ),

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -26,6 +26,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 
 import bambi as bmb
+import numpy as np
 import pandas as pd
 import pymc as pm
 
@@ -145,6 +146,23 @@ class _RLSSM(HSSMBase):
         # Validate config (ensures ssm_logp_func is present, etc.)
         model_config.validate()
 
+        # Custom choice labels are only safe for choice-only models, where the
+        # response is consumed purely as an action index. For SSM-backed RLSSMs
+        # (DDM/Angle/Weibull) the same response column is also fed to the LAN with
+        # its own choice coding, so a remap would silently corrupt that input.
+        # Require 0-based contiguous labels there and fail loudly otherwise.
+        if not model_config.is_choice_only and model_config.choices is not None:
+            declared = list(model_config.choices)
+            if declared != list(range(len(declared))):
+                raise ValueError(
+                    f"Custom choice labels {declared} are not supported for "
+                    "SSM-backed RLSSM models (e.g. the DDM/Angle/Weibull decision "
+                    "processes): the response column is also fed to the SSM "
+                    "likelihood with its own coding. Use 0-based contiguous action "
+                    "indices (e.g. [0, 1]). Arbitrary choice labels are currently "
+                    "supported only for the choice-only softmax model."
+                )
+
         # RLSSM reshapes rows into (n_participants, n_trials, ...) by position,
         # so _rearrange_data (which moves missing/deadline rows to the front)
         # would scramble per-participant trial sequences and corrupt RL dynamics.
@@ -227,6 +245,35 @@ class _RLSSM(HSSMBase):
             process_initvals=process_initvals,
             initval_jitter=initval_jitter,
             **kwargs,
+        )
+
+    def _remap_choice_only_responses(self) -> None:
+        """Map declared ``choices`` labels to internal 0..N-1 action indices.
+
+        The choice-only softmax logp and the Rescorla-Wagner Q-value scan consume
+        the response purely as a 0-based action index, so arbitrary integer
+        ``choices`` (e.g. ``[1, 2]`` or ``[-1, 1]``) are supported by remapping the
+        response column to its position in the declared ``choices`` list. This
+        operates on ``self.data`` (already a copy of the user's frame, so the
+        caller's DataFrame is untouched) and runs after ``_post_check_data_sanity``
+        — which validates/warns against the *declared* labels — and before the
+        distribution and ``bmb.Model`` are built. SSM-backed RLSSMs are not
+        choice-only and are rejected in ``__init__`` if given non-0-based labels.
+        """
+        if not self.is_choice_only:
+            return
+        declared = list(self.choices)  # type: ignore[arg-type]
+        if declared == list(range(len(declared))):
+            return  # already 0..N-1; nothing to remap
+        response_col = self.model_config.response[0]  # type: ignore[index]
+        remap = {int(label): idx for idx, label in enumerate(declared)}
+        original = self.data[response_col].to_numpy()
+        # Responses passed _post_check_data_sanity (integral, in `choices`), so
+        # rounding to int for the lookup is safe; keep the original column dtype.
+        int_responses = np.rint(original).astype(int)
+        self.data = self.data.copy()
+        self.data[response_col] = np.vectorize(remap.__getitem__)(int_responses).astype(
+            original.dtype
         )
 
     def _make_model_distribution(self) -> type[pm.Distribution]:

--- a/tests/distribution_utils/test_distribution_utils.py
+++ b/tests/distribution_utils/test_distribution_utils.py
@@ -12,6 +12,7 @@ from hssm.distribution_utils.dist import (
     ensure_positive_ndt,
     make_distribution,
     make_distribution_for_supported_model,
+    _apply_lapse_model,
     _create_arg_arrays,
     _extract_size,
     _get_p_outlier,
@@ -420,3 +421,63 @@ class TestGetPOutlier:
 
         assert p_outlier is None
         assert new_arg_arrays is arg_arrays
+
+
+# ---------------------------------------------------------------------------
+# Tests for _apply_lapse_model with float lapse_dist (choice-only models)
+# ---------------------------------------------------------------------------
+# Choice-only models pass a float `lapse_dist` (1/n_choices). The float branch
+# in _apply_lapse_model must not try `lapse_dist.args` (a float has none) and
+# must keep the 1-column choice shape instead of stacking a 2-column rt/choice
+# mask. Both shapes (1-D and (n_obs, 1)) are exercised below.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_lapse_model_float_lapse_1d_does_not_crash():
+    """Float lapse_dist with 1-D sims_out (choice-only) must not crash."""
+    rng = np.random.default_rng(0)
+    choices = [0, 1]
+    # 1-D input: shape (n_obs,) — pure choice-only output from ssms_rng_fn
+    sims_out = np.array([0, 1, 0, 1, 0], dtype=float)
+    # p_outlier=1.0 forces every trial to be replaced, guaranteeing replace_n > 0
+    # and that the lapse branch is reached every time.
+    result = _apply_lapse_model(
+        sims_out=sims_out,
+        p_outlier=1.0,
+        rng=rng,
+        lapse_dist=0.5,  # float — 1/n_choices for a 2-choice model
+        choices=choices,
+    )
+    assert result.shape == sims_out.shape
+    assert set(result).issubset(set(choices))
+
+
+def test_apply_lapse_model_float_lapse_2d_correct_shape():
+    """Float lapse_dist with 2-D (n_obs, 1) sims_out must return same shape."""
+    rng = np.random.default_rng(0)
+    choices = [0, 1]
+    # 2-D input: shape (n_obs, 1) — choice column only
+    sims_out = np.array([[0], [1], [0], [1], [0]], dtype=float)
+    result = _apply_lapse_model(
+        sims_out=sims_out,
+        p_outlier=1.0,
+        rng=rng,
+        lapse_dist=0.5,
+        choices=choices,
+    )
+    assert result.shape == sims_out.shape
+    assert set(result[:, -1]).issubset(set(choices))
+
+
+def test_apply_lapse_model_float_lapse_no_replacement_returns_input():
+    """With p_outlier=0 no trial lapses; the input is returned unchanged."""
+    rng = np.random.default_rng(0)
+    sims_out = np.array([0, 1, 0, 1, 0], dtype=float)
+    result = _apply_lapse_model(
+        sims_out=sims_out,
+        p_outlier=0.0,
+        rng=rng,
+        lapse_dist=0.5,
+        choices=[0, 1],
+    )
+    np.testing.assert_array_equal(result, sims_out)

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -727,15 +727,32 @@ class TestBuiltinModels:
         assert "rl_alpha" in config.bounds
         if model_name == "2AB_RescorlaWagner_Softmax":
             assert "beta" in config.bounds
-            assert config.ssm_logp_func.computed == {
-                "q0": registry._compute_q0_annotated,
-                "q1": registry._compute_q1_annotated,
-            }
+            # Both Q-value outputs are produced by the SAME annotated scan
+            # function (one scan, sliced per action), not two separate functions.
+            assert set(config.ssm_logp_func.computed) == {"q0", "q1"}
+            assert (
+                config.ssm_logp_func.computed["q0"]
+                is config.ssm_logp_func.computed["q1"]
+            )
         else:
             assert "scaler" in config.bounds
             assert config.ssm_logp_func.computed == {"v": registry._compute_v_annotated}
         assert config.choices == (0, 1)
         assert config.extra_fields == ["feedback"]
+
+    def test_three_action_softmax_registered(self) -> None:
+        """The 3-action softmax model exercises the N-action generalisation."""
+        assert "3AB_RescorlaWagner_Softmax" in registry._RLSSM_REGISTRY
+        config = registry.get_rlssm_model_config("3AB_RescorlaWagner_Softmax")
+        assert config.decision_process == "softmax_3AB"
+        assert config.choices == (0, 1, 2)
+        assert config.list_params == ["rl_alpha", "beta"]
+        # q0/q1/q2 all produced by the SAME annotated scan (one pass).
+        assert set(config.ssm_logp_func.computed) == {"q0", "q1", "q2"}
+        funcs = list(config.ssm_logp_func.computed.values())
+        assert all(f is funcs[0] for f in funcs)
+        # The logp inputs carry every action's Q-value column plus beta + response.
+        assert config.ssm_logp_func.inputs == ["beta", "q0", "q1", "q2", "response"]
 
 
 class TestListModels:

--- a/tests/rl/test_rl_likelihood_builder.py
+++ b/tests/rl/test_rl_likelihood_builder.py
@@ -1116,3 +1116,94 @@ class TestMultipleComputedParameters:
 
         assert result.shape[0] == rldm_data.total_trials
         assert not np.isnan(result).any()
+
+
+class TestMultiOutputComputedFunction:
+    """A single learning function emitting multiple named outputs.
+
+    Regression coverage for the per-action double scan: one annotated function
+    with ``outputs=["q0", "q1"]`` registered under both names must run ONCE and
+    have its (n, 2) block sliced into the two columns.
+    """
+
+    def _run(self):
+        n_participants, n_trials = 2, 3
+        total = n_participants * n_trials
+        call_count: list[int] = []
+
+        def _compute_q(subj_trials):
+            call_count.append(1)
+            # subj_trials columns follow .inputs: [rl_alpha, response, feedback]
+            return jnp.stack([subj_trials[:, 0], subj_trials[:, 2]], axis=1)
+
+        compute_q = annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+            outputs=["q0", "q1"],
+        )(_compute_q)
+
+        def _ssm_logp(lan_matrix):
+            # lan_matrix columns: [beta, q0, q1, response]
+            return lan_matrix[:, 1] * 100.0 + lan_matrix[:, 2]
+
+        ssm_logp = annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_q, "q1": compute_q},
+        )(_ssm_logp)
+
+        logp = make_rl_logp_func(
+            ssm_logp,
+            n_participants=n_participants,
+            n_trials=n_trials,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+
+        rng = np.random.default_rng(0)
+        response = rng.integers(0, 2, total).astype(float)
+        beta = rng.uniform(0.5, 2.0, total)
+        rl_alpha = rng.uniform(0.0, 1.0, total)
+        feedback = rng.integers(0, 2, total).astype(float)
+        result = np.asarray(logp(response.reshape(-1, 1), beta, rl_alpha, feedback))
+        return result, rl_alpha, feedback, call_count
+
+    def test_both_outputs_reach_logp(self):
+        result, rl_alpha, feedback, _ = self._run()
+        # q0 == rl_alpha column, q1 == feedback column → result == q0*100 + q1
+        np.testing.assert_allclose(result, rl_alpha * 100.0 + feedback, rtol=1e-5)
+
+    def test_compute_function_runs_once(self):
+        _, _, _, call_count = self._run()
+        assert sum(call_count) == 1
+
+
+class TestComputedOutputsGuard:
+    """A computed function must declare a non-empty, correctly-sized .outputs."""
+
+    def test_missing_outputs_raises(self):
+        def _compute_q(subj_trials):
+            return jnp.stack([subj_trials[:, 0], subj_trials[:, 2]], axis=1)
+
+        # No `outputs` attribute on the compute function.
+        compute_q = annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+        )(_compute_q)
+
+        ssm_logp = annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_q, "q1": compute_q},
+        )(lambda lan_matrix: lan_matrix[:, 1])
+
+        logp = make_rl_logp_func(
+            ssm_logp,
+            n_participants=2,
+            n_trials=3,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+        data = np.zeros((6, 1))
+        with pytest.raises(ValueError, match="non-empty `outputs`"):
+            logp(data, np.ones(6), np.ones(6), np.ones(6))

--- a/tests/rl/test_rlssm_choice_only.py
+++ b/tests/rl/test_rlssm_choice_only.py
@@ -65,11 +65,10 @@ def test_rlssm_softmax_no_rt_column(choice_only_data) -> None:
 def test_rlssm_softmax_invalid_response_rejected() -> None:
     """Response values outside {0, 1} must be rejected at construction time.
 
-    The softmax logp uses ``jnp.where(response == 1, ...)``, treating anything
-    other than 1 as choice 0.  An invalid value such as -1 or 2 would therefore
-    silently produce a wrong likelihood (and corrupt Q-value updates via negative
-    array indexing).  ``_post_check_data_sanity`` must catch these before any JAX
-    computation runs.
+    The softmax logp and the Q-value scan index per-action arrays by the integer
+    response, so an out-of-range value such as -1 or 2 would silently produce a
+    wrong likelihood (or corrupt Q-value updates via out-of-bounds indexing).
+    ``_post_check_data_sanity`` must catch these before any JAX computation runs.
     """
     rng = np.random.default_rng(0)
     n_total = 50
@@ -116,16 +115,28 @@ def test_rlssm_softmax_non_integral_response_rejected() -> None:
         RLSSM(data=bad_data, model="2AB_RescorlaWagner_Softmax")
 
 
-@pytest.mark.xfail(
-    reason="Choice label overrides are not remapped to the softmax model's internal binary actions yet.",
-    strict=True,
-)
-def test_rlssm_softmax_custom_choice_labels_behave_like_binary_actions() -> None:
-    """Non-default binary labels should be handled consistently.
+def _logp_at_initial_point(model: RLSSM) -> float:
+    """Compile and evaluate the model logp at its initial point."""
+    with model.pymc_model:
+        ip = model.pymc_model.initial_point()
+        return float(model.pymc_model.compile_logp()(ip))
 
-    The public RLSSM API accepts ``choices`` overrides, so a valid binary coding
-    such as ``[1, 2]`` should produce the same likelihood as the equivalent data
-    recoded to the internal binary actions ``[0, 1]``.
+
+@pytest.mark.parametrize(
+    "label_map, choices",
+    [
+        ({0.0: 1.0, 1.0: 2.0}, [1, 2]),  # shifted labels
+        ({0.0: -1.0, 1.0: 1.0}, [-1, 1]),  # signed labels (HSSM softmax convention)
+    ],
+)
+def test_rlssm_softmax_custom_choice_labels_behave_like_binary_actions(
+    label_map, choices
+) -> None:
+    """Arbitrary integer ``choices`` should reduce to the internal 0/1 actions.
+
+    The public RLSSM API accepts ``choices`` overrides; the response column is
+    remapped to 0-based action indices, so relabeling the two valid choices must
+    not change the log-likelihood relative to the canonical ``[0, 1]`` coding.
     """
     rng = np.random.default_rng(7)
     n_participants, n_trials = 4, 12
@@ -139,29 +150,83 @@ def test_rlssm_softmax_custom_choice_labels_behave_like_binary_actions() -> None
         }
     )
     relabeled_data = binary_data.copy()
-    relabeled_data["response"] = relabeled_data["response"].replace(
-        {0.0: 1.0, 1.0: 2.0}
-    )
+    relabeled_data["response"] = relabeled_data["response"].replace(label_map)
 
     default_model = RLSSM(data=binary_data, model="2AB_RescorlaWagner_Softmax")
     relabeled_model = RLSSM(
         data=relabeled_data,
         model="2AB_RescorlaWagner_Softmax",
-        choices=[1, 2],
+        choices=choices,
     )
 
-    with default_model.pymc_model:
-        default_ip = default_model.pymc_model.initial_point()
-        default_lp = default_model.pymc_model.compile_logp()(default_ip)
-
-    with relabeled_model.pymc_model:
-        relabeled_ip = relabeled_model.pymc_model.initial_point()
-        relabeled_lp = relabeled_model.pymc_model.compile_logp()(relabeled_ip)
+    default_lp = _logp_at_initial_point(default_model)
+    relabeled_lp = _logp_at_initial_point(relabeled_model)
 
     assert np.isclose(default_lp, relabeled_lp), (
         "Relabeling the two valid choices should not change the log-likelihood. "
         f"Expected matching values, got {default_lp} and {relabeled_lp}."
     )
+
+
+def test_rlssm_softmax_choice_remap_respects_declared_order() -> None:
+    """Remapping uses declared ``choices`` order: choices=[2, 1] maps 2->0, 1->1."""
+    rng = np.random.default_rng(11)
+    n_participants, n_trials = 4, 12
+    n_total = n_participants * n_trials
+    base_response = rng.integers(0, 2, size=n_total).astype(float)
+    feedback = rng.integers(0, 2, size=n_total).astype(float)
+    participant_id = np.repeat(np.arange(n_participants), n_trials)
+
+    canonical = pd.DataFrame(
+        {
+            "participant_id": participant_id,
+            "response": base_response,
+            "feedback": feedback,
+        }
+    )
+    # Map 0->2 and 1->1 so that declaring choices=[2, 1] inverts back to 0/1.
+    reordered = canonical.copy()
+    reordered["response"] = np.where(base_response == 0.0, 2.0, 1.0)
+
+    canonical_lp = _logp_at_initial_point(
+        RLSSM(data=canonical, model="2AB_RescorlaWagner_Softmax")
+    )
+    reordered_lp = _logp_at_initial_point(
+        RLSSM(data=reordered, model="2AB_RescorlaWagner_Softmax", choices=[2, 1])
+    )
+    assert np.isclose(canonical_lp, reordered_lp)
+
+
+def test_rlssm_softmax_remap_does_not_mutate_user_dataframe() -> None:
+    """The remap must operate on HSSM's copy, leaving the user's frame untouched."""
+    rng = np.random.default_rng(3)
+    n_total = 40
+    data = pd.DataFrame(
+        {
+            "participant_id": np.repeat(np.arange(4), 10),
+            "response": rng.choice([1.0, 2.0], size=n_total),
+            "feedback": rng.integers(0, 2, size=n_total).astype(float),
+        }
+    )
+    original_response = data["response"].copy()
+    RLSSM(data=data, model="2AB_RescorlaWagner_Softmax", choices=[1, 2])
+    pd.testing.assert_series_equal(data["response"], original_response)
+
+
+def test_rlssm_ddm_rejects_non_zero_based_choices() -> None:
+    """SSM-backed RLSSMs must reject custom labels (response is dual-use)."""
+    rng = np.random.default_rng(5)
+    n_total = 40
+    data = pd.DataFrame(
+        {
+            "participant_id": np.repeat(np.arange(4), 10),
+            "rt": rng.uniform(0.3, 1.5, size=n_total),
+            "response": rng.choice([1.0, 2.0], size=n_total),
+            "feedback": rng.integers(0, 2, size=n_total).astype(float),
+        }
+    )
+    with pytest.raises(ValueError, match="not supported for"):
+        RLSSM(data=data, model="2AB_RescorlaWagner_DDM", choices=[1, 2])
 
 
 def test_rlssm_softmax_warns_when_a_declared_choice_is_missing() -> None:
@@ -224,6 +289,44 @@ def test_rlssm_softmax_per_trial_logp_valid(choice_only_data) -> None:
         f"Some log-probabilities are positive (> 0), indicating the "
         f"lapse mixture probability exceeded 1. Max: {all_logp.max():.4f}"
     )
+
+
+@pytest.fixture(scope="module")
+def choice_only_data_3afc() -> pd.DataFrame:
+    """Synthetic balanced-panel 3-alternative choice-only dataset (no RT)."""
+    rng = np.random.default_rng(99)
+    n_participants, n_trials = 5, 20
+    n_total = n_participants * n_trials
+    return pd.DataFrame(
+        {
+            "participant_id": np.repeat(np.arange(n_participants), n_trials),
+            "response": rng.integers(0, 3, size=n_total).astype(float),
+            "feedback": rng.integers(0, 2, size=n_total).astype(float),
+        }
+    )
+
+
+def test_rlssm_softmax_3afc_instantiates_and_evaluates(choice_only_data_3afc) -> None:
+    """The registered 3-action softmax model builds and yields valid logp.
+
+    Exercises the N-action generalisation end to end: a single Q-value scan
+    produces q0/q1/q2, the generic softmax consumes them, and per-trial
+    log-probabilities are finite and non-positive.
+    """
+    model = RLSSM(data=choice_only_data_3afc, model="3AB_RescorlaWagner_Softmax")
+    assert model.model_config.is_choice_only
+    assert model.model_config.choices == (0, 1, 2)
+    # q0/q1/q2 are computed inside the Op, not free parameters.
+    assert {"rl_alpha", "beta"}.issubset(set(model.params))
+    assert not ({"q0", "q1", "q2"} & set(model.params))
+
+    with model.pymc_model:
+        ip = model.pymc_model.initial_point()
+        lp = model.pymc_model.compile_logp()(ip)
+        parts = model.pymc_model.compile_logp(sum=False)(ip)
+    assert np.isfinite(lp), f"Expected a finite logp, got {lp}"
+    all_logp = np.concatenate([np.atleast_1d(x) for x in parts])
+    assert np.all(all_logp <= 1e-6)
 
 
 @pytest.mark.slow

--- a/tests/rl/test_softmax_logp.py
+++ b/tests/rl/test_softmax_logp.py
@@ -1,0 +1,100 @@
+"""Unit tests for the generic N-action choice-only softmax likelihood.
+
+These exercise the pure JAX functions in ``hssm.rl.likelihoods.softmax`` directly
+(no PyMC), covering: equivalence to the legacy 2AFC formula, correctness and
+normalisation for N > 2 actions, and the single-pass Q-value scan.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.special import logsumexp
+
+from hssm.rl.likelihoods.softmax import (
+    make_compute_q_values_subject_wise,
+    softmax_logp_func,
+)
+
+
+def _legacy_binary_logp(params_matrix: np.ndarray) -> np.ndarray:
+    """Compute the pre-refactor 2AFC softmax formula (mask-based) for regression."""
+    beta = params_matrix[:, 0]
+    q0 = params_matrix[:, 1]
+    q1 = params_matrix[:, 2]
+    response = params_matrix[:, 3]
+    logits = np.stack((beta * q0, beta * q1), axis=1)
+    chosen = logits[:, 1] * (response == 1) + logits[:, 0] * (response == 0)
+    return chosen - logsumexp(logits, axis=1)
+
+
+def test_softmax_logp_matches_legacy_binary():
+    """For 2 actions the generic logp must equal the old masked formula exactly."""
+    rng = np.random.default_rng(0)
+    n = 64
+    beta = rng.uniform(0.1, 5.0, n)
+    q0 = rng.normal(size=n)
+    q1 = rng.normal(size=n)
+    response = rng.integers(0, 2, n).astype(float)
+    pm = np.stack([beta, q0, q1, response], axis=1)
+
+    new = np.asarray(softmax_logp_func(jnp.asarray(pm)))
+    legacy = _legacy_binary_logp(pm)
+    np.testing.assert_allclose(new, legacy, rtol=1e-5, atol=1e-6)
+
+
+def test_softmax_logp_three_actions_matches_manual():
+    """For 3 actions the logp equals beta*q[chosen] - logsumexp(beta*q)."""
+    rng = np.random.default_rng(1)
+    n = 40
+    beta = rng.uniform(0.1, 5.0, n)
+    q = rng.normal(size=(n, 3))
+    response = rng.integers(0, 3, n).astype(float)
+    pm = np.concatenate([beta[:, None], q, response[:, None]], axis=1)
+
+    out = np.asarray(softmax_logp_func(jnp.asarray(pm)))
+    logits = beta[:, None] * q
+    expected = logits[np.arange(n), response.astype(int)] - logsumexp(logits, axis=1)
+    np.testing.assert_allclose(out, expected, rtol=1e-5, atol=1e-6)
+    assert np.all(out <= 1e-6)  # log-probabilities are non-positive
+
+
+@pytest.mark.parametrize("n_actions", [2, 3, 4])
+def test_softmax_logp_normalizes_over_actions(n_actions):
+    """For one trial, probabilities over all possible chosen actions sum to 1."""
+    beta = np.array([2.0])
+    q = (np.arange(n_actions, dtype=float) * 0.3)[None, :]
+    probs = []
+    for action in range(n_actions):
+        pm = np.concatenate([beta[:, None], q, np.array([[float(action)]])], axis=1)
+        logp = float(np.asarray(softmax_logp_func(jnp.asarray(pm)))[0])
+        probs.append(np.exp(logp))
+    np.testing.assert_allclose(sum(probs), 1.0, rtol=1e-6)
+
+
+def test_compute_q_values_single_scan_n_actions():
+    """The N-action Q scan returns the full (n_trials, N) trajectory in one pass."""
+    n_actions = 3
+    compute_q = make_compute_q_values_subject_wise(n_actions)
+    alpha = 0.5
+    # columns: [rl_alpha, response (action index), feedback (reward)]
+    trials = jnp.asarray(
+        [
+            [alpha, 0.0, 1.0],
+            [alpha, 1.0, 0.0],
+            [alpha, 0.0, 0.0],
+        ]
+    )
+    q = np.asarray(compute_q(trials))
+    assert q.shape == (3, n_actions)
+    # Hand-rolled Rescorla-Wagner (init 0.5, alpha 0.5), reporting pre-update Q:
+    #  trial0 Q=[.5,.5,.5];  update action0, reward1 -> q0 = .5 + .5*(1-.5)=.75
+    #  trial1 Q=[.75,.5,.5]; update action1, reward0 -> q1 = .5 + .5*(0-.5)=.25
+    #  trial2 Q=[.75,.25,.5];update action0, reward0 -> (post-update, unused here)
+    expected = np.array(
+        [
+            [0.5, 0.5, 0.5],
+            [0.75, 0.5, 0.5],
+            [0.75, 0.25, 0.5],
+        ]
+    )
+    np.testing.assert_allclose(q, expected, rtol=1e-6)

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -475,16 +475,14 @@ def test_is_choice_only_and_deadline(data_ddm):
     assert model.response_c == "response"
     assert model.response_str == "response"
 
+    # Choice-only models have no RT column to censor, so a deadline is rejected.
     data_deadline = data_ddm.copy()
     data_deadline["deadline"] = 0
 
-    model_with_deadline = HSSM(
-        data=data_deadline, model="ddm", model_config=config_choice_only, deadline=True
-    )
-
-    assert model_with_deadline.is_choice_only
-    assert model_with_deadline.deadline
-    assert model_with_deadline.response is not None
-    assert len(model_with_deadline.response) == 2
-    assert model_with_deadline.response_c == "c(response, deadline)"
-    assert model_with_deadline.response_str == "response,deadline"
+    with pytest.raises(ValueError, match="Choice-only models cannot have a deadline"):
+        HSSM(
+            data=data_deadline,
+            model="ddm",
+            model_config=config_choice_only,
+            deadline=True,
+        )

--- a/tests/test_missing_data_mixin.py
+++ b/tests/test_missing_data_mixin.py
@@ -241,46 +241,43 @@ class TestChoiceOnlyMissingDataMixin:
                 missing_data=True, deadline=False, loglik_missing_data=None
             )
 
-    def test_deadline_column_missing_raises(self, choice_only_model):
-        """Specifying deadline with a column that doesn't exist must raise immediately."""
-        with pytest.raises(ValueError, match="not found in your dataset"):
-            choice_only_model._process_missing_data_and_deadline(
-                missing_data=False, deadline="nonexistent_col", loglik_missing_data=None
-            )
-
-    def test_deadline_true_missing_column_raises(self, choice_only_model):
-        """deadline=True with no 'deadline' column in data must raise."""
-        with pytest.raises(ValueError, match="not found in your dataset"):
+    def test_deadline_true_rejected(self, choice_only_model):
+        """deadline=True must raise for choice-only models (no RTs to censor)."""
+        with pytest.raises(
+            ValueError, match="Choice-only models cannot have a deadline"
+        ):
             choice_only_model._process_missing_data_and_deadline(
                 missing_data=False, deadline=True, loglik_missing_data=None
             )
 
-    def test_valid_deadline_appended_to_response(self, choice_only_model):
-        """Deadline column present in data should be appended to self.response."""
+    def test_deadline_str_rejected(self, choice_only_model):
+        """A deadline column name (str) must also raise for choice-only models."""
         choice_only_model.data["deadline"] = [1.0, 1.0, 1.0, 1.0, 1.0]
-        choice_only_model._process_missing_data_and_deadline(
-            missing_data=False, deadline=True, loglik_missing_data=None
-        )
-        assert "deadline" in choice_only_model.response
-        assert choice_only_model.deadline is True
+        with pytest.raises(
+            ValueError, match="Choice-only models cannot have a deadline"
+        ):
+            choice_only_model._process_missing_data_and_deadline(
+                missing_data=False, deadline="deadline", loglik_missing_data=None
+            )
 
-    def test_deadline_column_appended_once(self, choice_only_model):
-        """Deadline column already in response must not be duplicated."""
-        choice_only_model.data["deadline"] = [1.0, 1.0, 1.0, 1.0, 1.0]
-        choice_only_model.response.append("deadline")
-        choice_only_model._process_missing_data_and_deadline(
-            missing_data=False, deadline=True, loglik_missing_data=None
-        )
-        assert choice_only_model.response.count("deadline") == 1
-
-    def test_loglik_missing_data_without_deadline_raises(self, choice_only_model):
-        """Providing loglik_missing_data without deadline=True must raise for choice-only."""
+    def test_loglik_missing_data_rejected(self, choice_only_model):
+        """Providing loglik_missing_data must raise for choice-only models."""
         with pytest.raises(
             ValueError,
-            match="loglik_missing_data function specified, but you have not set the missing_data or deadline flag to True",
+            match="choice-only models do not support missing data or deadlines",
         ):
             choice_only_model._process_missing_data_and_deadline(
                 missing_data=False,
                 deadline=False,
                 loglik_missing_data=lambda x: x,
             )
+
+    def test_neither_set_disables_all(self, choice_only_model):
+        """With nothing requested, all missing-data/deadline state is disabled."""
+        choice_only_model._process_missing_data_and_deadline(
+            missing_data=False, deadline=False, loglik_missing_data=None
+        )
+        assert choice_only_model.missing_data is False
+        assert choice_only_model.deadline is False
+        assert choice_only_model.loglik_missing_data is None
+        assert choice_only_model.missing_data_network == MissingDataNetwork.NONE


### PR DESCRIPTION
This pull request introduces significant improvements to the support for N-alternative (N > 2) choice-only reinforcement learning models, particularly for softmax decision processes. The changes generalize the Q-value computation and softmax likelihood to handle any number of actions, optimize how learning rule outputs are computed, and clarify the handling of missing data and deadlines for choice-only models. Additionally, the registry and builder logic have been refactored to support these generalizations and improve efficiency.

**Generalization to N-alternative softmax and Q-value computation:**

* Refactored the Q-value scan and softmax log-likelihood in `src/hssm/rl/likelihoods/softmax.py` to support any number of actions (N), not just two. The Q-value scan now emits all per-action Q-values in a single pass, and the softmax log-likelihood consumes a variable number of Q-value columns, inferring the number of actions from the input shape. [[1]](diffhunk://#diff-fe3f90a7a38d109802f4037bef45fa15b4248646de5091b3d995d4fdc5bfb038L5-R17) [[2]](diffhunk://#diff-fe3f90a7a38d109802f4037bef45fa15b4248646de5091b3d995d4fdc5bfb038L29-R43) [[3]](diffhunk://#diff-fe3f90a7a38d109802f4037bef45fa15b4248646de5091b3d995d4fdc5bfb038L51-R124)
* Updated the RLSSM registry in `src/hssm/rl/registry.py` to dynamically construct annotated compute functions and log-likelihoods for arbitrary N-alternative softmax models, including a utility to extract the number of actions from the decision process name. [[1]](diffhunk://#diff-8a8a14ac2f268e692467a2779a48bcb258f4974fdde105d3545ef212d9c0b144R23-R31) [[2]](diffhunk://#diff-8a8a14ac2f268e692467a2779a48bcb258f4974fdde105d3545ef212d9c0b144L155-R191) [[3]](diffhunk://#diff-8a8a14ac2f268e692467a2779a48bcb258f4974fdde105d3545ef212d9c0b144L276-R300)

**Builder and compute function optimizations:**

* Modified the RL builder in `src/hssm/rl/likelihoods/builder.py` to ensure that each distinct compute function (e.g., the Q-value scan) is run only once, even if it produces multiple outputs registered under different names. This avoids redundant computation for multi-action models. [[1]](diffhunk://#diff-9a98541075087e11571ef291ed4e0542bb427fc9f9641e440801ebec8c3e92c3L554-R566) [[2]](diffhunk://#diff-9a98541075087e11571ef291ed4e0542bb427fc9f9641e440801ebec8c3e92c3L588-R605) [[3]](diffhunk://#diff-9a98541075087e11571ef291ed4e0542bb427fc9f9641e440801ebec8c3e92c3L653-R684)

**Choice-only model handling and API clarifications:**

* Clarified and enforced that missing data and deadline handling do not apply to choice-only models (which have no RT column), raising errors if these features are requested and ensuring internal flags are set appropriately in `src/hssm/missing_data_mixin.py`.
* Added a hook in `src/hssm/base.py` for subclasses to remap response labels to contiguous action indices, supporting arbitrary integer labels for choice-only models. [[1]](diffhunk://#diff-eaff11a3d060b73385e258bc362b6df7683fad454c6017f8b9e35ed224a700afR350-R355) [[2]](diffhunk://#diff-eaff11a3d060b73385e258bc362b6df7683fad454c6017f8b9e35ed224a700afR406-R414)

**Lapse model API and implementation:**

* Updated the lapse model API in `src/hssm/distribution_utils/dist.py` to allow a float for choice-only models (representing uniform choice probability), and implemented logic to replace lapsed trials with uniform random choices over the available actions. [[1]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL193-R193) [[2]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL205-R206) [[3]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL315-R316) [[4]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dL328-R333) [[5]](diffhunk://#diff-9cda7cfbef005161ff85e52f17656d7c1331079d76d73ea3c759ab9da66fa07dR351-R371)

These changes collectively enable efficient and flexible modeling of N-alternative choice-only RL tasks, improve code clarity, and ensure robust error handling for unsupported configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended choice model support from binary to N-alternative decisions (e.g., 3-choice tasks).
  * Added lapse probability handling for choice-only models.

* **Bug Fixes**
  * Choice-only models now properly reject incompatible features (deadline, missing-data handling) with clear error messages.

* **Refactor**
  * Improved internal efficiency by avoiding redundant computations in multi-output learning rules.

* **Tests**
  * Added comprehensive test coverage for N-alternative choice models and lapse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->