### PR TITLE
Scope the mypy pre-commit hook to src/hssm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,5 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies: [types-PyYAML]
+        # Match CI (`mypy src/hssm`) and pyrefly's project-includes.
+        files: ^src/hssm/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Two separate skip mechanisms for notebooks:
 |----------|---------|
 | `run_tests.yml` | Fast test suite |
 | `run_slow_tests.yml` | Slow tests (`@pytest.mark.slow`) |
-| `linting_and_type_checking.yml` | ruff + mypy |
+| `linting_and_type_checking.yml` | ruff + pyrefly + mypy |
 | `check_notebooks.yml` | Execute all non-skipped notebooks |
 | `coverage.yml` | Code coverage |
 | `build_docs.yml` | Build documentation |


### PR DESCRIPTION
- Adds `files: ^src/hssm/` to the `mirrors-mypy` hook so it checks the same surface as CI and pyrefly.
- Notes pyrefly in the CI workflow table in `CLAUDE.md` — it has run in `linting_and_type_checking.yml` since `5dc465cf`, but the table still said "ruff + mypy".

### Problem

The mypy hook is the only type-check surface in the repo without a file filter, so `uv run prek run --all-files` type-checks `tests/` — which neither CI nor pyrefly checks:

| | Scope |
|---|---|
| CI mypy | `uv run mypy src/hssm` |
| pyrefly (CI + hook) | `project-includes = ["src/hssm"]` |
| **mypy hook** | **everything** |

That produces 14 errors in `tests/rl/test_rlssm.py` and `tests/addm/oracle/validation.py` on an unmodified `main`. None are defects — they're mypy limitations on test code (`float(x)` guarded by `isinstance(x, Number)`; a `list` passed where `tuple[int, ...]` is declared and `rl/config.py:250` coerces with `tuple(...)` anyway).

Since `CLAUDE.md` instructs contributors to run `uv run prek run --all-files`, the current state is a guaranteed red on a clean checkout — the kind of false signal that trains people to ignore hook output.

### How it got here

Not a recent regression. #1040 moved the pre-commit type-check hook from mypy to pyrefly (`ef226813`), keeping mypy in CI. About an hour later `8bb7c3ee` restored mypy "alongside pyrefly", bringing back the pre-pyrefly block verbatim — including its lack of a filter, which had never mattered while mypy was the *only* type-check hook.

Running mypy at `8bb7c3ee` itself gives `Found 10 errors in 1 file (checked 119 source files)` — the hook was already failing the moment it was restored, and has never been green on `--all-files`. It grew to 14 as tests were added. CI never caught it by construction.

### Why scope rather than remove

#1040's plan and `CLAUDE.md:34` ("mypy (kept in CI)") both read as pre-commit = pyrefly, CI = mypy, which would argue for dropping the hook. But `8bb7c3ee` deliberately wanted both checkers running locally; nothing suggests the author wanted mypy gone, only that the filter was missed. Scoping fixes the oversight without overriding that intent, and keeps fast local mypy feedback on the code that actually ships.

Fixing the 14 test errors instead would mean `# type: ignore` noise and list→tuple churn on a surface the project deliberately does not gate.

### Verification

- `uv run prek run mypy --all-files` → `Passed`, `Success: no issues found in 82 source files`.
- 82 is exactly `git ls-files | grep -cE '^src/hssm/.*\.py$'` and matches CI's `mypy src/hssm` — the filter is not silently matching zero files.
- Full `uv run prek run --all-files`: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited automated mypy checks to the project’s source files.
* **Documentation**
  * Updated CI documentation to accurately list the linting and type-checking tools used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->