### PR TITLE
Add four-choice choice-only softmax registry

### DIFF
--- a/docs/tutorials/rlssm_hssm_custom_models.ipynb
+++ b/docs/tutorials/rlssm_hssm_custom_models.ipynb
@@ -157,8 +157,9 @@
    "source": [
     "## 2. What is already registered?\n",
     "\n",
-    "HSSM ships a few RLSSM templates out of the box. `list_models()` is the discovery\n",
-    "tool; `get_rlssm_model_config(name)` materializes any of them into an `RLSSMConfig`."
+    "HSSM discovers public RLSSM presets from `ssms.rl.preset` at runtime and merges\n",
+    "any HSSM-side custom registrations into the same `list_models()` discovery surface.\n",
+    "`get_rlssm_model_config(name)` materializes any listed model into an `RLSSMConfig`."
    ]
   },
   {
@@ -178,9 +179,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2AB_RescorlaWagner_DDM       RLSSM model with Rescorla-Wagner Q-learning and the standard DDM as decision process.\n",
-      "2AB_RescorlaWagner_Angle     RLSSM model with Rescorla-Wagner Q-learning and a collapsing-bound DDM (angle model) as decision process.\n",
-      "2AB_RescorlaWagner_Weibull   RLSSM model with Rescorla-Wagner Q-learning and a Weibull-bound DDM as decision process.\n"
+      "2AB_RW_DDM                         Two-armed bandit with a Rescorla-Wagner delta-rule learner and a DDM decision process.\n",
+      "2AB_RW_Angle                       Two-armed bandit with a Rescorla-Wagner delta-rule learner and an angle decision process.\n",
+      "2AB_RW_Weibull                     Two-armed bandit with a Rescorla-Wagner delta-rule learner and a Weibull-bound DDM decision process.\n",
+      "2AB_RW_DualAlpha_Angle             Two-armed bandit with a dual-alpha Rescorla-Wagner learner and an angle decision process.\n",
+      "2AB_RW_InvTempSoftmax              Two-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "2AB_RW_DualAlpha_InvTempSoftmax    Two-armed bandit with a dual-alpha Rescorla-Wagner learner and a choice-only inverse-temperature softmax decision process.\n",
+      "3AB_RW_InvTempSoftmax              Three-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "4AB_RW_InvTempSoftmax              Four-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n"
      ]
     },
     {
@@ -199,7 +205,7 @@
     "    print(f\"{name:28s} {description}\")\n",
     "\n",
     "# Peek at one built-in template.\n",
-    "builtin = get_rlssm_model_config(\"2AB_RescorlaWagner_Angle\")\n",
+    "builtin = get_rlssm_model_config(\"2AB_RW_Angle\")\n",
     "print(\"\\ndecision_process :\", builtin.decision_process)\n",
     "print(\"computed by learner:\", set(builtin.ssm_logp_func.computed))  # {'v'}\n",
     "print(\"sampled parameters :\", builtin.list_params)"

--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -8,9 +8,9 @@ This module provides:
     likelihood) are resolved automatically from
     `hssm.modelconfig.get_default_model_config` and do not need to be
     pre-registered here.
-- `_RLSSM_REGISTRY` — maps named RLSSM model strings (for example,
-    `"2AB_RescorlaWagner_DDM"`) to their default decision process,
-    learning process, and parameter info.
+- `_RLSSM_REGISTRY` — maps custom HSSM-side RLSSM model strings to their
+    default decision process, learning process, and parameter info. Built-in
+    public RLSSM presets are discovered dynamically from ``ssms.rl.preset``.
 - `get_rlssm_model_config` — builds an `RLSSMConfig` from a named model
     string with optional overrides.
 - `register_rlssm_model` — registers a custom named RLSSM model.
@@ -19,6 +19,7 @@ This module provides:
 
 from __future__ import annotations
 
+import importlib
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -36,6 +37,8 @@ from hssm.utils import annotate_function
 from .config import RLSSMConfig
 
 _logger = logging.getLogger(__name__)
+
+DEFAULT_RLSSM_MODEL = "2AB_RW_DDM"
 
 
 @dataclass
@@ -350,58 +353,14 @@ def _get_ssm_logp(name: str) -> Any:
 # ---------------------------------------------------------------------------
 # RLSSM named model registry
 # ---------------------------------------------------------------------------
-# Each entry provides:
+# Each custom entry provides:
 #   decision_process            - key into _SSM_REGISTRY
 #   learning_process_metadata   - LearningProcessMetadata for RL params and LP inputs
 #   choices                     - response choice values
 #   description                 - human-readable description
 #   decision_process_loglik_kind
 
