### PR TITLE
Re-declare scipy as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "numpy>=2.4.0,<2.5.0",
     "numpyro>=0.20",
     "onnx>=1.16.0",
+    # Direct import in hssm.plotting (gaussian_kde, chi2), not merely transitive via pymc.
+    "scipy>=1.10",
     "ssm-simulators>=0.13.1",
 ]
 


### PR DESCRIPTION
- Re-adds `scipy>=1.10` to `[project.dependencies]`, dropped in #1137.
- scipy is a **direct import** in shipped source, not a transitive dependency:
  - `src/hssm/plotting/predictive.py:13` — `from scipy.stats import gaussian_kde`
  - `src/hssm/plotting/quantile_probability.py:14` — `from scipy.stats import chi2`
- Today it arrives only via pymc. If pymc ever drops or re-scopes its scipy requirement, `hssm.plotting` breaks at import with no constraint to protect it — the same undeclared-direct-import fragility behind the numpy 2.5 `row_stack` CI breakage (#1144).

### Why this is not the #1145 objection

#1145 was rightly closed for declaring versions of **transitive** dependencies, which transfers version-management burden to us for packages we never import. That objection does not apply here: scipy is imported directly by code we ship, so declaring it is standard packaging practice (PEP 508 — declare what you import). The floor is deliberately loose (`>=1.10`, resolving to 1.18.0 today) so it constrains nothing in practice; it only guarantees scipy is present.

### Verification

- `uv lock` — no lockfile change; scipy already resolved at a satisfying version.
- `uv run prek run --all-files` — ruff check/format and all file hooks pass. The mypy and pyrefly hooks fail identically on unmodified `main` (14 pre-existing errors in `tests/rl/test_rlssm.py` and `tests/addm/oracle/validation.py`); unrelated to this change.
- `from scipy.stats import gaussian_kde, chi2` and both `hssm.plotting` modules import cleanly (scipy 1.18.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)