### PR TITLE
Improve coverage for main Codecov regressions

### DIFF
--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -629,7 +629,11 @@ def plot_model_cartoon(
     elif plotting_df_mean is not None:
         plotting_df = plotting_df_mean
 
-    assert plotting_df is not None
+    if plotting_df is None:
+        raise ValueError(
+            "At least one of `plot_predictive_samples` or `plot_predictive_mean` "
+            "must be True."
+        )
 
     # return plotting_df
 

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -629,11 +629,7 @@ def plot_model_cartoon(
     elif plotting_df_mean is not None:
         plotting_df = plotting_df_mean
 
-    if plotting_df is None:
-        raise ValueError(
-            "No data available to plot. Please check `plot_data`, "
-            "`plot_predictive_mean`, and `plot_predictive_samples` settings."
-        )
+    assert plotting_df is not None
 
     # return plotting_df
 

--- a/src/hssm/plotting/utils.py
+++ b/src/hssm/plotting/utils.py
@@ -190,7 +190,8 @@ def _get_plotting_df(
     extra_dims = [] if extra_dims is None else extra_dims
 
     if dt is None:
-        assert data is not None
+        if data is None:
+            raise ValueError("`data` must be provided when `dt` is not provided.")
         data = _process_data(data, extra_dims, quantile_by_dims)
 
         data.insert(0, "observed", "observed")

--- a/src/hssm/plotting/utils.py
+++ b/src/hssm/plotting/utils.py
@@ -190,8 +190,7 @@ def _get_plotting_df(
     extra_dims = [] if extra_dims is None else extra_dims
 
     if dt is None:
-        if data is None:
-            raise ValueError("Either dt or data must be provided.")
+        assert data is not None
         data = _process_data(data, extra_dims, quantile_by_dims)
 
         data.insert(0, "observed", "observed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,34 @@ def intercept_only_ddm_cartoon(cavanagh_test):
 
 
 @pytest.fixture
+def minimal_posterior_datatree():
+    """Return a factory for compact posterior DataTrees."""
+
+    def _make(
+        include_posterior_predictive=False,
+        posterior_var="v",
+        posterior_values=None,
+    ):
+        posterior_values = (
+            np.array([[0.4, 0.6]]) if posterior_values is None else posterior_values
+        )
+        groups = {
+            "posterior": xr.Dataset(
+                {posterior_var: (("chain", "draw"), posterior_values)},
+                coords={"chain": [0], "draw": [0, 1]},
+            )
+        }
+        if include_posterior_predictive:
+            groups["posterior_predictive"] = xr.Dataset(
+                {"prediction": (("chain", "draw"), np.array([[-1.0, -1.0]]))},
+                coords={"chain": [0], "draw": [0, 1]},
+            )
+        return xr.DataTree.from_dict(groups)
+
+    return _make
+
+
+@pytest.fixture
 def race_model_cartoon():
     """Return a race model for cartoon plots."""
     my_race_data = pd.read_csv(FIXTURES / "data_race.csv")

--- a/tests/distribution_utils/test_distribution_utils.py
+++ b/tests/distribution_utils/test_distribution_utils.py
@@ -10,6 +10,7 @@ import hssm
 from hssm import distribution_utils
 from hssm.distribution_utils import dist as dist_module
 from hssm.distribution_utils.dist import (
+    _apply_lapse_model,
     _create_arg_arrays,
     _extract_size,
     _get_p_outlier,
@@ -86,6 +87,21 @@ def test_lapse_distribution():
     random_sample_b = rv.rng_fn(rng2, *[0.5, 0.5, 0.5, 0.3], 0.05, 10)
 
     np.testing.assert_array_equal(random_sample_a, random_sample_b)
+
+
+def test_apply_lapse_model_rejects_numeric_lapse_distribution():
+    """Numeric choice-only lapse values cannot simulate RT lapse samples."""
+    sims_out = np.asarray([[0.2, 0.0], [0.3, 1.0]], dtype=float)
+    rng = np.random.default_rng(42)
+
+    with pytest.raises(TypeError, match="numeric lapse"):
+        _apply_lapse_model(
+            sims_out=sims_out,
+            p_outlier=0.5,
+            rng=rng,
+            lapse_dist=0.5,
+            choices=[0, 1],
+        )
 
 
 @pytest.mark.parametrize("rv", ["choice_only_model", lambda *args, **kwargs: None])

--- a/tests/distribution_utils/test_distribution_utils.py
+++ b/tests/distribution_utils/test_distribution_utils.py
@@ -1,3 +1,5 @@
+"""Tests for HSSM distribution utility helpers."""
+
 from unittest.mock import patch
 
 import bambi as bmb
@@ -25,6 +27,7 @@ hssm.set_floatX("float32")
 
 
 def test_make_hssm_rv():
+    """Check that generated HSSM random variables sample deterministically."""
     params = ["v", "a", "z", "t"]
     seed = 42
 
@@ -60,6 +63,7 @@ def test_make_hssm_rv():
 
 
 def test_lapse_distribution():
+    """Check lapse sampling shape, support, and reproducibility."""
     lapse_dist = bmb.Prior("Uniform", lower=0.0, upper=1.0)
     rv = distribution_utils.make_hssm_rv("ddm", ["v", "a", "z", "t"], lapse=lapse_dist)
     random_sample = rv.rng_fn(np.random.default_rng(), *[0.5, 0.5, 0.5, 0.3], 0.05, 10)
@@ -173,6 +177,8 @@ def test_apply_param_bounds_to_loglik():
 
 @pytest.mark.slow
 def test_make_distribution():
+    """Check custom distribution logp values and parameter-bound masking."""
+
     def fake_logp_function(data, param1, param2):
         """Make up a fake log likelihood function for this test only."""
         return data[:, 0] * param1 * param2
@@ -218,6 +224,7 @@ def test_make_distribution():
 
 @pytest.mark.slow
 def test_make_distribution_for_supported_model():
+    """Check supported-model distribution creation and unsupported-model errors."""
     data = np.zeros((10, 2))
     data[:, 0] = np.random.normal(size=10)
 
@@ -234,6 +241,7 @@ def test_make_distribution_for_supported_model():
 
 @pytest.mark.slow
 def test_extra_fields(data_ddm):
+    """Check extra likelihood fields are forwarded through generated distributions."""
     ones = np.ones(data_ddm.shape[0])
     x = ones * 0.5
     y = ones * 4.0
@@ -301,6 +309,7 @@ def test_extra_fields(data_ddm):
 
 @pytest.mark.slow
 def test_ensure_positive_ndt():
+    """Check that non-decision times above RT receive the sentinel logp."""
     data = np.zeros((1000, 2))
     data[:, 0] = np.random.uniform(size=1000)
 

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -12,6 +12,8 @@ from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 
+import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from hssm.rl import registry
@@ -168,6 +170,32 @@ class TestGetSsmLogp:
         assert "angle" in registry._SSM_LOGP_CACHE
         # Second call returns cached value without re-building.
         assert registry._get_ssm_logp("angle") is result
+
+
+class TestInvTempSoftmaxBaseLogp:
+    """Tests for the built-in inverse-temperature softmax base logp."""
+
+    def test_float64_input_downcasts_when_jax_x64_is_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The softmax logp should produce finite float32 values under x64-off JAX."""
+        logp = registry._make_inv_temp_softmax_base_logp(2)
+        lan_matrix = np.asarray(
+            [
+                [2.0, 0.1, 0.4, 1.0],
+                [2.0, 0.6, 0.2, 0.0],
+            ],
+            dtype=np.float64,
+        )
+
+        monkeypatch.setattr(registry.jax_config, "read", lambda key: False)
+        monkeypatch.setattr(registry.jnp, "asarray", np.asarray)
+
+        result = logp(lan_matrix)
+
+        assert result.shape == (2,)
+        assert result.dtype == jnp.float32
+        assert np.isfinite(np.asarray(result)).all()
 
 
 class TestBuildSsmLogpFunc:
@@ -739,6 +767,60 @@ class TestSsMsPresetDiscovery:
             ValueError, match="not found in the RLSSM registry or ssms presets"
         ):
             registry.get_rlssm_model_config("2AB_RescorlaWagner_DDM")
+
+    def test_discovery_is_empty_when_ssms_rl_is_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing ssms.rl should make discovery and resolution safe no-ops."""
+        monkeypatch.setattr(registry, "_get_ssms_rl_module", lambda: None)
+
+        assert registry._list_ssms_presets() == {}
+        assert registry._resolve_ssms_model("2AB_RW_DDM") is None
+
+    def test_get_ssms_rl_module_returns_none_on_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The low-level ssms.rl import helper should absorb ImportError."""
+
+        def _raise_import_error(name: str) -> object:
+            raise ImportError(name)
+
+        monkeypatch.setattr(registry.importlib, "import_module", _raise_import_error)
+
+        assert registry._get_ssms_rl_module() is None
+
+    def test_discovery_is_empty_without_callable_preset_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Old ssms builds without preset.list/resolve_model are ignored safely."""
+        fake_ssms_rl = SimpleNamespace(preset=SimpleNamespace(list=None))
+        monkeypatch.setattr(registry, "_get_ssms_rl_module", lambda: fake_ssms_rl)
+
+        assert registry._list_ssms_presets() == {}
+        assert registry._resolve_ssms_model("2AB_RW_DDM") is None
+
+    def test_register_model_warns_when_shadowing_ssms_preset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        learning_process: dict[str, Any],
+    ) -> None:
+        """Custom HSSM registrations may shadow ssms presets, but log a warning."""
+        self._install_fake_ssms(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger="hssm.rl.registry"):
+            registry.register_rlssm_model(
+                name="2AB_RW_DDM",
+                decision_process="angle",
+                learning_process=learning_process,
+                learning_process_params=["rl_alpha"],
+                learning_process_bounds={"rl_alpha": (0.0, 1.0)},
+                learning_process_params_default=[0.2],
+                extra_fields=["feedback"],
+                choices=[0, 1],
+            )
+
+        assert "is an ssms RL preset and will be shadowed" in caplog.text
 
 
 class TestListModels:

--- a/tests/rl/test_registry.py
+++ b/tests/rl/test_registry.py
@@ -172,30 +172,27 @@ class TestGetSsmLogp:
         assert registry._get_ssm_logp("angle") is result
 
 
-class TestInvTempSoftmaxBaseLogp:
-    """Tests for the built-in inverse-temperature softmax base logp."""
+def test_inv_temp_softmax_base_logp_downcasts_float64_when_jax_x64_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The softmax logp should produce finite float32 values under x64-off JAX."""
+    logp = registry._make_inv_temp_softmax_base_logp(2)
+    lan_matrix = np.asarray(
+        [
+            [2.0, 0.1, 0.4, 1.0],
+            [2.0, 0.6, 0.2, 0.0],
+        ],
+        dtype=np.float64,
+    )
 
-    def test_float64_input_downcasts_when_jax_x64_is_disabled(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The softmax logp should produce finite float32 values under x64-off JAX."""
-        logp = registry._make_inv_temp_softmax_base_logp(2)
-        lan_matrix = np.asarray(
-            [
-                [2.0, 0.1, 0.4, 1.0],
-                [2.0, 0.6, 0.2, 0.0],
-            ],
-            dtype=np.float64,
-        )
+    monkeypatch.setattr(registry.jax_config, "read", lambda key: False)
+    monkeypatch.setattr(registry.jnp, "asarray", np.asarray)
 
-        monkeypatch.setattr(registry.jax_config, "read", lambda key: False)
-        monkeypatch.setattr(registry.jnp, "asarray", np.asarray)
+    result = logp(lan_matrix)
 
-        result = logp(lan_matrix)
-
-        assert result.shape == (2,)
-        assert result.dtype == jnp.float32
-        assert np.isfinite(np.asarray(result)).all()
+    assert result.shape == (2,)
+    assert result.dtype == jnp.float32
+    assert np.isfinite(np.asarray(result)).all()
 
 
 class TestBuildSsmLogpFunc:

--- a/tests/rl/test_rl_likelihood_builder.py
+++ b/tests/rl/test_rl_likelihood_builder.py
@@ -1,32 +1,31 @@
 from pathlib import Path
-from typing import NamedTuple, Callable
-import pytest
+from typing import Callable, NamedTuple
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import pytensor
 import pytensor.tensor as pt
-import jax
-import jax.numpy as jnp
+import pytest
 
 import hssm
+from hssm.distribution_utils.func_utils import make_vjp_func
+from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
 from hssm.rl.likelihoods.builder import (
-    make_rl_logp_func,
-    make_rl_logp_op,
+    _collect_cols_arrays,
     _get_column_indices,
     _get_column_indices_with_computed,
-    _collect_cols_arrays,
+    _validate_args_array_shapes,
+    _validate_args_length,
     _validate_computed_parameters,
     _validate_data_shape,
-    _validate_args_length,
-    _validate_uniform_trials,
-    _validate_args_array_shapes,
     _validate_inputs,
+    _validate_uniform_trials,
+    make_rl_logp_func,
+    make_rl_logp_op,
 )
 from hssm.rl.likelihoods.two_armed_bandit import compute_v_subject_wise
 from hssm.utils import annotate_function
-from hssm.distribution_utils.func_utils import make_vjp_func
-
-from hssm.distribution_utils.onnx import make_jax_matrix_logp_funcs_from_onnx
 
 # Obtain the angle log-likelihood function from an ONNX model.
 angle_logp_jax_func = make_jax_matrix_logp_funcs_from_onnx(
@@ -782,6 +781,152 @@ class TestRldmLikelihoodBuilder:
 
         expected = np.asarray([-5.9, 5.2, -3.7], dtype=np.float32)
         np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+    def test_make_rl_logp_func_accepts_tuple_multi_output_computed_params(self):
+        """Shared computed functions may return one sequence item per output."""
+
+        @annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+            outputs=["q0", "q1"],
+        )
+        def compute_qs(subject_trials):
+            rl_alpha = subject_trials[:, 0]
+            feedback = subject_trials[:, 2]
+            return rl_alpha + feedback, rl_alpha - feedback
+
+        @annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_qs, "q1": compute_qs},
+        )
+        def ssm_logp_func(lan_matrix):
+            beta, q0, q1, response = lan_matrix.T
+            return beta + q0 + 10.0 * q1 + response
+
+        logp_fn = make_rl_logp_func(
+            ssm_logp_func,
+            n_participants=1,
+            n_trials=3,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+        data = np.asarray([[0.0], [1.0], [0.0]], dtype=np.float32)
+        beta = np.asarray([2.0, 2.0, 2.0], dtype=np.float32)
+        rl_alpha = np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+        feedback = np.asarray([1.0, 0.0, 1.0], dtype=np.float32)
+
+        result = logp_fn(data, beta, rl_alpha, feedback)
+
+        expected = np.asarray([-5.9, 5.2, -3.7], dtype=np.float32)
+        np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+    def test_make_rl_logp_func_accepts_last_axis_multi_output_array(self):
+        """Shared computed functions may return an array with output columns last."""
+
+        @annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+            outputs=["q0", "q1"],
+        )
+        def compute_qs(subject_trials):
+            rl_alpha = subject_trials[:, 0]
+            feedback = subject_trials[:, 2]
+            return jnp.stack([rl_alpha + feedback, rl_alpha - feedback], axis=-1)
+
+        @annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_qs, "q1": compute_qs},
+        )
+        def ssm_logp_func(lan_matrix):
+            beta, q0, q1, response = lan_matrix.T
+            return beta + q0 + 10.0 * q1 + response
+
+        logp_fn = make_rl_logp_func(
+            ssm_logp_func,
+            n_participants=1,
+            n_trials=3,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+        data = np.asarray([[0.0], [1.0], [0.0]], dtype=np.float32)
+        beta = np.asarray([2.0, 2.0, 2.0], dtype=np.float32)
+        rl_alpha = np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+        feedback = np.asarray([1.0, 0.0, 1.0], dtype=np.float32)
+
+        result = logp_fn(data, beta, rl_alpha, feedback)
+
+        expected = np.asarray([-5.9, 5.2, -3.7], dtype=np.float32)
+        np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+    def test_make_rl_logp_func_rejects_invalid_multi_output_shape(self):
+        """Multi-output computed functions must expose one value per output."""
+
+        @annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+            outputs=["q0", "q1"],
+        )
+        def compute_qs(subject_trials):
+            return jnp.ones((subject_trials.shape[0], 3))
+
+        @annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_qs, "q1": compute_qs},
+        )
+        def ssm_logp_func(lan_matrix):
+            return lan_matrix[:, 0]
+
+        logp_fn = make_rl_logp_func(
+            ssm_logp_func,
+            n_participants=1,
+            n_trials=3,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+        data = np.asarray([[0.0], [1.0], [0.0]], dtype=np.float32)
+        beta = np.asarray([2.0, 2.0, 2.0], dtype=np.float32)
+        rl_alpha = np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+        feedback = np.asarray([1.0, 0.0, 1.0], dtype=np.float32)
+
+        with pytest.raises(ValueError, match="multi-output computed function"):
+            logp_fn(data, beta, rl_alpha, feedback)
+
+    def test_make_rl_logp_func_rejects_missing_multi_output_value(self):
+        """Dict outputs must contain every requested computed parameter."""
+
+        @annotate_function(
+            inputs=["rl_alpha", "response", "feedback"],
+            outputs=["q0", "q1"],
+        )
+        def compute_qs(subject_trials):
+            return {"q0": subject_trials[:, 0] + subject_trials[:, 2]}
+
+        @annotate_function(
+            inputs=["beta", "q0", "q1", "response"],
+            outputs=["logp"],
+            computed={"q0": compute_qs, "q1": compute_qs},
+        )
+        def ssm_logp_func(lan_matrix):
+            return lan_matrix[:, 0]
+
+        logp_fn = make_rl_logp_func(
+            ssm_logp_func,
+            n_participants=1,
+            n_trials=3,
+            data_cols=["response"],
+            list_params=["beta", "rl_alpha"],
+            extra_fields=["feedback"],
+        )
+        data = np.asarray([[0.0], [1.0], [0.0]], dtype=np.float32)
+        beta = np.asarray([2.0, 2.0, 2.0], dtype=np.float32)
+        rl_alpha = np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+        feedback = np.asarray([1.0, 0.0, 1.0], dtype=np.float32)
+
+        with pytest.raises(ValueError, match=r"requested parameter\(s\): \['q1'\]"):
+            logp_fn(data, beta, rl_alpha, feedback)
 
     def test_make_rl_logp_func_accepts_1d_response_only_data(self):
         """Response-only observed data may arrive as a scalar 1D vector."""

--- a/tests/rl/test_rl_likelihood_builder.py
+++ b/tests/rl/test_rl_likelihood_builder.py
@@ -1,3 +1,5 @@
+"""Tests for RL likelihood builder helpers."""
+
 from pathlib import Path
 from typing import Callable, NamedTuple
 
@@ -81,6 +83,7 @@ class RLDMSetup(NamedTuple):
 
 @pytest.fixture
 def fixture_path():
+    """Return the shared fixture directory."""
     return Path(__file__).parent.parent / "fixtures"
 
 
@@ -180,6 +183,8 @@ def rldm_setup(rldm_data, model_config, param_arrays, annotated_ssm_logp_func):
 
 
 class TestGetDataColumnsFromDataArgs:
+    """Tests for data-column and argument-array lookup helpers."""
+
     def test_get_column_indices(self):
         """Test column indexing and data collection from data matrix and args.
 
@@ -313,7 +318,11 @@ class TestGetDataColumnsFromDataArgs:
 
 
 class TestAnnotateFunction:
+    """Tests for the annotate_function helper."""
+
     def test_decorator_adds_attributes(self):
+        """Check that decorator metadata is attached to the wrapped function."""
+
         @annotate_function(inputs=["input1", "input2"], outputs=["output1"], other=42)
         def sample_function():
             return
@@ -740,6 +749,8 @@ class TestValidateInputs:
 
 
 class TestRldmLikelihoodBuilder:
+    """Tests for RLDM likelihood construction and execution."""
+
     def test_make_rl_logp_func_extracts_shared_multi_output_computed_params(self):
         """Shared computed functions can produce several decision parameters."""
 
@@ -971,6 +982,7 @@ class TestRldmLikelihoodBuilder:
         np.testing.assert_allclose(result, expected, rtol=1e-6)
 
     def test_make_rl_logp_func(self, rldm_setup):
+        """Check the fixture-backed RL logp function shape and aggregate value."""
         result = rldm_setup.logp_fn(rldm_setup.values, *rldm_setup.args)
         assert result.shape[0] == rldm_setup.total_trials
         np.testing.assert_almost_equal(result.sum(), -6879.15, decimal=DECIMAL)

--- a/tests/rl/test_rlssm.py
+++ b/tests/rl/test_rlssm.py
@@ -9,6 +9,7 @@ import logging
 from collections.abc import Generator
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import bambi as bmb
@@ -347,6 +348,48 @@ class TestRLSSMModelStructure:
             model._make_model_distribution()
 
         assert captured.get("extra_fields") is None
+
+    def test_choice_only_response_validation_exits_when_metadata_is_incomplete(
+        self,
+    ) -> None:
+        """Choice-only validation is a no-op until response metadata is complete."""
+        data = pd.DataFrame({"response": [0, 1], "feedback": [1.0, 0.0]})
+
+        assert (
+            _RLSSM._validate_choice_only_responses(
+                data, SimpleNamespace(response=[], choices=[0, 1])
+            )
+            is None
+        )
+        assert (
+            _RLSSM._validate_choice_only_responses(
+                data, SimpleNamespace(response=["missing"], choices=[0, 1])
+            )
+            is None
+        )
+        assert (
+            _RLSSM._validate_choice_only_responses(
+                data, SimpleNamespace(response=["response"], choices=None)
+            )
+            is None
+        )
+
+    def test_choice_only_scalar_lapse_must_be_probability(self) -> None:
+        """Choice-only scalar lapse values must satisfy the documented bounds."""
+        model = object.__new__(_RLSSM)
+        model.list_params = ["rl_alpha", "beta", "p_outlier"]
+        model.model_config = SimpleNamespace(
+            extra_fields=[],
+            loglik=lambda *args: jnp.zeros(1),
+            model_name="choice_only_test",
+            is_choice_only=True,
+        )
+        model.data = pd.DataFrame({"response": [0, 1]})
+        model.bounds = {"rl_alpha": (0.0, 1.0), "beta": (0.001, 20.0)}
+        model.lapse = 0.0
+
+        with pytest.raises(ValueError, match="0 < lapse <= 1"):
+            model._make_model_distribution()
 
 
 class TestRLSSMSerialization:

--- a/tests/rl/test_rlssm_config.py
+++ b/tests/rl/test_rlssm_config.py
@@ -1,3 +1,5 @@
+"""Tests for RLSSMConfig construction, validation, defaults, and ssms bridges."""
+
 import sys
 import types
 
@@ -47,6 +49,7 @@ def create_config_dict(
     learning_process_kind="blackbox",
     ssm_logp_func=_module_dummy_ssm_logp,
 ):
+    """Create an RLSSM config dictionary for tests."""
     return dict(
         model_name=model_name,
         name=model_name,
@@ -69,6 +72,8 @@ def create_config_dict(
 # region fixtures and helpers
 @pytest.fixture
 def valid_rlssmconfig_kwargs():
+    """Return a valid RLSSMConfig kwargs dictionary."""
+
     @annotate_function(inputs=["v", "rt", "response"], outputs=["logp"], computed={})
     def _dummy_ssm_logp_func(x):
         return x
@@ -93,10 +98,12 @@ hssm.set_floatX("float32")
 
 
 def v_func(x):
+    """Return a doubled learning-process value."""
     return x * 2
 
 
 def a_func(x):
+    """Return an incremented learning-process value."""
     return x + 1
 
 
@@ -104,6 +111,8 @@ def a_func(x):
 
 
 class TestRLSSMConfigCreation:
+    """Tests for RLSSMConfig construction from dictionaries."""
+
     rlwm_config = create_config_dict(
         model_name="rlwm",
         list_params=["alpha", "beta", "gamma", "v", "a"],
@@ -173,6 +182,7 @@ class TestRLSSMConfigCreation:
         expected_choices,
         expected_learning_process,
     ):
+        """Check that dictionary configs map to expected RLSSMConfig fields."""
         config = RLSSMConfig.from_rlssm_dict(config_dict)
         assert config.model_name == expected_model_name
         assert config.params_default == expected_params_default
@@ -183,6 +193,8 @@ class TestRLSSMConfigCreation:
 
 
 class TestRLSSMConfigValidation:
+    """Tests for RLSSMConfig validation behavior."""
+
     @pytest.mark.parametrize(
         "field, value, error_msg",
         [
@@ -196,6 +208,7 @@ class TestRLSSMConfigValidation:
     def test_validate_missing_fields(
         self, field, value, error_msg, valid_rlssmconfig_kwargs
     ):
+        """Check that missing required validation fields raise clear errors."""
         # All required fields provided, then set one to None
         config = RLSSMConfig(**valid_rlssmconfig_kwargs)
         setattr(config, field, value)
@@ -216,6 +229,7 @@ class TestRLSSMConfigValidation:
     def test_constructor_missing_required_field(
         self, missing_field, valid_rlssmconfig_kwargs
     ):
+        """Check constructor errors for omitted dataclass-required fields."""
         # Provide all required fields, then remove one
         kwargs = valid_rlssmconfig_kwargs
         kwargs.pop(missing_field)
@@ -223,10 +237,12 @@ class TestRLSSMConfigValidation:
             RLSSMConfig(**kwargs)
 
     def test_validate_success(self, valid_rlssmconfig_kwargs):
+        """Check that a complete configuration validates successfully."""
         config = RLSSMConfig(**valid_rlssmconfig_kwargs)
         config.validate()
 
     def test_validate_params_default_mismatch(self, valid_rlssmconfig_kwargs):
+        """Check validation rejects mismatched default-parameter lengths."""
         config = RLSSMConfig(
             **{
                 **valid_rlssmconfig_kwargs,
@@ -240,12 +256,14 @@ class TestRLSSMConfigValidation:
             config.validate()
 
     def test_validate_ssm_logp_func_not_callable(self, valid_rlssmconfig_kwargs):
+        """Check validation rejects non-callable SSM logp functions."""
         config = RLSSMConfig(**valid_rlssmconfig_kwargs)
         config.ssm_logp_func = "not_a_callable"
         with pytest.raises(ValueError, match="must be a callable"):
             config.validate()
 
     def test_validate_ssm_logp_func_missing_annotations(self, valid_rlssmconfig_kwargs):
+        """Check validation rejects undecorated SSM logp functions."""
         config = RLSSMConfig(**valid_rlssmconfig_kwargs)
         # Replace with a plain callable that lacks @annotate_function attributes
         config.ssm_logp_func = lambda x: x
@@ -282,6 +300,8 @@ class TestRLSSMConfigValidation:
 
 
 class TestRLSSMConfigDefaults:
+    """Tests for RLSSMConfig default and bounds lookup."""
+
     @pytest.mark.parametrize(
         "list_params, params_default, bounds, param, expected_default, expected_bounds",
         [
@@ -328,6 +348,7 @@ class TestRLSSMConfigDefaults:
         expected_default,
         expected_bounds,
     ):
+        """Check get_defaults returns the expected prior placeholder and bounds."""
         config = RLSSMConfig(
             model_name="test_model",
             list_params=list_params,
@@ -346,7 +367,10 @@ class TestRLSSMConfigDefaults:
 
 
 class TestRLSSMConfigLearningProcess:
+    """Tests for learning-process mapping behavior."""
+
     def test_learning_process(self):
+        """Check learning-process functions are stored by parameter name."""
         config = RLSSMConfig(
             model_name="test_model",
             list_params=["alpha"],
@@ -364,6 +388,7 @@ class TestRLSSMConfigLearningProcess:
         assert config.learning_process["a"] is a_func
 
     def test_immutable_defaults(self):
+        """Check separate configs do not share mutable learning-process defaults."""
         config1 = RLSSMConfig(
             model_name="model1",
             list_params=["alpha"],
@@ -392,7 +417,10 @@ class TestRLSSMConfigLearningProcess:
 
 
 class TestRLSSMConfigEdgeCases:
+    """Tests for edge-case construction and dictionary conversion errors."""
+
     def test_from_rlssm_dict_missing_required(self):
+        """Check dictionary conversion rejects missing log-likelihood kind."""
         # Should raise ValueError if decision_process_loglik_kind is missing
         config_dict = {
             "model_name": "test_model",
@@ -416,6 +444,7 @@ class TestRLSSMConfigEdgeCases:
             RLSSMConfig.from_rlssm_dict(config_dict)
 
     def test_from_rlssm_dict_missing_ssm_logp_func(self):
+        """Check dictionary conversion rejects missing SSM logp functions."""
         # Should raise ValueError at construction time if ssm_logp_func is missing
         config_dict = {
             "model_name": "test_model",
@@ -437,6 +466,7 @@ class TestRLSSMConfigEdgeCases:
             RLSSMConfig.from_rlssm_dict(config_dict)
 
     def test_missing_decision_process_loglik_kind(self):
+        """Check constructor and dictionary errors for missing log-likelihood kind."""
         with pytest.raises(TypeError):
             RLSSMConfig(
                 model_name="test_model",
@@ -466,6 +496,7 @@ class TestRLSSMConfigEdgeCases:
             RLSSMConfig.from_rlssm_dict(config_dict)
 
     def test_with_modelconfig_decision_process(self):
+        """Check ModelConfig instances are accepted as decision processes."""
         decision_config = ModelConfig(
             response=["rt", "response"],
             list_params=["v", "a", "z", "t"],
@@ -503,6 +534,7 @@ class TestRLSSMConfigDefaultWarnings:
         }
 
     def test_warns_when_response_missing(self, _base_config_dict, caplog):
+        """Check default response warning and fallback."""
         _base_config_dict["choices"] = (0, 1)
         # 'response' deliberately omitted
         with caplog.at_level("WARNING", logger="hssm"):
@@ -511,6 +543,7 @@ class TestRLSSMConfigDefaultWarnings:
         assert config.response == list(DEFAULT_SSM_OBSERVED_DATA)
 
     def test_warns_when_choices_missing(self, _base_config_dict, caplog):
+        """Check default choices warning and fallback."""
         _base_config_dict["response"] = ["rt", "response"]
         # 'choices' deliberately omitted
         with caplog.at_level("WARNING", logger="hssm"):
@@ -519,6 +552,7 @@ class TestRLSSMConfigDefaultWarnings:
         assert config.choices == DEFAULT_SSM_CHOICES
 
     def test_warns_when_both_missing(self, _base_config_dict, caplog):
+        """Check both default warnings and fallbacks."""
         # Both 'response' and 'choices' omitted
         with caplog.at_level("WARNING", logger="hssm"):
             config = RLSSMConfig.from_rlssm_dict(_base_config_dict)
@@ -528,6 +562,7 @@ class TestRLSSMConfigDefaultWarnings:
         assert config.choices == DEFAULT_SSM_CHOICES
 
     def test_no_warning_when_both_provided(self, _base_config_dict, caplog):
+        """Check no default warning is emitted when both fields are provided."""
         _base_config_dict["response"] = ["rt", "response"]
         _base_config_dict["choices"] = (0, 1)
         with caplog.at_level("WARNING", logger="hssm"):
@@ -691,9 +726,12 @@ def _install_fake_choice_only_decision_logp(monkeypatch, n_choices):
 
 
 class TestRLSSMConfigFromSSMSModel:
+    """Tests for fake ssms.rl model bridging into RLSSMConfig."""
+
     def test_from_ssms_model_builds_hssm_config_from_assembled_metadata(
         self, monkeypatch
     ):
+        """Check assembled ssms metadata is translated into HSSM config fields."""
         _install_fake_ssms_rl(monkeypatch)
         _install_fake_decision_logp(monkeypatch)
 
@@ -728,6 +766,7 @@ class TestRLSSMConfigFromSSMSModel:
         assert config._ssms_assembled_model is not None
 
     def test_computed_function_uses_ssms_response_to_choice(self, monkeypatch):
+        """Check computed functions map raw SSM responses to ssms choices."""
         _install_fake_ssms_rl(monkeypatch)
         _install_fake_decision_logp(monkeypatch)
         config = RLSSMConfig.from_ssms_model("2AB_RW_Angle")
@@ -744,6 +783,7 @@ class TestRLSSMConfigFromSSMSModel:
         assert jnp.allclose(compute_v(subject_trials), jnp.asarray([0.0, 2.0]))
 
     def test_from_ssms_model_rejects_unavailable_gradient(self, monkeypatch):
+        """Check unavailable ssms gradients are rejected."""
         _install_fake_ssms_rl(monkeypatch, gradient="unavailable")
         _install_fake_decision_logp(monkeypatch)
 
@@ -751,6 +791,7 @@ class TestRLSSMConfigFromSSMSModel:
             RLSSMConfig.from_ssms_model("2AB_RW_Angle")
 
     def test_from_ssms_model_requires_ssms_rl(self, monkeypatch):
+        """Check from_ssms_model requires the optional ssms.rl module."""
         monkeypatch.setitem(sys.modules, "ssms.rl", None)
         with pytest.raises(ImportError, match="ssms.rl"):
             RLSSMConfig.from_ssms_model("2AB_RW_Angle")
@@ -832,6 +873,7 @@ class TestRLSSMConfigFromSSMSModel:
     def test_from_ssms_model_choice_only_inv_temp_softmax_metadata(
         self, monkeypatch, n_choices
     ):
+        """Check choice-only inverse-temperature softmax metadata conversion."""
         config_obj = _FakeChoiceOnlySSMSModelConfig(n_choices=n_choices)
         fake_rl = types.SimpleNamespace(
             ModelConfig=_FakeChoiceOnlySSMSModelConfig,
@@ -882,6 +924,7 @@ class TestRLSSMConfigFromRealSSMS:
 
     @pytest.mark.slow
     def test_from_ssms_model_real_2ab_rw_angle(self):
+        """Check the live ssms.rl 2AB RW angle bridge contract."""
         self._require_ssms_rl()
 
         config = RLSSMConfig.from_ssms_model("2AB_RW_Angle")

--- a/tests/rl/test_rlssm_config.py
+++ b/tests/rl/test_rlssm_config.py
@@ -8,7 +8,6 @@ import hssm
 from hssm.config import (
     DEFAULT_SSM_CHOICES,
     DEFAULT_SSM_OBSERVED_DATA,
-    Config,
     ModelConfig,
 )
 from hssm.rl import RLSSMConfig
@@ -816,6 +815,18 @@ class TestRLSSMConfigFromSSMSModel:
                 "feedback",
                 "condition",
             ]
+
+        subject_trials = jnp.asarray(
+            [
+                [0.2, 2.0, -1.0, 1.0, 0.0],
+                [0.4, 3.0, 1.0, 0.0, 1.0],
+            ]
+        )
+        result = config.ssm_logp_func.computed["v"](subject_trials)
+
+        assert set(result) == {"v", "a"}
+        assert jnp.allclose(result["v"], jnp.asarray([2.0, 3.0]))
+        assert jnp.allclose(result["a"], jnp.asarray([0.2, 0.4]))
 
     @pytest.mark.parametrize("n_choices", [2, 3])
     def test_from_ssms_model_choice_only_inv_temp_softmax_metadata(

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -1,3 +1,5 @@
+"""Tests for the HSSM public model interface."""
+
 import sys
 from copy import deepcopy
 from unittest.mock import Mock
@@ -29,22 +31,22 @@ param_a = param_v | dict(name="a", formula="a ~ 1 + x + y")
 
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "include, should_raise_exception",
+    "include, expected_exception",
     [
         (
             [param_v],
-            False,
+            None,
         ),
         (
             [
                 param_v,
                 param_a,
             ],
-            False,
+            None,
         ),
         (
             [{"name": "invalid_param", "prior": "invalid_param"}],
-            True,
+            ValueError,
         ),
         (
             [
@@ -57,7 +59,7 @@ param_a = param_v | dict(name="a", formula="a ~ 1 + x + y")
                     "invalid_key": "identity",
                 }
             ],
-            True,
+            TypeError,
         ),
         (
             [
@@ -69,13 +71,14 @@ param_a = param_v | dict(name="a", formula="a ~ 1 + x + y")
                     "formula": "invalid_formula",
                 }
             ],
-            True,
+            IndexError,
         ),
     ],
 )
-def test_transform_params_general(data_ddm_reg, include, should_raise_exception):
-    if should_raise_exception:
-        with pytest.raises(Exception):
+def test_transform_params_general(data_ddm_reg, include, expected_exception):
+    """Validate include specifications and reject malformed entries."""
+    if expected_exception is not None:
+        with pytest.raises(expected_exception):
             HSSM(data=data_ddm_reg, include=include)
     else:
         model = HSSM(data=data_ddm_reg, include=include)
@@ -88,6 +91,7 @@ def test_transform_params_general(data_ddm_reg, include, should_raise_exception)
 
 @pytest.mark.slow
 def test_custom_model(data_ddm):
+    """Validate custom-model configuration requirements."""
     with pytest.raises(
         ValueError, match="When using a custom model, please provide a `loglik_kind.`"
     ):
@@ -135,6 +139,7 @@ def test_custom_model(data_ddm):
 
 @pytest.mark.slow
 def test_model_definition_outside_include(data_ddm):
+    """Accept parameter definitions outside include and reject duplicates."""
     model_with_one_param_fixed = HSSM(data_ddm, a=0.5)
 
     assert "a" in model_with_one_param_fixed.params
@@ -160,6 +165,7 @@ def test_model_definition_outside_include(data_ddm):
 )
 @pytest.mark.slow
 def test_sample_prior_predictive(data_ddm_reg):
+    """Generate prior-predictive DataTrees across regression structures."""
     data_ddm_reg = data_ddm_reg.iloc[:10, :]
 
     model_no_regression = HSSM(data=data_ddm_reg)
@@ -169,6 +175,12 @@ def test_sample_prior_predictive(data_ddm_reg):
     prior_predictive_2 = model_no_regression.sample_prior_predictive(
         draws=10, random_seed=rng
     )
+    for prior_predictive in (prior_predictive_1, prior_predictive_2):
+        assert isinstance(prior_predictive, xr.DataTree)
+        assert {"prior", "prior_predictive", "observed_data"} <= set(
+            prior_predictive.children
+        )
+        assert prior_predictive["prior_predictive"].sizes["draw"] == 10
 
     model_regression = HSSM(
         data=data_ddm_reg, include=[dict(name="v", formula="v ~ 1 + x")]
@@ -203,6 +215,7 @@ def test_sample_prior_predictive(data_ddm_reg):
 
 @pytest.mark.slow
 def test_override_default_link(caplog, data_ddm_reg):
+    """Honor custom links while warning about unusual bounds."""
     param_v = {
         "name": "v",
         "prior": {
@@ -234,6 +247,7 @@ def test_override_default_link(caplog, data_ddm_reg):
 
 @pytest.mark.slow
 def test_resampling(data_ddm):
+    """Replace attached traces when a model is sampled again."""
     model = HSSM(data=data_ddm)
     sample_1 = model.sample(draws=10, chains=1, tune=0, progressbar=False)
     assert sample_1 is model.traces
@@ -361,6 +375,7 @@ def test_add_likelihood_parameters_accepts_explicit_datatree(data_ddm, monkeypat
 # Setting any parameter to a fixed value should work:
 @pytest.mark.slow
 def test_model_creation_constant_parameter(data_ddm):
+    """Allow any non-parent parameter to be fixed."""
     for param_name in ["v", "a", "z", "t"]:
         model = HSSM(data=data_ddm, **{param_name: 1.0})
         assert model._parent != param_name
@@ -374,6 +389,7 @@ def test_model_creation_constant_parameter(data_ddm):
     [("v", "Normal"), ("a", "Gamma"), ("z", "Beta"), ("t", "Gamma")],
 )
 def test_model_creation_single_regression(data_ddm_reg, param_name, dist_name):
+    """Use bounded default priors for one regression parameter."""
     model = HSSM(
         data=data_ddm_reg,
         include=[{"name": param_name, "formula": f"{param_name} ~ 1 + x"}],
@@ -384,6 +400,7 @@ def test_model_creation_single_regression(data_ddm_reg, param_name, dist_name):
 
 # Setting all parameters to fixed values should throw an error:
 def test_model_creation_all_parameters_constant(data_ddm):
+    """Reject models without any free parameters."""
     with pytest.raises(ValueError):
         HSSM(data=data_ddm, v=1.0, a=1.0, z=1.0, t=1.0)
 
@@ -391,6 +408,7 @@ def test_model_creation_all_parameters_constant(data_ddm):
 # Prior settings
 @pytest.mark.slow
 def test_prior_settings_basic(cavanagh_test):
+    """Apply requested prior-setting modes."""
     model_1 = HSSM(
         data=cavanagh_test,
         global_formula="y ~ 1 + (1|participant_id)",
@@ -414,6 +432,7 @@ def test_prior_settings_basic(cavanagh_test):
 
 @pytest.mark.slow
 def test_compile_logp(cavanagh_test):
+    """Compile log probability at the model's initial point."""
     model_1 = HSSM(
         data=cavanagh_test,
         global_formula="y ~ 1 + (1|participant_id)",
@@ -512,6 +531,7 @@ class TestFixedVectorParams:
 )
 @pytest.mark.slow
 def test_sample_do(data_ddm):
+    """Return intervention samples and the intervened PyMC model."""
     model = HSSM(data=data_ddm)
     sample_do, do_model = model.sample_do(
         params={"v": 1.0}, draws=10, return_model=True
@@ -610,6 +630,7 @@ def test_drop_parent_str_renames_response_mean(data_ddm):
 
 
 def test_is_choice_only_and_deadline(data_ddm):
+    """Expose choice-only and deadline response metadata."""
     config_choice_only = {"response": ["response"]}
 
     model = HSSM(data=data_ddm, model="ddm", model_config=config_choice_only)

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -1,13 +1,16 @@
 import sys
+from copy import deepcopy
+from unittest.mock import Mock
 
-import bambi as bmb
 import numpy as np
+import pymc as pm
 import pytest
+import xarray as xr
+from pymc.variational import Approximation
 
 import hssm
 from hssm import HSSM
 from hssm.likelihoods import DDM, logp_ddm
-from copy import deepcopy
 
 hssm.set_floatX("float32", update_jax=True)
 
@@ -276,6 +279,85 @@ def test_add_likelihood_parameters_to_data(data_ddm):
     )
 
 
+def test_log_likelihood_uses_attached_traces_and_returns_copy(data_ddm, monkeypatch):
+    """Attached traces are the default input without being mutated."""
+    model = HSSM(data=data_ddm)
+    traces = xr.DataTree.from_dict(
+        {"posterior": xr.Dataset({"v": (("chain", "draw"), np.array([[0.5]]))})}
+    )
+    model._inference_obj = traces
+    calls = []
+
+    def fake_compute_log_likelihood(bambi_model, dt, data, inplace):
+        calls.append((bambi_model, dt, data, inplace))
+        result = dt.copy(deep=True)
+        result["log_likelihood"] = xr.Dataset(
+            {"rt,response": (("chain", "draw"), np.array([[-1.0]]))}
+        )
+        return result
+
+    monkeypatch.setattr(
+        "hssm.base._compute_log_likelihood", fake_compute_log_likelihood
+    )
+
+    result = model.log_likelihood(
+        inplace=False,
+        keep_likelihood_params=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] is model.model
+    assert calls[0][1] is traces
+    assert calls[0][2] is None
+    assert calls[0][3] is False
+    assert result is not traces
+    assert isinstance(result, xr.DataTree)
+    assert "log_likelihood" in result
+    assert "log_likelihood" not in traces
+
+
+def test_add_likelihood_parameters_requires_traces(data_ddm):
+    """Likelihood parameters need supplied or previously attached traces."""
+    model = HSSM(data=data_ddm)
+
+    with pytest.raises(
+        ValueError,
+        match="No datatree provided and model not yet sampled!",
+    ):
+        model.add_likelihood_parameters_to_datatree()
+
+
+def test_add_likelihood_parameters_accepts_explicit_datatree(data_ddm, monkeypatch):
+    """An explicit DataTree is copied before likelihood parameters are added."""
+    model = HSSM(data=data_ddm)
+    traces = xr.DataTree.from_dict(
+        {"posterior": xr.Dataset({"v": (("chain", "draw"), np.array([[0.5]]))})}
+    )
+    received = []
+
+    def fake_compute_likelihood_params(dt):
+        received.append(dt)
+        dt["posterior"] = dt["posterior"].ds.assign(
+            v_mean=(("chain", "draw"), np.array([[0.5]]))
+        )
+        return dt
+
+    monkeypatch.setattr(
+        model.model,
+        "_compute_likelihood_params",
+        fake_compute_likelihood_params,
+    )
+
+    result = model.add_likelihood_parameters_to_datatree(dt=traces, inplace=False)
+
+    assert len(received) == 1
+    assert received[0] is not traces
+    assert result is received[0]
+    assert isinstance(result, xr.DataTree)
+    assert "v_mean" in result["posterior"].data_vars
+    assert "v_mean" not in traces["posterior"].data_vars
+
+
 # Setting any parameter to a fixed value should work:
 @pytest.mark.slow
 def test_model_creation_constant_parameter(data_ddm):
@@ -431,7 +513,10 @@ class TestFixedVectorParams:
 @pytest.mark.slow
 def test_sample_do(data_ddm):
     model = HSSM(data=data_ddm)
-    sample_do = model.sample_do(params={"v": 1.0}, draws=10)
+    sample_do, do_model = model.sample_do(
+        params={"v": 1.0}, draws=10, return_model=True
+    )
+    assert isinstance(do_model, pm.Model)
     assert sample_do is not None
     assert "v_mean" in sample_do.prior.data_vars
     assert set(sample_do.prior_predictive.dims) == {
@@ -447,6 +532,81 @@ def test_sample_do(data_ddm):
         "rt,response_dim",
     }
     assert np.unique(sample_do.prior["v_mean"].values) == [1.0]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected_message"),
+    [
+        (
+            "plot_trace",
+            "HSSM.plot_trace has been deprecated. Please use az.plot_trace_dist from "
+            "ArviZ directly. For example: "
+            "`az.plot_trace_dist(model.traces, var_names=[...])`.",
+        ),
+        (
+            "summary",
+            "HSSM.summary has been deprecated. Please use az.summary from ArviZ "
+            "directly. For example: `az.summary(model.traces, var_names=[...])`.",
+        ),
+    ],
+)
+def test_deprecated_inference_helpers_raise_documented_error(
+    data_ddm, method_name, expected_message
+):
+    """Removed inference helpers direct users to their ArviZ replacements."""
+    model = HSSM(data=data_ddm)
+
+    with pytest.raises(NotImplementedError) as error:
+        getattr(model, method_name)()
+
+    assert str(error.value) == expected_message
+
+
+def test_vi_idata_rejects_attached_approximation(data_ddm):
+    """VI approximations must be sampled before they can be exposed as DataTrees."""
+    model = HSSM(data=data_ddm)
+    model._inference_obj_vi = Mock(spec=Approximation)
+
+    with pytest.raises(ValueError, match="attached variational inference object"):
+        _ = model.vi_idata
+
+
+def test_drop_parent_str_requires_datatree(data_ddm):
+    """Posterior cleanup rejects a missing trace object."""
+    model = HSSM(data=data_ddm)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Please provide a DataTree \(traces\) object\.",
+    ):
+        model._drop_parent_str_from_datatree(None)
+
+
+def test_drop_parent_str_renames_response_mean(data_ddm):
+    """Posterior cleanup restores the model's response-parameter name."""
+    model = HSSM(data=data_ddm)
+    traces = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset(
+                {
+                    "rt,response_mean": (
+                        ("chain", "draw"),
+                        np.array([[0.5]]),
+                    )
+                }
+            )
+        }
+    )
+
+    result = model._drop_parent_str_from_datatree(traces)
+
+    assert result is traces
+    assert model._parent in result["posterior"].data_vars
+    assert "rt,response_mean" not in result["posterior"].data_vars
+    np.testing.assert_array_equal(
+        result["posterior"][model._parent].values,
+        np.array([[0.5]]),
+    )
 
 
 def test_is_choice_only_and_deadline(data_ddm):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -33,7 +33,7 @@ hssm.set_floatX("float32")
 
 
 def has_twin(ax):
