### PR TITLE
fix: restore posterior/prior predictive sampling on Python 3.14 (PEP 649 annotations vs numba's vendored cloudpickle)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@
 
 1. `bambi` floor raised to `>=0.19.0` (per-parameter non-centered support); `ssm-simulators` floor raised to `>=0.13.1` (aDDM engine + fixation continuation).
 
+#### Bug fixes:
+
+1. **Python 3.14: posterior/prior predictive sampling fixed.** On 3.14, the dynamically created SSM random-variable class carried PEP 649 annotation metadata that numba's vendored cloudpickle could not serialize (`TypeError: cannot pickle '_abc._abc_data' object`), breaking `sample_posterior_predictive` and related plotting under the numba backend. The class attributes are now un-annotated plain assignments, and the previous 3.14 xfail markers on the predictive/plotting tests have been removed.
+
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.

--- a/src/hssm/distribution_utils/dist.py
+++ b/src/hssm/distribution_utils/dist.py
@@ -222,9 +222,24 @@ def make_hssm_rv(
 
     # pylint: disable=W0511, R0903
     class HSSMRV(RandomVariable):
-        """HSSMRV random variable."""
+        """HSSMRV random variable.
 
-        name: str = model_name + "_RV"
+        The class attributes below are deliberately NOT type-annotated. On
+        Python 3.14, class-body annotations generate a PEP 649
+        ``__annotate_func__`` whose closure references the class namespace —
+        including ABCMeta's unpicklable ``_abc_impl`` (``HSSMRV``'s metaclass
+        chain is rooted in ``ABCMeta`` via pytensor's ``MetaType``). This
+        dynamic ``<locals>`` class is pickled by value by numba's vendored
+        cloudpickle whenever the numba backend object-mode-lifts an RV
+        ``perform`` (posterior/prior predictive sampling), and that vendored
+        cloudpickle cannot serialize the annotate function:
+        ``TypeError: cannot pickle '_abc._abc_data' object``. Plain
+        assignments create no ``__annotate_func__`` and pickle cleanly.
+        Types, for reference: ``name``/``signature``/``dtype``: ``str``;
+        ``_print_name``: ``tuple[str, str]``; ``_extra_fields``: ``dict | None``.
+        """
+
+        name = model_name + "_RV"
         # New in PyMC 5.16+: instead of using `ndims_supp`, we use `signature` to define
         # the signature of the random variable. The string to the left of the `->` sign
         # describes the input signature, which is `()` for each parameter, meaning each
@@ -235,10 +250,10 @@ def make_hssm_rv(
         # Override the output from ssm_simulator based on whether the model is
         # choice-only.
         output = "()" if is_choice_only else f"({obs_dim_int})"
-        signature: str = f"{','.join(['()'] * len(list_params))}->{output}"
+        signature = f"{','.join(['()'] * len(list_params))}->{output}"
 
-        dtype: str = "floatX"
-        _print_name: tuple[str, str] = ("SSM", "\\operatorname{SSM}")
+        dtype = "floatX"
+        _print_name = ("SSM", "\\operatorname{SSM}")
         _list_params = list_params
         _lapse = lapse
         # Optional per-inference covariates forwarded to the simulator so the
@@ -246,7 +261,7 @@ def make_hssm_rv(
         # per-trial inputs — e.g. aDDM fixations. Populated on the RV class at PPC
         # time (see aDDM._update_extra_fields); ``None`` keeps every existing
         # model's generative path byte-for-byte unchanged (a plain **{} splat).
-        _extra_fields: dict | None = None
+        _extra_fields = None
 
         # pylint: disable=arguments-renamed,bad-option-value,W0221
         # NOTE: `rng` now is a np.random.Generator instead of RandomState

--- a/tests/addm/test_addm_cartoon.py
+++ b/tests/addm/test_addm_cartoon.py
@@ -68,7 +68,7 @@ def test_plot_model_cartoon_addm_posterior():
 
     ax = hssm.plotting.plot_model_cartoon(
         model,
-        idata=idata,
+        dt=idata,
         n_samples=5,
         bins=20,
         plot_predictive_mean=True,

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -1,6 +1,5 @@
 """Tests for the HSSM public model interface."""
 
-import sys
 from copy import deepcopy
 from unittest.mock import Mock
 
@@ -158,11 +157,6 @@ def test_model_definition_outside_include(data_ddm):
         HSSM(data_ddm, include=[{"name": "a", "prior": 0.5}], a=0.5)
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 14),
-    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-    strict=True,  # This will let us know in the future when this is fixed
-)
 @pytest.mark.slow
 def test_sample_prior_predictive(data_ddm_reg):
     """Generate prior-predictive DataTrees across regression structures."""
@@ -524,11 +518,6 @@ class TestFixedVectorParams:
         assert "z" in idata.posterior.data_vars
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 14),
-    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-    strict=True,  # This will let us know in the future when this is fixed
-)
 @pytest.mark.slow
 def test_sample_do(data_ddm):
     """Return intervention samples and the intervened PyMC model."""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,7 +1,5 @@
 """Test plotting module."""
 
-import sys
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -186,11 +184,6 @@ class TestPlotting:
         assert len(g2.figure.axes) == 5 * 2
         assert len(g2.figure.axes[0].get_lines()) == 1
 
-    @pytest.mark.xfail(
-        sys.version_info >= (3, 14),
-        reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-        strict=True,  # This will let us know in the future when this is fixed
-    )
     def test_plot_predictive(self, cav_dt, cavanagh_test):
         """Check public predictive plotting across direct and sampled inputs."""
         model = hssm.HSSM(
@@ -361,11 +354,6 @@ class TestPlotting:
         )
         assert len(g.figure.axes) == 5 * 4
 
-    @pytest.mark.xfail(
-        sys.version_info >= (3, 14),
-        reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-        strict=True,  # This will let us know in the future when this is fixed
-    )
     @pytest.mark.parametrize("predictive_style", ["points", "ellipse", "both"])
     def test_plot_quantile_probability(self, cav_dt, cavanagh_test, predictive_style):
         """Tests the plot_quantile_probability function.

--- a/tests/test_plotting_cartoon.py
+++ b/tests/test_plotting_cartoon.py
@@ -1,18 +1,11 @@
 """Test plotting module."""
 
-import sys
-
-import pytest
 import numpy as np
+import pytest
 
 import hssm
 
 hssm.set_floatX("float32")
-
-pytestmark = pytest.mark.xfail(
-    sys.version_info >= (3, 14),
-    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-)
 
 
 # I want to parameter
@@ -96,7 +89,7 @@ def test_plot_model_cartoon_2_choice(
                 assert np.all(ax.row_names == cav_model_cartoon.data[row].unique())
             if col is not None:
                 assert np.all(ax.col_names == cav_model_cartoon.data[col].unique())
-        elif groups is ["dbs"]:
+        elif groups == ["dbs"]:
             assert isinstance(ax, list)
             assert len(ax) == len(cav_model_cartoon.data[groups[0]].unique())
 
@@ -162,7 +155,6 @@ def test_plot_model_cartoon_3_choice(
     col,
 ):
     """Test plot_model_cartoon for 3-choice data."""
-
     if (not plot_predictive_mean) and (not plot_predictive_samples):
         with pytest.raises(ValueError):
             ax = hssm.plotting.plot_model_cartoon(

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -1,7 +1,5 @@
 """Tests for HSSM posterior-predictive sampling."""
 
-import sys
-
 import numpy as np
 import pytest
 import xarray as xr
@@ -35,11 +33,6 @@ PARAMETER_GRID = [
 ]
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 14),
-    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-    strict=True,  # This will let us know in the future when this is fixed
-)
 @pytest.mark.slow
 @pytest.mark.parametrize(PARAMETER_NAMES, PARAMETER_GRID)
 def test_sample_posterior_predictive(cav_dt, cavanagh_test, draws, safe_mode, inplace):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 """Tests for HSSM utility helpers."""
 
-import sys
 from types import SimpleNamespace
 
 import numpy as np
@@ -348,11 +347,6 @@ def test_check_data_for_rl():
     assert n_trials == 2
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 14),
-    reason="sample_posterior_predictive fails on 3.14 with cpickle issue",
-    strict=True,  # This will let us know in the future when this is fixed
-)
 def test_predictive_idata_to_dataframe(data_ddm):
     """Convert prior-predictive draws to a tidy DataFrame."""
     model = hssm.HSSM(data=data_ddm)


### PR DESCRIPTION
## Summary

Fixes the Python 3.14-only slow-CI failure introduced-to-visibility by #967 (`tests/addm/test_addm_cartoon.py`, `TypeError: cannot pickle '_abc._abc_data' object`) — and with it, the repo's whole documented "`sample_posterior_predictive` fails on 3.14 with cpickle issue" caveat.

**Net diff: +29/−54.** The fix itself is semantic on five lines; most of the diff is *removing* the now-obsolete 3.14 xfail markers.

## Root cause

On Python 3.14, class-body annotations generate a PEP 649 `__annotate_func__` whose closure references the class namespace — which includes ABCMeta's unpicklable `_abc_impl` (`HSSMRV`'s metaclass chain roots in `ABCMeta` via pytensor's `MetaType`). The dynamic `<locals>` `HSSMRV` class is pickled **by value** by **numba's vendored cloudpickle** whenever the numba backend object-mode-lifts an RV `perform` (posterior/prior predictive sampling). The vendored cloudpickle predates PEP 649 handling (standalone cloudpickle 3.1.2 handles it fine) and dies on the annotate function.

Deterministic 2-second micro-repro (pre-fix, 3.14):

```python
from numba.core import serialize
from hssm.distribution_utils.dist import make_hssm_rv
serialize.dumps(make_hssm_rv("ddm", list_params=["v", "a", "z", "t"]))
# TypeError: cannot pickle '_abc._abc_data' object
```

## Fix

Make `HSSMRV`'s class attributes plain (un-annotated) assignments — no `__annotate_func__` is generated, and the class pickles cleanly on every Python version. The types are recorded in the class docstring, alongside an explanation so the annotations don't get innocently re-added. An AST sweep confirms `HSSMRV` was the **only** function-local class with annotated class attributes in the package.

## Why the xfail markers are removed

All 8 marker sites (58 test instances) carried `reason="sample_posterior_predictive fails on 3.14 with cpickle issue"` — this bug. With the fix they all pass on 3.14, and the 6 `strict=True` markers turn XPASS into hard failures **by design** ("This will let us know in the future when this is fixed" — it did). Removal is therefore part of the fix, not cleanup.

## Validation

- **3.14.6**: micro-repro passes; `tests/addm/test_addm_cartoon.py` passes (was the CI failure); all 8 previously-xfailed sites pass (35 xpassed non-strict + 23 XPASS(strict) confirmed individually)
- **3.12.13**: micro-repro passes; representative predictive/cartoon/aDDM tests pass (annotations were never load-bearing)
- ruff / ruff-format / mypy / pyrefly all pass

## Drive-bys (1 line each)

- `tests/addm/test_addm_cartoon.py`: `plot_model_cartoon(idata=…)` → `dt=` (the parameter was renamed on main; the stale kwarg was silently swallowed by `**kwargs` and only worked because `dt=None` falls back to `model.traces`)
- `docs/changelog.md`: bug-fix entry under Unreleased

## Ecosystem impact

HSSM-only; no cross-repo effects. Upstream note: the underlying limitation is numba's vendored cloudpickle lacking PEP 649 support — worth an upstream report, but HSSM shouldn't wait on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed prior and posterior predictive sampling with the numba backend on Python 3.14.
  - Restored predictive sampling and plotting functionality affected by serialization errors.
  - Corrected model-cartoon test comparisons for more reliable plotting behavior.

- **Documentation**
  - Added an unreleased changelog entry describing the Python 3.14 compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->