### PR TITLE
Port analytical LBA4 likelihood to JAX

### DIFF
--- a/src/hssm/likelihoods/analytical.py
+++ b/src/hssm/likelihoods/analytical.py
@@ -16,7 +16,7 @@ from jax.scipy.stats import norm
 from numpy import inf
 from pymc.distributions.dist_math import check_parameters
 
-from ..distribution_utils.dist import make_distribution
+from ..distribution_utils.dist import make_distribution, make_likelihood_callable
 
 LOGP_LB = pm.pytensorf.floatX(-66.1)
 
@@ -622,53 +622,6 @@ def _pt_lba3_ll(t, ch, A, b, v0, v1, v2):
     return pt.log(pt.clip(like[running_idx, ch] / (1 - prob_neg), __min, __max))
 
 
-def _pt_lba4_ll(t, ch, A, b, v0, v1, v2, v3):
-    s = 0.1
-    __min = pt.exp(LOGP_LB)
-    __max = pt.exp(-LOGP_LB)
-    k = len([0, 1, 2, 3])
-    like = pt.zeros((*t.shape, k))
-    running_idx = pt.arange(t.shape[0])
-
-    like_1 = (
-        _pt_tpdf(t, A, b, v0, s)
-        * (1 - _pt_tcdf(t, A, b, v1, s))
-        * (1 - _pt_tcdf(t, A, b, v2, s))
-        * (1 - _pt_tcdf(t, A, b, v3, s))
-    )
-    like_2 = (
-        (1 - _pt_tcdf(t, A, b, v0, s))
-        * _pt_tpdf(t, A, b, v1, s)
-        * (1 - _pt_tcdf(t, A, b, v2, s))
-        * (1 - _pt_tcdf(t, A, b, v3, s))
-    )
-    like_3 = (
-        (1 - _pt_tcdf(t, A, b, v0, s))
-        * (1 - _pt_tcdf(t, A, b, v1, s))
-        * _pt_tpdf(t, A, b, v2, s)
-        * (1 - _pt_tcdf(t, A, b, v3, s))
-    )
-    like_4 = (
-        (1 - _pt_tcdf(t, A, b, v0, s))
-        * (1 - _pt_tcdf(t, A, b, v1, s))
-        * (1 - _pt_tcdf(t, A, b, v2, s))
-        * _pt_tpdf(t, A, b, v3, s)
-    )
-
-    like = pt.stack([like_1, like_2, like_3, like_4], axis=-1)
-
-    # One should RETURN this because otherwise it will be pruned from graph
-    # like_printed = pytensor.printing.Print('like')(like)
-
-    prob_neg = (
-        _pt_normcdf(-v0 / s)
-        * _pt_normcdf(-v1 / s)
-        * _pt_normcdf(-v2 / s)
-        * _pt_normcdf(-v3 / s)
-    )
-    return pt.log(pt.clip(like[running_idx, ch] / (1 - prob_neg), __min, __max))
-
-
 def _pt_lba2_ll(t, ch, A, b, v0, v1):
     s = 0.1
     __min = pt.exp(LOGP_LB)
