### PR TITLE
Scheduled drift detection: weekly gates + monthly notebooks re-run against fresh resolves

### DIFF
--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -26,7 +26,8 @@ runs:
         version: "latest"
         enable-cache: true
 
+    # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
+    # no step with id `cache` exists, so it always evaluated true)
     - name: Install hssm
-      if: steps.cache.outputs.cache-hit != 'true'
       run: uv sync --group notebook
       shell: bash

--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -18,6 +18,8 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
 
+    # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
+    # no step with id `cache` exists, so it always evaluated true)
     - name: Install hssm
       run: uv sync --group notebook
       shell: bash

--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -26,6 +26,8 @@ runs:
         python-version: ${{ inputs.python-version }}
         enable-cache: true
 
+    # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
+    # no step with id `cache` exists, so it always evaluated true)
     - name: Install hssm
       run: uv sync
       shell: bash

--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -26,7 +26,8 @@ runs:
         version: "latest"
         enable-cache: true
 
+    # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
+    # no step with id `cache` exists, so it always evaluated true)
     - name: Install hssm
-      if: steps.cache.outputs.cache-hit != 'true'
       run: uv sync
       shell: bash

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -2,6 +2,7 @@ name: Check notebooks
 
 on:
   workflow_dispatch:
+  workflow_call:  # Called by drift.yml (monthly notebook drift run)
 
 jobs:
   check_notebooks:
@@ -10,10 +11,15 @@ jobs:
     env:
       PYTENSOR_FLAGS: "blas__ldflags=-L/usr/lib/x86_64-linux-gnu -lblas -llapack"
 
+    name: Check notebooks (shard ${{ matrix.shard }})
     strategy:
-      fail-fast: true
+      # Shards partition the ~37 executed notebooks so no single job can hit
+      # the 6-hour limit; fail-fast off so a drift run reports the full blast
+      # radius, not just the first broken shard.
+      fail-fast: false
       matrix:
         python-version: ["3.13"]
+        shard: [0, 1, 2, 3]
 
     steps:
       - name: Checkout repository
@@ -27,15 +33,24 @@ jobs:
       - name: Run notebooks
         run: |
           echo "Running notebooks with Python ${{ matrix.python-version }}"
-          # List of notebooks to skip (temporarily)
+          # List of notebooks to skip (temporarily). Entries must be the
+          # full find-produced path — bare filenames never match the loop
+          # comparison (the two workshop notebooks executed for months while
+          # "skipped").
           SKIP_NOTEBOOKS=(
             "docs/tutorials/tutorial_bayeux.ipynb"
-            "hssm_tutorial_workshop_1.ipynb"
-            "hssm_tutorial_workshop_2.ipynb"
+            "docs/tutorials/hssm_tutorial_workshop_1.ipynb"
+            "docs/tutorials/hssm_tutorial_workshop_2.ipynb"
           )
 
           EXIT_CODE=0
-          for notebook in $(find docs -name "*.ipynb"); do
+          INDEX=0
+          for notebook in $(find docs -name "*.ipynb" | sort); do
+            THIS_INDEX=$INDEX
+            INDEX=$((INDEX + 1))
+            if [ $((THIS_INDEX % 4)) -ne ${{ matrix.shard }} ]; then
+              continue
+            fi
             # Check if notebook is in skip list
             SKIP=false
             for skip_nb in "${SKIP_NOTEBOOKS[@]}"; do

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -2,16 +2,22 @@ name: Check notebooks
 
 on:
   workflow_dispatch:
+  workflow_call:  # Called by drift.yml (monthly notebook drift run)
 
 jobs:
   check_notebooks:
     runs-on: ubuntu-latest
     if: ${{ ! contains(github.event.head_commit.message, '[skip fast tests]') }}
 
+    name: Check notebooks (shard ${{ matrix.shard }})
     strategy:
-      fail-fast: true
+      # Shards partition the ~37 executed notebooks so no single job can hit
+      # the 6-hour limit; fail-fast off so a drift run reports the full blast
+      # radius, not just the first broken shard.
+      fail-fast: false
       matrix:
         python-version: ["3.13"]
+        shard: [0, 1, 2, 3]
 
     steps:
       - name: Checkout repository
@@ -25,16 +31,25 @@ jobs:
       - name: Run notebooks
         run: |
           echo "Running notebooks with Python ${{ matrix.python-version }}"
