### PR TITLE
Fix the two failures keeping the slow test suite red

### DIFF
--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -11,6 +11,14 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    # run_tests.yml sets PYTENSOR_FLAGS=blas__ldflags=... -lblas -llapack; the
+    # runner image ships only the runtime .so.3 objects, so without the -dev
+    # packages the linker cannot resolve those flags and PyTensor's C backend
+    # fails to compile any BLAS-using op.
+    - name: Install BLAS and LAPACK
+      run: sudo apt-get update && sudo apt-get install -y libblas-dev liblapack-dev
+      shell: bash
+
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,11 @@ HSSM uses PEP 735 dependency groups alongside traditional optional-dependencies:
 # Install all dev dependencies
 uv sync --group dev --group notebook --group docs
 
-# Run tests
+# Run tests (slow tests included — there is no --runslow flag)
 uv run pytest tests/
 
-# Run slow tests (marked with @pytest.mark.slow)
-uv run pytest tests/ --runslow
+# Skip slow tests (what CI's fast job runs)
+uv run pytest tests/ -m "not slow"
 
 # Build docs
 uv run --group notebook --group docs mkdocs build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ addopts = [
     "--reruns-delay=5",
 ]
 markers = [
-    "slow: marks tests as slow (add --runslow option to run these tests)",
+    "slow: marks tests as slow (deselect with -m 'not slow')",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,16 @@ def data_ddm_reg_va():
 
 
 @pytest.fixture
+def fixture_path():
+    """Return the shared test fixtures directory.
+
+    Use this instead of deriving the path from ``__file__`` so that moving a
+    test file between ``tests/`` subdirectories does not break it.
+    """
+    return FIXTURES
+
+
+@pytest.fixture
 def cav_dt():
     """Return Cavanagh idata."""
     return az.from_netcdf(FIXTURES / "cavanagh_idata.nc")

--- a/tests/unit/likelihoods/test_likelihoods.py
+++ b/tests/unit/likelihoods/test_likelihoods.py
@@ -4,7 +4,6 @@ These tests validate consistency of analytical, blackbox, and
 approx_differentiable (ONNX-wrapped) likelihood-related paths.
 """
 
-from pathlib import Path
 from itertools import product
 from hssm.utils import SuppressOutput
 
@@ -123,7 +122,7 @@ def test_analytical_gradient():
 
 @pytest.mark.slow
 @pytest.mark.parametrize("p_outlier, loglik_kind", param_matrix)
-def test_lapse_distribution_cav(p_outlier, loglik_kind):
+def test_lapse_distribution_cav(p_outlier, loglik_kind, fixture_path):
     true_values = (1.5, 0.5, 0.5)
     a, z, t = true_values
     # v is set to vector, because
@@ -138,7 +137,7 @@ def test_lapse_distribution_cav(p_outlier, loglik_kind):
         p_outlier=p_outlier,
         loglik_kind=loglik_kind,
         loglik=(
-            Path(__file__).parent / "fixtures" / "ddm.onnx"
+            fixture_path / "ddm.onnx"
             if loglik_kind == "approx_differentiable"
             else None
         ),
@@ -180,7 +179,7 @@ def test_lapse_distribution_cav(p_outlier, loglik_kind):
         logp_func = logp_ddm
     elif loglik_kind == "approx_differentiable":
         logp_func = make_likelihood_callable(
-            loglik=Path(__file__).parent / "fixtures" / "ddm.onnx",
+            loglik=fixture_path / "ddm.onnx",
             loglik_kind="approx_differentiable",
             backend="pytensor",
             params_is_reg=[False] * 4,


### PR DESCRIPTION
Closes #1151.

The slow suite has been red on `main` since 2026-08-04, for two unrelated reasons. `--exitfirst` means only one is ever visible at a time.

### 1. `test_lapse_distribution_cav` — wrong fixture path

- `dda0c52e` moved the test into `tests/unit/likelihoods/`, but it built its ONNX path from `Path(__file__).parent / "fixtures"`; the real fixtures are in `tests/fixtures/`.
- All 4 `approx_differentiable` parametrizations fail with `FileNotFoundError`.
- Fixed by adding a shared `fixture_path` fixture in `tests/conftest.py` (returns the existing `FIXTURES` constant) instead of a `parent.parent.parent` chain, so the next test move can't rebreak it. The name matches the local `fixture_path` fixtures already in six other test files, which can collapse onto it later.

### 2. `test_simple_models_deadline` — CI lost its BLAS libraries

- `c8cf627a` deleted the `Install BLAS and LAPACK` apt step from `.github/setup-env`, but `run_tests.yml:23` still sets `PYTENSOR_FLAGS=blas__ldflags=... -lblas -llapack`.
- The runner image ships only `libblas.so.3`/`liblapack.so.3`, not the unversioned dev symlinks, so PyTensor's C backend fails to link any BLAS-using op: `ld: cannot find -lblas`.
- Deterministic, not flaky: same runner image and identical resolved deps across the last green and first red run. The Aug 4 slow run started four minutes *before* `c8cf627a` landed, which is why it was the last one with BLAS present.
- Fixed by restoring the apt step.

### 3. Docs

- `CLAUDE.md` and the `slow` marker help advertised a `--runslow` flag that no `pytest_addoption` defines — the documented command errors out.

### Verification (local, macOS)

| Run | Result |
|---|---|
| `-m "not slow"` | 616 passed |
| `Remaining Slow` batch (the red one) | 189 passed, 4 skipped |
| `Missing Data` + `Core MCMC` batches | 177 passed |

Run with `--exitfirst` disabled so nothing hides behind an earlier failure.

**The BLAS fix cannot be verified locally** — macOS links Accelerate, so `ld: cannot find -lblas` only reproduces on the Linux runner. It rests on the log forensics above. Confirming it needs a `workflow_dispatch` of `run_slow_tests.yml` against this branch; the PR's own checks only run the fast job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing instructions to reflect the current handling of slow tests.
  * Added guidance for running the full suite or excluding slow tests.

* **Chores**
  * Improved development environment setup by installing required numerical libraries automatically.

* **Tests**
  * Added stable shared access to test fixtures.
  * Updated likelihood tests to use the shared fixture location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
