### PR TITLE
ci: manual publish dispatch + path-filtered slow tests & coverage

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      run_full_test_suite:
+        description: "Run the full test suite before publishing"
+        type: boolean
+        default: true
 
 jobs:
   lint_and_typecheck:
@@ -12,6 +18,8 @@ jobs:
 
   run_tests:
     name: Run full test suite
+    # Always run on release; on manual dispatch, respect the input.
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_full_test_suite }}
     uses: ./.github/workflows/run_tests.yml
     with:
       run_slow_tests: true
@@ -23,6 +31,8 @@ jobs:
   publish:
     name: Build wheel and publish to test-PyPI, then PyPI, and publish docs
     needs: [lint_and_typecheck, run_tests]
+    # run_tests may be skipped on manual dispatch; still require it to not have failed.
+    if: ${{ always() && needs.lint_and_typecheck.result == 'success' && needs.run_tests.result != 'failure' && needs.run_tests.result != 'cancelled' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/coverage.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "tests/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run_slow_tests.yml
+++ b/.github/workflows/run_slow_tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "src/**"
+      - "tests/**"
 
 jobs:
   run_slow_tests:

--- a/.github/workflows/run_slow_tests.yml
+++ b/.github/workflows/run_slow_tests.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/run_slow_tests.yml"
+      - ".github/workflows/run_tests.yml"
 
 jobs:
   run_slow_tests:


### PR DESCRIPTION
## What changed

- **`build_and_publish.yml`**: added a `workflow_dispatch` trigger with a `run_full_test_suite` boolean input (default `true`). The full-test-suite job is gated on it for manual runs, and the publish job's `if` now uses `always()` + explicit result checks so a skipped test job still allows publishing.
- **`run_slow_tests.yml`** & **`coverage.yml`**: added `paths` filters (`src/**`, `tests/**`) to the `push` trigger so they only run on `main` when source or tests change. Manual `workflow_dispatch` stays unconditional.

## Why

- Allow re-publishing / debugging releases manually without waiting on a release event, optionally skipping the full test suite.
- Stop wasting CI minutes running slow tests and coverage on docs-only or config-only pushes.

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a manual workflow option to run or skip the full test suite during on-demand runs.
  - Adjusted publishing so it proceeds only when required checks succeed and tests were not failed or cancelled (while still allowing publish when tests are intentionally skipped).
  - Updated the coverage workflow to run automatically only when relevant source/test files change.
  - Updated the slow-tests workflow to run automatically only when relevant source/test and related workflow files change; manual runs remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->