-    """Checks if an axes has a twin axes with the same bounds.
+    """Check whether an axes has a twin axes with the same bounds.
 
     Credit: https://stackoverflow.com/questions/36209575/how-to-detect-if-a-twin-axis-has-been-generated-for-a-matplotlib-axis
     """
@@ -50,10 +50,12 @@ class TestPlotting:
     """Grouping all plotting tests into a single slow pytest class."""
 
     def test__get_title(self):
+        """Check grouped title formatting."""
         assert _get_title(("a"), ("b")) == "a = b"
         assert _get_title(("a", "b"), ("c", "d")) == "a = c | b = d"
 
     def test__subset_df(self, cavanagh_test):
+        """Check dataframe subsetting and invalid group values."""
         with pytest.raises(ValueError):
             _row_mask_with_error(cavanagh_test, "conf", "Bad value")
         cav_subset = cavanagh_test.loc[
@@ -99,7 +101,6 @@ class TestPlotting:
 
     def test__get_plotting_df(self, posterior, cavanagh_test):
         """Test _get_plotting_df."""
-
         # Makes a mock DataTree object
         posterior_dataset = xr.Dataset(data_vars={"rt,response": posterior})
         idata = xr.DataTree.from_dict({"posterior_predictive": posterior_dataset})
@@ -147,6 +148,7 @@ class TestPlotting:
             _process_lines(["-", 1], mode="linestyles")
 
     def test__plot_predictive_1D(self, cav_dt, cavanagh_test):
+        """Check one-dimensional predictive plotting line counts."""
         df = _get_plotting_df(
             cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
@@ -161,6 +163,7 @@ class TestPlotting:
         assert len(ax2.get_lines()) == 1
 
     def test__plot_predictive_2D(self, cav_dt, cavanagh_test):
+        """Check two-dimensional predictive plotting facet and line counts."""
         df = _get_plotting_df(
             cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
@@ -189,6 +192,7 @@ class TestPlotting:
         strict=True,  # This will let us know in the future when this is fixed
     )
     def test_plot_predictive(self, cav_dt, cavanagh_test):
+        """Check public predictive plotting across direct and sampled inputs."""
         model = hssm.HSSM(
             data=cavanagh_test,
             include=[
@@ -266,6 +270,7 @@ class TestPlotting:
         )
 
     def test__process_df_for_qp_plot(self, cav_dt, cavanagh_test):
+        """Check quantile-probability dataframe preparation and errors."""
         df = _get_plotting_df(
             cav_dt, cavanagh_test, extra_dims=["participant_id", "conf"]
         )
@@ -699,7 +704,6 @@ class TestPlotting:
 
     def test__get_plotting_df_quantile_by_dims_validation(self, cav_dt, cavanagh_test):
         """Test _get_plotting_df with various quantile_by_dims inputs for validation coverage."""
-
         # Test 0: quantile_by_dims as None (should be None)
         df_none = _get_plotting_df(
             cav_dt,
@@ -765,7 +769,6 @@ class TestPlotting:
 
     def test__get_plotting_df_quantile_by_dims_edge_cases(self, cav_dt, cavanagh_test):
         """Test additional edge cases for quantile_by_dims to ensure full coverage."""
-
         # Test 1: quantile_by_dims provided but extra_dims is None
         df1 = _get_plotting_df(
             cav_dt,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -2,7 +2,6 @@
 
 import sys
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -10,23 +9,24 @@ import pytest
 import xarray as xr
 
 import hssm
-from hssm.plotting.utils import (
-    _get_plotting_df,
-    _xarray_to_df,
-    _get_title,
-    _subset_df,
-    _row_mask_with_error,
-    _process_df_for_qp_plot,
-)
 from hssm.plotting.predictive import (
     _plot_predictive_1D,
     _plot_predictive_2D,
+    _process_lines,
     plot_predictive,
 )
 from hssm.plotting.quantile_probability import (
     _plot_quantile_probability_1D,
     _plot_quantile_probability_2D,
     plot_quantile_probability,
+)
+from hssm.plotting.utils import (
+    _get_plotting_df,
+    _get_title,
+    _process_df_for_qp_plot,
+    _row_mask_with_error,
+    _subset_df,
+    _xarray_to_df,
 )
 
 hssm.set_floatX("float32")
@@ -128,6 +128,23 @@ class TestPlotting:
 
         with pytest.raises(ValueError):
             _get_plotting_df(idata, data=None, extra_dims=["participant_id", "conf"])
+
+        with pytest.raises(ValueError, match="Either dt or data must be provided"):
+            _get_plotting_df(dt=None, data=None)
+
+    def test__process_lines(self):
+        """Line style and width helpers normalize sequences and dictionaries."""
+        assert _process_lines(["--"], mode="linestyles") == ["--", "--"]
+        assert _process_lines(("--", ":"), mode="linestyles") == ["--", ":"]
+        assert _process_lines([1.5], mode="linewidths") == [1.5, 1.5]
+        assert _process_lines((1.0, 2.0), mode="linewidths") == [1.0, 2.0]
+        assert _process_lines({"predicted": "--"}, mode="linestyles") == ["--", "-"]
+        assert _process_lines({"observed": 2.0}, mode="linewidths") == [1.25, 2.0]
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            _process_lines("-", mode="colors")
+        with pytest.raises(ValueError, match="must be a str or a list of strs"):
+            _process_lines(["-", 1], mode="linestyles")
 
     def test__plot_predictive_1D(self, cav_dt, cavanagh_test):
         df = _get_plotting_df(
@@ -268,6 +285,17 @@ class TestPlotting:
         # Test 2: passing cond not as str
         with pytest.raises(ValueError):
             _process_df_for_qp_plot(df=df, q=6, cond=1, correct=None)
+
+        iterable_quantiles = _process_df_for_qp_plot(
+            df=df,
+            q=[0.25, 0.5, 0.75],
+            cond="conf",
+            correct=None,
+        )
+        np.testing.assert_allclose(
+            sorted(iterable_quantiles["quantile"].unique()),
+            [0.25, 0.5, 0.75],
+        )
 
     @pytest.mark.parametrize(
         "predictive_style",

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -1,8 +1,10 @@
 import sys
 
-import hssm
-import pytest
 import numpy as np
+import pytest
+import xarray as xr
+
+import hssm
 
 hssm.set_floatX("float32")
 
@@ -40,7 +42,6 @@ PARAMETER_GRID = [
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, inplace):
     """Test sample_posterior_predictive method."""
-
     model = hssm.HSSM(
         data=cavanagh_test,
         include=[
@@ -84,3 +85,82 @@ def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, in
             assert posterior_predictive.posterior_predictive.draw.size == size
     except AssertionError:
         raise
+
+
+def _minimal_posterior_datatree(include_posterior_predictive=False):
+    groups = {
+        "posterior": xr.Dataset(
+            {"v": (("chain", "draw"), np.array([[0.4, 0.6]]))},
+            coords={"chain": [0], "draw": [0, 1]},
+        )
+    }
+    if include_posterior_predictive:
+        groups["posterior_predictive"] = xr.Dataset(
+            {"prediction": (("chain", "draw"), np.array([[-1.0, -1.0]]))},
+            coords={"chain": [0], "draw": [0, 1]},
+        )
+    return xr.DataTree.from_dict(groups)
+
+
+def test_sample_posterior_predictive_uses_attached_traces_for_response_params(
+    data_ddm, monkeypatch
+):
+    """Response-parameter prediction delegates with attached traces by default."""
+    model = hssm.HSSM(data=data_ddm)
+    traces = _minimal_posterior_datatree()
+    expected = traces.copy(deep=True)
+    model._inference_obj = traces
+    calls = []
+
+    def fake_predict(dt, kind, data, inplace, include_group_specific):
+        calls.append((dt, kind, data, inplace, include_group_specific))
+        return expected
+
+    monkeypatch.setattr(model.model, "predict", fake_predict)
+
+    result = model.sample_posterior_predictive(
+        kind="response_params",
+        inplace=False,
+        include_group_specific=False,
+    )
+
+    assert result is expected
+    assert len(calls) == 1
+    assert calls[0][0] is traces
+    assert calls[0][1:] == ("response_params", None, False, False)
+
+
+def test_sample_posterior_predictive_replaces_existing_group_inplace(
+    caplog, data_ddm, monkeypatch
+):
+    """An explicit in-place prediction removes stale draws before replacement."""
+    model = hssm.HSSM(data=data_ddm)
+    traces = _minimal_posterior_datatree(include_posterior_predictive=True)
+    replacement = xr.Dataset(
+        {"prediction": (("chain", "draw"), np.array([[1.0, 2.0]]))},
+        coords={"chain": [0], "draw": [0, 1]},
+    )
+    calls = []
+
+    def fake_predict(dt, kind, data, inplace, include_group_specific):
+        calls.append((dt, kind, data, inplace, include_group_specific))
+        assert "posterior_predictive" not in dt
+        dt["posterior_predictive"] = replacement
+
+    monkeypatch.setattr(model.model, "predict", fake_predict)
+
+    result = model.sample_posterior_predictive(
+        dt=traces,
+        kind="response_params",
+        inplace=True,
+    )
+
+    assert result is None
+    assert len(calls) == 1
+    assert calls[0][0] is traces
+    assert calls[0][1:] == ("response_params", None, True, True)
+    np.testing.assert_array_equal(
+        traces["posterior_predictive"]["prediction"].values,
+        np.array([[1.0, 2.0]]),
+    )
+    assert "pre-existing posterior_predictive group deleted" in caplog.text

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -1,3 +1,5 @@
+"""Tests for HSSM posterior-predictive sampling."""
+
 import sys
 
 import numpy as np

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -89,27 +89,12 @@ def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, in
         raise
 
 
-def _minimal_posterior_datatree(include_posterior_predictive=False):
-    groups = {
-        "posterior": xr.Dataset(
-            {"v": (("chain", "draw"), np.array([[0.4, 0.6]]))},
-            coords={"chain": [0], "draw": [0, 1]},
-        )
-    }
-    if include_posterior_predictive:
-        groups["posterior_predictive"] = xr.Dataset(
-            {"prediction": (("chain", "draw"), np.array([[-1.0, -1.0]]))},
-            coords={"chain": [0], "draw": [0, 1]},
-        )
-    return xr.DataTree.from_dict(groups)
-
-
 def test_sample_posterior_predictive_uses_attached_traces_for_response_params(
-    data_ddm, monkeypatch
+    data_ddm, minimal_posterior_datatree, monkeypatch
 ):
     """Response-parameter prediction delegates with attached traces by default."""
     model = hssm.HSSM(data=data_ddm)
-    traces = _minimal_posterior_datatree()
+    traces = minimal_posterior_datatree()
     expected = traces.copy(deep=True)
     model._inference_obj = traces
     calls = []
@@ -133,11 +118,11 @@ def test_sample_posterior_predictive_uses_attached_traces_for_response_params(
 
 
 def test_sample_posterior_predictive_replaces_existing_group_inplace(
-    caplog, data_ddm, monkeypatch
+    caplog, data_ddm, minimal_posterior_datatree, monkeypatch
 ):
     """An explicit in-place prediction removes stale draws before replacement."""
     model = hssm.HSSM(data=data_ddm)
-    traces = _minimal_posterior_datatree(include_posterior_predictive=True)
+    traces = minimal_posterior_datatree(include_posterior_predictive=True)
     replacement = xr.Dataset(
         {"prediction": (("chain", "draw"), np.array([[1.0, 2.0]]))},
         coords={"chain": [0], "draw": [0, 1]},

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -102,3 +102,38 @@ def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
     assert loaded_model._inference_obj_vi is None
     assert loaded_model._inference_obj is not None
     compare_hssm_class_attributes(basic_hssm_model, loaded_model)
+
+
+@pytest.mark.parametrize(
+    ("existing_filename", "loaded_group", "missing_filename"),
+    [
+        ("traces.nc", "idata_mcmc", "vi_traces.nc"),
+        ("vi_traces.nc", "idata_vi", "traces.nc"),
+    ],
+)
+def test_load_model_traces_tolerates_each_missing_file(
+    caplog,
+    tmp_path,
+    existing_filename,
+    loaded_group,
+    missing_filename,
+):
+    """Either trace file can be loaded when its counterpart is absent."""
+    traces = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset(
+                {"theta": (("chain", "draw"), np.array([[0.25, 0.75]]))},
+                coords={"chain": [0], "draw": [0, 1]},
+            )
+        }
+    )
+    traces.to_netcdf(tmp_path / existing_filename)
+
+    loaded = hssm.HSSM.load_model_traces(tmp_path)
+
+    assert set(loaded.children) == {loaded_group}
+    xr.testing.assert_identical(
+        loaded[f"{loaded_group}/posterior"].ds,
+        traces["posterior"].ds,
+    )
+    assert f"{missing_filename} file does not exist" in caplog.text

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,3 +1,5 @@
+"""Tests for HSSM model and trace serialization."""
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -7,6 +9,7 @@ import hssm
 
 # Check some attributes are the same
 def compare_hssm_class_attributes(model_a, model_b):
+    """Assert that persisted and restored models share core state."""
     a = np.array([type(v) for k, v in model_a._init_args.items()])
     b = np.array([type(v) for k, v in model_b._init_args.items()])
     assert (a == b).all(), "Init arg types not the same"
@@ -24,6 +27,7 @@ def compare_hssm_class_attributes(model_a, model_b):
 
 @pytest.mark.slow
 def test_save_load_model_only(basic_hssm_model, tmp_path):
+    """Round-trip a model without attached traces."""
     tmp_model_name = "hssm_model_pytest"
     basic_hssm_model.save_model(
         model_name=tmp_model_name, base_path=tmp_path, allow_absolute_base_path=True
@@ -34,6 +38,7 @@ def test_save_load_model_only(basic_hssm_model, tmp_path):
 
 @pytest.mark.slow
 def test_save_load_vi_mcmc(basic_hssm_model, tmp_path):
+    """Round-trip model and trace directories across MCMC and VI states."""
     # Sample to attach vi and mcmc traces to model
     # Using minimal parameters since we only need traces to exist, not be accurate
     basic_hssm_model.sample(

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -132,13 +132,17 @@ def test_load_model_traces_tolerates_each_missing_file(
             )
         }
     )
-    traces.to_netcdf(tmp_path / existing_filename)
+    trace_path = tmp_path / existing_filename
+    traces.to_netcdf(trace_path)
 
-    loaded = hssm.HSSM.load_model_traces(tmp_path)
+    try:
+        loaded = hssm.HSSM.load_model_traces(tmp_path)
 
-    assert set(loaded.children) == {loaded_group}
-    xr.testing.assert_identical(
-        loaded[f"{loaded_group}/posterior"].ds,
-        traces["posterior"].ds,
-    )
-    assert f"{missing_filename} file does not exist" in caplog.text
+        assert set(loaded.children) == {loaded_group}
+        xr.testing.assert_identical(
+            loaded[f"{loaded_group}/posterior"].ds,
+            traces["posterior"].ds,
+        )
+        assert f"{missing_filename} file does not exist" in caplog.text
+    finally:
+        trace_path.unlink(missing_ok=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+"""Tests for HSSM utility helpers."""
+
 import sys
 from types import SimpleNamespace
 
@@ -22,6 +24,7 @@ hssm.set_floatX("float32")
 
 @pytest.mark.slow
 def test_get_alias_dict():
+    """Build aliases for default and regression parameterizations."""
     # Simulate some data:
     v_true, a_true, z_true, t_true = [0.5, 1.5, 0.5, 0.5]
     obs_ddm = simulator([v_true, a_true, z_true, t_true], model="ddm", n_samples=1000)
@@ -85,6 +88,7 @@ def test_get_alias_dict():
 
 
 def test_set_floatX():
+    """Synchronize floating-point precision across computational backends."""
     # Should raise error when wrong value is passed.
     with pytest.raises(ValueError):
         set_floatX("bad_value")
@@ -228,6 +232,7 @@ def test__generate_random_indice(caplog, n_samples, n_draws, expected):
 
 
 def assertions(caplog, obj, n_samples, expected):
+    """Assert random-sampling behavior for one xarray object."""
     if expected == "error":
         with pytest.raises(ValueError):
             sampled_obj = _random_sample(obj, n_samples=n_samples)
@@ -235,7 +240,7 @@ def assertions(caplog, obj, n_samples, expected):
         sampled_obj = _random_sample(obj, n_samples=n_samples)
         assert sampled_obj.draw.size == expected
         assert sampled_obj.chain.size == 2
-        assert type(sampled_obj) == type(obj)
+        assert type(sampled_obj) is type(obj)
         if n_samples and n_samples > obj.draw.size:
             assert "n_samples > n_draws" in caplog.text
 
@@ -260,6 +265,7 @@ def test__random_sample(
     n_samples,
     expected,
 ):
+    """Subsample posterior groups for supported sample specifications."""
     posterior = cav_dt["posterior"]
     posterior_predictive = cav_dt["posterior_predictive"]
 
@@ -268,6 +274,7 @@ def test__random_sample(
 
 
 def test_check_data_for_rl():
+    """Validate and sort reinforcement-learning trial data."""
     # Valid DataFrame
     data_valid = pd.DataFrame(
         {
@@ -337,6 +344,7 @@ def test_check_data_for_rl():
     strict=True,  # This will let us know in the future when this is fixed
 )
 def test_predictive_idata_to_dataframe(data_ddm):
+    """Convert prior-predictive draws to a tidy DataFrame."""
     model = hssm.HSSM(data=data_ddm)
     sample_do = model.sample_do(params={"v": 1.0}, draws=10)
     assert isinstance(sample_do, xr.DataTree)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,24 +102,28 @@ def test_set_floatX():
     assert config.read("jax_enable_x64")
 
 
-def _minimal_log_likelihood_datatree(include_log_likelihood=False):
-    groups = {
-        "posterior": xr.Dataset(
-            {"theta": (("chain", "draw"), np.array([[0.25, 0.75]]))},
-            coords={"chain": [0], "draw": [0, 1]},
+@pytest.fixture
+def minimal_log_likelihood_datatree(minimal_posterior_datatree):
+    """Return a factory for compact log-likelihood DataTrees."""
+
+    def _make(include_log_likelihood=False):
+        traces = minimal_posterior_datatree(
+            posterior_var="theta",
+            posterior_values=np.array([[0.25, 0.75]]),
         )
-    }
-    if include_log_likelihood:
-        groups["log_likelihood"] = xr.Dataset(
-            {
-                "rt,response": (
-                    ("chain", "draw", "__obs__"),
-                    np.full((1, 2, 1), -99.0),
-                )
-            },
-            coords={"chain": [0], "draw": [0, 1], "__obs__": [0]},
-        )
-    return xr.DataTree.from_dict(groups)
+        if include_log_likelihood:
+            traces["log_likelihood"] = xr.Dataset(
+                {
+                    "rt,response": (
+                        ("chain", "draw", "__obs__"),
+                        np.full((1, 2, 1), -99.0),
+                    )
+                },
+                coords={"chain": [0], "draw": [0, 1], "__obs__": [0]},
+            )
+        return traces
+
+    return _make
 
 
 def _log_likelihood_model(family):
@@ -154,10 +158,12 @@ def _fake_log_likelihood(family, **kwargs):
     )
 
 
-def test_compute_log_likelihood_returns_deep_copy(monkeypatch):
+def test_compute_log_likelihood_returns_deep_copy(
+    minimal_log_likelihood_datatree, monkeypatch
+):
     """Non-in-place computation leaves the supplied posterior untouched."""
     model = _log_likelihood_model(family=object())
-    traces = _minimal_log_likelihood_datatree()
+    traces = minimal_log_likelihood_datatree()
     monkeypatch.setattr("hssm.utils.log_likelihood", _fake_log_likelihood)
 
     result = _compute_log_likelihood(model, traces, data=None, inplace=False)
@@ -170,10 +176,12 @@ def test_compute_log_likelihood_returns_deep_copy(monkeypatch):
     assert traces["posterior"]["theta"].values[0, 0] == 0.25
 
 
-def test_compute_log_likelihood_rejects_missing_family():
+def test_compute_log_likelihood_rejects_missing_family(
+    minimal_log_likelihood_datatree,
+):
     """Log-likelihood computation requires a configured model family."""
     model = _log_likelihood_model(family=None)
-    traces = _minimal_log_likelihood_datatree()
+    traces = minimal_log_likelihood_datatree()
 
     with pytest.raises(
         ValueError,
@@ -182,10 +190,12 @@ def test_compute_log_likelihood_rejects_missing_family():
         _compute_log_likelihood(model, traces, data=None)
 
 
-def test_compute_log_likelihood_warns_and_replaces_existing_group(caplog, monkeypatch):
+def test_compute_log_likelihood_warns_and_replaces_existing_group(
+    caplog, minimal_log_likelihood_datatree, monkeypatch
+):
     """Recomputation replaces stale log-likelihood values in-place."""
     model = _log_likelihood_model(family=object())
-    traces = _minimal_log_likelihood_datatree(include_log_likelihood=True)
+    traces = minimal_log_likelihood_datatree(include_log_likelihood=True)
     monkeypatch.setattr("hssm.utils.log_likelihood", _fake_log_likelihood)
 
     result = _compute_log_likelihood(model, traces, data=None, inplace=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,18 +1,20 @@
 import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
 import pytensor
 import pytest
 import xarray as xr
-from ssms.basic_simulators.simulator import simulator
 from jax import config
+from ssms.basic_simulators.simulator import simulator
 
 import hssm
 from hssm.utils import (
-    set_floatX,
+    _compute_log_likelihood,
     _generate_random_indices,
     _random_sample,
+    set_floatX,
 )
 
 hssm.set_floatX("float32")
@@ -94,6 +96,102 @@ def test_set_floatX():
     set_floatX("float64")
     assert pytensor.config.floatX == "float64"
     assert config.read("jax_enable_x64")
+
+
+def _minimal_log_likelihood_datatree(include_log_likelihood=False):
+    groups = {
+        "posterior": xr.Dataset(
+            {"theta": (("chain", "draw"), np.array([[0.25, 0.75]]))},
+            coords={"chain": [0], "draw": [0, 1]},
+        )
+    }
+    if include_log_likelihood:
+        groups["log_likelihood"] = xr.Dataset(
+            {
+                "rt,response": (
+                    ("chain", "draw", "__obs__"),
+                    np.full((1, 2, 1), -99.0),
+                )
+            },
+            coords={"chain": [0], "draw": [0, 1], "__obs__": [0]},
+        )
+    return xr.DataTree.from_dict(groups)
+
+
+def _log_likelihood_model(family):
+    def compute_likelihood_params(
+        dt,
+        data,
+        include_group_specific,
+        sample_new_groups,
+    ):
+        assert data is None
+        assert include_group_specific is True
+        assert sample_new_groups is False
+        return dt
+
+    return SimpleNamespace(
+        response_component=SimpleNamespace(
+            term=SimpleNamespace(alias="rt,response", name="c(rt, response)")
+        ),
+        family=family,
+        _compute_likelihood_params=compute_likelihood_params,
+    )
+
+
+def _fake_log_likelihood(family, **kwargs):
+    assert family is kwargs["model"].family
+    assert kwargs["data"] is None
+    assert kwargs["posterior"].name == "posterior"
+    return xr.DataArray(
+        np.array([[[-1.0], [-2.0]]]),
+        dims=("chain", "draw", "__obs__"),
+        coords={"chain": [0], "draw": [0, 1], "__obs__": [0]},
+    )
+
+
+def test_compute_log_likelihood_returns_deep_copy(monkeypatch):
+    """Non-in-place computation leaves the supplied posterior untouched."""
+    model = _log_likelihood_model(family=object())
+    traces = _minimal_log_likelihood_datatree()
+    monkeypatch.setattr("hssm.utils.log_likelihood", _fake_log_likelihood)
+
+    result = _compute_log_likelihood(model, traces, data=None, inplace=False)
+
+    assert result is not traces
+    assert isinstance(result, xr.DataTree)
+    assert "log_likelihood" in result
+    assert "log_likelihood" not in traces
+    result["posterior"]["theta"].values[0, 0] = 10.0
+    assert traces["posterior"]["theta"].values[0, 0] == 0.25
+
+
+def test_compute_log_likelihood_rejects_missing_family():
+    """Log-likelihood computation requires a configured model family."""
+    model = _log_likelihood_model(family=None)
+    traces = _minimal_log_likelihood_datatree()
+
+    with pytest.raises(
+        ValueError,
+        match="Model family is not defined. Cannot compute log-likelihood.",
+    ):
+        _compute_log_likelihood(model, traces, data=None)
+
+
+def test_compute_log_likelihood_warns_and_replaces_existing_group(caplog, monkeypatch):
+    """Recomputation replaces stale log-likelihood values in-place."""
+    model = _log_likelihood_model(family=object())
+    traces = _minimal_log_likelihood_datatree(include_log_likelihood=True)
+    monkeypatch.setattr("hssm.utils.log_likelihood", _fake_log_likelihood)
+
+    result = _compute_log_likelihood(model, traces, data=None, inplace=True)
+
+    assert result is traces
+    np.testing.assert_array_equal(
+        traces["log_likelihood"]["rt,response"].values,
+        np.array([[[-1.0], [-2.0]]]),
+    )
+    assert "Replacing existing log_likelihood group in dt." in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

This PR addresses the Codecov coverage regressions on `main` after the PyMC 6 /
DataTree migration. The intent is to raise patch coverage without changing the
Codecov threshold, changing the coverage workflow, or weakening the existing
`--cov=.` policy.

The changes are deliberately focused on meaningful behavioral assertions around
branches that already existed but were not covered by the migrated tests:

- DataTree migration paths in HSSM model utilities, save/load, and posterior
  predictive sampling.
- RLSSM migration and registry branches.
- Plotting and distribution utility branches highlighted by the coverage report.

## What changed and why

### `tests/test_hssm.py`

This file was expanded because several uncovered branches live on the core HSSM
model object and were introduced or exposed by the DataTree migration.

The new tests cover:

- `HSSM.sample()` storing a PyMC `DataTree` inference result on the model.
- `HSSM.sample()` preserving a non-DataTree return when the sampler returns an
  alternate object type.
- `HSSM.get_model_info()` reporting either `None` or the stored inference
  object based on whether traces are available.
- `HSSM._update_model()` rejecting updates without an existing inference object.
- `HSSM.sample_posterior_predictive()` updating an existing `DataTree` in place.
- The explicit `NotImplementedError` for posterior predictive sampling on
  non-DataTree traces.

These assertions are aimed at the migration contract rather than simply calling
methods for coverage.

### `tests/test_sample_posterior_predictive.py`

This file was touched because posterior predictive utilities are a major part of
the DataTree migration surface and had uncovered error/merge branches.

The new tests cover:

- Appending posterior predictive samples into an existing `DataTree`.
- Returning only the posterior predictive group when `include_posterior=False`.
- Rejecting unsupported traces that are neither `DataTree` nor `None`.
- Warning and recovery behavior when posterior predictive samples are missing
  and need to be regenerated.

This verifies both the stored-trace and explicit-argument paths used by HSSM's
public predictive APIs.

### `tests/test_save_load.py`

This file was touched because save/load behavior had migrated from
`InferenceData` assumptions to DataTree-aware persistence.

The added tests cover:

- Saving and loading an `HSSM` model with a `DataTree` trace.
- Preserving important model metadata across the round trip.
- Saving when no trace is present.
- Rejecting unsupported trace objects during save/load workflows.

These assertions protect the serialized form expected by users after the
migration.

### `tests/test_utils.py`

This file was expanded because shared utility helpers now have DataTree-specific
branches that Codecov flagged as uncovered.

The new tests cover:

- Converting DataTree predictive groups to plotting dataframes.
- Returning observed-only plotting data when no predictive tree is supplied.
- Handling missing predictive groups and missing observed data.
- Updating an existing DataTree with newly generated posterior predictive or
  prior predictive samples.
- Error behavior when utility functions receive unsupported trace-like objects.

The assertions focus on shape, group presence, mutation semantics, and clear
error handling.

### `tests/rl/test_registry.py`

This file was touched because RL registry discovery and fallback behavior had
several uncovered branches.

The new tests cover:

- The inverse-temperature softmax base logp path under x64-disabled JAX,
  including the float64-to-float32 downcast behavior.
- Optional `ssms.rl` discovery fallbacks when the module cannot be imported.
- Missing `preset.list` and missing `resolve_model` behavior in optional ssms
  integration.
- The warning emitted when a custom HSSM registration shadows an ssms preset
  name.

These tests make the optional dependency boundary explicit and ensure registry
behavior remains deterministic when ssms capabilities differ by installation.

### `tests/rl/test_rl_likelihood_builder.py`

This file was touched because computed-parameter handling in the RL likelihood
builder had uncovered multi-output and error branches.

The new tests cover:

- Tuple-returning multi-output computed functions.
- Last-axis array multi-output computed functions.
- Rejection of invalid multi-output array shapes.
- Rejection of dict outputs that omit a requested computed parameter.

These assertions verify that computed RLSSM parameters are reconstructed
correctly before they flow into likelihood evaluation.

### `tests/rl/test_rlssm.py`

This file was touched because RLSSM validation branches were uncovered after the
migration.

The new tests cover:

- Choice-only response validation as a no-op when response metadata is
  incomplete.
- Missing response-column metadata.
- Missing choice metadata.
- Scalar choice-only lapse bounds, including the documented `0 < lapse <= 1`
  validation.

These tests avoid over-constraining incomplete model metadata while still
protecting the choice-only lapse contract.

### `tests/rl/test_rlssm_config.py`

This file was touched to exercise the ssms-backed RLSSM bridge more completely.

The existing fake multi-parameter ssms bridge test now executes the shared
computed wrapper and asserts exact `v` / `a` values. This covers the actual
bridge behavior rather than only checking that the bridge object is assembled.

### `tests/distribution_utils/test_distribution_utils.py`

This file was touched because `_apply_lapse_model` had an uncovered branch for
numeric lapse values.

The added test verifies that numeric choice-only lapse values are rejected when
`p_outlier` asks for RT lapse simulation. Numeric lapse is valid for
choice-only probability handling, but it cannot generate reaction-time lapse
samples; the test documents that distinction.

### `tests/test_plotting.py`

This file was touched because plotting helper branches were highlighted by the
coverage report.

The new tests cover:

- `_get_plotting_df(dt=None, data=None)` raising the documented no-input error.
- `_process_lines()` handling one- and two-element line style / line width
  sequences.
- `_process_lines()` handling dictionaries with default predicted/observed
  values.
- `_process_lines()` rejecting invalid modes and invalid element types.
- `_process_df_for_qp_plot()` accepting iterable quantiles.

Ruff also removed one unused `arviz` import and sorted the touched import block.

### `src/hssm/plotting/utils.py`

This file was touched because coverage showed a duplicate nested validation
branch that was unreachable.

The function already raises when both `dt` and `data` are `None`. The nested
`if data is None` inside the `dt is None` branch could therefore never be
reached. I removed that duplicate runtime branch and added an assertion after
the top-level validation to keep Pyrefly's type narrowing explicit.

### `src/hssm/plotting/model_cartoon.py`

This file was touched for the same reason: the coverage report identified an
unreachable fallback guard.

The public no-predictive path is already rejected earlier with the
`At least one of plot_predictive_mean or plot_predictive_samples must be True`
validation. The later `plotting_df is None` guard was dead under the current
validated control flow. I removed the unreachable raise and replaced it with an
assertion at the merge point so static analysis still knows the dataframe is
present.

## What did not change

- No Codecov threshold was lowered.
- No coverage workflow was changed.
- No dependency metadata was changed.
- No public plotting, RLSSM, save/load, or predictive API behavior was intended
  to change.
- No generated scratch files were committed.

## Verification

Targeted DataTree migration tests:

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run pytest tests/test_hssm.py tests/test_sample_posterior_predictive.py \
  tests/test_save_load.py tests/test_utils.py \
  -o addopts="--timeout=360 --reruns=2 --reruns-delay=5" \
  --cov=src/hssm --cov-report=term-missing
```

Result: `82 passed, 267 warnings in 231.68s`.

- `src/hssm/base.py`: 183 -> 158 missing lines; 71% -> 75% in this focused
  four-module slice.
- `src/hssm/utils.py`: 42 -> 38 missing lines; 80% -> 82%.
- None of the 19 requested baseline DataTree migration lines remained in the
  final missing-line report.

Task 1 lint follow-up after review:

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run ruff check tests/test_hssm.py \
  tests/test_sample_posterior_predictive.py tests/test_save_load.py \
  tests/test_utils.py
```

Result: `All checks passed!` with no ignores.

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run ruff format --check tests/test_hssm.py \
  tests/test_sample_posterior_predictive.py tests/test_save_load.py \
  tests/test_utils.py
```

Result: `4 files already formatted`.

Targeted RLSSM migration tests:

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run pytest tests/rl/test_registry.py tests/rl/test_rl_likelihood_builder.py \
  tests/rl/test_rlssm.py tests/rl/test_rlssm_config.py \
  -o addopts="--timeout=360 --reruns=2 --reruns-delay=5" \
  --cov=src/hssm --cov-report=term-missing
```

Result: `158 passed, 6 warnings in 12.37s`.

Targeted plotting/distribution tests:

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run pytest tests/test_plotting.py tests/test_plotting_cartoon.py \
  tests/distribution_utils/test_distribution_utils.py \
  -o addopts="--timeout=360 --reruns=2 --reruns-delay=5" \
  --cov=src/hssm --cov-report=term-missing
```

Result: `87 passed, 1585 warnings in 184.36s`.

Static checks:

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run pyrefly check
```

Result: `0 errors (60 suppressed, 32 warnings not shown)`.

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run ruff format --check <touched files>
```

Result: all touched files already formatted.

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run ruff check <touched files> \
  --ignore D100,D101,D102,D103,D202,D401,E501,B017,F841,E721
```

Result: `All checks passed!`.

Plain Ruff still reports pre-existing legacy test style debt in older test
modules, especially missing docstrings, line length, and unused assignments.
Those were not broadened in this PR because the goal is Codecov remediation, not
a broad style rewrite.

Docstring coverage follow-up:

CodeRabbit reported docstring coverage at `78.18%`, below its `80.00%`
threshold. The follow-up commit `570e9e80` adds concise docstrings to the
changed test helpers, classes, and methods that were counted by the docstring
coverage check, without changing production behavior.

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run ruff check tests/test_hssm.py tests/test_sample_posterior_predictive.py \
  tests/test_save_load.py tests/test_utils.py tests/rl/test_registry.py \
  tests/rl/test_rl_likelihood_builder.py tests/rl/test_rlssm.py \
  tests/rl/test_rlssm_config.py tests/distribution_utils/test_distribution_utils.py \
  tests/test_plotting.py src/hssm/plotting/utils.py \
  src/hssm/plotting/model_cartoon.py --select D
```

Result: `All checks passed!`.

```bash
UV_PROJECT_ENVIRONMENT=/Users/krishnbera/Documents/HSSMSpine/_local/venvs/fix-main-codecov-regressions \
  uv run pytest tests/distribution_utils/test_distribution_utils.py \
  tests/rl/test_rl_likelihood_builder.py tests/rl/test_rlssm_config.py \
  tests/test_plotting.py --no-cov -q
```

Result: `138 passed, 12 warnings in 20.71s`.

```bash
git diff --check
```

Result: no whitespace errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened validation for plotting inputs and quantile/line processing, with clearer error messages.
  - Improved handling of RL/likelihood computed-parameter outputs (tuple/multi-output array support and shape checks) and numeric lapse misuse.
  - Updated log-likelihood and posterior-predictive sampling behavior around attached traces, copying vs in-place updates, and tolerant loading of available trace files.
- **Tests**
  - Expanded coverage for RL preset discovery/resolution safety, RLSSM configuration/model structure rules, likelihood builders, plotting utilities, and save/load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->