@@ -726,6 +679,50 @@ def logp_lba3(
     return checked_logp
 
 
+def _jax_lba_tpdf(t, A, b, v, s):
+    """Return the LBA first-passage-time density for one accumulator."""
+    g = (b - A - t * v) / (t * s)
+    h = (b - t * v) / (t * s)
+    return (-v * norm.cdf(g) + s * norm.pdf(g) + v * norm.cdf(h) - s * norm.pdf(h)) / A
+
+
+def _jax_lba_tcdf(t, A, b, v, s):
+    """Return the LBA first-passage-time CDF for one accumulator."""
+    g = (b - A - t * v) / (t * s)
+    h = (b - t * v) / (t * s)
+    return (
+        1
+        + ((b - A - t * v) / A) * norm.cdf(g)
+        - ((b - t * v) / A) * norm.cdf(h)
+        + ((t * s) / A) * norm.pdf(g)
+        - ((t * s) / A) * norm.pdf(h)
+    )
+
+
+def _jax_lba4_ll(t, ch, A, b, v0, v1, v2, v3):
+    """Return the four-choice LBA log-likelihood at the JAX level."""
+    s = 0.1
+    drift_rates = jnp.stack(jnp.broadcast_arrays(v0, v1, v2, v3))
+    all_pdfs = vmap(lambda v: _jax_lba_tpdf(t, A, b, v, s))(drift_rates)
+    all_cdfs = vmap(lambda v: _jax_lba_tcdf(t, A, b, v, s))(drift_rates)
+
+    trial_idx = jnp.arange(ch.shape[0])
+    winner_pdf = all_pdfs[ch, trial_idx]
+    loser_mask = jnp.arange(drift_rates.shape[0])[:, None] != ch
+    likelihood = winner_pdf * jnp.prod(
+        jnp.where(loser_mask, 1.0 - all_cdfs, 1.0), axis=0
+    )
+
+    prob_neg = jnp.prod(norm.cdf(-drift_rates / s), axis=0)
+    return jnp.log(
+        jnp.clip(
+            likelihood / (1.0 - prob_neg),
+            jnp.exp(LOGP_LB),
+            jnp.exp(-LOGP_LB),
+        )
+    )
+
+
 def logp_lba4(
     data: np.ndarray,
     A: float,
@@ -736,14 +733,12 @@ def logp_lba4(
     v3: float,
 ) -> np.ndarray:
     """Compute the log-likelihood of the LBA model with 4 drift rates."""
-    data = pt.reshape(data, (-1, 2)).astype(pytensor.config.floatX)
-    rt = pt.abs(data[:, 0])
-    response = data[:, 1]
-    response_int = pt.cast(response, "int32")
-    logp = _pt_lba4_ll(rt, response_int, A, b, v0, v1, v2, v3).squeeze()
-    # pyrefly: ignore[bad-argument-type]
-    checked_logp = check_parameters(logp, b > A, msg="b > A")
-    return checked_logp
+    data_reshaped = jnp.reshape(data, (-1, 2)).astype(pytensor.config.floatX)
+    rt = jnp.abs(data_reshaped[:, 0])
+    response = data_reshaped[:, 1]
+    response_int = response.astype(jnp.int32)
+    logp = _jax_lba4_ll(rt, response_int, A, b, v0, v1, v2, v3).squeeze()
+    return jax_check_parameters(logp, b > A, msg="b > A")
 
 
 lba2_params = ["A", "b", "v0", "v1"]
@@ -788,9 +783,15 @@ LBA3: type[pm.Distribution] = make_distribution(
     bounds=lba3_bounds,
 )
 
+_lba4_jax_loglik = make_likelihood_callable(
+    logp_lba4,
+    loglik_kind="analytical",
+    backend="jax",
+)
+
 LBA4: type[pm.Distribution] = make_distribution(
     rv="lba4",
-    loglik=logp_lba4,
+    loglik=_lba4_jax_loglik,
     list_params=lba4_params,
     bounds=lba4_bounds,
 )

--- a/src/hssm/modelconfig/lba4_config.py
+++ b/src/hssm/modelconfig/lba4_config.py
@@ -25,7 +25,7 @@ def get_lba4_config() -> DefaultConfig:
         "likelihoods": {
             "analytical": {
                 "loglik": logp_lba4,
-                "backend": None,
+                "backend": "jax",
                 "default_priors": {},
                 "bounds": lba4_bounds,
                 "extra_fields": None,

--- a/tests/slow/test_mcmc.py
+++ b/tests/slow/test_mcmc.py
@@ -4,6 +4,7 @@ import arviz as az
 import matplotlib.pyplot as plt
 import hssm
 import numpy as np
+import pandas as pd
 import pymc as pm
 from copy import deepcopy
 import xarray as xr
@@ -99,11 +100,26 @@ def test_lba_sampling():
 
     lba3_model = hssm.HSSM(model="lba3", data=lba3_data_out)
 
+    lba4_data = pd.DataFrame(
+        [[rt, choice] for rt in (0.35, 0.50) for choice in range(4)],
+        columns=["rt", "response"],
+    )
+    lba4_model = hssm.HSSM(model="lba4", data=lba4_data, p_outlier=0)
+
     traces_2 = lba2_model.sample(sampler="numpyro", draws=10, tune=10, chains=1)
     traces_3 = lba3_model.sample(sampler="numpyro", draws=10, tune=10, chains=1)
+    traces_4 = lba4_model.sample(
+        sampler="numpyro",
+        draws=10,
+        tune=10,
+        chains=1,
+        cores=1,
+        progressbar=False,
+    )
 
     assert isinstance(traces_2, xr.DataTree)
     assert isinstance(traces_3, xr.DataTree)
+    assert isinstance(traces_4, xr.DataTree)
 
 
 @pytest.mark.slow

--- a/tests/test_likelihoods_lba.py
+++ b/tests/test_likelihoods_lba.py
@@ -2,6 +2,7 @@
 
 from itertools import product
 
+import jax
 import numpy as np
 import pymc as pm
 import pytest
@@ -73,7 +74,6 @@ def make_lba_data(n_choices):
     [
         (logp_lba2, theta_lba2, 2),
         (logp_lba3, theta_lba3, 3),
-        (logp_lba4, theta_lba4, 4),
     ],
 )
 def test_lba_synthetic_data(logp_func, theta, n_choices):
@@ -92,6 +92,53 @@ def test_lba_synthetic_data(logp_func, theta, n_choices):
     for A, b in product([np.full(size, 0.6), 0.6], [np.full(size, 0.5), 0.5]):
         with pytest.raises(pm.logprob.utils.ParameterValueError):
             logp_func(lba_data, A=A, b=b, **filter_theta(theta, ["A", "b"])).eval()
+
+
+def test_lba4_jax_likelihood_supports_jit_vectors_and_gradients():
+    """LBA4 should be a native JAX likelihood with differentiable parameters."""
+    lba_data = make_lba_data(4)
+    expected = np.array(
+        [
+            0.65798534,
+            0.65798534,
+            0.65798534,
+            0.65798534,
+            -6.08265287,
+            -6.08265287,
+            -6.08265287,
+            -6.08265287,
+        ],
+        dtype=np.float32,
+    )
+
+    output = np.asarray(jax.jit(logp_lba4)(lba_data, **theta_lba4))
+    np.testing.assert_allclose(output, expected, rtol=1e-5, atol=1e-5)
+
+    for param in theta_lba4:
+        vectorized = np.asarray(
+            logp_lba4(lba_data, **vectorize_param(theta_lba4, param, len(lba_data)))
+        )
+        np.testing.assert_allclose(vectorized, expected, rtol=1e-5, atol=1e-5)
+
+        def summed_logp(value):
+            params = theta_lba4 | {param: value}
+            return logp_lba4(lba_data, **params).sum()
+
+        gradient = np.asarray(jax.grad(summed_logp)(theta_lba4[param]))
+        assert np.isfinite(gradient).all()
+
+    invalid = np.asarray(
+        logp_lba4(
+            lba_data,
+            A=0.6,
+            b=0.5,
+            v0=1.0,
+            v1=1.0,
+            v2=1.0,
+            v3=1.0,
+        )
+    )
+    assert np.isneginf(invalid).all()
 
 
 @pytest.mark.slow

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -116,7 +116,7 @@ def test_get_lba4_config():
 
     likelihood = lba4_model_config["likelihoods"]["analytical"]
     assert likelihood["loglik"] is logp_lba4
-    assert likelihood["backend"] is None
+    assert likelihood["backend"] == "jax"
     assert likelihood["default_priors"] == {}
     assert likelihood["bounds"] == lba4_bounds
     assert likelihood["extra_fields"] is None


### PR DESCRIPTION
## Summary

Port HSSM's analytical LBA4 likelihood from PyTensor to native JAX while preserving the existing lba4 model interface.

Changes:
- implement JAX LBA4 density/CDF and four-choice log-likelihood evaluation
- support JIT execution, trialwise vector parameters, autodiff, and JAX/PyTensor bridging
- configure the LBA4 analytical likelihood with backend="jax"
- add direct numerical/gradient/configuration coverage
- add a deterministic one-chain NumPyro LBA4 sampling smoke test

## Validation

- MPLCONFIGDIR=/tmp/.mpl PYTENSOR_FLAGS=compiledir=/tmp/hssm-pytensor-lba4 .venv/bin/pytest tests/test_likelihoods_lba.py tests/test_modelconfig.py tests/distribution_utils/test_distribution_utils.py tests/distribution_utils/test_jax.py --no-cov -q — 62 passed
- marked slow LBA sampling test via -m slow — passed
- uv run pyrefly check — 0 errors
- Ruff production check and format check — passed
- git diff --check — passed

The checkout does not register the older --runslow pytest option, so the slow test was selected with -m slow. Existing sampler/NumPyro warnings and tiny-run divergence warnings remain expected for the 10-draw smoke run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JAX support for the four-choice LBA likelihood.
  * Enabled JIT compilation, vectorized inputs, and parameter gradient calculations.
  * Updated the default four-choice LBA configuration to use the JAX backend.

* **Bug Fixes**
  * Invalid parameter configurations now return an appropriate invalid likelihood result.

* **Tests**
  * Added coverage for four-choice LBA sampling and JAX likelihood behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->