### PR TITLE
docs: prepare release v0.4.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,13 @@
 3. **Fixed incorrect gradients for choice-only models with all-scalar parameters and outlier modeling.** For likelihoods that take parameters only (CPN/OPN networks) with no regression parameters, the gradient computation ignored any transformation applied downstream of the likelihood — for example the `p_outlier` mixture. Gradient-based fitting (VI, or NUTS on the default backend) of such models silently used incorrect gradients. The gradient is now exact, and a regression test asserts the chain rule holds on every backend.
 4. **Internal cleanup of the LAN likelihood operators.** The Op classes are now defined once at module level instead of once per model, so building many models in one long-running process (e.g. a parameter-recovery loop in a notebook) no longer grows PyTensor's dispatch registry — which previously kept every model's network weights in memory for the lifetime of the process. The gradient hook was also migrated from PyTensor's deprecated `grad` to the new `pullback` API, silencing a `FutureWarning` that appeared on every model fit.
 
+### 0.4.2
+
+This version includes the following changes:
+
+1. **LBA4 analytical likelihood now uses JAX.** The LBA4 likelihood has been ported from PyTensor to JAX, enabling JAX/NumPyro-compatible sampling and gradients for the analytical LBA4 model.
+2. **Documentation build fix for the marimo aDDM tutorial.** The docs build now includes the marimo dependency needed to parse the aDDM marimo tutorial, and skips CI execution for its button-gated sampling cells.
+
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,7 +5,11 @@
     </span>
     Navigate the site here!
 </span>
-<span class="right-margin"> v0.4.0 is released! </span>
+<span class="right-margin">
+    <a href="/HSSM/changelog/#040">
+        Read the v0.4.0 release notes for major new capabilities and migration guidance
+    </a>
+</span>
 <span>
     <span class="twemoji">
         {% include ".icons/material/head-question.svg" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HSSM"
-version = "0.4.1"
+version = "0.4.2"
 description = "Bayesian inference for hierarchical sequential sampling models."
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },


### PR DESCRIPTION
## Summary
- Bump HSSM package version to 0.4.2.
- Add 0.4.2 changelog notes for the JAX LBA4 likelihood and docs-build fix.
- Keep the docs banner focused on the v0.4.0 release notes for major capability and migration guidance.

## Verification
- MPLCONFIGDIR=/tmp/.mpl uv run --group notebook --group docs mkdocs build
- uv run --group dev pyrefly check
- uv run --group dev ruff check pyproject.toml
- uv run --group dev ruff format --check pyproject.toml
- uv build
- git diff --check

## Notes
- This PR does not tag or publish the release.
- HSSM does not currently track uv.lock on main, and this release-prep change does not update dependencies.
- Ruff was not run on docs/changelog.md or docs/overrides/main.html because Ruff treats the Jinja/HTML override as Python; docs validation is covered by the MkDocs build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - LBA4 analytical likelihood now supports JAX and NumPyro-compatible sampling and gradient calculations.
- **Documentation**
  - Updated the changelog with release 0.4.2 details.
  - Improved the documentation build for the aDDM tutorial.
  - Added a direct link to the v0.4.0 release notes in the documentation announcement.
- **Release**
  - Updated the project version to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->