### PR TITLE
aDDM: per-call fixation-continuation policy for PPC + PPC/cartoon tutorial

### DIFF
--- a/docs/tutorials/attentional_ddm.py
+++ b/docs/tutorials/attentional_ddm.py
@@ -512,6 +512,14 @@ def _(mo):
     stochastic sample trajectories, the non-decision time, and the choice-split RT histograms
     (observed vs predicted). It reads the geometry from *simulator* metadata, so it works for
     the aDDM exactly as it does for the built-in SSMs.
+
+    > **Caveat — this is not the §6 PPC.** For the aDDM the cartoon re-simulates at the
+    > posterior-mean parameters with the simulator *self-sampling* its own gaze sequence
+    > (Mode 1), and its predictive uses the **default** continuation policy — the
+    > `continuation_mode` you set above does **not** reach it. Read the cartoon as a schematic
+    > of the fitted drift/boundary geometry, not as the fixation-conditioned predictive check
+    > of §6. Conditioning the cartoon on the observed fixations is tracked in
+    > [issue #1039](https://github.com/lnccbrown/HSSM/issues/1039).
     """)
     return
 

--- a/docs/tutorials/attentional_ddm.py
+++ b/docs/tutorials/attentional_ddm.py
@@ -438,12 +438,15 @@ def _(az, idata, plt):
 @app.cell
 def _(mo):
     mo.md("""
-    ## 6. Posterior predictive, conditioned on the observed fixations
+    ## 6. Posterior predictive checks
 
-    `sample_posterior_predictive` draws new (rt, choice) from the posterior **using
-    each trial's real fixation sequence** — the handshake from section 2 feeds the
-    observed `r1, r2, flag, sacc_array, d` to the simulator, so the check is faithful
+    `sample_posterior_predictive` draws new (rt, choice) from the posterior. By default it
+    conditions on **each trial's observed fixation sequence** — the handshake from section 2
+    feeds the observed `r1, r2, flag, sacc_array, d` to the simulator, so the check is faithful
     to the gaze pattern that produced the data.
+
+    Observed (pink) vs predicted (blue) RT densities below; `rt` is signed by choice, and
+    `x_range` zooms past the `p_outlier` lapse tail.
     """)
     return
 
@@ -451,9 +454,80 @@ def _(mo):
 @app.cell
 def _(idata, model, plt):
     model.sample_posterior_predictive(idata, kind="response", draws=100)
-    # Observed (pink) vs predicted (blue) RT densities. rt is signed by choice;
-    # x_range zooms in past the p_outlier lapse tail.
     model.plot_predictive(x_range=(-4, 4))
+    plt.gcf()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ### Fixation-continuation policies
+
+    A re-simulated particle may still be undecided when it reaches the **last observed
+    fixation** — the observed gaze sequence is right-censored at the response, so its last
+    fixation was cut short. How the fixation process is *continued* past that point is a
+    modelling choice, selectable **per PPC call** on the same fitted model (no re-fit) via
+    `continuation_mode` / `continuation_params`:
+
+    - **`prolong_last_fixation`** (default) — hold the last gaze's drift to `max_t`. The classic
+      behaviour; byte-identical to before this option existed.
+    - **`sample_continuation`** — draw the continuation (tail) fixation durations from a chosen
+      positive distribution and keep alternating gaze. This resamples the censored last fixation
+      to a natural (uncensored) duration instead of freezing it.
+    - **`resample_all_fixations`** — ignore the observed fixation schedule entirely and
+      self-sample the whole fixation behaviour (first gaze + durations), keeping only the
+      observed stimulus (`r1`, `r2`). A fully generative check of the model's fixation process.
+
+    Distributions come from a `scipy.stats` positive-distribution factory (gamma, lognormal,
+    weibull, invgauss, …); `dist_params` are scipy-native (gamma's shape is `a`, so
+    `{"a": 6.0, "scale": 0.1}` is `Gamma(shape=6, scale=0.1)`).
+    """)
+    return
+
+
+@app.cell
+def _(idata, model, plt):
+    # Same fitted model, a different continuation policy — chosen per call, no re-fit.
+    _gamma = {"dist": "gamma", "dist_params": {"a": 6.0, "scale": 0.1}}
+    model.sample_posterior_predictive(
+        idata,
+        kind="response",
+        draws=100,
+        continuation_mode="sample_continuation",
+        continuation_params=_gamma,
+    )
+    model.plot_predictive(x_range=(-4, 4))
+    plt.gcf()
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 7. Model cartoon
+
+    `hssm.plotting.plot_model_cartoon` renders the fitted aDDM as a *cartoon*: the collapsing
+    decision bounds $\pm(a - b\,t)$, the drift path from the starting point $x_0$, a few
+    stochastic sample trajectories, the non-decision time, and the choice-split RT histograms
+    (observed vs predicted). It reads the geometry from *simulator* metadata, so it works for
+    the aDDM exactly as it does for the built-in SSMs.
+    """)
+    return
+
+
+@app.cell
+def _(hssm, idata, model, plt):
+    hssm.plotting.plot_model_cartoon(
+        model,
+        idata=idata,
+        n_samples=8,
+        n_trajectories=5,
+        bins=25,
+        plot_predictive_mean=True,
+        plot_predictive_samples=False,
+        title="aDDM model cartoon",
+    )
     plt.gcf()
     return
 

--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -15,6 +15,7 @@ materializing the 2-D ``sacc_array`` covariate (:meth:`_stack_sacc_array`).
 from dataclasses import replace
 from typing import Any, Literal, cast
 
+import arviz as az
 import bambi as bmb
 import numpy as np
 import pandas as pd
@@ -23,7 +24,7 @@ import pymc as pm
 from ..base import HSSMBase
 from ..distribution_utils import make_distribution
 from .attention_process import resolve_attention_process
-from .config import aDDMConfig
+from .config import _validate_continuation, aDDMConfig
 from .likelihoods.builder import make_addm_logp_op
 
 
@@ -161,8 +162,23 @@ class aDDM(HSSMBase):
         """
         if extra_fields_data is None or self.extra_fields is None:
             return
