### PR TITLE
[pymc6 migration] Updated main documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </a>
 </div>
 
-## HSSM - Hierarchical Sequential Sampling Modeling
+# HSSM - Hierarchical Sequential Sampling Modeling
 
 [![DOI](https://zenodo.org/badge/545006401.svg)](https://doi.org/10.5281/zenodo.17247695)
 ![GitHub Repo stars](https://img.shields.io/github/stars/lnccbrown/HSSM)
@@ -18,7 +18,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![codecov](https://codecov.io/gh/lnccbrown/HSSM/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/HSSM)
 
-### Overview
+## Overview
 
 HSSM is an open-source Python toolbox for computational modeling in cognitive
 neuroscience. It supports a broad range of sequential sampling models used to
@@ -29,7 +29,7 @@ probabilistic programming to enable flexible hierarchical Bayesian inference via
 modern MCMC samplers. It is user-friendly and provides the ability to rigorously
 estimate the impact of neural and other trial-by-trial covariates through
 parameter-wise mixed-effects models. HSSM is a
-<a href="https://ccbs.carney.brown.edu/brainstorm">BRAINSTORM</a> project in
+[Brainstorm](https://ccbs.carney.brown.edu/brainstorm) project in
 collaboration with the Center for Computation and Visualization and the Center
 for Computational Brain Science within the Carney Institute at Brown University.
 
@@ -41,10 +41,12 @@ for Computational Brain Science within the Carney Institute at Brown University.
 - Built on PyMC with support from the Python Bayesian ecosystem at large.
 - Incorporates Bambi's intuitive `lmer`-like regression parameter specification
   for within- and between-subject effects.
+- (💥 New in HSSM 0.4.0) Support for reinforcement learning sequential sampling models.
 - Native ArviZ support for plotting and other convenience functions to aid the
   Bayesian workflow.
 - Utilizes the ONNX format for translation of differentiable likelihood
   approximators across backends.
+- Broad ecosystem support for differentiable likelihoods sourced from the sbi and BayesFlow libraries.
 
 ### [Official documentation](https://lnccbrown.github.io/HSSM/).
 
@@ -52,7 +54,7 @@ for Computational Brain Science within the Carney Institute at Brown University.
 
 ## Cite HSSM
 
-Fengler, A., Xu, Y., Bera, K., Paniagua, C.,  Omar, A., Frank, M.J. (in preparation). HSSM: A
+Fengler, A., Xu, Y., Bera, K., Paniagua, C., Omar, A., Frank, M.J. (in preparation). HSSM: A
 widely applicable toolbox for hierarchical bayesian neurocognitive modeling.
 
 Please also use this DOI: [https://doi.org/10.5281/zenodo.17247695](https://doi.org/10.5281/zenodo.17247695)
@@ -95,47 +97,37 @@ For a deeper dive into HSSM, please follow
 
 ## Installation
 
-HSSM can be directly installed into your conda environment on Linux and MacOS.
-Installing HSSM on windows takes only one more simple step. We have a more
-detailed
-[installation guide](https://lnccbrown.github.io/HSSM/getting_started/installation/)
-for users with more specific setups.
+(💥 New in HSSM 0.4.0) HSSM supports installation directly through `pip` or `uv` on
+all platforms.
 
-### Install HSSM on Linux and MacOS (CPU only)
+### Install HSSM (CPU only)
 
 Use the following command to install HSSM into your virtual environment:
 
 ```bash
-conda install -c conda-forge hssm
+pip install hssm
 ```
 
-### Install HSSM on Linux and MacOS (with GPU Support)
+YOu can also install HSSM with `uv`:
+
+```bash
+uv add hssm
+```
+
+### Install HSSM with IO support
+
+If you need to save/load models and traces, please install HSSM with IO support:
+
+```bash
+pip install hssm[io]
+```
+
+### Install HSSM (with GPU Support)
 
 If you need to sample with GPU, please install JAX with GPU support before
 installing HSSM:
 
 ```bash
-conda install jaxlib=*=*cuda* jax cuda-nvcc -c conda-forge -c nvidia
-conda install -c conda-forge hssm
-```
-
-### Install HSSM on Windows (CPU only)
-
-Because dependencies such as `jaxlib` and `numpyro` are not up-to-date on Conda,
-the easiest way to install HSSM on Windows is to install PyMC first and install
-HSSM via `pip`:
-
-```bash
-conda install -c conda-forge pymc
-pip install hssm
-```
-
-### Install HSSM on Windows (with GPU support)
-
-You simply need to install JAX with GPU support after installing PyMC:
-
-```bash
-conda install -c conda-forge pymc
 pip install hssm[cuda12]
 ```
 
@@ -144,24 +136,6 @@ pip install hssm[cuda12]
 JAX also has support other GPUs. Please follow the
 [Official JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html)
 to install the correct version of JAX before installing HSSM.
-
-## Advanced Installation
-
-### Install HSSM directly with Pip
-
-HSSM is also available through PyPI. You can directly install it with pip into
-any virtual environment via:
-
-```bash
-pip install hssm
-```
-
-**Note:** While this installation is much simpler, you might encounter this
-warning message
-`WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.`
-Please refer to our
-[advanced installation guide](https://lnccbrown.github.io/HSSM/getting_started/installation/)
-for more details.
 
 ### Install the dev version of HSSM
 
@@ -184,12 +158,12 @@ Colab regardless of the backend you are using:
 ## Troubleshooting
 
 **Note:** Possible solutions to any issues with installations with hssm can be
-located [here](https://github.com/lnccbrown/HSSM/discussions). Also feel free to
-start a new discussion thread if you don't find answers there. We recommend
-installing HSSM into a new conda environment with Python 3.10 or 3.11 to prevent
+located [on GitHub Discussions](https://github.com/lnccbrown/HSSM/discussions). Also
+feel free to start a new discussion thread if you don't find answers there. We recommend
+installing HSSM into a new conda environment with Python 3.12 through 3.14 to prevent
 any problems with dependencies during the installation process. Please note that
-hssm is only tested for python 3.10, 3.11. As of HSSM v0.2.0, support for Python
-3.9 is dropped. Use unsupported python versions with caution.
+hssm is only tested for python 3.12 through 3.14. As of HSSM v0.4.0, support for Python
+3.11 or lower is dropped. Use unsupported python versions with caution.
 
 ## License
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 0.4.0
+
+This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.
+
+#### Major new features:
+
+1. A new `RLSSM` class has been added to support reinforcement learning sequential sampling models.
+
+#### Breaking changes that requiresmigration:
+
+1. Dependencies has been streamlined to support PyMC 6.0+, ppytensor 3.0+, ArviZ 1.0+, and Bambi 0.18+.
+2. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
+3. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.
+4. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.
+5. HSSM can now be installed directly from PyPI via `pip` or `uv`. Conda support is no longer provided.
+
 ### 0.3.0
 
 This version includes the following changes:

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,78 +1,56 @@
 # Installation
 
-**Important Update:** From HSSM 0.2.2, `conda-forge` is the official way of installing HSSM. This will also install other libraries such as `libblas` that PyMC requires to run properly.
+**Important Update:** From HSSM 0.4.0, HSSM supports installation directly through `pip` or `uv` on all platforms. You can still install HSSM into conda environments via `pip`, but `conda install hssm` no longer installs the latest version of HSSM.
 
-## Step 1: Create a conda environment
+Please follow the instructions below to install HSSM.
 
-If you haven't already, please follow the [Anaconda official website](https://www.anaconda.com/download) to install conda. We assume that you already have one of [Anaconda](https://www.anaconda.com/download), [Miniconda](https://docs.anaconda.com/free/miniconda/index.html), [miniforge](https://github.com/conda-forge/miniforge/releases), or [mambaforge](https://github.com/conda-forge/miniforge/releases) installed on your system and have access to either `conda` or `mamba` available on your command line.
+## Option 1: Installation with uv
 
-To create a conda environment, use the following command. Substitute `mamba` for `conda` if `mamba` is available:
+We highly recommend that the installation of HSSM is done through `uv`, a package manager that simplifies the installation of Python packages and their dependencies. You can install `uv` by following the instructions on the [uv official website](https://docs.astral.sh/uv/getting-started/installation/).
 
-```bash
-conda create -n <your-env-name> python=3.11
-conda activate <your-env-name>
-```
-
-Substitute `<your-env-name>` with the name of the virtual environment that you choose. HSSM 0.2.0 and above supports Python versions 3.10 and 3.11.
-
-## Step 2: Install HSSM
-
-HSSM can be directly installed into your conda environment on Linux and MacOS. Installing HSSM on windows takes only one more simple step.
-
-### Install HSSM on Linux and MacOS (CPU only)
-
-Use the following command to install HSSM into your virtual environment:
+Once `uv` is installed, you can install uv in one of the following ways:
 
 ```bash
-conda install -c conda-forge hssm
+uv venv ## creates a new virtual environment
+uv pip install hssm
 ```
 
-### Install HSSM on Linux and MacOS (with GPU Support)
-
-If you need to sample with GPU, please install JAX with GPU support before installing HSSM:
+You can also add hssm to an existing Python project by:
 
 ```bash
-conda install jaxlib=*=*cuda* jax cuda-nvcc -c conda-forge -c nvidia
-conda install -c conda-forge hssm
+uv add hssm
 ```
 
-### Install HSSM on Windows (CPU only)
+## Option 2: Installation with pip
 
-Because `jaxlib` is not available through `conda-forge` on Windows, you need to install JAX on Windows through `pip` before getting HSSM:
-
-```bash
-pip install jax
-conda install -c conda-forge hssm
-```
-
-### Install HSSM on Windows (with GPU support)
-
-You simply need to install JAX with GPU support before getting HSSM:
-
-```bash
-pip install jax[cuda12]
-conda install -c conda-forge hssm
-```
-
-### Support for Apple Silicon, AMD, and other GPUs
-
-JAX also has support other GPUs. Please follow the [Official JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html) to install the correct version of JAX before installing HSSM.
-
-
-## Advanced Installation
-
-### Install HSSM directly with Pip
-
-HSSM is also available through PyPI. You can directly install it with pip into any virtual environment via:
+HSSM can also be installed directly through `pip`. You can install HSSM into any virtual environment via:
 
 ```bash
 pip install hssm
 ```
 
-!!! note
+### Install HSSM with IO support
 
-    While this installation is much simpler, you might encounter this warning message `WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.` You can follow
-    [this discussion](https://github.com/pymc-devs/pytensor/issues/524) to link a BLAS library with `pytensor`.
+If you need to save/load models and traces, please install HSSM with IO support:
+
+```bash
+pip install hssm[io]
+```
+
+### Install HSSM (with GPU Support)
+
+If you need to sample with GPU, please install JAX with GPU support before
+installing HSSM:
+
+```bash
+pip install hssm[cuda12]
+```
+
+### Support for Apple Silicon, AMD, and other GPUs
+
+JAX also has support other GPUs. Please follow the
+[Official JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html)
+to install the correct version of JAX before installing HSSM.
 
 ### Install the dev version of HSSM
 
@@ -84,7 +62,9 @@ pip install git+https://github.com/lnccbrown/HSSM.git
 
 ### Install HSSM on Google Colab
 
-Google Colab comes with PyMC and JAX pre-configured. That holds true even if you are using the GPU and TPU backend, so you simply need to install HSSM via pip on Colab regardless of the backend you are using:
+Google Colab comes with PyMC and JAX pre-configured. That holds true even if you
+are using the GPU and TPU backend, so you simply need to install HSSM via pip on
+Colab regardless of the backend you are using:
 
 ```bash
 !pip install hssm
@@ -97,14 +77,14 @@ packages installed for additional features such as sampling with `blackjax` or G
 for `JAX`. Please follow the instructions below if you need any of these additional
 features:
 
-### 1. Sampling with JAX through `numpyro` or `blackjax`
+### 1. Sampling with JAX through `numpyro`, `nutpie` or `blackjax`
 
-JAX-based sampling is done through `numpyro` and `blackjax`. `numpyro` is installed as
+JAX-based sampling is done through `numpyro`, `nutpie`, or `blackjax`. `numpyro` is installed as
 a dependency by default. You need to have `blackjax` installed if you want to use the
 `blackjax` sampler.
 
 ```bash
-pip install blackjax
+pip install blackjax nutpie
 ```
 
 ### 2. Visualizing the model with `graphviz`
@@ -140,11 +120,11 @@ pip install graphviz
 WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.
 ```
 
-   This is because `pytensor`, the compute backend of PyMC, cannot find a BLAS library on your
-   system to optimize its computation. This can be resolved by following the recommended
-   steps to install HSSM into a conda environment. If conda cannot be used, you can follow
-   [this discussion](https://github.com/pymc-devs/pytensor/issues/524) to link a BLAS library
-   with `pytensor`.
+This is because `pytensor`, the compute backend of PyMC, cannot find a BLAS library on your
+system to optimize its computation. This can be resolved by following the recommended
+steps to install HSSM into a conda environment. If conda cannot be used, you can follow
+[this discussion](https://github.com/pymc-devs/pytensor/issues/524) to link a BLAS library
+with `pytensor`.
 
 2. `pip` installation fails with missing dependencies:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,10 +45,12 @@ models in cognitive neuroscience.
 - Built on PyMC with support from the Python Bayesian ecosystem at large.
 - Incorporates Bambi's intuitive `lmer`-like regression parameter specification
   for within- and between-subject effects.
+- (💥 New in HSSM 0.4.0) Support for reinforcement learning sequential sampling models.
 - Native ArviZ support for plotting and other convenience functions to aid the
   Bayesian workflow.
 - Utilizes the ONNX format for translation of differentiable likelihood
   approximators across backends.
+- Broad ecosystem support for differentiable likelihoods sourced from the sbi and BayesFlow libraries.
 
 ## Example
 
@@ -87,48 +89,37 @@ HSSM, please follow [our main tutorial](tutorials/main_tutorial.ipynb).
 
 ## Installation
 
-HSSM can be directly installed into your conda environment on Linux and MacOS.
-Installing HSSM on windows takes only one more simple step. We have a more
-detailed
-[installation guide](https://lnccbrown.github.io/HSSM/getting_started/installation/)
-for users with more specific setups.
+(💥 New in HSSM 0.4.0) HSSM supports installation directly through `pip` or `uv` on
+all platforms.
 
-**Important Update:** From HSSM 0.2.2, the official recommended way to install
-HSSM is through conda.
-
-### Install HSSM on Linux and MacOS (CPU only)
+### Install HSSM (CPU only)
 
 Use the following command to install HSSM into your virtual environment:
 
 ```bash
-conda install -c conda-forge hssm
+pip install hssm
 ```
 
-### Install HSSM on Linux and MacOS (with GPU Support)
+YOu can also install HSSM with `uv`:
+
+```bash
+uv add hssm
+```
+
+### Install HSSM with IO support
+
+If you need to save/load models and traces, please install HSSM with IO support:
+
+```bash
+pip install hssm[io]
+```
+
+### Install HSSM (with GPU Support)
 
 If you need to sample with GPU, please install JAX with GPU support before
 installing HSSM:
 
 ```bash
-conda install jaxlib=*=*cuda* jax cuda-nvcc -c conda-forge -c nvidia
-conda install -c conda-forge hssm
-```
-
-### Install HSSM on Windows (CPU only)
-
-On Windows, we need to install pymc through conda, and then HSSM through pip:
-
-```bash
-conda install -c conda-forge pymc
-pip install hssm
-```
-
-### Install HSSM on Windows (with GPU support)
-
-You simply need to install JAX with GPU support before getting HSSM:
-
-```bash
-conda install -c conda-forge pymc
 pip install hssm[cuda12]
 ```
 
@@ -137,21 +128,6 @@ pip install hssm[cuda12]
 JAX also has support other GPUs. Please follow the
 [Official JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html)
 to install the correct version of JAX before installing HSSM.
-
-## Advanced Installation
-
-### Install HSSM directly with Pip
-
-HSSM is also available through PyPI. You can directly install it with pip into
-any virtual environment via:
-
-```bash
-pip install hssm
-```
-
-!!! note
-
-    While this installation is much simpler, you might encounter this warning message `WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.` Please refer to our [advanced installation guide](https://lnccbrown.github.io/HSSM/getting_started/installation/) for more details.
 
 ### Install the dev version of HSSM
 
@@ -175,13 +151,12 @@ Colab regardless of the backend you are using:
 
 !!! note
 
-    Possible solutions to any issues with installations with hssm can be located
-    [here](https://github.com/lnccbrown/HSSM/discussions). Also feel free to start a new
-    discussion thread if you don't find answers there. We recommend installing HSSM into
-    a new conda environment with Python 3.10 or 3.11 to prevent any problems with dependencies
-    during the installation process. Please note that hssm is only tested for python 3.10,
-    3.11. As of HSSM v0.2.0, support for Python 3.9 is dropped. Use unsupported python
-    versions with caution.
+    Possible solutions to any issues with installations with hssm can be found
+    [in GitHub Discussions](https://github.com/lnccbrown/HSSM/discussions). Also feel free
+    to start a newdiscussion thread if you don't find answers there. We recommend installing
+    HSSM into a new virtual environment with Python 3.12 through 3.14 to prevent any problems with
+    dependencies during the installation process. Please note that hssm is only tested for
+    python 3.12 through 3.14. Use unsupported python versions with caution.
 
 ## License
 

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -31,7 +31,7 @@ uv will handle the creation of the virtual environment with all dev and test
 dependencies with the following command:
 
 ```sh
-uv sync --group dev --group test
+uv sync --group notebook # dev group is synced by default. notebook groups is required for running the Jupyter notebook in the dev environment.
 ```
 
 This tells uv to install not only the HSSM dependencies but also the `dev` and `test`
@@ -53,85 +53,7 @@ uv sync --group dev --group test --extra cuda12
 
 Please ensure that you have a GPU that supports CUDA 12 for this installation.
 
-## Step 3. Set up a linear algebra package
-
-Different from installation through `conda`, which is what we recommend for HSSM users,
-when HSSM is installed through `uv` in a local development environment, `pytensor` does
-not usually know how to find the linear algebra acceleration library on your system, and
-when that happens, you will typically get slow inference speed using the default `pymc`
-NUTS sampler with the following warning:
-
-```
-WARNING (pytensor.tensor.blas): Using NumPy C-API based implementation for BLAS functions.
-```
-
-If this happens, it means that we need to tell `pytensor` where the linear algebra
-library is installed on your system. There are many ways to do this, but the most
-convenient way is to create a `.pytensorrc` file in your home directory with the
-following content:
-
-```
-[blas]
-ldflags=...
-```
-
-What `...` actually is depends on your operating system and hardware architecture.
-Here's the recommendation for certain setups:
-
-### MacOS with ARM chips (M-series processors)
-
-MacOS with ARM chips comes with
-[accelerate framework](https://developer.apple.com/documentation/accelerate), and you
-just need to tell your `pytensor` to use it:
-
-```
-[blas]
-ldflags=-framework Accelerate
-```
-
-### Intel Macs, Linux and Windows (WSL) on Intel processors
-
-Intel has the oneAPI Math Kernel Library (oneMKL) that you can use as your acceleration
-library. You need to install the [oneMKL library](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html#gs.now6fh)
-and then point your `.pytensorrc` file to it:
-
-```
-[blas]
-ldflags=-Lwherever/mkl/is -lmkl_core -lmkl_rt -lpthread -lm
-```
-
-Just replace `wherever/mkl/is` with the absolute path of MKL installed on your system.
-
-!!! note
-
-    If you wish to develop HSSM on Oscar, Brown University's HPC cluster, MKL is already
-    available through a module. You can [follow this instruction](https://github.com/lnccbrown/HSSM/discussions/440)
-    on how to write the `.pytensorrc` file.
-
-### Other systems
-
-On other systems, we recommend installing `openblas` or `lapack`. You can follow
-the instructions on [the openblas website](http://www.openmathlib.org/OpenBLAS/) or
-[the lapack website](https://www.netlib.org/lapack/) to install one of these libraries.
-
-If you installed `openblas`, then your `.pytensorrc` file should look like this:
-
-```
-[blas]
-ldflags=-L/path/to/openblas/lib -lopenblas
-```
-
-If you installed `openblas`, then your `.pytensorrc` file should look like this:
-
-```
-[blas]
-ldflags=-L/path/to/lapack/lib -lblas
-```
-
 ## Follow-up
-
-Once the above steps are done, you should be able to run a `pytensor` based sampler
-without any warnings.
 
 We recommend that you also configure your IDE to use the Python interpreter in the
 virtual environment created by `uv`. Typically, this virtual environment is in the

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,45 +1,45 @@
 {% extends "base.html" %} {% block announce %}
 <span class="show-on-small right-margin">
-  <span class="twemoji right-margin show-on-small move-down">
-    {% include ".icons/fontawesome/solid/angles-down.svg" %}
-  </span>
-  Navigate the site here!
+    <span class="twemoji right-margin show-on-small move-down">
+        {% include ".icons/fontawesome/solid/angles-down.svg" %}
+    </span>
+    Navigate the site here!
 </span>
-<span class="right-margin"> v0.3.0 is released! </span>
+<span class="right-margin"> v0.4.0 is released! </span>
 <span>
-  <span class="twemoji">
-    {% include ".icons/material/head-question.svg" %}
-  </span>
-  Questions?
-  <a href="https://github.com/lnccbrown/HSSM/discussions">
-    Open a discussion here!
-  </a>
+    <span class="twemoji">
+        {% include ".icons/material/head-question.svg" %}
+    </span>
+    Questions?
+    <a href="https://github.com/lnccbrown/HSSM/discussions">
+        Open a discussion here!
+    </a>
 </span>
 {% endblock %} {% block content %} {{ super() }}
 
 <style>
-  pre {
-    font-size: 0.7rem;
-  }
+    pre {
+        font-size: 0.7rem;
+    }
 
-  .jp-OutputArea-executeResult pre {
-    font-size: 0.7rem;
-  }
+    .jp-OutputArea-executeResult pre {
+        font-size: 0.7rem;
+    }
 
-  .jp-xr-text-repr-fallback pre {
-    font-size: 0.7rem;
-  }
+    .jp-xr-text-repr-fallback pre {
+        font-size: 0.7rem;
+    }
 
-  .xr-sections {
-    font-size: 0.7rem;
-  }
+    .xr-sections {
+        font-size: 0.7rem;
+    }
 
-  div .jp-RenderedText {
-    font-size: 0.7rem !important;
-  }
+    div .jp-RenderedText {
+        font-size: 0.7rem !important;
+    }
 
-  .jupyter-wrapper .jp-RenderedText pre {
-    font-size: 0.7rem !important;
-  }
+    .jupyter-wrapper .jp-RenderedText pre {
+        font-size: 0.7rem !important;
+    }
 </style>
 {% endblock content %}

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -34,7 +34,7 @@ from .onnx_utils.model import load_onnx_model
 
 _logger = logging.getLogger("hssm")
 
-LOGP_LB = pm.floatX(-66.1)
+LOGP_LB = pm.pytensorf.floatX(-66.1)
 
 
 def apply_param_bounds_to_loglik(
@@ -62,7 +62,10 @@ def apply_param_bounds_to_loglik(
     """
     dist_params_dict = dict(zip(list_params, dist_params))
 
-    bounds = {k: (pm.floatX(v[0]), pm.floatX(v[1])) for k, v in bounds.items()}
+    bounds = {
+        k: (pm.pytensorf.floatX(v[0]), pm.pytensorf.floatX(v[1]))
+        for k, v in bounds.items()
+    }
     out_of_bounds_mask = pt.zeros_like(logp, dtype=bool)
 
     for param_name, param in dist_params_dict.items():
@@ -486,7 +489,9 @@ def make_distribution(
     if fixed_vector_params:
         for name, vector in fixed_vector_params.items():
             idx = list_params.index(name)
-            _fixed_vector_substitutions[idx] = pt.as_tensor_variable(pm.floatX(vector))
+            _fixed_vector_substitutions[idx] = pt.as_tensor_variable(
+                pm.pytensorf.floatX(vector)
+            )
 
     if lapse is not None:
         if list_params[-1] != "p_outlier":
@@ -520,7 +525,8 @@ def make_distribution(
         @classmethod
         def dist(cls, **kwargs):  # pylint: disable=arguments-renamed
             dist_params = [
-                pt.as_tensor_variable(pm.floatX(kwargs[param])) for param in cls._params
+                pt.as_tensor_variable(pm.pytensorf.floatX(kwargs[param]))
+                for param in cls._params
             ]
             other_kwargs = {k: v for k, v in kwargs.items() if k not in cls._params}
             return super().dist(dist_params, **other_kwargs)

--- a/src/hssm/likelihoods/analytical.py
+++ b/src/hssm/likelihoods/analytical.py
@@ -18,7 +18,7 @@ from pymc.distributions.dist_math import check_parameters
 
 from ..distribution_utils.dist import make_distribution
 
-LOGP_LB = pm.floatX(-66.1)
+LOGP_LB = pm.pytensorf.floatX(-66.1)
 
 π = np.pi
 τ = 2 * π
@@ -751,8 +751,8 @@ def logp_poisson_race(
         inside a PyMC/PyTensor model the returned object is a symbolic tensor,
         and evaluating/compiling the graph yields an ndarray.
     """
-    epsilon = pm.floatX(epsilon)
-    one = pm.floatX(1.0)
+    epsilon = pm.pytensorf.floatX(epsilon)
+    one = pm.pytensorf.floatX(1.0)
     data = pt.reshape(data, (-1, 2)).astype(pytensor.config.floatX)
 
     rt = pt.abs(data[:, 0])


### PR DESCRIPTION
Mainly updated .md file and one tutorial (getting_started.ipynb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: HSSM v0.4.0

* **New Features**
  * Added support for reinforcement learning sequential sampling models (RLSSM).

* **Breaking Changes**
  * `sample()` now returns `xarray.DataTree` instead of `arviz.InferenceData`.
  * `vi()` return type updated; returns `Approximation` and `DataTree`.
  * Removed `plot_trace()` and `summary()` convenience methods; use ArviZ directly.
  * Installation now requires pip/uv only; Conda support removed.
  * Python 3.11 no longer supported; requires Python 3.12+.
  * Default sampling backend changed to `numba`.

* **Documentation**
  * Updated installation guides, changelog, and API documentation for v0.4.0.

* **Chores**
  * Streamlined core dependencies to PyMC 6.0+, ArviZ 1.0+, and Bambi 0.18+.
  * Updated Python version matrix in CI workflows to 3.12–3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->