### PR TITLE
Re-release v0.4.2 as v0.4.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,8 +13,8 @@ This version contains major breaking updates for HSSM. Please read the release n
 
 #### Breaking changes that require migration:
 
-1. Dependencies have been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.18+.
-2. We added support for Python 3.14. However, `sample_posterior_predictive` sometimes fails due to a `cloudpickle` issue. Use Python 3.14 with caution if you have to perform posterior predictive sampling.
+1. Dependencies have been streamlined to support PyMC 6.0+, pytensor 3.0+, ArviZ 1.0+, and Bambi 0.19+.
+2. We added support for Python 3.14.
 3. Consistent with PyMC 6.0+ and ArviZ 1,0+ expectations, the `model.sample()` by default uses `numba` as the compute backend.
 4. `model.sample()` now returns an `xarray.DataTree` object instead of the `arviz.InferenceData` object. Other functions that expect `arviz.InferenceData` objects have been updated to accept `xarray.DataTree` objects.
 5. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,30 +1,5 @@
 # Changelog
 
-### Unreleased
-
-#### Major new features:
-
-1. Per-parameter centered vs. non-centered parameterization. Pass `noncentered` to `HSSM(...)` as a `dict` keyed by parameter name (e.g. `noncentered={"v": False, "a": True}`), or set a per-prior `noncentered` field on a group term's prior (dict or `hssm.Prior`) to override the model-level choice. Requires Bambi >= 0.19. See the "Per-parameter centered vs. non-centered parameterization" tutorial.
-2. **Attentional Drift Diffusion Model (aDDM)**: new `hssm.aDDM` model (with `aDDMConfig`) built on a vendored, differentiable JAX first-passage-time likelihood. Supports per-trial fixation covariates (`r1, r2, flag, sacc_array, d, sigma`), **trial-wise regression / hierarchical priors** on the core parameters (`eta, kappa, a, b, x0`), a sampled non-decision time `t`, and posterior-predictive checks conditioned on the observed fixations (via the aDDM simulator in ssm-simulators). See the "Attentional DDM" tutorial and `scripts/addm_parameter_recovery.py` for an end-to-end recovery check.
-
-#### Dependency changes:
-
-1. `bambi` floor raised to `>=0.19.0` (per-parameter non-centered support); `ssm-simulators` floor raised to `>=0.13.1` (aDDM engine + fixation continuation).
-
-#### Bug fixes:
-
-1. **Python 3.14: posterior/prior predictive sampling fixed.** On 3.14, the dynamically created SSM random-variable class carried PEP 649 annotation metadata that numba's vendored cloudpickle could not serialize (`TypeError: cannot pickle '_abc._abc_data' object`), breaking `sample_posterior_predictive` and related plotting under the numba backend. The class attributes are now un-annotated plain assignments, and the previous 3.14 xfail markers on the predictive/plotting tests have been removed.
-2. **`model.vi(..., backend="jax")` now works (#1056).** PyMC 6 added a `backend` option to `pm.fit()`, which `HSSM.vi()` forwards. Requesting `backend="jax"` failed with `NotImplementedError: No JAX conversion for the given Op: LANLogpVJPOp`, because the operator that computes LAN likelihood gradients had no JAX translation. It now has one, and its gradients are tested to match the existing execution path exactly. Two remaining PyMC bugs (which break `pm.fit(backend="jax")` for *any* model, HSSM or not; tracked in #1056) are worked around by scoped, self-disabling compatibility shims in `hssm._vi_compat`, applied only when `backend="jax"` is requested — they detect a fixed PyMC and become no-ops, and will be removed once the pinned PyMC includes the upstream fixes. Known limitation: models with a single free parameter dimension may still fail to compile; use `backend="c"` there.
-3. **Fixed incorrect gradients for choice-only models with all-scalar parameters and outlier modeling.** For likelihoods that take parameters only (CPN/OPN networks) with no regression parameters, the gradient computation ignored any transformation applied downstream of the likelihood — for example the `p_outlier` mixture. Gradient-based fitting (VI, or NUTS on the default backend) of such models silently used incorrect gradients. The gradient is now exact, and a regression test asserts the chain rule holds on every backend.
-4. **Internal cleanup of the LAN likelihood operators.** The Op classes are now defined once at module level instead of once per model, so building many models in one long-running process (e.g. a parameter-recovery loop in a notebook) no longer grows PyTensor's dispatch registry — which previously kept every model's network weights in memory for the lifetime of the process. The gradient hook was also migrated from PyTensor's deprecated `grad` to the new `pullback` API, silencing a `FutureWarning` that appeared on every model fit.
-
-### 0.4.2
-
-This version includes the following changes:
-
-1. **LBA4 analytical likelihood now uses JAX.** The LBA4 likelihood has been ported from PyTensor to JAX, enabling JAX/NumPyro-compatible sampling and gradients for the analytical LBA4 model.
-2. **Documentation build fix for the marimo aDDM tutorial.** The docs build now includes the marimo dependency needed to parse the aDDM marimo tutorial, and skips CI execution for its button-gated sampling cells.
-
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.
@@ -32,6 +7,9 @@ This version contains major breaking updates for HSSM. Please read the release n
 #### Major new features:
 
 1. A new `RLSSM` class has been added to support reinforcement learning sequential sampling models.
+2. **Attentional Drift Diffusion Model (aDDM)**: new `hssm.aDDM` model (with `aDDMConfig`) built on a vendored, differentiable JAX first-passage-time likelihood. Supports per-trial fixation covariates (`r1, r2, flag, sacc_array, d, sigma`), **trial-wise regression / hierarchical priors** on the core parameters (`eta, kappa, a, b, x0`), a sampled non-decision time `t`, and posterior-predictive checks conditioned on the observed fixations (via the aDDM simulator in ssm-simulators). See the "Attentional DDM" tutorial and `scripts/addm_parameter_recovery.py` for an end-to-end recovery check.
+3. **Analytical four-choice LBA (LBA4)**, with a JAX likelihood enabling JAX/NumPyro-compatible sampling and gradients for the analytical LBA4 model.
+4. Per-parameter centered vs. non-centered parameterization. Pass `noncentered` to `HSSM(...)` as a `dict` keyed by parameter name (e.g. `noncentered={"v": False, "a": True}`), or set a per-prior `noncentered` field on a group term's prior (dict or `hssm.Prior`) to override the model-level choice. Requires Bambi >= 0.19. See the "Per-parameter centered vs. non-centered parameterization" tutorial.
 
 #### Breaking changes that require migration:
 
@@ -42,9 +20,18 @@ This version contains major breaking updates for HSSM. Please read the release n
 5. `model.summary()` and `model.plot_trace()` methods are now removed. Use `az.summary()` and `az.plot_trace_dist()` instead.
 6. HSSM can now be installed directly from PyPI via `pip` or `uv`. Conda support is no longer provided.
 
+#### Dependency changes:
+
+1. `bambi` floor raised to `>=0.19.0` (per-parameter non-centered support); `ssm-simulators` floor raised to `>=0.13.1` (aDDM engine + fixation continuation).
+
 #### Bug fixes:
 
 1. **Restore JAX-NUTS jitter control**: HSSM again disables the built-in initial-value jitter of the `numpyro`/`blackjax` samplers (PyMC 6 removed the public switch that made this possible), so sampling starts from HSSM's own controlled `initval_jitter` instead of an extra uniform jitter (#999).
+2. **Python 3.14: posterior/prior predictive sampling fixed.** On 3.14, the dynamically created SSM random-variable class carried PEP 649 annotation metadata that numba's vendored cloudpickle could not serialize (`TypeError: cannot pickle '_abc._abc_data' object`), breaking `sample_posterior_predictive` and related plotting under the numba backend. The class attributes are now un-annotated plain assignments, and the previous 3.14 xfail markers on the predictive/plotting tests have been removed.
+3. **`model.vi(..., backend="jax")` now works (#1056).** PyMC 6 added a `backend` option to `pm.fit()`, which `HSSM.vi()` forwards. Requesting `backend="jax"` failed with `NotImplementedError: No JAX conversion for the given Op: LANLogpVJPOp`, because the operator that computes LAN likelihood gradients had no JAX translation. It now has one, and its gradients are tested to match the existing execution path exactly. Two remaining PyMC bugs (which break `pm.fit(backend="jax")` for *any* model, HSSM or not; tracked in #1056) are worked around by scoped, self-disabling compatibility shims in `hssm._vi_compat`, applied only when `backend="jax"` is requested — they detect a fixed PyMC and become no-ops, and will be removed once the pinned PyMC includes the upstream fixes. Known limitation: models with a single free parameter dimension may still fail to compile; use `backend="c"` there.
+4. **Fixed incorrect gradients for choice-only models with all-scalar parameters and outlier modeling.** For likelihoods that take parameters only (CPN/OPN networks) with no regression parameters, the gradient computation ignored any transformation applied downstream of the likelihood — for example the `p_outlier` mixture. Gradient-based fitting (VI, or NUTS on the default backend) of such models silently used incorrect gradients. The gradient is now exact, and a regression test asserts the chain rule holds on every backend.
+5. **Internal cleanup of the LAN likelihood operators.** The Op classes are now defined once at module level instead of once per model, so building many models in one long-running process (e.g. a parameter-recovery loop in a notebook) no longer grows PyTensor's dispatch registry — which previously kept every model's network weights in memory for the lifetime of the process. The gradient hook was also migrated from PyTensor's deprecated `grad` to the new `pullback` API, silencing a `FutureWarning` that appeared on every model fit.
+6. **Documentation build fix for the marimo aDDM tutorial.** The docs build now includes the marimo dependency needed to parse the aDDM marimo tutorial, and skips CI execution for its button-gated sampling cells.
 
 ### 0.3.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HSSM"
-version = "0.4.2"
+version = "0.4.0"
 description = "Bayesian inference for hierarchical sequential sampling models."
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },


### PR DESCRIPTION
Closes #1067

- Revert package version `0.4.2` → `0.4.0` in `pyproject.toml` (0.4.0/0.4.1 never reached PyPI)
- Consolidate all changelog entries since 0.4.0 (Unreleased + 0.4.2) into a single `0.4.0` section
- Discussion #1051 (v0.4.0 release notes) updated to incorporate all changes since 0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated release documentation for version 0.4.0, including RLSSM, four-choice LBA (with JAX likelihood), expanded aDDM coverage, and per-parameter parameterization.

* **Breaking Changes**
  * Documented migration items: updated default sampling backend/return types, removal of `model.summary()` and `model.plot_trace()`, and streamlined installation/version handling (including Python 3.14 support).

* **Bug Fixes**
  * Noted improvements to posterior and prior-predictive sampling (Python 3.14), JAX backend for `vi`, corrected gradients for choice-only outlier mixtures, and additional likelihood/doc build fixes.

* **Chores**
  * Bumped package version to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->