-
-def _make_rescorla_wagner_learning_metadata() -> LearningProcessMetadata:
-    """Return the shared learning metadata for built-in Rescorla-Wagner RLSSMs."""
-    return LearningProcessMetadata(
-        learning_process={"v": _compute_v_annotated},
-        sampled_params=["rl_alpha", "scaler"],
-        bounds={"rl_alpha": (0.0, 1.0), "scaler": (0.0, 10.0)},
-        defaults=[0.1, 1.0],
-        extra_fields=["feedback"],
-        kind="blackbox",
-    )
-
-
-_RLSSM_REGISTRY: dict[str, RLSSMRegistryEntry] = {
-    "2AB_RescorlaWagner_DDM": RLSSMRegistryEntry(
-        decision_process="ddm",
-        learning_process_metadata=_make_rescorla_wagner_learning_metadata(),
-        choices=[0, 1],
-        description=(
-            "RLSSM model with Rescorla-Wagner Q-learning and the "
-            "standard DDM as decision process."
-        ),
-        decision_process_loglik_kind="approx_differentiable",
-    ),
-    "2AB_RescorlaWagner_Angle": RLSSMRegistryEntry(
-        decision_process="angle",
-        learning_process_metadata=_make_rescorla_wagner_learning_metadata(),
-        choices=[0, 1],
-        description=(
-            "RLSSM model with Rescorla-Wagner Q-learning and a "
-            "collapsing-bound DDM (angle model) as decision process."
-        ),
-        decision_process_loglik_kind="approx_differentiable",
-    ),
-    "2AB_RescorlaWagner_Weibull": RLSSMRegistryEntry(
-        decision_process="weibull",
-        learning_process_metadata=_make_rescorla_wagner_learning_metadata(),
-        choices=[0, 1],
-        description=(
-            "RLSSM model with Rescorla-Wagner Q-learning and a "
-            "Weibull-bound DDM as decision process."
-        ),
-        decision_process_loglik_kind="approx_differentiable",
-    ),
-}
+_RLSSM_REGISTRY: dict[str, RLSSMRegistryEntry] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -459,13 +418,79 @@ def _derive_lp_params(
     return learning_process_params
 
 
+def _get_ssms_rl_module() -> Any | None:
+    """Return the installed ``ssms.rl`` module when available."""
+    try:
+        return importlib.import_module("ssms.rl")
+    except ImportError:
+        return None
+
+
+def _list_ssms_presets() -> dict[str, str | None]:
+    """Return public ssms RL preset names and descriptions.
+
+    ssms owns the public preset library. HSSM treats this list as a dynamic
+    discovery surface while retaining `_RLSSM_REGISTRY` for custom HSSM-side
+    registrations.
+    """
+    ssms_rl = _get_ssms_rl_module()
+    if ssms_rl is None:
+        return {}
+
+    preset_module = getattr(ssms_rl, "preset", None)
+    list_func = getattr(preset_module, "list", None)
+    if not callable(list_func):
+        return {}
+
+    try:
+        names = list(list_func())
+    except Exception as exc:  # pragma: no cover - defensive against old ssms builds
+        _logger.debug("Could not list ssms RL presets: %s", exc)
+        return {}
+
+    info_func = getattr(preset_module, "info", None)
+    presets: dict[str, str | None] = {}
+    for name in names:
+        description = None
+        if callable(info_func):
+            try:
+                info = info_func(name)
+            except Exception as exc:  # pragma: no cover - defensive
+                _logger.debug(
+                    "Could not read ssms RL preset info for %s: %s", name, exc
+                )
+            else:
+                if isinstance(info, dict):
+                    raw_description = info.get("description")
+                    if raw_description is not None:
+                        description = str(raw_description)
+        presets[str(name)] = description
+    return presets
+
+
+def _resolve_ssms_model(model: str) -> Any | None:
+    """Resolve *model* through ssms without raising for unknown names."""
+    ssms_rl = _get_ssms_rl_module()
+    if ssms_rl is None:
+        return None
+
+    resolve_model = getattr(ssms_rl, "resolve_model", None)
+    if not callable(resolve_model):
+        return None
+
+    try:
+        return resolve_model(model)
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Public factory
 # ---------------------------------------------------------------------------
 
 
 def get_rlssm_model_config(
-    model: str = "2AB_RescorlaWagner_DDM",
+    model: str = DEFAULT_RLSSM_MODEL,
     choices: list[int] | None = None,
     learning_process: dict[str, Any] | None = None,
     decision_process: str | None = None,
@@ -475,7 +500,8 @@ def get_rlssm_model_config(
     Parameters
     ----------
     model:
-        Name of a registered RLSSM model (e.g. ``"2AB_RescorlaWagner_DDM"``).
+        Name of an ``ssms.rl`` preset (e.g. ``"2AB_RW_DDM"``) or a custom
+        HSSM-side model registered with `register_rlssm_model`.
     choices:
         Override the response choice values stored in the registry.
     learning_process:
@@ -494,9 +520,25 @@ def get_rlssm_model_config(
         If *model* or the resolved *decision_process* is not registered.
     """
     if model not in _RLSSM_REGISTRY:
-        available = list(_RLSSM_REGISTRY.keys())
+        ssms_model = _resolve_ssms_model(model)
+        if ssms_model is not None:
+            if (
+                choices is not None
+                or learning_process is not None
+                or decision_process is not None
+            ):
+                raise ValueError(
+                    "choices, learning_process, and decision_process overrides are "
+                    "only supported for HSSM-registered custom RLSSM models. "
+                    "For ssms presets, customize the ssms ModelConfig and pass it "
+                    "to RLSSMConfig.from_ssms_model(), or pass model_config= "
+                    "directly to RLSSM()."
+                )
+            return RLSSMConfig.from_ssms_model(ssms_model)
+
+        available = list(list_models().keys())
         raise ValueError(
-            f"Model '{model}' not found in the RLSSM registry. "
+            f"Model '{model}' not found in the RLSSM registry or ssms presets. "
             f"Available models: {available}. "
             "To add a custom model, use register_rlssm_model() "
             "(and register_ssm() for custom decision processes), "
@@ -578,10 +620,12 @@ def get_rlssm_model_config(
 
 
 def list_models() -> dict[str, str | None]:
-    """Return the names and descriptions of all registered RLSSM models.
+    """Return names and descriptions of available RLSSM models.
 
     This is the recommended starting point for new users who want to discover
-    which models are available out of the box.
+    which models are available. Built-in public presets are discovered from
+    ``ssms.rl.preset`` at call time; HSSM-side custom registrations are merged
+    in afterwards and take precedence on name conflicts.
 
     Returns
     -------
@@ -593,9 +637,11 @@ def list_models() -> dict[str, str | None]:
     --------
     >>> import hssm
     >>> hssm.rl.list_models()
-    {'2AB_RescorlaWagner_DDM': 'RLSSM model with Rescorla-Wagner ...', ...}
+    {'2AB_RW_DDM': 'Two-armed bandit with ...', ...}
     """
-    return {name: entry.description for name, entry in _RLSSM_REGISTRY.items()}
+    models = _list_ssms_presets()
+    models.update({name: entry.description for name, entry in _RLSSM_REGISTRY.items()})
+    return models
 
 
 # ---------------------------------------------------------------------------
@@ -648,6 +694,12 @@ def register_rlssm_model(
     if name in _RLSSM_REGISTRY:
         _logger.warning(
             "Model '%s' is already in the RLSSM registry and will be overwritten.",
+            name,
+        )
+    elif name in _list_ssms_presets():
+        _logger.warning(
+            "Model '%s' is an ssms RL preset and will be shadowed by this "
+            "HSSM-side custom registration.",
             name,
         )
     learning_process_metadata = LearningProcessMetadata(

--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -26,6 +26,7 @@ from inspect import signature
 from typing import Any
 
 import jax.numpy as jnp
+from jax import config as jax_config
 from jax.scipy.special import logsumexp
 
 from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
@@ -179,6 +180,8 @@ def _make_inv_temp_softmax_base_logp(n_choices: int) -> Any:
     @annotate_function(inputs=inputs, outputs=["logp"])
     def _base_logp(lan_matrix):
         lan_matrix = jnp.asarray(lan_matrix)
+        if lan_matrix.dtype == jnp.float64 and not jax_config.read("jax_enable_x64"):
+            lan_matrix = lan_matrix.astype(jnp.float32)
         beta = lan_matrix[:, 0]
         q_values = lan_matrix[:, 1 : 1 + n_choices]
         response = lan_matrix[:, -1]
@@ -218,6 +221,7 @@ def _register_inv_temp_softmax_ssm(n_choices: int) -> None:
 
 _register_inv_temp_softmax_ssm(2)
 _register_inv_temp_softmax_ssm(3)
+_register_inv_temp_softmax_ssm(4)
 
 
 def _make_ssm_base_logp_from_onnx(

--- a/src/hssm/rl/registry.py
+++ b/src/hssm/rl/registry.py
@@ -24,7 +24,7 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from inspect import signature
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import jax.numpy as jnp
 from jax import config as jax_config
@@ -39,6 +39,9 @@ from .config import RLSSMConfig
 _logger = logging.getLogger(__name__)
 
 DEFAULT_RLSSM_MODEL = "2AB_RW_DDM"
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
 
 
 @dataclass
@@ -443,7 +446,7 @@ def _list_ssms_presets() -> dict[str, str | None]:
         return {}
 
     try:
-        names = list(list_func())
+        names = list(cast("Callable[[], Iterable[Any]]", list_func)())
     except Exception as exc:  # pragma: no cover - defensive against old ssms builds
         _logger.debug("Could not list ssms RL presets: %s", exc)
         return {}

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -44,7 +44,7 @@ from hssm.rl.utils import validate_balanced_panel
 
 from ..base import HSSMBase, classproperty
 from .config import RLSSMConfig
-from .registry import get_rlssm_model_config, list_models
+from .registry import DEFAULT_RLSSM_MODEL, get_rlssm_model_config, list_models
 
 _logger = logging.getLogger(__name__)
 
@@ -423,7 +423,8 @@ class RLSSM(_RLSSM):
     data : pd.DataFrame
         Trial-level data (balanced panel required).
     model : str | None, optional
-        Name of a registered RLSSM model. Defaults to ``"2AB_RescorlaWagner_DDM"``.
+        Name of an ``ssms.rl`` preset or custom registered RLSSM model. Defaults
+        to ``"2AB_RW_DDM"``.
     choices : list[int] | None, optional
         Override the choice values in the registry. ``None`` uses the registry
         default.
@@ -484,7 +485,7 @@ class RLSSM(_RLSSM):
     def __init__(
         self,
         data: pd.DataFrame,
-        model: str | None = "2AB_RescorlaWagner_DDM",
+        model: str | None = DEFAULT_RLSSM_MODEL,
         choices: list[int] | None = None,
         include: list[dict[str, Any] | Any] | None = None,
         model_config: RLSSMConfig | None = None,
@@ -506,7 +507,7 @@ class RLSSM(_RLSSM):
         _my_init_args = self._store_init_args(locals(), kwargs)
 
         ignored_overrides_provided = (
-            model != "2AB_RescorlaWagner_DDM"
+            model != DEFAULT_RLSSM_MODEL
             or learning_process is not None
             or decision_process is not None
             or choices is not None
@@ -518,7 +519,7 @@ class RLSSM(_RLSSM):
             )
 
         model_config = model_config or get_rlssm_model_config(
-            model=model or "2AB_RescorlaWagner_DDM",
+            model=model or DEFAULT_RLSSM_MODEL,
             choices=choices,
             learning_process=learning_process,
             decision_process=decision_process,
@@ -571,6 +572,6 @@ class RLSSM(_RLSSM):
         --------
         >>> from hssm.rl import RLSSM
         >>> RLSSM.list_models
-        {'2AB_RescorlaWagner_DDM': 'RLSSM model with ...', ...}
+        {'2AB_RW_DDM': 'Two-armed bandit with ...', ...}
         """
         return list_models()

--- a/tests/rl/test_choice_only_rl.py
+++ b/tests/rl/test_choice_only_rl.py
@@ -331,15 +331,37 @@ class TestChoiceOnlyRealSSMSSmoke:
             pytest.skip(f"installed ssms.rl does not expose {model_name}")
 
     @pytest.mark.parametrize(
-        ("model_name", "n_choices"),
+        ("model_name", "n_choices", "expected_params", "dist_kwargs"),
         [
-            ("2AB_RW_InvTempSoftmax", 2),
-            ("3AB_RW_InvTempSoftmax", 3),
+            (
+                "2AB_RW_InvTempSoftmax",
+                2,
+                ["rl_alpha", "beta"],
+                {"rl_alpha": 0.5, "beta": 2.0},
+            ),
+            (
+                "2AB_RW_DualAlpha_InvTempSoftmax",
+                2,
+                ["rl_alpha", "rl_alpha_neg", "beta"],
+                {"rl_alpha": 0.5, "rl_alpha_neg": 0.3, "beta": 2.0},
+            ),
+            (
+                "3AB_RW_InvTempSoftmax",
+                3,
+                ["rl_alpha", "beta"],
+                {"rl_alpha": 0.5, "beta": 2.0},
+            ),
+            (
+                "4AB_RW_InvTempSoftmax",
+                4,
+                ["rl_alpha", "beta"],
+                {"rl_alpha": 0.5, "beta": 2.0},
+            ),
         ],
     )
     @pytest.mark.slow
     def test_real_ssms_choice_only_rlssm_compiles_finite_active_lapse_logp(
-        self, model_name, n_choices
+        self, model_name, n_choices, expected_params, dist_kwargs
     ):
         """A real ssms choice-only preset can compile a finite active-lapse logp."""
         self._require_choice_only_ssms_model(model_name)
@@ -350,7 +372,7 @@ class TestChoiceOnlyRealSSMSSmoke:
             expected_qs = {f"q{i}" for i in range(n_choices)}
             assert config.response == ["response"]
             assert config.decision_process == f"inv_temp_softmax_{n_choices}"
-            assert config.list_params == ["rl_alpha", "beta"]
+            assert config.list_params == expected_params
             assert set(config.ssm_logp_func.computed) == expected_qs
             data = pd.DataFrame(
                 {
@@ -369,8 +391,7 @@ class TestChoiceOnlyRealSSMSSmoke:
             logp = logp_fn(model.initial_point(transformed=False))
             dist_logp = pm.logp(
                 model.model_distribution.dist(
-                    rl_alpha=0.5,
-                    beta=2.0,
+                    **dist_kwargs,
                     p_outlier=0.05,
                 ),
                 data["response"].to_numpy(),

--- a/tests/rl/test_choice_only_rl.py
+++ b/tests/rl/test_choice_only_rl.py
@@ -90,6 +90,42 @@ def _fake_choice_only_data(responses):
                 ]
             ),
         ),
+        (
+            "inv_temp_softmax_4",
+            ["beta", "q0", "q1", "q2", "q3", "response"],
+            jnp.asarray(
+                [
+                    [1.0, 0.2, 1.2, 2.2, 3.2, 3.0],
+                    [1.0, 0.2, 1.2, 2.2, 3.2, 0.0],
+                    [3.0, 0.2, 1.2, 2.2, 3.2, 3.0],
+                ]
+            ),
+            jnp.asarray(
+                [
+                    3.2
+                    - jnp.log(
+                        jnp.exp(0.2)
+                        + jnp.exp(1.2)
+                        + jnp.exp(2.2)
+                        + jnp.exp(3.2)
+                    ),
+                    0.2
+                    - jnp.log(
+                        jnp.exp(0.2)
+                        + jnp.exp(1.2)
+                        + jnp.exp(2.2)
+                        + jnp.exp(3.2)
+                    ),
+                    9.6
+                    - jnp.log(
+                        jnp.exp(0.6)
+                        + jnp.exp(3.6)
+                        + jnp.exp(6.6)
+                        + jnp.exp(9.6)
+                    ),
+                ]
+            ),
+        ),
     ],
 )
 def test_inv_temp_softmax_base_logp_values_and_metadata(
@@ -103,7 +139,7 @@ def test_inv_temp_softmax_base_logp_values_and_metadata(
     assert base_logp.inputs == inputs
     assert base_logp.outputs == ["logp"]
     assert result.shape == (matrix.shape[0],)
-    np.testing.assert_allclose(np.asarray(result), np.asarray(expected), rtol=1e-6)
+    np.testing.assert_allclose(np.asarray(result), np.asarray(expected), rtol=1e-5)
     assert result[-1] > result[0]
 
 
@@ -127,6 +163,16 @@ def test_inv_temp_softmax_base_logp_values_and_metadata(
                     [1.0, 0.2, 1.2, 2.2, -1.0],
                     [1.0, 0.2, 1.2, 2.2, 3.0],
                     [1.0, 0.2, 1.2, 2.2, 1.5],
+                ]
+            ),
+        ),
+        (
+            "inv_temp_softmax_4",
+            jnp.asarray(
+                [
+                    [1.0, 0.2, 1.2, 2.2, 3.2, -1.0],
+                    [1.0, 0.2, 1.2, 2.2, 3.2, 4.0],
+                    [1.0, 0.2, 1.2, 2.2, 3.2, 1.5],
                 ]
             ),
         ),

--- a/tests/rl/test_choice_only_rl.py
+++ b/tests/rl/test_choice_only_rl.py
@@ -104,24 +104,15 @@ def _fake_choice_only_data(responses):
                 [
                     3.2
                     - jnp.log(
-                        jnp.exp(0.2)
-                        + jnp.exp(1.2)
-                        + jnp.exp(2.2)
-                        + jnp.exp(3.2)
+                        jnp.exp(0.2) + jnp.exp(1.2) + jnp.exp(2.2) + jnp.exp(3.2)
                     ),
                     0.2
                     - jnp.log(
-                        jnp.exp(0.2)
-                        + jnp.exp(1.2)
-                        + jnp.exp(2.2)
-                        + jnp.exp(3.2)
+                        jnp.exp(0.2) + jnp.exp(1.2) + jnp.exp(2.2) + jnp.exp(3.2)
                     ),
                     9.6
                     - jnp.log(
-                        jnp.exp(0.6)
-                        + jnp.exp(3.6)
-                        + jnp.exp(6.6)
-                        + jnp.exp(9.6)
+                        jnp.exp(0.6) + jnp.exp(3.6) + jnp.exp(6.6) + jnp.exp(9.6)
                     ),
                 ]
             ),
@@ -139,7 +130,9 @@ def test_inv_temp_softmax_base_logp_values_and_metadata(
     assert base_logp.inputs == inputs
     assert base_logp.outputs == ["logp"]
     assert result.shape == (matrix.shape[0],)
-    np.testing.assert_allclose(np.asarray(result), np.asarray(expected), rtol=1e-5)
+    np.testing.assert_allclose(
+        np.asarray(result), np.asarray(expected), rtol=1e-5, atol=1e-6
+    )
     assert result[-1] > result[0]
 
 

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -55,8 +56,10 @@ def annotated_ssm_base_logp() -> Any:
 
 
 class TestBuildSsmSpecFromModelconfig:
+    """Tests for deriving SSM specs from HSSM modelconfig entries."""
+
     def test_unknown_model_raises(self) -> None:
-        """Completely unknown names should raise ValueError from the modelconfig bridge."""
+        """Unknown names should raise ValueError from the modelconfig bridge."""
         with pytest.raises(ValueError, match="not a registered custom SSM"):
             registry._build_ssm_spec_from_modelconfig("totally_unknown_model")
 
@@ -88,8 +91,7 @@ class TestBuildSsmSpecFromModelconfig:
         monkeypatch: pytest.MonkeyPatch,
         annotated_ssm_base_logp: Any,
     ) -> None:
-        """The lazy factory should call make_jax_matrix_logp_funcs_from_onnx with the
-        correct filename."""
+        """Call make_jax_matrix_logp_funcs_from_onnx with the correct filename."""
         import hssm.distribution_utils.onnx as onnx_module
 
         called_with: list[str] = []
@@ -115,6 +117,8 @@ class TestBuildSsmSpecFromModelconfig:
 
 
 class TestGetSsmLogp:
+    """Tests for lazy SSM logp resolution and caching."""
+
     def test_builds_lazy_factory_once(self, annotated_ssm_base_logp: Any) -> None:
         """Lazy SSM factories should only build and cache one function instance."""
         call_count = 0
@@ -167,12 +171,14 @@ class TestGetSsmLogp:
 
 
 class TestBuildSsmLogpFunc:
+    """Tests for adding RL computed functions to SSM logp callables."""
+
     def test_raises_if_already_computed(
         self,
         annotated_ssm_base_logp: Any,
         learning_process: dict[str, Any],
     ) -> None:
-        """_build_ssm_logp_func must refuse functions that already have .computed set."""
+        """Refuse functions that already have .computed set."""
         precomputed = annotate_function(
             inputs=annotated_ssm_base_logp.inputs,
             outputs=annotated_ssm_base_logp.outputs,
@@ -184,6 +190,8 @@ class TestBuildSsmLogpFunc:
 
 
 class TestDeriveRlParams:
+    """Tests for deriving sampled RL parameters from learning functions."""
+
     def test_excludes_response_and_extra_fields(
         self,
         learning_process: dict[str, Any],
@@ -198,7 +206,7 @@ class TestDeriveRlParams:
         assert derived == ["rl_alpha"]
 
     def test_warns_for_unannotated_lp_func(self) -> None:
-        """A learning-process function without .inputs should log a warning and be skipped."""
+        """A learning-process function without .inputs should be skipped."""
 
         def unannotated_func(x):  # type: ignore[no-untyped-def]
             return x
@@ -214,6 +222,8 @@ class TestDeriveRlParams:
 
 
 class TestRegisterSsm:
+    """Tests for registering custom SSM decision processes."""
+
     def test_caches_prebuilt_function(self, annotated_ssm_base_logp: Any) -> None:
         """Registering a pre-built SSM should populate the cache immediately."""
         registry.register_ssm(
@@ -232,7 +242,7 @@ class TestRegisterSsm:
         annotated_ssm_base_logp: Any,
         learning_process: dict[str, Any],
     ) -> None:
-        """SSM registration should reject functions that already carry computed params."""
+        """Reject functions that already carry computed params."""
         precomputed_logp = annotate_function(
             inputs=annotated_ssm_base_logp.inputs,
             outputs=annotated_ssm_base_logp.outputs,
@@ -335,6 +345,8 @@ class TestRegisterSsm:
 
 
 class TestRegisterRlssmModel:
+    """Tests for registering custom HSSM-side RLSSM model templates."""
+
     def test_copies_mutable_inputs(
         self,
         learning_process: dict[str, Any],
@@ -416,6 +428,8 @@ class TestRegisterRlssmModel:
 
 
 class TestGetRlssmModelConfig:
+    """Tests for materializing RLSSMConfig objects from registry names."""
+
     def test_builds_expected_config(
         self,
         annotated_ssm_base_logp: Any,
@@ -491,7 +505,9 @@ class TestGetRlssmModelConfig:
 
     def test_unknown_model_raises(self) -> None:
         """Unknown RLSSM model names should fail with a clear error."""
-        with pytest.raises(ValueError, match="not found in the RLSSM registry"):
+        with pytest.raises(
+            ValueError, match="not found in the RLSSM registry or ssms presets"
+        ):
             registry.get_rlssm_model_config("does_not_exist")
 
     def test_learning_process_override_with_matching_metadata(
@@ -611,99 +627,138 @@ class TestGetRlssmModelConfig:
             registry.get_rlssm_model_config("no_bounds_model")
 
 
-class TestBuiltinModels:
-    @pytest.mark.parametrize(
-        "model_name, expected_dp",
-        [
-            ("2AB_RescorlaWagner_DDM", "ddm"),
-            ("2AB_RescorlaWagner_Weibull", "weibull"),
-        ],
-    )
-    def test_are_registered(self, model_name: str, expected_dp: str) -> None:
-        """2AB_RescorlaWagner_DDM and _Weibull must be present in the RLSSM registry."""
-        assert model_name in registry._RLSSM_REGISTRY
-        entry = registry._RLSSM_REGISTRY[model_name]
-        metadata = entry.learning_process_metadata
-        assert entry.decision_process == expected_dp
-        assert metadata.sampled_params == ["rl_alpha", "scaler"]
-        assert metadata.extra_fields == ["feedback"]
-        assert entry.choices == [0, 1]
-        assert entry.decision_process_loglik_kind == "approx_differentiable"
-        assert metadata.kind == "blackbox"
+class TestSsMsPresetDiscovery:
+    """Tests for dynamic ssms preset discovery and resolution."""
 
-    def test_builtin_model_re_resolves_registered_ssm(
-        self,
+    @staticmethod
+    def _install_fake_ssms(monkeypatch: pytest.MonkeyPatch):
+        names = [
+            "2AB_RW_DDM",
+            "2AB_RW_Angle",
+            "2AB_RW_Weibull",
+            "2AB_RW_DualAlpha_Angle",
+            "2AB_RW_InvTempSoftmax",
+            "2AB_RW_DualAlpha_InvTempSoftmax",
+            "3AB_RW_InvTempSoftmax",
+            "4AB_RW_InvTempSoftmax",
+        ]
+
+        def _info(name: str) -> dict[str, str]:
+            if name not in names:
+                raise ValueError(name)
+            return {"description": f"Description for {name}"}
+
+        def _resolve_model(name: str) -> object:
+            if name not in names:
+                raise ValueError(name)
+            return SimpleNamespace(model_name=name)
+
+        fake_ssms_rl = SimpleNamespace(
+            preset=SimpleNamespace(list=lambda: list(names), info=_info),
+            resolve_model=_resolve_model,
+        )
+        monkeypatch.setattr(registry, "_get_ssms_rl_module", lambda: fake_ssms_rl)
+        return fake_ssms_rl
+
+    def test_list_models_uses_dynamic_ssms_presets(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Built-in starter models should pick up later register_ssm() overrides."""
+        """Ssms presets should surface dynamically in HSSM discovery."""
+        self._install_fake_ssms(monkeypatch)
 
-        @annotate_function(
-            inputs=["v", "custom_a", "rt", "response"],
-            outputs=["logp"],
-        )
-        def custom_ddm_logp(lan_matrix):
-            return lan_matrix[:, 1]
+        result = registry.list_models()
 
-        registry.register_ssm(
-            name="ddm",
-            ssm_base_logp_func=custom_ddm_logp,
-            list_params_ssm=["v", "custom_a"],
-            bounds_ssm={"custom_a": (0.3, 3.0)},
-            params_default_ssm=[0.0, 1.5],
-            response=["rt", "response"],
+        assert "2AB_RW_DDM" in result
+        assert "2AB_RW_DualAlpha_Angle" in result
+        assert "2AB_RW_DualAlpha_InvTempSoftmax" in result
+        assert "4AB_RW_InvTempSoftmax" in result
+        assert "2AB_RescorlaWagner_DDM" not in result
+        assert result["4AB_RW_InvTempSoftmax"] == (
+            "Description for 4AB_RW_InvTempSoftmax"
         )
 
-        config = registry.get_rlssm_model_config("2AB_RescorlaWagner_DDM")
-
-        assert config.decision_process == "ddm"
-        assert config.list_params == ["rl_alpha", "scaler", "custom_a"]
-        assert config.bounds["custom_a"] == (0.3, 3.0)
-        assert config.params_default[-1] == 1.5
-
-    @pytest.mark.parametrize(
-        "model_name",
-        ["2AB_RescorlaWagner_DDM", "2AB_RescorlaWagner_Weibull"],
-    )
-    def test_config_structure(
+    def test_list_models_merges_custom_hssm_registrations(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        annotated_ssm_base_logp: Any,
-        model_name: str,
+        learning_process: dict[str, Any],
     ) -> None:
-        """get_rlssm_model_config should produce a well-formed RLSSMConfig for
-        both the DDM and Weibull starter-pack models."""
-        import hssm.distribution_utils.onnx as onnx_module
-
-        monkeypatch.setattr(
-            onnx_module,
-            "make_jax_matrix_logp_funcs_from_onnx",
-            lambda model: annotated_ssm_base_logp,
-        )
-        monkeypatch.setattr(
-            registry,
-            "make_jax_matrix_logp_funcs_from_onnx",
-            lambda model: annotated_ssm_base_logp,
+        """User-registered HSSM models should still appear alongside ssms presets."""
+        self._install_fake_ssms(monkeypatch)
+        registry.register_rlssm_model(
+            name="custom_hssm_rlssm",
+            decision_process="angle",
+            learning_process=learning_process,
+            learning_process_params=["rl_alpha"],
+            learning_process_bounds={"rl_alpha": (0.0, 1.0)},
+            learning_process_params_default=[0.2],
+            description="Custom HSSM-side model",
         )
 
-        config = registry.get_rlssm_model_config(model_name)
+        result = registry.list_models()
 
-        assert isinstance(config, RLSSMConfig)
-        # RL params come first
-        assert config.list_params[:2] == ["rl_alpha", "scaler"]
-        assert "rl_alpha" in config.bounds
-        assert "scaler" in config.bounds
-        assert config.choices == (0, 1)
-        assert config.extra_fields == ["feedback"]
-        assert config.ssm_logp_func.computed == {"v": registry._compute_v_annotated}
+        assert result["2AB_RW_Angle"] == "Description for 2AB_RW_Angle"
+        assert result["custom_hssm_rlssm"] == "Custom HSSM-side model"
+
+    def test_get_rlssm_model_config_delegates_ssms_presets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Canonical ssms names should delegate to RLSSMConfig.from_ssms_model."""
+        self._install_fake_ssms(monkeypatch)
+        called_with = []
+        sentinel_config = object()
+
+        def _fake_from_ssms_model(cls, ssms_model):  # type: ignore[no-untyped-def]
+            called_with.append(ssms_model.model_name)
+            return sentinel_config
+
+        monkeypatch.setattr(
+            RLSSMConfig,
+            "from_ssms_model",
+            classmethod(_fake_from_ssms_model),
+        )
+
+        result = registry.get_rlssm_model_config("2AB_RW_DualAlpha_Angle")
+
+        assert result is sentinel_config
+        assert called_with == ["2AB_RW_DualAlpha_Angle"]
+
+    def test_ssms_preset_overrides_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HSSM-side overrides are intentionally limited to custom registry entries."""
+        self._install_fake_ssms(monkeypatch)
+
+        with pytest.raises(ValueError, match="only supported for HSSM-registered"):
+            registry.get_rlssm_model_config("2AB_RW_DDM", choices=[-1, 1])
+
+    def test_legacy_long_names_are_not_aliases(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Old HSSM-owned built-in names should not be kept as brittle aliases."""
+        self._install_fake_ssms(monkeypatch)
+
+        with pytest.raises(
+            ValueError, match="not found in the RLSSM registry or ssms presets"
+        ):
+            registry.get_rlssm_model_config("2AB_RescorlaWagner_DDM")
 
 
 class TestListModels:
+    """Tests for the public RLSSM discovery helper."""
+
     def test_returns_all_names(self) -> None:
-        """list_models should return every key in _RLSSM_REGISTRY with its description."""
+        """list_models should include custom registry entries with descriptions."""
+        registry.register_rlssm_model(
+            name="listed_custom_model",
+            decision_process="angle",
+            learning_process={},
+            learning_process_params=[],
+            learning_process_bounds={},
+            learning_process_params_default=[],
+            description="Custom listed model",
+        )
+
         result = registry.list_models()
 
-        assert set(result.keys()) == set(registry._RLSSM_REGISTRY.keys())
-        for name, desc in result.items():
-            assert desc == registry._RLSSM_REGISTRY[name].description
+        assert result["listed_custom_model"] == "Custom listed model"
 
     def test_public_rl_api_matches_registry(self) -> None:
         """The public hssm.rl and RLSSM accessors should delegate to the registry."""

--- a/tests/rl/test_rlssm.py
+++ b/tests/rl/test_rlssm.py
@@ -103,6 +103,23 @@ def rlssm_config() -> RLSSMConfig:
     )
 
 
+def _register_custom_rldm(
+    name: str = "rldm_custom_test",
+    decision_process: str = "angle",
+) -> None:
+    """Register a small HSSM-side RLSSM template for simplified-interface tests."""
+    register_rlssm_model(
+        name=name,
+        decision_process=decision_process,
+        learning_process={"v": _compute_v_annotated},
+        learning_process_params=["rl_alpha", "scaler"],
+        learning_process_bounds={"rl_alpha": (0.0, 1.0), "scaler": (0.0, 10.0)},
+        learning_process_params_default=[0.1, 1.0],
+        extra_fields=["feedback"],
+        choices=[0, 1],
+    )
+
+
 class TestRLSSMInit:
     """Basic construction and invalid-input guards at construction time."""
 
@@ -380,31 +397,56 @@ class TestRLSSMSimplifiedInterface:
         """RLSSM must be a subclass of _RLSSM."""
         assert issubclass(RLSSM, _RLSSM)
 
-    @pytest.mark.parametrize(
-        "model_name, expected_dp",
-        [
-            ("2AB_RescorlaWagner_DDM", "ddm"),
-            ("2AB_RescorlaWagner_Angle", "angle"),
-            ("2AB_RescorlaWagner_Weibull", "weibull"),
-        ],
-    )
-    def test_rlssm_builtin_models_instantiate(
-        self, rldm_data, model_name: str, expected_dp: str
+    def test_rlssm_model_arg_delegates_to_registry(
+        self,
+        rldm_data,
+        rlssm_config,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """All built-in 2AB_RescorlaWagner_* models should instantiate correctly."""
-        model = RLSSM(data=rldm_data, model=model_name)
+        """The public model= argument should be delegated to the registry factory."""
+        import hssm.rl.rlssm as rlssm_module
+
+        called_with = {}
+
+        def _fake_get_rlssm_model_config(**kwargs):  # type: ignore[no-untyped-def]
+            called_with.update(kwargs)
+            return rlssm_config
+
+        monkeypatch.setattr(
+            rlssm_module, "get_rlssm_model_config", _fake_get_rlssm_model_config
+        )
+
+        model = RLSSM(data=rldm_data, model="2AB_RW_DDM")
+
         assert isinstance(model, RLSSM)
-        assert model.model_config.decision_process == expected_dp
+        assert called_with["model"] == "2AB_RW_DDM"
+        assert model.model_config.model_name == rlssm_config.model_name
         assert "rl_alpha" in model.params
         assert "scaler" in model.params
-        assert "a" in model.params
-        assert "v" not in model.params
 
-    def test_rlssm_default_model_is_ddm(self, rldm_data) -> None:
-        """Omitting model should default to '2AB_RescorlaWagner_DDM'."""
+    def test_rlssm_default_model_is_canonical_ssms_ddm(
+        self,
+        rldm_data,
+        rlssm_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Omitting model should default to the canonical ssms `2AB_RW_DDM` name."""
+        import hssm.rl.rlssm as rlssm_module
+
+        called_with = {}
+
+        def _fake_get_rlssm_model_config(**kwargs):  # type: ignore[no-untyped-def]
+            called_with.update(kwargs)
+            return rlssm_config
+
+        monkeypatch.setattr(
+            rlssm_module, "get_rlssm_model_config", _fake_get_rlssm_model_config
+        )
+
         model = RLSSM(data=rldm_data)
+
         assert isinstance(model, RLSSM)
-        assert model.model_config.decision_process == "ddm"
+        assert called_with["model"] == registry.DEFAULT_RLSSM_MODEL
 
     def test_rlssm_model_config_provided(self, rldm_data, rlssm_config) -> None:
         """Passing model_config= directly should bypass the registry."""
@@ -413,51 +455,57 @@ class TestRLSSMSimplifiedInterface:
 
     def test_rlssm_unregistered_model_raises(self, rldm_data) -> None:
         """Using an unknown model name should raise ValueError."""
-        with pytest.raises(ValueError, match="not found in the RLSSM registry"):
+        with pytest.raises(
+            ValueError, match="not found in the RLSSM registry or ssms presets"
+        ):
             RLSSM(data=rldm_data, model="model_not_in_registry")
 
-    def test_rlssm_missing_data_property_raises(self, rldm_data) -> None:
+    def test_rlssm_missing_data_property_raises(self, rldm_data, rlssm_config) -> None:
         """Accessing .missing_data on a built RLSSM must raise."""
-        model = RLSSM(data=rldm_data, model="2AB_RescorlaWagner_DDM")
+        model = RLSSM(data=rldm_data, model_config=rlssm_config)
         with pytest.raises(NotImplementedError, match="missing_data"):
             _ = model.missing_data
 
-    def test_rlssm_deadline_property_raises(self, rldm_data) -> None:
+    def test_rlssm_deadline_property_raises(self, rldm_data, rlssm_config) -> None:
         """Accessing .deadline on a built RLSSM must raise."""
-        model = RLSSM(data=rldm_data, model="2AB_RescorlaWagner_DDM")
+        model = RLSSM(data=rldm_data, model_config=rlssm_config)
         with pytest.raises(NotImplementedError, match="deadline"):
             _ = model.deadline
 
-    def test_rlssm_loglik_missing_data_property_raises(self, rldm_data) -> None:
+    def test_rlssm_loglik_missing_data_property_raises(
+        self, rldm_data, rlssm_config
+    ) -> None:
         """Accessing .loglik_missing_data on a built RLSSM must raise."""
-        model = RLSSM(data=rldm_data, model="2AB_RescorlaWagner_DDM")
+        model = RLSSM(data=rldm_data, model_config=rlssm_config)
         with pytest.raises(NotImplementedError, match="loglik_missing_data"):
             _ = model.loglik_missing_data
 
     def test_register_rlssm_model(self, rldm_data) -> None:
         """A user-registered model should instantiate via the simplified API."""
-        # Re-use the existing annotated learning function and ssm logp from the
-        # module-level helpers defined at the top of this test file.
-        register_rlssm_model(
-            name="rldm_custom_test",
-            decision_process="angle",
-            learning_process={"v": _compute_v_annotated},
-            learning_process_params=["rl_alpha", "scaler"],
-            learning_process_bounds={"rl_alpha": (0.0, 1.0), "scaler": (0.0, 10.0)},
-            learning_process_params_default=[0.1, 1.0],
-            extra_fields=["feedback"],
-            choices=[0, 1],
-        )
+        _register_custom_rldm()
         model = RLSSM(data=rldm_data, model="rldm_custom_test")
         assert isinstance(model, RLSSM)
         assert "rl_alpha" in model.params
         assert "v" not in model.params
 
-    def test_rlssm_init_args_uses_simplified_interface(self, rldm_data) -> None:
+    def test_rlssm_init_args_uses_simplified_interface(
+        self,
+        rldm_data,
+        rlssm_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """_init_args should reflect the simplified constructor, not model_config."""
-        model = RLSSM(data=rldm_data, model="2AB_RescorlaWagner_DDM")
+        import hssm.rl.rlssm as rlssm_module
+
+        monkeypatch.setattr(
+            rlssm_module,
+            "get_rlssm_model_config",
+            lambda **_: rlssm_config,
+        )
+
+        model = RLSSM(data=rldm_data)
         assert "model" in model._init_args
-        assert model._init_args["model"] == "2AB_RescorlaWagner_DDM"
+        assert model._init_args["model"] == registry.DEFAULT_RLSSM_MODEL
         # model_config should not be baked in as a hard reference
         assert "model_config" in model._init_args
         assert model._init_args["model_config"] is None
@@ -488,6 +536,7 @@ class TestRLSSMSimplifiedInterface:
         self, rldm_data
     ) -> None:
         """Public RLSSM accepts LP overrides with the same sampled params."""
+        _register_custom_rldm("rldm_custom_for_lp_override", decision_process="ddm")
 
         @annotate_function(
             inputs=["rl_alpha", "scaler", "response", "feedback"],
@@ -498,7 +547,7 @@ class TestRLSSMSimplifiedInterface:
 
         model = RLSSM(
             data=rldm_data,
-            model="2AB_RescorlaWagner_DDM",
+            model="rldm_custom_for_lp_override",
             learning_process={"v": alt_compute_v},
         )
 
@@ -510,17 +559,20 @@ class TestRLSSMSimplifiedInterface:
         self, rldm_data
     ) -> None:
         """Public RLSSM constructor should respect decision_process overrides."""
+        _register_custom_rldm("rldm_custom_for_dp_override", decision_process="ddm")
+
         model = RLSSM(
             data=rldm_data,
-            model="2AB_RescorlaWagner_DDM",
+            model="rldm_custom_for_dp_override",
             decision_process="angle",
         )
 
         assert model.model_config.decision_process == "angle"
         assert "theta" in model.params
 
-    def test_rlssm_builtin_model_re_resolves_registered_ssm(self, rldm_data) -> None:
-        """Built-in RLSSM models should pick up later register_ssm() overrides."""
+    def test_rlssm_custom_model_re_resolves_registered_ssm(self, rldm_data) -> None:
+        """Custom HSSM RLSSM models should pick up later register_ssm() overrides."""
+        _register_custom_rldm("rldm_custom_ddm", decision_process="ddm")
 
         @annotate_function(
             inputs=["v", "custom_a", "rt", "response"],
@@ -538,7 +590,7 @@ class TestRLSSMSimplifiedInterface:
             response=["rt", "response"],
         )
 
-        model = RLSSM(data=rldm_data, model="2AB_RescorlaWagner_DDM")
+        model = RLSSM(data=rldm_data, model="rldm_custom_ddm")
 
         assert model.model_config.decision_process == "ddm"
         assert "rl_alpha" in model.params


### PR DESCRIPTION
## Summary

This PR extends the choice-only inverse-temperature softmax RLSSM registry to include the four-choice case needed for 4-arm bandit models.

Changes:
- register `inv_temp_softmax_4` via the existing helper-based registry path
- add a narrow dtype guard for float64 LAN matrices when JAX x64 is disabled
- add 4-choice softmax logp and invalid-response coverage

## Validation

- `.venv/bin/python -m ruff check src/hssm/rl/registry.py tests/rl/test_choice_only_rl.py`
- `PYTENSOR_FLAGS=base_compiledir=/tmp/.pytensor,compiledir=/tmp/.pytensor/compiled,mode=FAST_COMPILE MPLCONFIGDIR=/tmp/.mpl .venv/bin/python -m pytest -p no:rerunfailures -o addopts='' tests/rl/test_choice_only_rl.py -q`
- `PYTENSOR_FLAGS=base_compiledir=/tmp/.pytensor,compiledir=/tmp/.pytensor/compiled,mode=FAST_COMPILE MPLCONFIGDIR=/tmp/.mpl .venv/bin/python -m pytest -p no:rerunfailures -o addopts='' tests/rl/test_rlssm_config.py -m 'not slow' -q`

Note: running `tests/rl/test_choice_only_rl.py` without `mode=FAST_COMPILE` in this local environment still hits the known Numba object-mode pickling failure in the two slow compile-logp smoke tests; the non-slow and 4-choice-specific cases pass before that point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of RLSSM presets alongside custom registered models.
  * Added support for four-choice inverse-temperature softmax models.
  * Updated the default RLSSM model to `2AB_RW_DDM`.
  * Custom model registrations now take precedence when names overlap with presets.

* **Bug Fixes**
  * Improved compatibility when JAX 64-bit mode is disabled.

* **Documentation**
  * Updated RLSSM tutorials and examples to reflect the new preset discovery and model names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->