### PR TITLE
Add model.plot_model_cartoon() convenience method

### DIFF
--- a/docs/api/hssm.md
+++ b/docs/api/hssm.md
@@ -21,5 +21,6 @@ Use `hssm.HSSM` class to construct an HSSM model.
             - graph
             - plot_predictive
             - plot_quantile_probability
+            - plot_model_cartoon
             - restore_traces
             - initial_point

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -1183,6 +1183,22 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         """
         return plotting.plot_quantile_probability(self, **kwargs)
 
+    def plot_model_cartoon(
+        self, **kwargs
+    ) -> mpl.axes.Axes | sns.FacetGrid | list[sns.FacetGrid]:
+        """Produce a model cartoon plot.
+
+        Equivalent to calling `hssm.plotting.plot_model_cartoon()` with the
+        model. Please see that function for
+        [full documentation][hssm.plotting.plot_model_cartoon].
+
+        Returns
+        -------
+        mpl.axes.Axes | sns.FacetGrid | list[sns.FacetGrid]
+            The matplotlib axis or seaborn FacetGrid object containing the plot.
+        """
+        return plotting.plot_model_cartoon(self, **kwargs)
+
     def predict(self, **kwargs) -> DataTree:
         """Generate samples from the predictive distribution."""
         return self.model.predict(**kwargs)

--- a/src/hssm/plotting/utils.py
+++ b/src/hssm/plotting/utils.py
@@ -56,7 +56,9 @@ def _xarray_to_df(
     # Rename the columns
     stacked.columns = response_str.split(",")
 
-    return stacked.loc[:, ["rt", "response"]]
+    # `.to_pandas()` above is typed DataFrame | Series; with a list selector
+    # `.loc` always yields a DataFrame here.
+    return cast("pd.DataFrame", stacked.loc[:, ["rt", "response"]])
 
 
 def _process_data(

--- a/tests/unit/test_plot_methods.py
+++ b/tests/unit/test_plot_methods.py
@@ -1,0 +1,30 @@
+"""Delegation tests for the HSSM plotting convenience methods.
+
+docs/api/plotting.md promises every plotting function an equivalent method on
+`hssm.HSSM`; these tests enforce that claim for all three.
+"""
+
+import pytest
+
+import hssm
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["plot_predictive", "plot_quantile_probability", "plot_model_cartoon"],
+)
+def test_plot_method_delegates(monkeypatch, method):
+    captured = {}
+
+    def fake(model, **kwargs):
+        captured["model"] = model
+        captured["kwargs"] = kwargs
+        return "sentinel"
+
+    monkeypatch.setattr(hssm.plotting, method, fake)
+    model = object.__new__(hssm.HSSM)  # delegation needs no model state
+    result = getattr(hssm.HSSM, method)(model, foo=1)
+
+    assert result == "sentinel"
+    assert captured["model"] is model  # self passed positionally
+    assert captured["kwargs"] == {"foo": 1}


### PR DESCRIPTION
Closes #1129.

- Adds the `plot_model_cartoon` delegation method on `HSSMBase`, mirroring `plot_predictive`/`plot_quantile_probability` exactly — `docs/api/plotting.md`'s claim that every plotting function has a method equivalent is now true
- Registers the method in the `docs/api/hssm.md` mkdocstrings members list (required for it to render)
- Adds the repo's first delegation tests, parametrized over all three plot methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a convenient `plot_model_cartoon` method to HSSM models for generating model structure visualizations.
  - Supports passing plotting options directly and returns the resulting visualization.

- **Documentation**
  - Updated the HSSM API documentation to include the new model visualization method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->