-        mapping = dict(zip(self.extra_fields, extra_fields_data))
+        mapping: dict[str, Any] = dict(zip(self.extra_fields, extra_fields_data))
+        # Continuation policy for the generative rng_fn: a per-call override
+        # (set by sample_posterior_predictive) if present, else the aDDMConfig default.
+        # Resolved here (not written once at build) so the base PPC path's
+        # _update_extra_fields refresh keeps an active override, not the config default.
+        mode, params = self._continuation_setting()
+        mapping["continuation_mode"] = mode
+        mapping["continuation_params"] = params
         type(dist.rv_op)._extra_fields = mapping
+
+    def _continuation_setting(self) -> tuple[str, dict | None]:
+        """(mode, params): a live per-call override if set, else the config default."""
+        override = getattr(self, "_continuation_override", None)
+        if override is not None:
+            return override
+        cfg = cast("aDDMConfig", self.model_config)
+        return cfg.continuation_mode, cfg.continuation_params
 
     def _update_extra_fields(self, new_data: pd.DataFrame | None = None) -> None:
         """Refresh the distribution's extra fields, stacking ``sacc_array`` to 2-D.
@@ -179,6 +195,49 @@ class aDDM(HSSMBase):
             extra_fields_data = self._addm_extra_fields_data(new_data)
             self.model_distribution.extra_fields = extra_fields_data
             self._push_rv_extra_fields(self.model_distribution, extra_fields_data)
+
+    def sample_posterior_predictive(
+        self,
+        idata: az.InferenceData | None = None,
+        data: pd.DataFrame | None = None,
+        inplace: bool = True,
+        include_group_specific: bool = True,
+        kind: Literal["response", "response_params"] = "response",
+        draws: int | float | list[int] | np.ndarray | None = None,
+        safe_mode: bool = True,
+        continuation_mode: str | None = None,
+        continuation_params: dict | None = None,
+    ) -> az.InferenceData | None:
+        """Posterior-predictive draws with a per-call fixation-continuation policy.
+
+        ``continuation_mode`` / ``continuation_params`` (default: the ``aDDMConfig``
+        values) select how fixations continue past the observed ones, for THIS call
+        only (see ``ssms.basic_simulators.fixation_continuation`` for the modes). They
+        rewrite the RV class attr the generative ``rng_fn`` reads at draw time, so one
+        fitted model can be swept across policies with no rebuild/re-fit; each call sets
+        them explicitly, so calls never leak. Other args match the base method.
+        """
+        cfg = cast("aDDMConfig", self.model_config)
+        mode = (
+            continuation_mode
+            if continuation_mode is not None
+            else cfg.continuation_mode
+        )
+        params = (
+            continuation_params
+            if continuation_params is not None
+            else cfg.continuation_params
+        )
+        _validate_continuation(mode, params)
+        # Set the live override; the base PPC's _update_extra_fields re-pushes it onto
+        # the RV before drawing. Restore after so calls don't leak into each other.
+        self._continuation_override: tuple[str, dict | None] | None = (mode, params)
+        try:
+            return super().sample_posterior_predictive(
+                idata, data, inplace, include_group_specific, kind, draws, safe_mode
+            )
+        finally:
+            self._continuation_override = None
 
     # ------------------------------------------------------------------ #
     # aDDM-specific data handling

--- a/src/hssm/addm/config.py
+++ b/src/hssm/addm/config.py
@@ -21,6 +21,33 @@ from ..config import BaseModelConfig
 from .attention_process import resolve_attention_process
 
 
+def _validate_continuation(mode: str, params: dict | None) -> None:
+    """Validate a fixation-continuation mode + params against ssm-sim's registries.
+
+    Reused by ``aDDMConfig.validate`` and the per-call PPC override. Defensive: if the
+    installed ssm-simulators predates the continuation module, validation is skipped;
+    the simulator validates authoritatively at PPC time.
+    """
+    try:
+        from ssms.basic_simulators.fixation_continuation import (
+            resolve_continuation_mode,
+            resolve_distribution,
+        )
+    except ImportError:
+        return
+    resolve_continuation_mode(mode)  # raises ValueError on an unknown mode
+    if mode == "prolong_last_fixation":
+        if params is not None:
+            raise ValueError("prolong_last_fixation takes no continuation_params.")
+        return
+    if not isinstance(params, dict) or "dist" not in params:
+        raise ValueError(
+            f"continuation_mode={mode!r} requires "
+            "continuation_params={'dist': <name>, 'dist_params': {...}}."
+        )
+    resolve_distribution(params["dist"])  # raises ValueError on an unknown distribution
+
+
 @dataclass
 class aDDMConfig(BaseModelConfig):
     """Config for the attentional DDM (subclass formulation).