-          # List of notebooks to skip (temporarily)
+          # List of notebooks to skip (temporarily). Entries must be the
+          # full find-produced path — bare filenames never match the loop
+          # comparison (the two workshop notebooks executed for months while
+          # "skipped").
           SKIP_NOTEBOOKS=(
             "docs/tutorials/tutorial_bayeux.ipynb"
             "docs/tutorials/hsgp_regression.ipynb"
-            "hssm_tutorial_workshop_1.ipynb"
-            "hssm_tutorial_workshop_2.ipynb"
+            "docs/tutorials/hssm_tutorial_workshop_1.ipynb"
+            "docs/tutorials/hssm_tutorial_workshop_2.ipynb"
           )
 
           EXIT_CODE=0
-          for notebook in $(find docs -name "*.ipynb"); do
+          INDEX=0
+          for notebook in $(find docs -name "*.ipynb" | sort); do
+            THIS_INDEX=$INDEX
+            INDEX=$((INDEX + 1))
+            if [ $((THIS_INDEX % 4)) -ne ${{ matrix.shard }} ]; then
+              continue
+            fi
             # Check if notebook is in skip list
             SKIP=false
             for skip_nb in "${SKIP_NOTEBOOKS[@]}"; do

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -25,7 +25,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   lint:
@@ -54,6 +53,16 @@ jobs:
     needs: [lint, fast, slow, notebooks]
     if: always()
     runs-on: ubuntu-latest
+    # Only this job needs issue-write; the tokens above run freshly-resolved
+    # third-party test code and stay read-only (inherited from the workflow).
+    permissions:
+      contents: read
+      issues: write
+    # One issue reconciler at a time: the read at `gh issue list` and the write
+    # below are not atomic, so an overlapping dispatch could file a duplicate.
+    concurrency:
+      group: drift-issue-${{ github.repository }}
+      cancel-in-progress: false
     steps:
       - name: Create, update, or close the deduped drift issue
         env:
@@ -69,13 +78,23 @@ jobs:
           TITLE="drift: HSSM scheduled checks failing"
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
+          # Three outcomes matter separately. `skipped` is neutral by design —
+          # the monthly notebooks job is skipped in every weekly run. But
+          # `cancelled` is not evidence of health, and `report` runs under
+          # `if: always()`, which includes cancellation: without this
+          # distinction a cancelled run would silently close a real drift
+          # issue. Closing therefore requires at least one genuine success and
+          # nothing cancelled.
           FAILED_JOBS=""
+          CANCELLED_JOBS=""
+          SUCCEEDED=""
           for job in lint fast slow notebooks; do
             var="RESULT_$(echo "$job" | tr '[:lower:]' '[:upper:]')"
-            # skipped is neutral: monthly-gated jobs are skipped in weekly runs
-            if [ "${!var}" = "failure" ]; then
-              FAILED_JOBS="$FAILED_JOBS $job"
-            fi
+            case "${!var}" in
+              failure) FAILED_JOBS="$FAILED_JOBS $job" ;;
+              cancelled) CANCELLED_JOBS="$CANCELLED_JOBS $job" ;;
+              success) SUCCEEDED="yes" ;;
+            esac
           done
           if [ "$FORCE_FAIL" = "true" ]; then
             FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
@@ -86,9 +105,14 @@ jobs:
             --json number --jq '.[0].number // empty')
 
           if [ -z "$FAILED_JOBS" ]; then
