### PR TITLE
feat: per-parameter centered/non-centered parameterization

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,10 +7,11 @@ This version contains major breaking updates for HSSM. Please read the release n
 #### Major new features:
 
 1. A new `RLSSM` class has been added to support reinforcement learning sequential sampling models.
+2. Per-parameter centered vs. non-centered parameterization. Pass `noncentered` to `HSSM(...)` as a `dict` keyed by parameter name (e.g. `noncentered={"v": False, "a": True}`), or set a per-prior `noncentered` field on a group term's prior (dict or `hssm.Prior`) to override the model-level choice. Requires Bambi >= 0.19. See the "Per-parameter centered vs. non-centered parameterization" tutorial.
 
 #### Breaking changes that requires migration:
 
-1. Dependencies has been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.18+.
+1. Dependencies has been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.19+.
 2. We added support for Python 3.14. However, `sample_posterior_predictive` sometimes fails due to a `cloudpickle` issue. Use Python 3.14 with caution if you have to perform posterior predictive sampling.
 3. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
 4. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,9 @@ This version contains major breaking updates for HSSM. Please read the release n
 1. A new `RLSSM` class has been added to support reinforcement learning sequential sampling models.
 2. Per-parameter centered vs. non-centered parameterization. Pass `noncentered` to `HSSM(...)` as a `dict` keyed by parameter name (e.g. `noncentered={"v": False, "a": True}`), or set a per-prior `noncentered` field on a group term's prior (dict or `hssm.Prior`) to override the model-level choice. Requires Bambi >= 0.19. See the "Per-parameter centered vs. non-centered parameterization" tutorial.
 
-#### Breaking changes that requires migration:
+#### Breaking changes that require migration:
 
-1. Dependencies has been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.19+.
+1. Dependencies have been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.19+.
 2. We added support for Python 3.14. However, `sample_posterior_predictive` sometimes fails due to a `cloudpickle` issue. Use Python 3.14 with caution if you have to perform posterior predictive sampling.
 3. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
 4. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.

