### PR TITLE
Fixed numpy version

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -6,7 +6,9 @@ name: Dev container
 # the `hssm` remote user, and the uv-synced .venv.
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - .devcontainer/**
       - Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,6 @@
 name: Docker image (GHCR)
 
-# PRs: amd64 build only (fast sanity). Release: multi-arch build + push to GHCR.
+# Merge to main: amd64 build only (fast sanity). Release: multi-arch build + push to GHCR.
 # Manual dispatch: multi-arch build, pushed only if `publish` is set (otherwise a
 # build-only validation of the arm64 leg).
 on:
@@ -10,7 +10,9 @@ on:
         description: "Push the image to GHCR (otherwise multi-arch build-only)"
         type: boolean
         default: false
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - Dockerfile
       - .dockerignore
@@ -42,14 +44,14 @@ jobs:
           echo "value=$V" >> "$GITHUB_OUTPUT"
 
       # Push only on release (or an explicit `publish` dispatch). Multi-arch
-      # everywhere except PRs, which stay amd64 for fast turnaround.
+      # everywhere except merge-to-main, which stays amd64 for fast turnaround.
       - name: Configure build
         id: cfg
         run: |
           case "${{ github.event_name }}" in
-            pull_request) echo "push=false"; echo "platforms=linux/amd64";;
-            release)      echo "push=true";  echo "platforms=linux/amd64,linux/arm64";;
-            *)            echo "push=${{ inputs.publish }}"; echo "platforms=linux/amd64,linux/arm64";;
+            push)     echo "push=false"; echo "platforms=linux/amd64";;
+            release)  echo "push=true";  echo "platforms=linux/amd64,linux/arm64";;
+            *)        echo "push=${{ inputs.publish }}"; echo "platforms=linux/amd64,linux/arm64";;
           esac >> "$GITHUB_OUTPUT"
 
       # QEMU is needed to build the linux/arm64 leg on an amd64 runner. The arm64

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ pypi-token
 pre-commit
 .github/copilot-instructions.md
 uv.lock
+
+.claude/CLAUDE.local.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,19 +24,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "absl-py>=2.3.1",
+    "absl-py>=2.5.0",
     "bambi>=0.19.0",
     "h5netcdf>=1.8.1",
     "h5py>=3.16.0",
     "hddm-wfpt>=0.1.6",
     "huggingface-hub>=1.17.0",
     "jaxonnxruntime>=0.3.0",
-    "numpyro>=0.19",
+    "numpy>=2.4.0,<2.5.0",
+    "numpyro>=0.20",
     "onnx>=1.16.0",
-    # Imported directly by hssm.plotting (gaussian_kde, chi2); previously only
-    # a transitive dependency via pymc.
-    "scipy>=1.10",
-    # 0.13.1 ships the aDDM engine + fixation_continuation (used by aDDM PPC).
     "ssm-simulators>=0.13.1",
 ]
 
@@ -55,16 +52,16 @@ dev = [
     "mypy>=2.1",
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.6.1",
-    "pytest>=8.3.1",
     "pytest-random-order>=1.1.1",
     "pytest-rerunfailures>=15.0",
     "pytest-timeout>=2.3.1",
-    "ruff>=0.15.0",
     "types-PyYAML",
     "psutil>=7.2.2",
     "prek>=0.4.8",
     "pyrefly>=1.1.1",
     "onnxruntime>=1.27.0",
+    "ruff>=0.16.1",
+    "pytest>=9.1.1",
 ]
 
 notebook = [


### PR DESCRIPTION
`numba` still only supports `numpy>=2.4.0, <2.5.0`. However, dependency version resolving in CI can install numpy >= 2.5, which causes `numba` to break, because its source code still uses deprecated numpy functions, which are removed in numpy 2.5. This PR fixes this issue

This PR also updates the devcontainer and docker build workflows, so that they only run on merge to main when relevant files have changed. No need to run them at every push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved repository configuration and local development file handling.
  - Updated maintenance and quality-tooling settings for a more consistent development experience.
  - Refined environment settings to support current runtime and testing workflows.
  - Updated development workflows to validate changes on pushes to the main branch.
  - Enhanced Docker image automation for main-branch builds, releases, and multi-platform publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->