### PR TITLE
1086 optimize ci workflows

### DIFF
--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -8,25 +8,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
-
-    - name: Install BLAS and LAPACK
-      run: sudo apt-get update && sudo apt-get install -y libblas-dev liblapack-dev
-      shell: bash
-
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v9
       with:
         version: "latest"
         enable-cache: true
 
     - name: Install hssm
-      if: steps.cache.outputs.cache-hit != 'true'
       run: uv sync --group notebook
       shell: bash

--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -15,6 +15,7 @@ runs:
       uses: astral-sh/setup-uv@v9.0.0
       with:
         version: "latest"
+        python-version: ${{ inputs.python-version }}
         enable-cache: true
 
     - name: Install hssm

--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -12,7 +12,7 @@ runs:
       uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         version: "latest"
         enable-cache: true

--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -8,25 +8,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ inputs.python-version }}
-
-    - name: Install BLAS and LAPACK
-      run: sudo apt-get update && sudo apt-get install -y libblas-dev liblapack-dev
-      shell: bash
-
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v9
       with:
         version: "latest"
+        python-version: ${{ inputs.python-version }}
         enable-cache: true
 
     - name: Install hssm
-      if: steps.cache.outputs.cache-hit != 'true'
       run: uv sync
       shell: bash

--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -12,7 +12,7 @@ runs:
       uses: actions/checkout@v7
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v9
+      uses: astral-sh/setup-uv@v9.0.0
       with:
         version: "latest"
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -5,34 +5,15 @@ on:
     types:
       - published
   workflow_dispatch:
-    inputs:
-      run_full_test_suite:
-        description: "Run the full test suite before publishing"
-        type: boolean
-        default: true
 
 jobs:
   lint_and_typecheck:
     name: Lint and type-check
     uses: ./.github/workflows/linting_and_type_checking.yml
 
-  run_tests:
-    name: Run full test suite
-    # Always run on release; on manual dispatch, respect the input.
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.run_full_test_suite }}
-    uses: ./.github/workflows/run_tests.yml
-    with:
-      run_slow_tests: true
-
-  # check_notebooks:
-  #   name: Check notebooks
-  #   uses: ./.github/workflows/check_notebooks.yml
-
   publish:
     name: Build wheel and publish to test-PyPI, then PyPI, and publish docs
-    needs: [lint_and_typecheck, run_tests]
-    # run_tests may be skipped on manual dispatch; still require it to not have failed.
-    if: ${{ always() && needs.lint_and_typecheck.result == 'success' && needs.run_tests.result != 'failure' && needs.run_tests.result != 'cancelled' }}
+    needs: [lint_and_typecheck]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -7,8 +7,6 @@ jobs:
   check_notebooks:
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.head_commit.message, '[skip fast tests]') }}
-    env:
-      PYTENSOR_FLAGS: "blas__ldflags=-L/usr/lib/x86_64-linux-gnu -lblas -llapack"
 
     strategy:
       fail-fast: true

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -56,5 +56,3 @@ jobs:
             fi
           done
           exit $EXIT_CODE
-        env:
-          PYTENSOR_FLAGS: ${{ env.PYTENSOR_FLAGS }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    env:
-      PYTENSOR_FLAGS: "blas__ldflags=-L/usr/lib/x86_64-linux-gnu -lblas -llapack"
 
     strategy:
       fail-fast: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Run all tests with coverage
         run: uv run pytest --cov=src/hssm --cov-report=term-missing --cov-report=xml
-        env:
-          PYTENSOR_FLAGS: ${{ env.PYTENSOR_FLAGS }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
Some immediate improvements to our ci workflows

1. Removed test step in the publish workflow
2. Removed the setup python step in reusable workflows. No need for it because uv sets up Python
3. Removed installation of lapack because sampling is done in numba now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build environments and tooling for more consistent setup and dependency caching.
  * Improved Python environment setup across automated workflows.
  * Streamlined publishing so releases proceed after successful linting and type checks.
  * Simplified continuous integration by removing redundant full-test and notebook validation paths.
  * Cleaned up obsolete environment configuration from coverage and notebook checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->