### PR TITLE
[pymc6 migration] Restore no-jitter behavior for JAX NUTS samplers (#999)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,10 @@ This version contains major breaking updates for HSSM. Please read the release n
 5. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.
 6. HSSM can now be installed directly from PyPI via `pip` or `uv`. Conda support is no longer provided.
 
+#### Bug fixes:
+
+1. **Restore JAX-NUTS jitter control**: HSSM again disables the built-in initial-value jitter of the `numpyro`/`blackjax` samplers (PyMC 6 removed the public switch that made this possible), so sampling starts from HSSM's own controlled `initval_jitter` instead of an extra uniform jitter (#999).
+
 ### 0.3.1
 
 This version includes the following changes:

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -43,6 +43,7 @@ from hssm.distribution_utils import (
 from hssm.missing_data_mixin import MissingDataMixin
 from hssm.utils import (
     _compute_log_likelihood,
+    _force_jax_nuts_no_jitter,
     _get_alias_dict,
     _print_prior,
     _split_array,
@@ -566,6 +567,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             Note that the old sampler names such as "mcmc", "nuts_numpyro",
             "nuts_blackjax" will be deprecated and removed in future releases. A warning
             will be raised if any of these old names are used.
+            For the JAX samplers ("numpyro"/"blackjax"), HSSM disables the
+            sampler's built-in initial-value jitter and uses its own controlled
+            `initval_jitter` instead.
         init: optional
             Initialization method to use for the sampler. If any of the NUTS samplers
             is used, defaults to `"adapt_diag"`. Otherwise, defaults to `"auto"`.
@@ -671,22 +675,6 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             else:
                 init = "auto"
 
-        # TODO: add back jitter after knowing what to do
-        # If sampler is finally `numpyro` make sure
-        # the jitter argument is set to False
-        # if sampler == "numpyro":
-        #     if "nuts" in kwargs:
-        #         if kwargs["nuts"].get("jitter"):
-        #             _logger.warning(
-        #                 "The jitter argument is set to True. "
-        #                 + "This argument is not supported "
-        #                 + "by the numpyro backend. "
-        #                 + "The jitter argument will be set to False."
-        #             )
-        #         kwargs["nuts"]["jitter"] = False
-        #     else:
-        #         kwargs["nuts"] = {"jitter": False}
-
         if sampler != "pymc" and "step" in kwargs:
             raise ValueError(
                 "`step` samplers (enabled by the `step` argument) are only supported "
@@ -714,13 +702,18 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         # which silently downgraded user choice — surfaced via the sbi NLE
         # tutorial where sampler="numpyro" still went through PyMC's multiprocess
         # path and tripped cloudpickle on the ONNX ModelProto.
-        self._inference_obj = self.model.fit(
-            inference_method=sampler,
-            init=init,
-            include_response_params=include_response_params,
-            omit_offsets=omit_offsets,
-            **kwargs,
-        )
+        # PyMC 6's JAX-NUTS samplers ("numpyro"/"blackjax") always jitter initial
+        # values and expose no supported switch; HSSM already applies its own
+        # controlled `initval_jitter`, so disable the sampler's jitter for them
+        # (issue #999; see also the upstream pymc gap this works around).
+        with _force_jax_nuts_no_jitter(active=sampler in ("numpyro", "blackjax")):
+            self._inference_obj = self.model.fit(
+                inference_method=sampler,
+                init=init,
+                include_response_params=include_response_params,
+                omit_offsets=omit_offsets,
+                **kwargs,
+            )
 
         # Separate out log likelihood computation
         if compute_likelihood:

--- a/src/hssm/utils.py
+++ b/src/hssm/utils.py
@@ -605,6 +605,58 @@ class SuppressOutput:
         logging.disable(logging.NOTSET)  # Re-enable logging
 
 
+@contextlib.contextmanager
+def _force_jax_nuts_no_jitter(active: bool = True):
+    """Temporarily disable the JAX-NUTS initial-value jitter inside ``pm.sample``.
+
+    PyMC 6's ``pm.sample(nuts_sampler="numpyro"|"blackjax")`` always calls
+    ``pymc.sampling.jax.sample_jax_nuts`` with its default ``jitter=True`` and exposes
+    no supported way to turn it off (passing ``jitter`` via ``nuts=`` routes it into the
+    NumPyro/BlackJAX *kernel* and raises ``TypeError``). HSSM applies its own controlled
+    jitter to the initial values (``initval_jitter``, default 0.01), so the sampler's
+    extra ``uniform(-1, 1)`` jitter is unwanted. Because ``pymc.sampling.mcmc`` resolves
+    the sampler as a module attribute at call time, temporarily replacing that attribute
+    with a wrapper that forces ``jitter=False`` is picked up by ``pm.sample``.
+
+    Parameters
+    ----------
+    active
+        When ``False`` the context manager is a no-op (used for the non-JAX samplers).
+        This lets callers wrap the ``fit`` call unconditionally without importing
+        ``contextlib`` themselves. Defaults to ``True``.
+
+    Notes
+    -----
+    If a future PyMC release removes or renames ``sample_jax_nuts``, the context manager
+    degrades to a no-op instead of raising.
+    """
+    if not active:
+        yield
+        return
+
+    try:
+        import pymc.sampling.jax as pymc_jax
+    except ImportError:  # pragma: no cover - jax extras always present in HSSM
+        yield
+        return
+
+    original = getattr(pymc_jax, "sample_jax_nuts", None)
+    if original is None:  # pragma: no cover - guards a future pymc refactor
+        yield
+        return
+
+    @functools.wraps(original)
+    def _no_jitter_sample_jax_nuts(*args, **kwargs):
+        kwargs["jitter"] = False
+        return original(*args, **kwargs)
+
+    pymc_jax.sample_jax_nuts = _no_jitter_sample_jax_nuts
+    try:
+        yield
+    finally:
+        pymc_jax.sample_jax_nuts = original
+
+
 def annotate_function(**kwargs):
     """Attach arbitrary metadata as attributes to a function.
 

--- a/tests/test_jitter.py
+++ b/tests/test_jitter.py
@@ -1,0 +1,80 @@
+"""Tests for restoring the JAX-NUTS "no jitter" behavior (issue #999).
+
+HSSM disables the built-in initial-value jitter of PyMC's JAX samplers
+("numpyro"/"blackjax") in favor of its own controlled `initval_jitter`. Because
+PyMC 6 exposes no supported switch, HSSM does this by temporarily patching
+`pymc.sampling.jax.sample_jax_nuts` via `_force_jax_nuts_no_jitter`.
+"""
+
+import pymc.sampling.jax as pymc_jax
+import pytest
+
+from hssm.utils import _force_jax_nuts_no_jitter
+
+
+def test_cm_injects_jitter_false_and_restores(monkeypatch):
+    """Inside the CM, `sample_jax_nuts` receives `jitter=False`; restored on exit."""
+    captured = {}
+
+    def fake_sample_jax_nuts(*args, **kwargs):
+        captured["jitter"] = kwargs.get("jitter", "MISSING")
+        return "idata-sentinel"
+
+    monkeypatch.setattr(pymc_jax, "sample_jax_nuts", fake_sample_jax_nuts)
+    original = pymc_jax.sample_jax_nuts
+
+    with _force_jax_nuts_no_jitter(active=True):
+        # The attribute is swapped for the wrapper while active.
+        assert pymc_jax.sample_jax_nuts is not original
+        # A caller-supplied jitter=True is overridden to False and delegated.
+        assert pymc_jax.sample_jax_nuts(jitter=True) == "idata-sentinel"
+        assert captured["jitter"] is False
+
+    # Original (here, the monkeypatched fake) is restored on exit.
+    assert pymc_jax.sample_jax_nuts is original
+
+
+def test_cm_inactive_is_noop(monkeypatch):
+    """`active=False` leaves `sample_jax_nuts` untouched."""
+    sentinel = object()
+    monkeypatch.setattr(pymc_jax, "sample_jax_nuts", sentinel)
+
+    with _force_jax_nuts_no_jitter(active=False):
+        assert pymc_jax.sample_jax_nuts is sentinel
+
+    assert pymc_jax.sample_jax_nuts is sentinel
+
+
+def test_cm_missing_attr_is_noop(monkeypatch):
+    """A future pymc without `sample_jax_nuts` degrades to a no-op, no raise."""
+    monkeypatch.delattr(pymc_jax, "sample_jax_nuts", raising=False)
+
+    with _force_jax_nuts_no_jitter(active=True):
+        assert not hasattr(pymc_jax, "sample_jax_nuts")
+
+    assert not hasattr(pymc_jax, "sample_jax_nuts")
+
+
+class _StopSampling(Exception):
+    """Sentinel raised to abort once the jitter kwarg has been captured."""
+
+
+def test_hssm_numpyro_forces_jitter_false(monkeypatch, basic_hssm_model):
+    """`sampler="numpyro"` must reach `sample_jax_nuts` with `jitter=False`.
+
+    Exercises the whole HSSM -> bambi -> pm.sample dispatch (including HSSM's own
+    context manager) but aborts at the `pymc.sampling.jax` boundary, so no MCMC
+    and no JAX sampler compilation actually run.
+    """
+    captured = {}
+
+    def fake_sample_jax_nuts(*args, **kwargs):
+        captured["jitter"] = kwargs.get("jitter", "MISSING")
+        raise _StopSampling
+
+    monkeypatch.setattr(pymc_jax, "sample_jax_nuts", fake_sample_jax_nuts)
+
+    with pytest.raises(_StopSampling):
+        basic_hssm_model.sample(sampler="numpyro", draws=10, tune=10, chains=1, cores=1)
+
+    assert captured.get("jitter") is False


### PR DESCRIPTION
Closes #999.

## Problem
The pymc6 migration silently changed jitter behavior for the JAX samplers. `pymc.sampling.jax.sample_jax_nuts(jitter: bool = True)` still has the switch, but `pm.sample(nuts_sampler="numpyro"|"blackjax")` (which HSSM reaches via bambi) **never forwards a way to set it** — `_sample_external_nuts` calls `sample_jax_nuts(...)` without `jitter=`, so it is always `True`. Passing it via `nuts=`/`nuts_sampler_kwargs` routes it into the NumPyro/BlackJAX *kernel* → `TypeError: NUTS.__init__() got an unexpected keyword argument 'jitter'`.

HSSM historically disabled numpyro's jitter (it applies its own controlled `initval_jitter`, default 0.01); that code had been commented out with a `TODO: add back jitter after knowing what to do`.

## Fix
`pm.sample` resolves the sampler as a **call-time module attribute** (`import pymc.sampling.jax as pymc_jax; pymc_jax.sample_jax_nuts(...)`), so a context manager that temporarily patches that attribute to inject `jitter=False`, wrapped around HSSM's existing `self.model.fit(...)` call, is picked up by `pm.sample`. This keeps **all** of bambi's plumbing intact (only the one hardcoded `jitter` is overridden).

- `utils.py`: `_force_jax_nuts_no_jitter(active=...)` context manager. Guards a future pymc rename/removal (→ no-op); `active=False` is a no-op for the non-JAX samplers.
- `base.py`: wrap the `fit()` call with `active=sampler in ("numpyro", "blackjax")`; remove the dead commented block; one docstring sentence.
- `tests/test_jitter.py`: 3 fast unit tests (patch/inject/restore + missing-attr guard) and 1 fast full-stack test asserting `jitter=False` reaches `sample_jax_nuts` through the real HSSM→bambi→pm.sample dispatch (capture-and-raise sentinel, no MCMC). All 4 pass in <1s.

## Result
For `sampler in {"numpyro","blackjax"}`, chains again start from HSSM's controlled `initval_jitter` initvals (matching pre-migration `main` and the pymc sampler, which HSSM already runs with `init="adapt_diag"`), instead of the sampler's extra uniform[-1,1] jitter.

## Edge cases (validated)
- **Multiprocessing:** the JAX samplers run in the main process (chain parallelism via `pmap`/`vmap`, no Python fork), so the in-process patch applies — confirmed with `chains=2`. Forking only happens for `sampler="pymc"`, where the CM is inactive.
- **blackjax:** same `sample_jax_nuts` dispatch → covered.
- **Reentrancy/exceptions:** `try/finally` restores the captured attribute even if `fit()` raises.

## Upstream note
This is an interim workaround. `pm.sample` has no supported way to forward `jitter` to the external samplers; a pymc issue proposing to plumb it through (the parameter already exists on `sample_jax_nuts`) will be filed and linked here.

Verified: `ruff check`/`format` clean, `mypy` clean, `pytest tests/test_jitter.py` 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)