### PR TITLE
test: fix PSIS-degenerate flake in the aDDM WAIC/LOO slow test (seed + real adaptation)

### DIFF
--- a/tests/addm/test_addm_waic_loo.py
+++ b/tests/addm/test_addm_waic_loo.py
@@ -31,12 +31,19 @@ def test_addm_log_likelihood_enables_waic_loo():
     df = make_addm_dataframe(30, seed=1)
     model = hssm.aDDM(data=df)
 
-    # >=26 total draws so arviz 1.x PSIS-LOO has a >=5-sample Pareto tail.
+    # arviz 1.x PSIS-LOO fits a generalized Pareto to the top ~min(0.2*S, 3*sqrt(S))
+    # importance weights per observation and RAISES on a degenerate tail: it needs
+    # >=5 tail draws (count) AND spread among them (distinctness). Duplicate draws
+    # from a barely-adapted sampler (every rejected proposal repeats the previous
+    # state) make the tail values bit-identical -> "All tail values are the same".
+    # So: enough tune for the chains to actually move, and a fixed seed so CI
+    # doesn't gamble on sampler luck.
     idata = model.sample(
-        draws=30,
-        tune=15,
+        draws=50,
+        tune=100,
         chains=2,
         cores=1,
+        random_seed=20260713,
         idata_kwargs={"log_likelihood": True},
     )
 
@@ -45,7 +52,7 @@ def test_addm_log_likelihood_enables_waic_loo():
     ll = idata.log_likelihood
     var = next(iter(ll.data_vars))
     arr = np.asarray(ll[var])
-    assert arr.shape[:2] == (2, 30)  # (chain, draw, ...)
+    assert arr.shape[:2] == (2, 50)  # (chain, draw, ...)
     assert arr.shape[-1] == len(df)  # one column per observed trial
     assert np.isfinite(arr).all()
 


### PR DESCRIPTION
## Summary

Fixes the slow-suite failure on `main`:

```
FAILED tests/addm/test_addm_waic_loo.py::test_addm_log_likelihood_enables_waic_loo
  - ValueError: All tail values are the same
```

One file, test-only. The failure is a statistics bug in the test's sampler settings, not in HSSM code.

## Principle

arviz 1.x PSIS-LOO fits a **generalized Pareto distribution to the tail of each observation's importance weights** (top `~min(0.2·S, 3·√S)` weights; ≈12 of the test's 60 samples). A GPD fit needs *spread*: arviz raises `All tail values are the same` when the tail is bit-identical (`arviz_stats/base/diagnostics.py`; arviz 0.x merely warned).

Identical tail weights have one natural source: **duplicate posterior draws** — every rejected MCMC proposal repeats the previous state. The test sampled with `tune=15` and **no seed**: a barely-adapted NUTS chain rejects often, so ≥12 consecutive identical draws (enough to fill an observation's whole tail) are *likely* on some platforms. Hence 3-for-3 failures on CI (pytest-rerunfailures re-rolls unseeded dice) while the same test passed repeatedly elsewhere.

**Synthetic proof** (no MCMC): planting 14 identical extreme values in one observation's `log_likelihood` reproduces the exact `ValueError`; distinct draws pass.

The previous fix to this test addressed PSIS's *count* threshold (`n_draws_tail must be at least 5` → "≥26 total draws") but missed the *distinctness* requirement — this PR completes it.

## Fix

- `tune` 15 → 100: chains actually adapt. Measured on the seeded run: duplicate transitions drop to **1/98** with a **longest identical run of 2**, so a ~20-draw tail cannot be degenerate — the tested property becomes structural, not seed-lucky.
- `draws` 30 → 50 (margin over the count threshold); shape assertion updated.
- `random_seed` pinned — a CI test must not gamble on unseeded sampler luck.
- Comment rewritten to state the actual PSIS requirement (count **and** distinctness) so the settings don't get shrunk again.

**Rejected alternatives:** catching the degenerate `ValueError` (arviz's own moment-matching module falls back on exactly these messages, but in a *test* that could silently disable the integration check forever); dropping `az.loo` (consumability by arviz is the test's purpose).

## Validation

- Fixed test passes twice locally (seeded → identical), ~1.5 min — no runtime regression vs. the old ~2 min CI attempts
- Duplicate-draw diagnostic: old settings produce long identical runs; new settings 1/98 duplicates, max run 2
- ruff / ruff-format / mypy / pyrefly green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved PSIS-LOO and WAIC test stability by increasing sampling iterations and using a fixed random seed.
  * Updated expected log-likelihood dimensions to reflect the expanded sampling configuration.
  * Continued validation of finite log-likelihood values and successful leave-one-out analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->