### PR TITLE
[pymc6 migration] add python 314 support

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,13 +8,14 @@ This version contains major breaking updates for HSSM. Please read the release n
 
 1. A new `RLSSM` class has been added to support reinforcement learning sequential sampling models.
 
-#### Breaking changes that requiresmigration:
+#### Breaking changes that requires migration:
 
-1. Dependencies has been streamlined to support PyMC 6.0+, ppytensor 3.0+, ArviZ 1.0+, and Bambi 0.18+.
-2. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
-3. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.
-4. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.
-5. HSSM can now be installed directly from PyPI via `pip` or `uv`. Conda support is no longer provided.
+1. Dependencies has been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.18+.
+2. We added support for Python 3.14. However, `sample_posterior_predictive` sometimes fails due to a `cloudpickle` issue. Use Python 3.14 with caution if you have to perform posterior predictive sampling.
+3. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
+4. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.
+5. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.
+6. HSSM can now be installed directly from PyPI via `pip` or `uv`. Conda support is no longer provided.
 
 ### 0.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "jaxonnxruntime>=0.3.0",
     "numpyro>=0.19",
     "onnx>=1.16.0",
-    "ssm-simulators>=0.12.2",
+    "ssm-simulators>=0.12.4",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,13 @@ readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["HSSM", "sequential sampling models", "bayesian", "bayes", "mcmc"]
 
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -1,3 +1,5 @@
+import sys
+
 import bambi as bmb
 import numpy as np
 import pytest
@@ -148,6 +150,11 @@ def test_model_definition_outside_include(data_ddm):
         HSSM(data_ddm, include=[{"name": "a", "prior": 0.5}], a=0.5)
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 14),
+    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+    strict=True,  # This will let us know in the future when this is fixed
+)
 @pytest.mark.slow
 def test_sample_prior_predictive(data_ddm_reg):
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
@@ -416,6 +423,11 @@ class TestFixedVectorParams:
         assert "z" in idata.posterior.data_vars
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 14),
+    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+    strict=True,  # This will let us know in the future when this is fixed
+)
 @pytest.mark.slow
 def test_sample_do(data_ddm):
     model = HSSM(data=data_ddm)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,12 +1,13 @@
 """Test plotting module."""
 
-import pytest
+import sys
 
+import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
-import arviz as az
 
 import hssm
 from hssm.plotting.utils import (
@@ -165,6 +166,11 @@ class TestPlotting:
         assert len(g2.figure.axes) == 5 * 2
         assert len(g2.figure.axes[0].get_lines()) == 1
 
+    @pytest.mark.xfail(
+        sys.version_info >= (3, 14),
+        reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+        strict=True,  # This will let us know in the future when this is fixed
+    )
     def test_plot_predictive(self, cav_dt, cavanagh_test):
         model = hssm.HSSM(
             data=cavanagh_test,
@@ -322,6 +328,11 @@ class TestPlotting:
         )
         assert len(g.figure.axes) == 5 * 4
 
+    @pytest.mark.xfail(
+        sys.version_info >= (3, 14),
+        reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+        strict=True,  # This will let us know in the future when this is fixed
+    )
     @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
     def test_plot_quantile_probability(self, cav_dt, cavanagh_test, predictive_style):
         """Tests the plot_quantile_probability function.

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -9,7 +9,7 @@ import hssm
 
 hssm.set_floatX("float32")
 
-pytestmark = xfail_mark = pytest.mark.xfail(
+pytestmark = pytest.mark.xfail(
     sys.version_info >= (3, 14),
     reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
 )

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -1,10 +1,18 @@
 """Test plotting module."""
 
+import sys
+
 import pytest
 import numpy as np
+
 import hssm
 
 hssm.set_floatX("float32")
+
+pytestmark = xfail_mark = pytest.mark.xfail(
+    sys.version_info >= (3, 14),
+    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+)
 
 
 # I want to parameter

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -1,3 +1,5 @@
+import sys
+
 import hssm
 import pytest
 import numpy as np
@@ -29,6 +31,11 @@ PARAMETER_GRID = [
 ]
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 14),
+    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+    strict=True,  # This will let us know in the future when this is fixed
+)
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, inplace):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pandas as pd
 import pytensor
@@ -231,6 +233,11 @@ def test_check_data_for_rl():
     assert n_trials == 2
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 14),
+    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
+    strict=True,  # This will let us know in the future when this is fixed
+)
 def test_predictive_idata_to_dataframe(data_ddm):
     model = hssm.HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)


### PR DESCRIPTION
Updated `ssm-simulators` dependency to support Python 3.14. Also updated CI workflow to add tests for Python 3.14