### PR TITLE
Add analytical LBA4 model support

### DIFF
--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -22,6 +22,7 @@ SupportedModels = Literal[
     "race_no_bias_angle_4",
     "ddm_seq2_no_bias",
     "lba3",
+    "lba4",
     "lba2",
     "racing_diffusion_3",
     "poisson_race",

--- a/src/hssm/likelihoods/analytical.py
+++ b/src/hssm/likelihoods/analytical.py
@@ -615,6 +615,53 @@ def _pt_lba3_ll(t, ch, A, b, v0, v1, v2):
     return pt.log(pt.clip(like[running_idx, ch] / (1 - prob_neg), __min, __max))
 
 
+def _pt_lba4_ll(t, ch, A, b, v0, v1, v2, v3):
+    s = 0.1
+    __min = pt.exp(LOGP_LB)
+    __max = pt.exp(-LOGP_LB)
+    k = len([0, 1, 2, 3])
+    like = pt.zeros((*t.shape, k))
+    running_idx = pt.arange(t.shape[0])
+
+    like_1 = (
+        _pt_tpdf(t, A, b, v0, s)
+        * (1 - _pt_tcdf(t, A, b, v1, s))
+        * (1 - _pt_tcdf(t, A, b, v2, s))
+        * (1 - _pt_tcdf(t, A, b, v3, s))
+    )
+    like_2 = (
+        (1 - _pt_tcdf(t, A, b, v0, s))
+        * _pt_tpdf(t, A, b, v1, s)
+        * (1 - _pt_tcdf(t, A, b, v2, s))
+        * (1 - _pt_tcdf(t, A, b, v3, s))
+    )
+    like_3 = (
+        (1 - _pt_tcdf(t, A, b, v0, s))
+        * (1 - _pt_tcdf(t, A, b, v1, s))
+        * _pt_tpdf(t, A, b, v2, s)
+        * (1 - _pt_tcdf(t, A, b, v3, s))
+    )
+    like_4 = (
+        (1 - _pt_tcdf(t, A, b, v0, s))
+        * (1 - _pt_tcdf(t, A, b, v1, s))
+        * (1 - _pt_tcdf(t, A, b, v2, s))
+        * _pt_tpdf(t, A, b, v3, s)
+    )
+
+    like = pt.stack([like_1, like_2, like_3, like_4], axis=-1)
+
+    # One should RETURN this because otherwise it will be pruned from graph
+    # like_printed = pytensor.printing.Print('like')(like)
+
+    prob_neg = (
+        _pt_normcdf(-v0 / s)
+        * _pt_normcdf(-v1 / s)
+        * _pt_normcdf(-v2 / s)
+        * _pt_normcdf(-v3 / s)
+    )
+    return pt.log(pt.clip(like[running_idx, ch] / (1 - prob_neg), __min, __max))
+
+
 def _pt_lba2_ll(t, ch, A, b, v0, v1):
     s = 0.1
     __min = pt.exp(LOGP_LB)
@@ -670,8 +717,28 @@ def logp_lba3(
     return checked_logp
 
 
+def logp_lba4(
+    data: np.ndarray,
+    A: float,
+    b: float,
+    v0: float,
+    v1: float,
+    v2: float,
+    v3: float,
+) -> np.ndarray:
+    """Compute the log-likelihood of the LBA model with 4 drift rates."""
+    data = pt.reshape(data, (-1, 2)).astype(pytensor.config.floatX)
+    rt = pt.abs(data[:, 0])
+    response = data[:, 1]
+    response_int = pt.cast(response, "int32")
+    logp = _pt_lba4_ll(rt, response_int, A, b, v0, v1, v2, v3).squeeze()
+    checked_logp = check_parameters(logp, b > A, msg="b > A")
+    return checked_logp
+
+
 lba2_params = ["A", "b", "v0", "v1"]
 lba3_params = ["A", "b", "v0", "v1", "v2"]
+lba4_params = ["A", "b", "v0", "v1", "v2", "v3"]
 
 lba2_bounds = {
     "A": (0.0, inf),
@@ -688,6 +755,15 @@ lba3_bounds = {
     "v2": (0.0, inf),
 }
 
+lba4_bounds = {
+    "A": (0.0, inf),
+    "b": (0.2, inf),
+    "v0": (0.0, inf),
+    "v1": (0.0, inf),
+    "v2": (0.0, inf),
+    "v3": (0.0, inf),
+}
+
 LBA2: type[pm.Distribution] = make_distribution(
     rv="lba2",
     loglik=logp_lba2,
@@ -700,6 +776,13 @@ LBA3: type[pm.Distribution] = make_distribution(
     loglik=logp_lba3,
     list_params=lba3_params,
     bounds=lba3_bounds,
+)
+
+LBA4: type[pm.Distribution] = make_distribution(
+    rv="lba4",
+    loglik=logp_lba4,
+    list_params=lba4_params,
+    bounds=lba4_bounds,
 )
 
 

--- a/src/hssm/modelconfig/__init__.py
+++ b/src/hssm/modelconfig/__init__.py
@@ -15,6 +15,8 @@ get_lba2_config() -> DefaultConfig
 
 get_lba3_config() -> DefaultConfig
 
+get_lba4_config() -> DefaultConfig
+
 get_angle_config() -> DefaultConfig
 
 get_levy_config() -> DefaultConfig

--- a/src/hssm/modelconfig/lba4_config.py
+++ b/src/hssm/modelconfig/lba4_config.py
@@ -8,7 +8,7 @@ from ..likelihoods.analytical import (
 
 def get_lba4_config() -> DefaultConfig:
     """
-    Get the default configuration for the Levy-Beard Model 4 (LBA4).
+    Get the default configuration for the Linear Ballistic Accumulator 4 (LBA4).
 
     Returns
     -------

--- a/src/hssm/modelconfig/lba4_config.py
+++ b/src/hssm/modelconfig/lba4_config.py
@@ -1,0 +1,34 @@
+from .._types import DefaultConfig  # noqa: D100
+from ..likelihoods.analytical import (
+    lba4_bounds,
+    lba4_params,
+    logp_lba4,
+)
+
+
+def get_lba4_config() -> DefaultConfig:
+    """
+    Get the default configuration for the Levy-Beard Model 4 (LBA4).
+
+    Returns
+    -------
+    DefaultConfig
+        A dictionary containing the default configuration settings for the LBA4,
+        including response variables, model parameters, choices, description,
+        and likelihood specifications.
+    """
+    return {
+        "response": ["rt", "response"],
+        "list_params": lba4_params,
+        "choices": [0, 1, 2, 3],
+        "description": "Linear Ballistic Accumulator 4 Choices (LBA4)",
+        "likelihoods": {
+            "analytical": {
+                "loglik": logp_lba4,
+                "backend": None,
+                "default_priors": {},
+                "bounds": lba4_bounds,
+                "extra_fields": None,
+            }
+        },
+    }

--- a/tests/test_likelihoods_lba.py
+++ b/tests/test_likelihoods_lba.py
@@ -9,7 +9,7 @@ import pytest
 import hssm
 
 # pylint: disable=C0413
-from hssm.likelihoods.analytical import logp_lba2, logp_lba3
+from hssm.likelihoods.analytical import logp_lba2, logp_lba3, logp_lba4
 
 hssm.set_floatX("float32")
 
@@ -57,6 +57,41 @@ def vectorize_param(theta, param, size):
 
 theta_lba2 = dict(A=0.2, b=0.5, v0=1.0, v1=1.0)
 theta_lba3 = theta_lba2 | {"v2": 1.0}
+theta_lba4 = theta_lba3 | {"v3": 1.0}
+
+
+def make_lba_data(n_choices):
+    """Make deterministic LBA-like data with all choices represented."""
+    rows = [[0.35, choice] for choice in range(n_choices)] + [
+        [0.5, choice] for choice in range(n_choices)
+    ]
+    return np.array(rows, dtype=np.float32)
+
+
+@pytest.mark.parametrize(
+    "logp_func, theta, n_choices",
+    [
+        (logp_lba2, theta_lba2, 2),
+        (logp_lba3, theta_lba3, 3),
+        (logp_lba4, theta_lba4, 4),
+    ],
+)
+def test_lba_synthetic_data(logp_func, theta, n_choices):
+    lba_data = make_lba_data(n_choices)
+    size = lba_data.shape[0]
+
+    out_base = logp_func(lba_data, **theta).eval()
+    assert out_base.shape == (size,)
+    assert np.isfinite(out_base).all()
+
+    for param in theta:
+        param_vec = vectorize_param(theta, param, size)
+        out_vec = logp_func(lba_data, **param_vec).eval()
+        assert np.allclose(out_vec, out_base, atol=CLOSE_TOLERANCE)
+
+    for A, b in product([np.full(size, 0.6), 0.6], [np.full(size, 0.5), 0.5]):
+        with pytest.raises(pm.logprob.utils.ParameterValueError):
+            logp_func(lba_data, A=A, b=b, **filter_theta(theta, ["A", "b"])).eval()
 
 
 @pytest.mark.slow

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
 
+import hssm
+from hssm.likelihoods.analytical import lba4_bounds, logp_lba4
 from hssm.modelconfig import get_default_model_config
 from hssm.modelconfig._softmax_inv_temperature_config import (
     softmax_inv_temperature_config,
 )
-import hssm
 
 
 def test_get_ddm_sdv_config():
@@ -102,6 +103,23 @@ def test_get_ornstein_config():
         "g": (-1.0, 1.0),
         "t": (1e-3, 2.0),
     }
+
+
+def test_get_lba4_config():
+    lba4_model_config = get_default_model_config("lba4")
+    assert lba4_model_config["response"] == ["rt", "response"]
+    assert lba4_model_config["choices"] == [0, 1, 2, 3]
+    assert lba4_model_config["list_params"] == ["A", "b", "v0", "v1", "v2", "v3"]
+    assert lba4_model_config["description"] == (
+        "Linear Ballistic Accumulator 4 Choices (LBA4)"
+    )
+
+    likelihood = lba4_model_config["likelihoods"]["analytical"]
+    assert likelihood["loglik"] is logp_lba4
+    assert likelihood["backend"] is None
+    assert likelihood["default_priors"] == {}
+    assert likelihood["bounds"] == lba4_bounds
+    assert likelihood["extra_fields"] is None
 
 
 @pytest.mark.parametrize("model", hssm.list_models())


### PR DESCRIPTION
## Summary
- add analytical PyTensor log-likelihood support for plain four-choice LBA (`lba4`)
- add the built-in `lba4` model config and register it in `SupportedModels`
- add fast synthetic likelihood coverage for LBA2/LBA3/LBA4 and config assertions for `lba4`

## Verification
- `uv run pytest tests/test_modelconfig.py tests/test_config.py tests/test_likelihoods_lba.py -q` (`36 passed`)
- `uv run ruff check src/hssm/likelihoods/analytical.py src/hssm/modelconfig/lba4_config.py src/hssm/modelconfig/__init__.py src/hssm/_types.py`
- `uv run ruff check .`

## Dependency Notes
- Depends on lnccbrown/ssm-simulators#297 for `hssm.simulate_data("lba4", ...)` and predictive simulation support from `ssm-simulators`.
- No dependency pin bump is included here; that should wait for an `ssm-simulators` release containing `lba4`.
- Analytical inference for `lba4` is implemented directly in HSSM and covered with synthetic data that does not require unreleased simulator support.

## Out of Scope
- No angle or constrained LBA4 variants are added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new 4-choice LBA model option.
  * New model configuration is available with a 4-choice response set and matching defaults.

* **Tests**
  * Expanded coverage for the new model option, including synthetic data checks and validation of invalid parameter settings.

* **Documentation**
  * Updated model configuration listings to include the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->