### PR TITLE
Fix docs build for marimo tutorial

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ plugins:
         - getting_started/getting_started.ipynb
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
+        - tutorials/attentional_ddm.py
         - tutorials/ddm_hierarchical_tutorial.ipynb
         - tutorials/choice_only_models.ipynb
         - tutorials/choice_only_rlssm.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ notebook = [
 ]
 
 docs = [
+    "marimo>=0.23.13",
     "mkdocs-material>=9.5.21",
     "mkdocs>=1.6.0",
     "mkdocs-jupyter>=0.25.1",


### PR DESCRIPTION
## Purpose
Fix the Build docs workflow failure on run 29381409675. MkDocs/Jupytext needs marimo installed to read docs/tutorials/attentional_ddm.py, and that marimo source should not be executed during CI because it contains button-gated sampling guarded by mo.stop().

## Changes
- Add marimo>=0.23.13 to the docs dependency group.
- Add tutorials/attentional_ddm.py to mkdocs-jupyter execute_ignore.

## Verification
- MPLCONFIGDIR=/tmp/.mpl uv run --group notebook --group docs mkdocs build
- git diff --check

## Notes
The local build still emits existing docs warnings for unlinked pages, missing design links, and griffe docstring/signature mismatches; these are pre-existing warnings and do not fail the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation build reliability by excluding a tutorial that should not be executed automatically.
  * Added Marimo to the documentation tooling requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->