### PR TITLE
Docker image, GHCR publish, and Codespaces devcontainer (dockerHSSM)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "HSSM",
+
+  // Reuse the runnable image's Dockerfile so the dev container and the published
+  // image share one definition (python 3.13, uv, graphviz, non-root `hssm` user).
+  // Building here (rather than pulling the image) means Codespaces works before the
+  // image is ever published. Swap for `"image": "ghcr.io/lnccbrown/hssm:latest"`
+  // once it's on GHCR if you'd rather pull than build.
+  "build": { "dockerfile": "../Dockerfile", "context": ".." },
+  "remoteUser": "hssm",
+
+  // Editable dev env on top of the image. `uv sync` installs the project + the
+  // default `dev` group (pytest, ruff, mypy, pre-commit) from uv.lock into .venv.
+  // ponytail: dev group only — `uv sync --group notebook` / `--group docs` are one
+  // command away when a contributor needs the heavy notebook/docs stacks.
+  // onCreateCommand runs during prebuilds, so the venv is baked in → fast startup.
+  "onCreateCommand": "uv sync",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": ".venv/bin/python"
+      }
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,6 @@ tests
 .pytest_cache
 .ruff_cache
 .mypy_cache
+# Only docs/tutorials is copied into the image; drop the rest of docs/ from context.
+docs/*
+!docs/tutorials

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keep the build context small. The Dockerfile only COPYs pyproject/README/LICENSE,
+# src, and docs/tutorials; everything else is noise.
+.git
+.github
+.venv
+**/__pycache__
+*.pyc
+*.pyo
+**/.ipynb_checkpoints
+tests
+.pytest_cache
+.ruff_cache
+.mypy_cache

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -12,6 +12,8 @@ on:
       - Dockerfile
       - pyproject.toml
       - uv.lock