-            if [ -n "$EXISTING" ]; then
-              gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-                --comment "Scheduled drift checks green again: $RUN_URL"
+            if [ -n "$SUCCEEDED" ] && [ -z "$CANCELLED_JOBS" ]; then
+              if [ -n "$EXISTING" ]; then
+                gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                  --comment "Scheduled drift checks green again: $RUN_URL"
+              fi
+            else
+              echo "::notice::Inconclusive run (cancelled:${CANCELLED_JOBS:- none};" \
+                "no job succeeded) — drift issue state left unchanged."
             fi
             exit 0
           fi

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,0 +1,112 @@
+name: Drift
+
+# Scheduled drift detection: re-run the repo's existing gates against a fresh
+# dependency resolve of an unchanged main. With no committed lockfile, a red
+# run here means an upstream or toolchain release broke us — before any PR
+# trips over it. Failures file ONE deduped `drift`-labeled issue (the durable
+# queue the spine's healing agent drains); green runs close it.
+#
+# NOTE: the cron strings below are matched verbatim by the job-level `if`
+# gates — edit them in lockstep.
+on:
+  schedule:
+    - cron: "0 5 * * 1" # weekly: lint + fast + slow
+    - cron: "0 3 1 * *" # monthly: notebooks
+  workflow_dispatch:
+    inputs:
+      force_fail:
+        description: "Exercise the drift-issue path without a real failure"
+        type: boolean
+        default: false
+      run_notebooks:
+        description: "Also run the (expensive) notebook suite"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lint:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 5 * * 1'
+    uses: ./.github/workflows/linting_and_type_checking.yml
+
+  fast:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 5 * * 1'
+    uses: ./.github/workflows/run_tests.yml
+    with:
+      # Clear the PR-oriented addopts: --exitfirst truncates the blast radius
+      # and --reruns=2 masks flakiness — both wrong for drift triage. The
+      # timeout is re-added explicitly. (No spaces inside any word: test_args
+      # expands unquoted in run_tests.yml.)
+      test_args: "-o addopts= --timeout=360"
+
+  slow:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 5 * * 1'
+    uses: ./.github/workflows/run_slow_tests.yml
+
+  notebooks:
+    if: (github.event_name == 'workflow_dispatch' && inputs.run_notebooks) || github.event.schedule == '0 3 1 * *'
+    uses: ./.github/workflows/check_notebooks.yml
+
+  report:
+    needs: [lint, fast, slow, notebooks]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create, update, or close the deduped drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT_LINT: ${{ needs.lint.result }}
+          RESULT_FAST: ${{ needs.fast.result }}
+          RESULT_SLOW: ${{ needs.slow.result }}
+          RESULT_NOTEBOOKS: ${{ needs.notebooks.result }}
+          FORCE_FAIL: ${{ inputs.force_fail }}
+        run: |
+          set -euo pipefail
+          KEY="drift-key: HSSM-scheduled"
+          TITLE="drift: HSSM scheduled checks failing"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          FAILED_JOBS=""
+          for job in lint fast slow notebooks; do
+            var="RESULT_$(echo "$job" | tr '[:lower:]' '[:upper:]')"
+            # skipped is neutral: monthly-gated jobs are skipped in weekly runs
+            if [ "${!var}" = "failure" ]; then
+              FAILED_JOBS="$FAILED_JOBS $job"
+            fi
+          done
+          if [ "$FORCE_FAIL" = "true" ]; then
+            FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
+          fi
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label drift \
+            --state open --search "in:body \"$KEY\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "$FAILED_JOBS" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                --comment "Scheduled drift checks green again: $RUN_URL"
+            fi
+            exit 0
+          fi
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing (${FAILED_JOBS# }): $RUN_URL"
+          else
+            gh label create drift --repo "$GITHUB_REPOSITORY" \
+              --description "scheduled drift detection failure" \
+              --force 2>/dev/null || true
+            BODY=$(printf '%s\n' \
+              "<!-- $KEY -->" \
+              "Scheduled drift run failed in:${FAILED_JOBS}" \
+              "Run: $RUN_URL" \
+              "" \
+              "These jobs re-run existing gates against a fresh dependency resolve of an unchanged main — a failure here usually means an upstream or toolchain release, not a code change." \
+              "Triage via the spine's audit-drift skill (dev-ci-triage classification: root / matrix-cancel / external / infra).")
+            gh issue create --repo "$GITHUB_REPOSITORY" --label drift \
+              --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/run_slow_tests.yml
+++ b/.github/workflows/run_slow_tests.yml
@@ -2,6 +2,7 @@ name: Run slow tests
 
 on:
   workflow_dispatch:  # Manual trigger
+  workflow_call:  # Called by drift.yml (scheduled drift detection)
   push:
     branches:
       - main


### PR DESCRIPTION
Part of the ecosystem self-healing rollout (spine PR lnccbrown/HSSMSpine#35 is the aggregation layer).

- new `drift.yml`: weekly (lint + fast + slow) and monthly (notebooks) scheduled re-runs of the existing gates via `workflow_call`, against a fresh PyPI resolve of unchanged main — with no committed lockfile this is the detector for upstream/toolchain releases breaking us (ruff 0.16 and pyrefly both did, silently, last month)
- failures create/update ONE deduped `drift`-labeled issue; green runs close it; `force_fail` dispatch input rehearses the path
- `run_slow_tests.yml` / `check_notebooks.yml` gain `workflow_call:`
- fixes riding along: SKIP_NOTEBOOKS bare-filename entries never matched (workshop notebooks ran while "skipped"); notebook run sharded 4-way (single job could exceed the 6 h limit); drift runs clear the `--exitfirst`/`--reruns` addopts; dead `cache-hit` guards removed from the setup-env composite actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled weekly quality checks and monthly notebook validation.
  * Added automated reporting for failed checks, including issue tracking and resolution updates.
  * Enabled notebook and slow-test workflows to be reused by other automation workflows.
  * Added manual controls for running notebooks and handling check failures.

* **Improvements**
  * Notebook checks now run across four parallel jobs for faster feedback.
  * Improved notebook selection and workshop exclusions for more reliable validation.
  * Installation steps now run consistently across environment setup workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->