### PR TITLE
Restore jax-backend VI shim gate lost in the #1059/#1060 merge

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -805,9 +805,21 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         # Run variational inference directly from pymc model
         # pyrefly: ignore[bad-context-manager]
         with self.pymc_model:
-            self._vi_approx = pm.fit(
-                n=niter, method=method, backend=backend, **vi_kwargs
-            )
+            if backend == "jax":
+                # Two PyMC bugs currently break backend="jax" for every
+                # model; this scoped, self-disabling shim works around the
+                # first (static parameter shapes) until the pinned PyMC
+                # includes the upstream fixes (see hssm._vi_compat, #1056).
+                # Gate on the *resolved* backend: it is a named parameter,
+                # so it never appears in vi_kwargs.
+                with _vi_compat.static_shape_vi_params():
+                    self._vi_approx = pm.fit(
+                        n=niter, method=method, backend=backend, **vi_kwargs
+                    )
+            else:
+                self._vi_approx = pm.fit(
+                    n=niter, method=method, backend=backend, **vi_kwargs
+                )
 
             # Sample from the approximate posterior
             if self._vi_approx is not None:

--- a/tests/slow/test_vi.py
+++ b/tests/slow/test_vi.py
@@ -116,15 +116,19 @@ def test_reg_models_v_a(data_ddm_reg_va, loglik_kind, backend, method, expected)
 
 @pytest.mark.slow
 @pytest.mark.parametrize("method", ["advi", "fullrank_advi"])
-def test_vi_jax_compile_backend(data_ddm, method):
+@pytest.mark.parametrize("backend_arg", ["jax", None])
+def test_vi_jax_compile_backend(data_ddm, method, backend_arg):
     """End-to-end regression test for #1056: VI compiled through the JAX linker.
 
     Exercises the LANLogpVJPOp jax_funcify registration plus the scoped
     PyMC compatibility shims in `hssm._vi_compat` (static parameter shapes;
-    numpy coercion before `approx.sample`).
+    numpy coercion before `approx.sample`). Runs both with an explicit
+    ``backend="jax"`` and with ``backend=None``, where the jax backend is
+    inferred from the angle model's jax model config (#1060) — the inferred
+    route must hit the same shims.
     """
     model = hssm.HSSM(data_ddm, model="angle", p_outlier=0.0)
-    model.vi(method=method, niter=100, draws=10, backend="jax", progressbar=False)
+    model.vi(method=method, niter=100, draws=10, backend=backend_arg, progressbar=False)
     assert isinstance(model.vi_idata, xr.DataTree)
     assert isinstance(model.vi_approx, pm.variational.Approximation)
 

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -585,7 +585,15 @@ def test_deprecated_inference_helpers_raise_documented_error(
 def test_vi_passes_backend_to_pm_fit(
     data_ddm, monkeypatch, config_backend, backend_arg, expected_backend
 ):
-    """The resolved backend is forwarded to `pm.fit`."""
+    """The resolved backend is forwarded to `pm.fit`, with the jax shim active.
+
+    The shim assertion guards against the `_vi_compat.static_shape_vi_params`
+    gate being dropped or gated on the wrong variable (regression of the
+    #1059/#1060 merge): whenever the *resolved* backend is "jax", the
+    static-shape patch must be active at the moment `pm.fit` runs.
+    """
+    from pymc.variational import approximations
+
     model = HSSM(data=data_ddm, model="ddm")
     model.model_config.backend = config_backend
 
@@ -593,6 +601,11 @@ def test_vi_passes_backend_to_pm_fit(
 
     def fake_fit(*args, **kwargs):
         captured["backend"] = kwargs.get("backend")
+        # The shim wraps create_shared_params with functools.wraps, so the
+        # patched method carries __wrapped__ while the context is active.
+        captured["shim_active"] = hasattr(
+            approximations.MeanFieldGroup.create_shared_params, "__wrapped__"
+        )
 
     monkeypatch.setattr("hssm.base.pm.fit", fake_fit)
     # Skip post-processing since fake_fit returns no approximation object.
@@ -601,6 +614,11 @@ def test_vi_passes_backend_to_pm_fit(
     model.vi(niter=1, draws=1, backend=backend_arg)
 
     assert captured["backend"] == expected_backend
+    assert captured["shim_active"] == (expected_backend == "jax")
+    # The patch is scoped: always reverted after vi() returns.
+    assert not hasattr(
+        approximations.MeanFieldGroup.create_shared_params, "__wrapped__"
+    )
 
 
 def test_vi_idata_rejects_attached_approximation(data_ddm):


### PR DESCRIPTION
- Fixes the `Remaining Slow` failure on main (`test_missing_data_and_deadline_vi ... TypeError: Shapes must be 1D sequences of concrete values`): the merge resolution of #1059 (after #1060) kept the resolved-backend forwarding but dropped the `_vi_compat.static_shape_vi_params()` wrapper, so every jax-config model's `vi()` hit pymc-devs/pymc#8359 — with #1060's inference making that the default route for all LAN models.
- Re-gates the shim on the **resolved** `backend` variable (a named parameter, never present in `vi_kwargs` — the exact interaction flagged in [the #1060 review comment](https://github.com/lnccbrown/HSSM/pull/1060#issuecomment-4962756050)).
- Fast-suite guard added so this can't regress silently again: `test_vi_passes_backend_to_pm_fit` now asserts the shim is active inside `pm.fit` iff the resolved backend is `jax`, and reverted after `vi()` returns.
- E2e jax VI test now also covers the inferred-backend route (`backend=None` + jax model config).
- Verified locally: the exact failing CI test passes (3.8s); all three slow VI files pass (47 tests, incl. the jax-config grids that now implicitly use the jax compile backend); hooks clean.

Refs #1056, #1058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variational inference compatibility when using the JAX backend.
  * Preserved existing behavior for other inference backends.
  * Improved automatic backend selection when running inference.

* **Tests**
  * Expanded coverage for JAX and automatically detected backend configurations.
  * Added validation that compatibility adjustments are applied only during inference and are properly cleaned up afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->