@@ -59,6 +86,11 @@ class aDDMConfig(BaseModelConfig):
         default_factory=lambda: [0.3, 1.0, 1.0, 2.0, 0.0, 0.0]
     )
     attention_process: str | Callable = "standard_alternating"
+    # Fixation-continuation policy for posterior predictive (Mode-2 tail behaviour). The
+    # default reproduces the pre-feature "hold the last gaze"; override per PPC call via
+    # aDDM.sample_posterior_predictive. See ssms.basic_simulators.fixation_continuation.
+    continuation_mode: str = "prolong_last_fixation"
+    continuation_params: dict | None = None
     # ``loglik`` and ``backend`` are inherited (default ``None``) and injected by
     # ``aDDM.__init__`` via ``dataclasses.replace`` in Commit 4 — not redeclared here.
 
@@ -68,6 +100,7 @@ class aDDMConfig(BaseModelConfig):
             raise ValueError("Please provide `list_params` in the configuration.")
         # Raises ValueError (unknown name) / TypeError (bad type) on failure.
         resolve_attention_process(self.attention_process)
+        _validate_continuation(self.continuation_mode, self.continuation_params)
         if self.params_default and len(self.params_default) != len(self.list_params):
             raise ValueError(
                 f"params_default length ({len(self.params_default)}) doesn't match "

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -412,6 +412,14 @@ def plot_model_cartoon(
 ) -> Axes | sns.FacetGrid | list[sns.FacetGrid]:
     """Plot the posterior predictive distribution against the observed data.
 
+    Note (aDDM / covariate models): this cartoon re-simulates at the posterior-mean
+    parameters with the simulator self-sampling its own fixation sequence (Mode 1)
+    and regenerates its predictive with the model's default continuation policy. It
+    does NOT condition on the observed fixations, and a ``continuation_mode`` passed
+    to ``sample_posterior_predictive`` does not reach it, so it is a schematic of the
+    fitted drift/boundary geometry, not the fixation-conditioned predictive check.
+    Tracked in lnccbrown/HSSM#1039.
+
     Parameters
     ----------
     model : hssm.HSSM

--- a/tests/addm/test_addm_continuation.py
+++ b/tests/addm/test_addm_continuation.py
@@ -1,0 +1,99 @@
+"""aDDM fixation-continuation: config validation + per-call PPC policy override.
+
+The continuation policy for posterior predictive is a per-call knob on
+aDDM.sample_posterior_predictive (continuation_mode / continuation_params). It
+rewrites entries on the RV class attr the generative rng_fn reads at draw time, so
+one fitted model can be swept across policies with no rebuild/re-fit.
+
+Requires the ssm-simulators build with ``cssm.addm`` AND the ``fixation_continuation``
+module; skips otherwise (like the aDDM PPC tests).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_addm_subclass import make_addm_dataframe  # noqa: E402
+
+try:
+    from ssms.basic_simulators.fixation_continuation import (  # noqa: F401
+        FIXATION_CONTINUATION_MODES,
+    )
+    from ssms.config import model_config as _ssms_model_config
+
+    _HAS_ADDM_CONT = "addm" in _ssms_model_config
+except Exception:  # pragma: no cover - old ssm-sim build
+    _HAS_ADDM_CONT = False
+
+needs_addm_continuation = pytest.mark.skipif(
+    not _HAS_ADDM_CONT,
+    reason="ssm-simulators build without aDDM fixation-continuation support",
+)
+
+import hssm  # noqa: E402
+from hssm.addm.config import aDDMConfig  # noqa: E402
+
+_GAMMA = {"dist": "gamma", "dist_params": {"a": 2.0, "scale": 0.3}}
+
+
+@needs_addm_continuation
+def test_addm_config_validates_continuation():
+    """aDDMConfig.validate accepts good continuation settings and rejects bad ones."""
+    aDDMConfig(
+        continuation_mode="sample_continuation", continuation_params=_GAMMA
+    ).validate()
+    aDDMConfig(
+        continuation_mode="resample_all_fixations", continuation_params=_GAMMA
+    ).validate()
+    aDDMConfig().validate()  # default (prolong_last_fixation, None) is valid
+
+    for bad in (
+        dict(continuation_mode="nope"),
+        dict(continuation_mode="sample_continuation"),  # missing params
+        dict(
+            continuation_mode="sample_continuation",
+            continuation_params={"dist": "not_a_dist"},
+        ),
+        dict(continuation_mode="prolong_last_fixation", continuation_params=_GAMMA),
+    ):
+        with pytest.raises(ValueError):
+            aDDMConfig(**bad).validate()
+
+
+@needs_addm_continuation
+@pytest.mark.slow
+def test_addm_ppc_per_call_continuation_override():
+    """One fitted model: the per-call policy threads to the RV conduit and reverts.
+
+    Each sample_posterior_predictive call also runs the generative simulator, so this
+    exercises all three continuation modes end-to-end.
+    """
+    model = hssm.aDDM(data=make_addm_dataframe(30, seed=3))
+    idata = model.sample(
+        draws=10, tune=10, chains=1, cores=1, idata_kwargs={"log_likelihood": False}
+    )
+    rv_cls = type(model.model_distribution.rv_op)
+
+    # Config default -> prolong_last_fixation on the conduit.
+    model.sample_posterior_predictive(idata, inplace=True)
+    assert rv_cls._extra_fields["continuation_mode"] == "prolong_last_fixation"
+    assert rv_cls._extra_fields["continuation_params"] is None
+
+    # Per-call override reaches the RV conduit (and runs the simulator without error).
+    for mode in ("sample_continuation", "resample_all_fixations"):
+        model.sample_posterior_predictive(
+            idata, inplace=False, continuation_mode=mode, continuation_params=_GAMMA
+        )
+        assert rv_cls._extra_fields["continuation_mode"] == mode
+        assert rv_cls._extra_fields["continuation_params"]["dist"] == "gamma"
+
+    # The finally-block cleared the per-call override — the actual leak guard;
+    # without it the next default call could not revert.
+    assert model._continuation_override is None
+
+    # A later call with no override reverts to the config default (no leakage).
+    model.sample_posterior_predictive(idata, inplace=False)
+    assert rv_cls._extra_fields["continuation_mode"] == "prolong_last_fixation"
+    assert rv_cls._extra_fields["continuation_params"] is None

--- a/tests/addm/test_addm_ppc.py
+++ b/tests/addm/test_addm_ppc.py
@@ -60,7 +60,10 @@ def test_addm_rv_extra_fields_populated():
     model = hssm.aDDM(data=df)
     ef = type(model.model_distribution.rv_op)._extra_fields
     assert ef is not None
-    assert set(ef.keys()) == {"r1", "r2", "flag", "sacc_array", "d", "sigma"}
+    # The 6 observed covariates plus the fixation-continuation policy (default = prolong).
+    assert {"r1", "r2", "flag", "sacc_array", "d", "sigma"} <= set(ef.keys())
+    assert ef["continuation_mode"] == "prolong_last_fixation"
+    assert ef["continuation_params"] is None
     assert np.asarray(ef["sacc_array"]).shape[0] == len(df)
     assert np.array_equal(np.asarray(ef["r1"]), df["r1"].to_numpy())
 


### PR DESCRIPTION
## aDDM per-call fixation-continuation policy for posterior predictive (+ tutorial)

Stacked on #1032 (base: `addm-cartoon`). Top of the HSSM aDDM stack: **#967 → #1032 → this**.

> **Cross-repo dependency:** requires the ssm-simulators continuation release (lnccbrown/ssm-simulators#294-stack). The `ssm-simulators` pin must be bumped to that published version before this merges — `aDDMConfig` validation and the generative path both need `ssms.basic_simulators.fixation_continuation`.

### What's added
- **Per-call continuation policy on `aDDM.sample_posterior_predictive`** (`continuation_mode` / `continuation_params`) — build + fit the model **once**, then sweep policies across PPC runs with **no rebuild/re-fit**. Works because the generative `rng_fn` reads the RV's `_extra_fields` class attribute at every draw, which the override rewrites per call (and restores in a `finally`, so calls don't leak).
- **`aDDMConfig` default** (`continuation_mode="prolong_last_fixation"`, `continuation_params=None`) — the pre-feature behaviour; validated against ssm-sim's registries.
- **Tutorial** (`docs/tutorials/attentional_ddm.py`): expanded posterior-predictive section demonstrating all three policies on one fitted model, plus a model-cartoon section (`hssm.plotting.plot_model_cartoon`).

```python
model = hssm.aDDM(data=df); idata = model.sample()          # default = prolong_last_fixation
ppc_freeze  = model.sample_posterior_predictive(idata)
ppc_gamma   = model.sample_posterior_predictive(
    idata, continuation_mode="sample_continuation",
    continuation_params={"dist": "gamma", "dist_params": {"a": 2.0, "scale": 0.3}})
```

### Tests
`tests/addm/test_addm_continuation.py`: config validation (fast) + one fitted model swept across all three policies, asserting the policy threads to the RV conduit and reverts (leak guard). Full `tests/addm/` suite: **68 passed** locally.

Reviewed via an 8-surface ponytail + correctness pass (findings applied: validation delegated to ssm-sim's resolvers; redundant PPC pre-push removed; leak-guard assertion strengthened).