--- a/docs/tutorials/parameterization_per_parameter.ipynb
+++ b/docs/tutorials/parameterization_per_parameter.ipynb
@@ -1,0 +1,501 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e93eb83e",
+   "metadata": {},
+   "source": [
+    "# Per-parameter centered vs. non-centered parameterization\n",
+    "\n",
+    "Hierarchical models can express a group-specific (random) effect in one of two\n",
+    "equivalent ways:\n",
+    "\n",
+    "- **Centered:** $\\theta_g \\sim \\mathrm{Normal}(\\mu, \\sigma)$.\n",
+    "- **Non-centered:** $\\theta_g = \\mu + \\sigma \\, z_g$, with $z_g \\sim \\mathrm{Normal}(0, 1)$.\n",
+    "\n",
+    "They imply the same model but sample very differently. Non-centered usually\n",
+    "samples better when a group is only weakly informed by the data (it avoids\n",
+    "Neal's funnel); centered can be better when a group is strongly informed. In a\n",
+    "model with several parameters, the better choice can **differ from parameter to\n",
+    "parameter** — so a single global switch is often too coarse.\n",
+    "\n",
+    "HSSM surfaces bambi's per-parameter control, letting you pick the\n",
+    "parameterization **per parameter**, or even **per term**.\n",
+    "\n",
+    "> **Requirements.** The per-parameter forms below (a `noncentered` *dict* and the\n",
+    "> per-prior `noncentered` field) require **bambi ≥ 0.19**\n",
+    "> ([PR #983](https://github.com/bambinos/bambi/pull/983)), which HSSM depends on.\n",
+    "> The plain `noncentered=True/False` form works on any supported bambi."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8503894c",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e3da97f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:15.011969Z",
+     "iopub.status.busy": "2026-07-13T00:03:15.011851Z",
+     "iopub.status.idle": "2026-07-13T00:03:16.789634Z",
+     "shell.execute_reply": "2026-07-13T00:03:16.789261Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You supplied a model 'lba4', which is currently not supported in the ssm_simulators package. An error will be thrown when sampling from the random variable or when using any posterior or prior predictive sampling methods.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting PyTensor floatX type to float32.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting \"jax_enable_x64\" to False. If this is not intended, please set `jax` to False.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hssm 0.4.0 | bambi 0.19.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import warnings\n",
+    "\n",
+    "warnings.simplefilter(\"ignore\")\n",
+    "logging.getLogger(\"hssm\").setLevel(logging.ERROR)  # quiet info/warnings for the demo\n",
+    "\n",
+    "import bambi as bmb\n",
+    "\n",
+    "import hssm\n",
+    "from hssm import Prior\n",
+    "\n",
+    "hssm.set_floatX(\"float32\")\n",
+    "print(\"hssm\", hssm.__version__, \"| bambi\", bmb.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ce06658c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:16.790769Z",
+     "iopub.status.busy": "2026-07-13T00:03:16.790697Z",
+     "iopub.status.idle": "2026-07-13T00:03:16.798778Z",
+     "shell.execute_reply": "2026-07-13T00:03:16.798415Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>participant_id</th>\n",
+       "      <th>stim</th>\n",
+       "      <th>rt</th>\n",
+       "      <th>response</th>\n",
+       "      <th>theta</th>\n",
+       "      <th>dbs</th>\n",
+       "      <th>conf</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>LL</td>\n",
+       "      <td>1.21</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.656275</td>\n",
+       "      <td>1</td>\n",
+       "      <td>HC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>WL</td>\n",
+       "      <td>1.63</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>-0.327889</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>WW</td>\n",
+       "      <td>1.03</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>-0.480285</td>\n",
+       "      <td>1</td>\n",
+       "      <td>HC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>WL</td>\n",
+       "      <td>2.77</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.927427</td>\n",
+       "      <td>1</td>\n",
+       "      <td>LC</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>WW</td>\n",
+       "      <td>1.14</td>\n",
+       "      <td>-1.0</td>\n",
+       "      <td>-0.213236</td>\n",
+       "      <td>1</td>\n",
+       "      <td>HC</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   participant_id stim    rt  response     theta  dbs conf\n",
+       "0               0   LL  1.21       1.0  0.656275    1   HC\n",
+       "1               0   WL  1.63       1.0 -0.327889    1   LC\n",
+       "2               0   WW  1.03       1.0 -0.480285    1   HC\n",
+       "3               0   WL  2.77       1.0  1.927427    1   LC\n",
+       "4               0   WW  1.14      -1.0 -0.213236    1   HC"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = hssm.load_data(\"cavanagh_theta\")\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcdd93a8",
+   "metadata": {},
+   "source": [
+    "We will detect the parameterization **structurally**, without sampling: bambi\n",
+    "creates a standard-normal `<param>_..._offset` random variable for each\n",
+    "*non-centered* group term (and a `Deterministic` equal to `offset * sigma`). A\n",
+    "*centered* term instead has a direct `<param>_<group>` random variable. So the\n",
+    "set of parameters that own an `*_offset` free RV is exactly the set of\n",
+    "non-centered parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b1060547",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:16.799736Z",
+     "iopub.status.busy": "2026-07-13T00:03:16.799683Z",
+     "iopub.status.idle": "2026-07-13T00:03:16.801245Z",
+     "shell.execute_reply": "2026-07-13T00:03:16.800917Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def noncentered_params(model):\n",
+    "    \"\"\"Return HSSM parameters whose group term uses the non-centered form.\"\"\"\n",
+    "    names = [rv.name for rv in model.pymc_model.free_RVs]\n",
+    "    return sorted({n.split(\"_\")[0] for n in names if \"_offset\" in n})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ce0d69b",
+   "metadata": {},
+   "source": [
+    "## A hierarchical model — the default\n",
+    "\n",
+    "We give both `v` (drift rate) and `a` (boundary separation) a by-participant\n",
+    "random intercept. bambi's default is **non-centered everywhere**, so both\n",
+    "parameters get an `*_offset`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e7f26c9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:16.802127Z",
+     "iopub.status.busy": "2026-07-13T00:03:16.802073Z",
+     "iopub.status.idle": "2026-07-13T00:03:16.936114Z",
+     "shell.execute_reply": "2026-07-13T00:03:16.935770Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model initialized successfully.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['a', 'v']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hierarchical = [\n",
+    "    {\"name\": \"v\", \"formula\": \"v ~ 1 + (1|participant_id)\"},\n",
+    "    {\"name\": \"a\", \"formula\": \"a ~ 1 + (1|participant_id)\"},\n",
+    "]\n",
+    "\n",
+    "model_default = hssm.HSSM(data=data, model=\"ddm\", include=hierarchical, p_outlier=0.0)\n",
+    "noncentered_params(model_default)  # -> ['a', 'v']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46a0b5cf",
+   "metadata": {},
+   "source": [
+    "## Choose per parameter with a dict\n",
+    "\n",
+    "Pass `noncentered` as a `dict` keyed by **HSSM parameter name**. Here we make\n",
+    "`v` centered while keeping `a` non-centered. Only `a` keeps an `*_offset`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "96b882f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:16.937624Z",
+     "iopub.status.busy": "2026-07-13T00:03:16.937300Z",
+     "iopub.status.idle": "2026-07-13T00:03:17.003536Z",
+     "shell.execute_reply": "2026-07-13T00:03:17.003088Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model initialized successfully.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['a']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_mixed = hssm.HSSM(\n",
+    "    data=data,\n",
+    "    model=\"ddm\",\n",
+    "    include=hierarchical,\n",
+    "    p_outlier=0.0,\n",
+    "    noncentered={\"v\": False, \"a\": True},\n",
+    ")\n",
+    "noncentered_params(model_mixed)  # -> ['a']  (v is now centered)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b407990f",
+   "metadata": {},
+   "source": [
+    "## Override a single term with a per-prior `noncentered`\n",
+    "\n",
+    "For the finest control, attach `noncentered` directly to a term's prior. It\n",
+    "**overrides** the model-level setting for just that term. The precedence is:\n",
+    "\n",
+    "```\n",
+    "per-prior noncentered  >  model-level noncentered dict  >  default (True)\n",
+    "```\n",
+    "\n",
+    "This works whether you specify the prior as a plain `dict` or as an\n",
+    "`hssm.Prior` object. Below, the model-level dict asks for centered `v`, but the\n",
+    "per-prior field wins and makes it non-centered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "559925f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:17.004607Z",
+     "iopub.status.busy": "2026-07-13T00:03:17.004469Z",
+     "iopub.status.idle": "2026-07-13T00:03:17.038070Z",
+     "shell.execute_reply": "2026-07-13T00:03:17.037782Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model initialized successfully.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['v']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prior = {\n",
+    "    \"1|participant_id\": Prior(\n",
+    "        \"Normal\",\n",
+    "        mu=0.0,\n",
+    "        sigma=Prior(\"HalfNormal\", sigma=1.0),\n",
+    "        noncentered=True,  # overrides the model-level setting for this term\n",
+    "    )\n",
+    "}\n",
+    "\n",
+    "model_override = hssm.HSSM(\n",
+    "    data=data,\n",
+    "    model=\"ddm\",\n",
+    "    include=[{\"name\": \"v\", \"formula\": \"v ~ 1 + (1|participant_id)\", \"prior\": prior}],\n",
+    "    p_outlier=0.0,\n",
+    "    noncentered={\"v\": False},  # model says \"centered\"; the per-prior field wins\n",
+    ")\n",
+    "noncentered_params(model_override)  # -> ['v']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62316c4c",
+   "metadata": {},
+   "source": [
+    "## Caveats\n",
+    "\n",
+    "- **Hierarchical terms only.** `noncentered` affects group-specific terms\n",
+    "  (e.g. `... + (1|participant_id)`). Setting it for a parameter with no group\n",
+    "  term is a silent no-op.\n",
+    "- **Unknown keys fail fast.** A typo'd parameter name in the dict raises at\n",
+    "  construction, listing the valid names.\n",
+    "- **`mu` is dropped under non-centered.** The non-centered reparameterization is\n",
+    "  `offset * sigma`; a non-zero `mu` on a group `Normal` prior is ignored when\n",
+    "  that term is non-centered. Put the location on the common `Intercept` instead.\n",
+    "- **Bounded group priors.** A bounded/truncated prior on a group term is\n",
+    "  incompatible with bambi's group-hyperprior requirement regardless of\n",
+    "  `noncentered` — unrelated to this feature, but worth knowing.\n",
+    "\n",
+    "The unknown-key guard in action:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "66dbce4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-13T00:03:17.039344Z",
+     "iopub.status.busy": "2026-07-13T00:03:17.039220Z",
+     "iopub.status.idle": "2026-07-13T00:03:17.044738Z",
+     "shell.execute_reply": "2026-07-13T00:03:17.044333Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unknown component name(s) in `noncentered`: ['vv']. Valid component names for this model: ['a', 't', 'v', 'z'].\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    hssm.HSSM(\n",
+    "        data=data,\n",
+    "        model=\"ddm\",\n",
+    "        include=[{\"name\": \"v\", \"formula\": \"v ~ 1 + (1|participant_id)\"}],\n",
+    "        p_outlier=0.0,\n",
+    "        noncentered={\"vv\": True},  # typo: there is no parameter \"vv\"\n",
+    "    )\n",
+    "except ValueError as err:\n",
+    "    print(err)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Variational Inference: tutorials/variational_inference.ipynb
       - Hierarchical Variational Inference: tutorials/variational_inference_hierarchical.ipynb
       - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
+      - Per-parameter centered vs. non-centered parameterization: tutorials/parameterization_per_parameter.ipynb
       - Using HSSM low-level API directly with PyMC: tutorials/pymc.ipynb
       - RLSSM — Basic tutorial: tutorials/rlssm_basic.ipynb
       - RLSSM — Custom models with ssms.rl: tutorials/rlssm_advanced.ipynb
@@ -91,6 +92,7 @@ plugins:
         - tutorials/variational_inference.ipynb
         - tutorials/variational_inference_hierarchical.ipynb
         - tutorials/centered_vs_noncentered_basic_logic.ipynb
+        - tutorials/parameterization_per_parameter.ipynb
         - tutorials/initial_values.ipynb
         - tutorials/pymc.ipynb
         - tutorials/jax_callable_contribution_onnx_example.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "absl-py>=2.3.1",
-    "bambi>=0.18.0",
+    "bambi>=0.19.0",
     "h5netcdf>=1.8.1",
     "h5py>=3.16.0",
     "hddm-wfpt>=0.1.6",

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -191,6 +191,17 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         If `True`, the model will process the initial values. Defaults to `True`.
     initval_jitter : optional
         The jitter value for the initial values. Defaults to `0.01`.
+    noncentered : optional
+        Controls the centered vs. non-centered parameterization of
+        group-specific (hierarchical) terms. ``True`` (bambi's default) uses the
+        non-centered parameterization everywhere, ``False`` uses centered. A
+        ``dict`` keyed by HSSM parameter name (e.g. ``{"v": False, "a": True}``)
+        sets it per parameter; an unknown key raises at construction. A per-prior
+        ``noncentered`` field (inside a prior ``dict`` or on an ``hssm.Prior``)
+        overrides the model-level value for that term (precedence: per-prior >
+        model-level dict > default ``True``). Only affects parameters that have a
+        group-specific term (e.g. ``... + (1|participant_id)``); setting it for a
+        non-hierarchical parameter is a silent no-op. Passed to ``bmb.Model``.
     **kwargs
         Additional arguments passed to the `bmb.Model` object.
 

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -193,6 +193,17 @@ class HSSM(HSSMBase):
         If `True`, the model will process the initial values. Defaults to `True`.
     initval_jitter : optional
         The jitter value for the initial values. Defaults to `0.01`.
+    noncentered : optional
+        Controls the centered vs. non-centered parameterization of
+        group-specific (hierarchical) terms. ``True`` (bambi's default) uses the
+        non-centered parameterization everywhere, ``False`` uses centered. A
+        ``dict`` keyed by HSSM parameter name (e.g. ``{"v": False, "a": True}``)
+        sets it per parameter; an unknown key raises at construction. A per-prior
+        ``noncentered`` field (inside a prior ``dict`` or on an ``hssm.Prior``)
+        overrides the model-level value for that term (precedence: per-prior >
+        model-level dict > default ``True``). Only affects parameters that have a
+        group-specific term (e.g. ``... + (1|participant_id)``); setting it for a
+        non-hierarchical parameter is a silent no-op. Passed to ``bmb.Model``.
     **kwargs
         Additional arguments passed to the `bmb.Model` object.
 

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -41,6 +41,10 @@ class Prior(bmb.Prior):  # noqa: PLW1641
         ``name``, ``dims``, and ``shape``, as well as its own keyworded arguments.
     bounds : optional
         A tuple of two floats indicating the lower and upper bounds of the prior.
+    noncentered : optional
+        For a group-specific (hierarchical) ``Normal`` prior, whether to use the
+        non-centered parameterization. ``None`` (default) inherits the model-level
+        ``noncentered`` setting; ``True``/``False`` overrides it for this term.
     """
 
     def __init__(
@@ -49,8 +53,13 @@ class Prior(bmb.Prior):  # noqa: PLW1641
         auto_scale: bool = True,
         dist: Callable | None = None,
         bounds: tuple[float, float] | None = None,
+        noncentered: bool | None = None,
         **kwargs,
     ):
+        # Forward the per-term non-centered override (bambi >= 0.19, PR #983) to
+        # bambi only when set, so the default path is unchanged.
+        if noncentered is not None:
+            kwargs["noncentered"] = noncentered
         bmb.Prior.__init__(self, name, auto_scale, dist, **kwargs)
         self.is_truncated = False
         self.bounds = bounds

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -99,23 +99,38 @@ class Prior(bmb.Prior):  # noqa: PLW1641
 
     def __eq__(self, other) -> bool:
         """Test equality."""
+        # `noncentered` lives outside `.args` (it changes the group-term
+        # parameterization), so it must be part of equality in every path.
         if isinstance(other, Prior):
             if self.is_truncated and other.is_truncated:
                 return (
                     self.name == other.name
                     and self._args == other._args
                     and self.bounds == other.bounds
+                    and self.noncentered == other.noncentered
                 )
             if not self.is_truncated and not other.is_truncated:
-                return self.name == other.name and self.args == other.args
+                return (
+                    self.name == other.name
+                    and self.args == other.args
+                    and self.noncentered == other.noncentered
+                )
             return False
 
         if isinstance(other, bmb.Prior):
             if self.is_truncated:
                 return False
             if self.dist is not None:
-                return self.name == other.name and self.dist == other.dist
-            return self.name == other.name and self.args == other.args
+                return (
+                    self.name == other.name
+                    and self.dist == other.dist
+                    and self.noncentered == other.noncentered
+                )
+            return (
+                self.name == other.name
+                and self.args == other.args
+                and self.noncentered == other.noncentered
+            )
 
         return False
 

--- a/tests/test_noncentered.py
+++ b/tests/test_noncentered.py
@@ -1,0 +1,103 @@
+"""Structure-only tests for per-parameter centered/non-centered parameterization.
+
+A group-specific term is non-centered iff bambi emits a ``{label}_offset ~
+Normal(0, 1)`` free RV (and a ``Deterministic(label, offset * sigma)``); a
+centered term has a direct ``{label}`` group RV instead. We assert on the
+presence/absence of ``*_offset`` free RVs, so no sampling is required.
+
+These exercise per-parameter ``noncentered`` (bambi >= 0.19) end-to-end through
+HSSM.
+"""
+
+import pytest
+
+import hssm
+from hssm import Prior
+
+hssm.set_floatX("float32")
+
+GS = "1|participant_id"
+
+
+def _offset_params(model) -> set[str]:
+    """HSSM params whose group term carries a non-centered ``*_offset`` RV."""
+    return {
+        name.split("_")[0]
+        for name in (rv.name for rv in model.pymc_model.free_RVs)
+        if "_offset" in name
+    }
+
+
+def _hierarchical_v(prior=None) -> list[dict]:
+    """Include-spec for a hierarchical ``v ~ 1 + (1|participant_id)``."""
+    spec: dict = {"name": "v", "formula": f"v ~ 1 + ({GS})"}
+    if prior is not None:
+        spec["prior"] = prior
+    return [spec]
+
+
+def _build(cavanagh_test, include, **kwargs):
+    return hssm.HSSM(
+        data=cavanagh_test, model="ddm", include=include, p_outlier=0.0, **kwargs
+    )
+
+
+def test_default_is_noncentered(cavanagh_test):
+    """Bambi's default (`noncentered=True`) non-centers the group term."""
+    model = _build(cavanagh_test, _hierarchical_v())
+    assert "v" in _offset_params(model)
+
+
+def test_scalar_noncentered_both_directions(cavanagh_test):
+    """The plain `bool` form centers/non-centers the whole model."""
+    assert (
+        _offset_params(_build(cavanagh_test, _hierarchical_v(), noncentered=False))
+        == set()
+    )
+    assert "v" in _offset_params(
+        _build(cavanagh_test, _hierarchical_v(), noncentered=True)
+    )
+
+
+def test_model_level_dict_per_parameter(cavanagh_test):
+    """`noncentered={"v": ...}` centers/non-centers just that parameter."""
+    centered = _build(cavanagh_test, _hierarchical_v(), noncentered={"v": False})
+    assert _offset_params(centered) == set()
+
+    noncentered = _build(cavanagh_test, _hierarchical_v(), noncentered={"v": True})
+    assert "v" in _offset_params(noncentered)
+
+
+def test_unknown_dict_key_raises_at_construction(cavanagh_test):
+    """A typo'd component name fails loudly with the valid names listed."""
+    with pytest.raises(ValueError, match="[Uu]nknown component"):
+        _build(cavanagh_test, _hierarchical_v(), noncentered={"nonexistent": True})
+
+
+@pytest.mark.parametrize("flag, expect_offset", [(True, True), (False, False)])
+def test_per_prior_dict_overrides_model_dict(cavanagh_test, flag, expect_offset):
+    """A `noncentered` field in a prior dict beats the model-level dict."""
+    prior = {
+        GS: {
+            "name": "Normal",
+            "mu": 0.0,
+            "sigma": {"name": "HalfNormal", "sigma": 1.0},
+            "noncentered": flag,
+        }
+    }
+    # model-level sets the OPPOSITE so a per-prior win is unambiguous.
+    model = _build(cavanagh_test, _hierarchical_v(prior), noncentered={"v": not flag})
+    assert ("v" in _offset_params(model)) is expect_offset
+
+
+@pytest.mark.parametrize("flag, expect_offset", [(True, True), (False, False)])
+def test_per_prior_object_overrides_model_dict(cavanagh_test, flag, expect_offset):
+    """An `hssm.Prior(noncentered=...)` object beats the model-level dict."""
+    prior = {
+        GS: Prior(
+            "Normal", mu=0.0, sigma=Prior("HalfNormal", sigma=1.0), noncentered=flag
+        )
+    }
+    assert prior[GS].noncentered is flag  # captured as a named attr, not in .args
+    model = _build(cavanagh_test, _hierarchical_v(prior), noncentered={"v": not flag})
+    assert ("v" in _offset_params(model)) is expect_offset

--- a/tests/test_noncentered.py
+++ b/tests/test_noncentered.py
@@ -21,11 +21,18 @@ GS = "1|participant_id"
 
 def _offset_params(model) -> set[str]:
     """HSSM params whose group term carries a non-centered ``*_offset`` RV."""
-    return {
-        name.split("_")[0]
-        for name in (rv.name for rv in model.pymc_model.free_RVs)
-        if "_offset" in name
-    }
+    # Offset RVs are named ``{param}_{group_term}_offset``; match the longest
+    # param prefix so names with underscores (e.g. ``rl_alpha``) are preserved.
+    params = sorted(model.list_params, key=len, reverse=True)
+    result: set[str] = set()
+    for name in (rv.name for rv in model.pymc_model.free_RVs):
+        if not name.endswith("_offset"):
+            continue
+        for param in params:  # longest first
+            if name.startswith(f"{param}_"):
+                result.add(param)
+                break
+    return result
 
 
 def _hierarchical_v(prior=None) -> list[dict]:
@@ -101,3 +108,13 @@ def test_per_prior_object_overrides_model_dict(cavanagh_test, flag, expect_offse
     assert prior[GS].noncentered is flag  # captured as a named attr, not in .args
     model = _build(cavanagh_test, _hierarchical_v(prior), noncentered={"v": not flag})
     assert ("v" in _offset_params(model)) is expect_offset
+
+
+def test_prior_equality_includes_noncentered():
+    """Priors differing only in `noncentered` must not compare equal."""
+    centered = Prior("Normal", mu=0.0, sigma=1.0, noncentered=False)
+    noncentered = Prior("Normal", mu=0.0, sigma=1.0, noncentered=True)
+    assert centered != noncentered
+    # ... but priors that agree on `noncentered` (including the default) still are.
+    assert Prior("Normal", mu=0.0, sigma=1.0) == Prior("Normal", mu=0.0, sigma=1.0)
+    assert centered == Prior("Normal", mu=0.0, sigma=1.0, noncentered=False)


### PR DESCRIPTION
## What

Exposes bambi's **per-parameter centered/non-centered parameterization** (bambi
[PR #983](https://github.com/bambinos/bambi/pull/983)) to HSSM users. You can now
choose the parameterization per model parameter, or per term:

```python
# model-level, per parameter (keys are HSSM parameter names)
hssm.HSSM(..., noncentered={"v": False, "a": True})

# per-prior override (highest precedence) — dict or hssm.Prior object
prior = {"1|participant_id": hssm.Prior("Normal", mu=0.0,
            sigma=hssm.Prior("HalfNormal", sigma=1.0), noncentered=True)}
hssm.HSSM(..., include=[{"name": "v", "formula": "v ~ 1 + (1|participant_id)",
                         "prior": prior}], noncentered={"v": False})
```

The capability already flowed through HSSM end-to-end (param names == bambi
component names; `noncentered` rides `**kwargs` into `bmb.Model`; prior
dicts/objects reach `bmb.Prior` where the new `noncentered=` arg binds). This PR
makes it **discoverable, guarded, tested, and documented** — it is mostly
hardening + docs, not new wiring.

## Base branch

Targets **`migration-pymc6`**, not `main`: the capability exists only on the
bambi 0.18.x line, which is **pymc6 / pytensor 3 / py≥3.12** only.

## ⚠️ Blocked on a bambi release — do not merge yet

PR #983 is merged upstream but **not in any released bambi** (it landed one
commit past the `0.18.0` tag). This branch temporarily pins bambi to the #983
merge commit (`240008b`) so it can build and test against the capability now.

**Before merge:**
- [ ] bambi cuts a release containing #983
- [ ] replace the TEMP git pin in `pyproject.toml` with `bambi>=<that release>`
- [ ] remove `parameterization_per_parameter.ipynb` from `SKIP_NOTEBOOKS` in
      `.github/workflows/check_notebooks.yml`, then run the notebook CI

## Changes

- **`src/hssm/prior.py`** — explicit `noncentered` param on `hssm.Prior`
  (forwarded to bambi only when set; default path unchanged on any bambi) +
  cached `_bambi_supports_per_parameter_noncentered()` capability check.
- **`src/hssm/base.py`** — guard for the paths that bypass `hssm.Prior`
  (model-level `noncentered` dict, and a `noncentered` field in a prior dict):
  a clear `ValueError` on a bambi without #983, instead of the field being
  **silently swallowed** into `prior.args` (wrong model, no error).
- **`src/hssm/base.py` + `src/hssm/hssm.py`** — `noncentered` documented in both
  constructor docstrings (bool | dict, per-prior field, precedence, caveats).
- **`tests/test_noncentered.py`** — 9 structure-only tests (offset-RV inspection,
  no sampling): dict form, per-prior dict/object overrides, precedence,
  unknown-key error, and the unsupported-bambi guard.
- **`docs/tutorials/parameterization_per_parameter.ipynb`** — new tutorial
  (nav + `execute_ignore`; CI-skipped until the bambi release); changelog entry.

## Verification (bambi `0.18.1.dev2+g240008b80` / pymc 6.0.1 / pytensor 3.0.7)

- `pytest tests/test_noncentered.py` → 9 passed
- `ruff check .` + `ruff format --check .` clean; `mypy` (prior/base/hssm) clean
- tutorial executes end-to-end with no errors; `mkdocs build` renders it
  (baked outputs, `execute=False`); `uv lock --check` consistent

## Caveats (documented in the tutorial + docstrings)

- `noncentered` only affects **hierarchical/group** terms; setting it on a
  non-grouped parameter is a silent no-op.
- Under non-centered, a group `Normal`'s `mu` is dropped (`offset * sigma`).
- Bounded/truncated group priors are incompatible with bambi's group-hyperprior
  requirement regardless of `noncentered` (pre-existing, unrelated limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centered vs. non-centered parameterization controls globally, per HSSM parameter, or per hierarchical prior.
  * Per-prior settings override model-level choices, including validation for unsupported parameter keys.
* **Documentation**
  * Added a new tutorial for per-parameter centered vs. non-centered workflows.
  * Expanded API docs for the `noncentered` option.
  * Updated the changelog’s migration note to support Bambi `0.19+`.
* **Tests**
  * Extended non-centered tests to ensure `Prior(noncentered=...)` participates in equality as expected.
* **Chores**
  * Updated the minimum supported Bambi version to `0.19.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->