### PR TITLE
Infer VI backend from model_config (#1058)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HSSM"
-version = "0.4.0"
+version = "0.4.1"
 description = "Bayesian inference for hierarchical sequential sampling models."
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -763,13 +763,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return_idata : bool
             If True, returns a DataTree object. Otherwise, returns the
             approximation object directly. Defaults to True.
-        backend : {"numba", "c", "jax"} | None
-            The computational backend passed to ``pm.fit`` (one of "numba",
-            "c", or "jax"). If None (the default), the backend is inferred from
-            the model's ``model_config.backend``: a "jax" model config uses the
-            "jax" backend, a "pytensor" model config uses the "c" backend, and
-            if the model config backend is also None, the "numba" backend is
-            used.
+        backend : {"numba", "c", "jax"}, optional
+            The computational backend passed to ``pm.fit``. If None (the
+            default), the backend is inferred from the model's
+            ``model_config.backend``: a "jax" model config uses the "jax"
+            backend, a "pytensor" model config uses the "c" backend, and if the
+            model config backend is also None, the "numba" backend is used.
 
         Returns
         -------

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -745,6 +745,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         draws: int = 1000,
         return_idata: bool = True,
         ignore_mcmc_start_point_defaults=False,
+        backend: Literal["numba", "c", "jax"] | None = None,
         **vi_kwargs,
     ) -> Approximation | DataTree:
         """Perform Variational Inference.
@@ -762,6 +763,13 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         return_idata : bool
             If True, returns a DataTree object. Otherwise, returns the
             approximation object directly. Defaults to True.
+        backend : {"numba", "c", "jax"} | None
+            The computational backend passed to ``pm.fit`` (one of "numba",
+            "c", or "jax"). If None (the default), the backend is inferred from
+            the model's ``model_config.backend``: a "jax" model config uses the
+            "jax" backend, a "pytensor" model config uses the "c" backend, and
+            if the model config backend is also None, the "numba" backend is
+            used.
 
         Returns
         -------
@@ -782,10 +790,24 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             _logger.info("Using MCMC starting point defaults.")
             vi_kwargs["start"] = self._initvals
 
+        # Resolve the computational backend passed to `pm.fit`. If not given
+        # explicitly, infer it from the model's configured backend so that a
+        # jax model config actually uses the jax backend for VI.
+        if backend is None:
+            config_backend = self.model_config.backend
+            if config_backend == "jax":
+                backend = "jax"
+            elif config_backend == "pytensor":
+                backend = "c"
+            else:
+                backend = "numba"
+
         # Run variational inference directly from pymc model
         # pyrefly: ignore[bad-context-manager]
         with self.pymc_model:
-            self._vi_approx = pm.fit(n=niter, method=method, **vi_kwargs)
+            self._vi_approx = pm.fit(
+                n=niter, method=method, backend=backend, **vi_kwargs
+            )
 
             # Sample from the approximate posterior
             if self._vi_approx is not None:

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -571,6 +571,36 @@ def test_deprecated_inference_helpers_raise_documented_error(
     assert str(error.value) == expected_message
 
 
+@pytest.mark.parametrize(
+    "config_backend, backend_arg, expected_backend",
+    [
+        (None, None, "numba"),
+        ("jax", None, "jax"),
+        ("pytensor", None, "c"),
+        ("jax", "numba", "numba"),
+    ],
+)
+def test_vi_passes_backend_to_pm_fit(
+    data_ddm, monkeypatch, config_backend, backend_arg, expected_backend
+):
+    """The resolved backend is forwarded to `pm.fit`."""
+    model = HSSM(data=data_ddm, model="ddm")
+    model.model_config.backend = config_backend
+
+    captured = {}
+
+    def fake_fit(*args, **kwargs):
+        captured["backend"] = kwargs.get("backend")
+
+    monkeypatch.setattr("hssm.base.pm.fit", fake_fit)
+    # Skip post-processing since fake_fit returns no approximation object.
+    monkeypatch.setattr(model, "_clean_posterior_group", lambda dt=None: None)
+
+    model.vi(niter=1, draws=1, backend=backend_arg)
+
+    assert captured["backend"] == expected_backend
+
+
 def test_vi_idata_rejects_attached_approximation(data_ddm):
     """VI approximations must be sampled before they can be exposed as DataTrees."""
     model = HSSM(data=data_ddm)

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -578,6 +578,8 @@ def test_deprecated_inference_helpers_raise_documented_error(
         ("jax", None, "jax"),
         ("pytensor", None, "c"),
         ("jax", "numba", "numba"),
+        ("pytensor", "numba", "numba"),
+        ("pytensor", "jax", "jax"),
     ],
 )
 def test_vi_passes_backend_to_pm_fit(


### PR DESCRIPTION
- Add `backend` argument to `HSSMBase.vi()`, defaulting to `None`
- When `None`, infer from `model_config.backend`: `jax` → `jax`, `pytensor` → `c`, `None` → `numba`
- Forward the resolved backend to `pm.fit` so a `jax` model config actually uses jax for VI
- Add test asserting `vi()` forwards the resolved backend to `pm.fit`
- Bump version to 0.4.1

Fixes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Variational inference now allows selecting a computation backend directly.
  - If not provided, the backend is auto-selected from the model configuration (mapping: `jax`→`jax`, `pytensor`→`c`, otherwise→`numba`).

- **Tests**
  - Added a slow test to verify the backend selection is correctly forwarded during variational inference.

- **Chores**
  - Updated the package version to **0.4.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->