+      - README.md
+      - LICENSE
       - src/**
       - .github/workflows/devcontainer.yml
 
@@ -20,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # devcontainers/ci mounts the workspace into the container; don't leave
+          # the GITHUB_TOKEN in .git/config where the container could read it.
+          persist-credentials: false
 
       - name: Build dev container and smoke-test the env
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,34 @@
+name: Dev container
+
+# Build the Codespaces/VS Code dev container exactly as Codespaces does (image
+# build + onCreateCommand `uv sync`) and smoke-test that the contributor env is
+# wired up. This covers what the image-only build check can't: the lifecycle,
+# the `hssm` remote user, and the uv-synced .venv.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .devcontainer/**
+      - Dockerfile
+      - pyproject.toml
+      - uv.lock
+      - src/**
+      - .github/workflows/devcontainer.yml
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build dev container and smoke-test the env
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          # Verify the env, not the repo's cleanliness: hssm is importable from the
+          # uv-synced venv, and the dev-group tools are present. Deliberately avoids
+          # `ruff check .` / `pytest` so unrelated lint/test debt can't fail this job.
+          runCmd: |
+            uv run python -c "import hssm; print('hssm', hssm.__version__)"
+            uv run ruff --version
+            uv run pytest --version

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # devcontainers/ci mounts the workspace into the container; don't leave
           # the GITHUB_TOKEN in .git/config where the container could read it.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,66 @@
+name: Docker image (GHCR)
+
+# Build the HSSM image on relevant PRs (validation only, no push) and publish it
+# to GHCR on release or manual dispatch.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-image.yml
+      - pyproject.toml
+      - src/**
+  release:
+    types: [published]
+
+env:
+  IMAGE: ghcr.io/lnccbrown/hssm
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          V=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "value=$V" >> "$GITHUB_OUTPUT"
+
+      # Push on release/dispatch; PRs only build to validate the Dockerfile.
+      - name: Decide whether to push
+        id: push
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.push.outputs.value == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          # ponytail: amd64 only until ssm-simulators + hddm-wfpt publish
+          # linux/arm64 wheels; then add ,linux/arm64 here for native multi-arch.
+          platforms: linux/amd64
+          push: ${{ steps.push.outputs.value }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.version.outputs.value }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,15 @@
 name: Docker image (GHCR)
 
-# Build the HSSM image on relevant PRs (validation only, no push) and publish it
-# to GHCR on release or manual dispatch.
+# PRs: amd64 build only (fast sanity). Release: multi-arch build + push to GHCR.
+# Manual dispatch: multi-arch build, pushed only if `publish` is set (otherwise a
+# build-only validation of the arm64 leg).
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Push the image to GHCR (otherwise multi-arch build-only)"
+        type: boolean
+        default: false
   pull_request:
     paths:
       - Dockerfile
@@ -32,20 +38,25 @@ jobs:
           V=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "value=$V" >> "$GITHUB_OUTPUT"
 
-      # Push on release/dispatch; PRs only build to validate the Dockerfile.
-      - name: Decide whether to push
-        id: push
+      # Push only on release (or an explicit `publish` dispatch). Multi-arch
+      # everywhere except PRs, which stay amd64 for fast turnaround.
+      - name: Configure build
+        id: cfg
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "value=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=true" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ github.event_name }}" in
+            pull_request) echo "push=false"; echo "platforms=linux/amd64";;
+            release)      echo "push=true";  echo "platforms=linux/amd64,linux/arm64";;
+            *)            echo "push=${{ inputs.publish }}"; echo "platforms=linux/amd64,linux/arm64";;
+          esac >> "$GITHUB_OUTPUT"
 
+      # QEMU is needed to build the linux/arm64 leg on an amd64 runner. The arm64
+      # deps install from prebuilt wheels (ssm-simulators, hddm-wfpt), so this is
+      # wheel-install-under-emulation, not a from-source compile.
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: steps.push.outputs.value == 'true'
+        if: steps.cfg.outputs.push == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -55,10 +66,8 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          # ponytail: amd64 only until ssm-simulators + hddm-wfpt publish
-          # linux/arm64 wheels; then add ,linux/arm64 here for native multi-arch.
-          platforms: linux/amd64
-          push: ${{ steps.push.outputs.value }}
+          platforms: ${{ steps.cfg.outputs.platforms }}
+          push: ${{ steps.cfg.outputs.push }}
           tags: |
             ${{ env.IMAGE }}:${{ steps.version.outputs.value }}
             ${{ env.IMAGE }}:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,7 +16,10 @@ on:
       - .dockerignore
       - .github/workflows/docker-image.yml
       - pyproject.toml
+      - README.md
+      - LICENSE
       - src/**
+      - docs/tutorials/**
   release:
     types: [published]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Read version from pyproject.toml
         id: version
@@ -55,18 +55,18 @@ jobs:
       # QEMU is needed to build the linux/arm64 leg on an amd64 runner. The arm64
       # deps install from prebuilt wheels (ssm-simulators, hddm-wfpt), so this is
       # wheel-install-under-emulation, not a from-source compile.
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: steps.cfg.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ steps.cfg.outputs.platforms }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@
 # arm64 works because ssm-simulators (>=0.12.5) and hddm-wfpt (>=0.1.7) now ship
 # manylinux aarch64 wheels, so nothing compiles from source on either arch.
 
-FROM python:3.13-slim
+# Base bundles pinned uv 0.11.28 + Python 3.13 on a slim Debian (trixie) base,
+# so uv and Python come ready — no separate uv copy step needed.
+FROM ghcr.io/astral-sh/uv:0.11.28-python3.13-trixie-slim
 
 LABEL org.opencontainers.image.source="https://github.com/lnccbrown/HSSM"
 LABEL org.opencontainers.image.description="Bayesian inference for hierarchical sequential sampling models (HSSM) with JupyterLab."
@@ -17,9 +19,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends graphviz \
     && rm -rf /var/lib/apt/lists/*
 
-# uv for fast installs (ecosystem standard). Pinned for reproducible builds.
-COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /usr/local/bin/uv
-
 # Non-root user.
 RUN useradd --create-home --uid 1000 hssm
 WORKDIR /home/hssm/build
@@ -28,16 +27,29 @@ WORKDIR /home/hssm/build
 # exactly and there is no release-timing race. Dependencies still arrive as wheels.
 # Deliberately resolves latest-compatible deps (not uv.lock) — this is the runnable
 # demo image; the reproducible/locked path is the dev container (`uv sync`).
-# ponytail: core + a minimal notebook UI only. The heavy optional stacks
-# (bayesflow, sbi, lanfactory, keras) are NOT included — add them at run time
-# (`uv pip install ...`) or in a follow-up "full" image if a tutorial needs them.
+# ponytail: core + a minimal notebook UI + light zeus-mcmc — enough for 30 of the
+# 34 tutorials. The 4 needing the heavy PyTorch/TensorFlow stack (bayesflow/keras,
+# sbi, lanfactory) are left out to keep the image slim; see README_DOCKER.md below.
 COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
-RUN uv pip install --system --no-cache . jupyterlab ipywidgets graphviz
+RUN uv pip install --system --no-cache . jupyterlab ipywidgets graphviz zeus-mcmc
 
-# Tutorials to explore. Some advanced notebooks need the heavy stacks above.
+# Tutorials to explore, plus a note about the 4 that need extra packages.
 COPY docs/tutorials /home/hssm/tutorials
-RUN chown -R hssm:hssm /home/hssm
+RUN printf '%s\n' \
+      '# Running the tutorials in this image' \
+      '' \
+      '30 of the 34 tutorials run as-is. Four advanced ones need heavy extras that are' \
+      'left out to keep the image small:' \
+      '' \
+      '  - bayesflow_lre_integration, bayesflow_nle_onnx_integration  -> bayesflow, keras' \
+      '  - sbi_nre_integration                                        -> sbi, torch' \
+      '  - jax_callable_contribution_onnx_example                     -> lanfactory' \
+      '' \
+      'Install them here:  uv pip install --system bayesflow keras sbi lanfactory' \
+      'or use the HSSM dev container (Codespaces / VS Code): uv sync --group notebook' \
+      > /home/hssm/tutorials/README_DOCKER.md \
+    && chown -R hssm:hssm /home/hssm
 
 USER hssm
 WORKDIR /home/hssm/tutorials

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@
 #   docker run --rm -p 8888:8888 ghcr.io/lnccbrown/hssm:latest
 # Built and published from .github/workflows/docker-image.yml.
 #
-# ponytail: amd64 only for now. ssm-simulators and hddm-wfpt ship no linux/arm64
-# wheels yet, so a native arm64 build would have to compile them from source
-# (GSL/OpenMP). Apple Silicon runs this image fine under emulation. Flip to
-# multi-arch by adding linux/arm64 to the workflow's `platforms` once both
-# packages publish aarch64 Linux wheels (tracked upstream).
+# Multi-arch (linux/amd64,linux/arm64) is driven by the workflow's `platforms`.
+# arm64 works because ssm-simulators (>=0.12.5) and hddm-wfpt (>=0.1.7) now ship
+# manylinux aarch64 wheels, so nothing compiles from source on either arch.
 
 FROM python:3.13-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends graphviz \
     && rm -rf /var/lib/apt/lists/*
 
-# uv for fast, reproducible installs (ecosystem standard).
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# uv for fast installs (ecosystem standard). Pinned for reproducible builds.
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /usr/local/bin/uv
 
 # Non-root user.
 RUN useradd --create-home --uid 1000 hssm
@@ -26,6 +26,8 @@ WORKDIR /home/hssm/build
 
 # Install HSSM from this checkout (not PyPI): the image matches the built ref
 # exactly and there is no release-timing race. Dependencies still arrive as wheels.
+# Deliberately resolves latest-compatible deps (not uv.lock) — this is the runnable
+# demo image; the reproducible/locked path is the dev container (`uv sync`).
 # ponytail: core + a minimal notebook UI only. The heavy optional stacks
 # (bayesflow, sbi, lanfactory, keras) are NOT included — add them at run time
 # (`uv pip install ...`) or in a follow-up "full" image if a tutorial needs them.
@@ -41,6 +43,8 @@ USER hssm
 WORKDIR /home/hssm/tutorials
 EXPOSE 8888
 
-# ponytail: tokenless is convenient for a local demo container; the server only
-# listens inside the container's network. Set a token if you expose the port publicly.
-CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--IdentityProvider.token="]
+# Secure by default: Jupyter generates a token and prints the full URL (with token)
+# to the container logs — copy it from `docker run` output. For a frictionless
+# tokenless server on a trusted local network, override the command and append
+# `--IdentityProvider.token=`.
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Runnable HSSM image: HSSM + JupyterLab, ready to explore the tutorials.
+#   docker run --rm -p 8888:8888 ghcr.io/lnccbrown/hssm:latest
+# Built and published from .github/workflows/docker-image.yml.
+#
+# ponytail: amd64 only for now. ssm-simulators and hddm-wfpt ship no linux/arm64
+# wheels yet, so a native arm64 build would have to compile them from source
+# (GSL/OpenMP). Apple Silicon runs this image fine under emulation. Flip to
+# multi-arch by adding linux/arm64 to the workflow's `platforms` once both
+# packages publish aarch64 Linux wheels (tracked upstream).
+
+FROM python:3.13-slim
+
+LABEL org.opencontainers.image.source="https://github.com/lnccbrown/HSSM"
+LABEL org.opencontainers.image.description="Bayesian inference for hierarchical sequential sampling models (HSSM) with JupyterLab."
+LABEL org.opencontainers.image.licenses="MIT"
+
+# graphviz: the `dot` binary the python `graphviz` package shells out to for model graphs.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv for fast, reproducible installs (ecosystem standard).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Non-root user.
+RUN useradd --create-home --uid 1000 hssm
+WORKDIR /home/hssm/build
+
+# Install HSSM from this checkout (not PyPI): the image matches the built ref
+# exactly and there is no release-timing race. Dependencies still arrive as wheels.
+# ponytail: core + a minimal notebook UI only. The heavy optional stacks
+# (bayesflow, sbi, lanfactory, keras) are NOT included — add them at run time
+# (`uv pip install ...`) or in a follow-up "full" image if a tutorial needs them.
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+RUN uv pip install --system --no-cache . jupyterlab ipywidgets graphviz
+
+# Tutorials to explore. Some advanced notebooks need the heavy stacks above.
+COPY docs/tutorials /home/hssm/tutorials
+RUN chown -R hssm:hssm /home/hssm
+
+USER hssm
+WORKDIR /home/hssm/tutorials
+EXPOSE 8888
+
+# ponytail: tokenless is convenient for a local demo container; the server only
+# listens inside the container's network. Set a token if you expose the port publicly.
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--IdentityProvider.token="]


### PR DESCRIPTION
Adds a runnable HSSM Docker image, a workflow that publishes it to **GHCR** (`ghcr.io/lnccbrown/hssm`) on release, and a **Codespaces / dev container** so people can contribute to HSSM in the browser.

## Credit / origin
This revives **#439 (dockerHSSM)** by @panwanke and @hcp4715 — thank you. That PR (May 2024) is now stale against `main` (deprecated `jupyter/scipy-notebook` base, China-mirror pins, `pymc==5.14`, and a version read from the long-gone `tool.poetry.version`). Rather than rebase its ~4k lines of regenerated-notebook churn, this reworks the ~90 lines that matter for today's HSSM. Original authorship is preserved via `Co-authored-by` trailers.

## What's here
- **`Dockerfile`** — `python:3.13-slim` + `graphviz` + `uv`. Installs HSSM **from the checked-out source** (image matches the built ref exactly; no PyPI release-timing race) plus a minimal JupyterLab UI. Non-root user; tutorials baked in. `docker run --rm -p 8888:8888 ghcr.io/lnccbrown/hssm:latest` opens a notebook.
- **`.github/workflows/docker-image.yml`** — builds on relevant PRs (**validation only, no push**) and publishes on `release`/`workflow_dispatch`. Version read via stdlib `tomllib` from `[project].version`; auth via `GITHUB_TOKEN` (no secrets needed for GHCR).
- **`.devcontainer/devcontainer.json`** — Codespaces / VS Code dev container. Builds from the same `Dockerfile` (so run-image and dev-image share one base), then `uv sync` on create layers an editable dev env (project + `dev` group: pytest, ruff, mypy, pre-commit). `onCreateCommand` is baked into Codespaces prebuilds for fast startup.
- **`.dockerignore`** — lean build context.

## Deliberate scope
- **amd64-only for now.** `ssm-simulators` and `hddm-wfpt` publish no `linux/arm64` wheels, so a native arm64 image would have to compile them from source (GSL/OpenMP). Apple Silicon still runs this image under emulation, and Codespaces is amd64. Native multi-arch is a one-line `platforms:` change once those packages ship aarch64 Linux wheels — **ssm-simulators side is up in lnccbrown/ssm-simulators#293**; `hddm-wfpt` to follow.
- **Core + notebook UI only** in the image — heavy optional stacks (bayesflow, sbi, lanfactory, keras) are excluded to keep it slim; the dev container adds the `dev` group, and `uv sync --group notebook/docs` pulls the rest on demand.

## Follow-ups (not in this PR)
1. `hddm-wfpt` aarch64 wheels (mirror of ssm-simulators#293) → then flip the image `platforms:` to `linux/amd64,linux/arm64`.
2. Enable Codespaces prebuilds on the repo (Settings → Codespaces → Prebuilds) once merged.

Draft until CI image build passes and the direction is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dev container setup for a consistent local development environment.
  * Added CI automation to build and smoke-test the dev container.
  * Added Docker image build and publish workflows with multi-architecture support and versioned tags.
  * Added a runnable container image with JupyterLab and included tutorial content.
* **Chores**
  * Reduced Docker build context noise to speed up container builds.
  * Updated the container’s JupyterLab launch to use standard token-based access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->