### PR TITLE
Declare directly-imported dependencies; cap numpy<2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,19 +25,32 @@ classifiers = [
 
 dependencies = [
     "absl-py>=2.3.1",
+    # arviz, jax, numpy, pandas, pymc, pytensor, and xarray are imported
+    # directly throughout src/hssm but were previously only transitive
+    # dependencies (via bambi/numpyro), so upstream releases reached us
+    # unbounded — see https://github.com/lnccbrown/HSSM/issues/1144.
+    "arviz>=1.0",
     "bambi>=0.19.0",
     "h5netcdf>=1.8.1",
     "h5py>=3.16.0",
     "hddm-wfpt>=0.1.6",
     "huggingface-hub>=1.17.0",
+    "jax>=0.7.0",
     "jaxonnxruntime>=0.3.0",
+    # numpy 2.5 removed np.row_stack, which the resolved pytensor stack still
+    # calls; lift the cap when upstream compatibility is restored (#1144).
+    "numpy>=2.0,<2.5",
     "numpyro>=0.19",
     "onnx>=1.16.0",
+    "pandas>=2.0",
+    "pymc>=6.0",
+    "pytensor>=3.0",
     # Imported directly by hssm.plotting (gaussian_kde, chi2); previously only
     # a transitive dependency via pymc.
     "scipy>=1.10",
     # 0.13.1 ships the aDDM engine + fixation_continuation (used by aDDM PPC).
     "ssm-simulators>=0.13.1",
+    "xarray>=2024.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #1144

- Declares the seven packages `src/hssm` imports directly but never declared (`arviz`, `jax`, `numpy`, `pandas`, `pymc`, `pytensor`, `xarray`) — until now their versions arrived transitively via bambi/numpyro with no floor and no cap, which is exactly how the numpy 2.5 breakage landed unbounded.
- Adds a temporary `numpy>=2.0,<2.5` cap: numpy 2.5 removed `np.row_stack`, which the freshly-resolved Linux CI stack (pytensor 3.2.4 path) still calls, failing `tests/addm/test_addm_builder.py` on every fresh resolve of unchanged main (#1144). The cap comment in `pyproject.toml` links the issue; once this merges, the spine's package radar tracks the cap as a standing `ceiling-crossed` event, so lifting it when upstream is fixed cannot be forgotten.
- Floors chosen at the majors the codebase already assumes (pymc≥6 / arviz≥1 from the 0.4.0 migration, jax≥0.7.0 matching the cuda extras, numpy≥2.0 matching ssm-simulators); all sit well below today's resolutions.

Commands run: `uv lock` resolves cleanly (288 packages; numpy → 2.4.6, pymc 6.2.0 / pytensor 3.2.4 unchanged from the last green run — lockfile not committed, HSSM resolves fresh by design).

First mechanical healing PR of the drift-homeostasis rollout (see #1143); rebasing/rerunning #1143 after this merges should turn its `run_tests` legs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependency requirements to specify supported minimum versions.
  * Added a compatibility constraint for NumPy versions.
  * Documented dependency sources and compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->