### PR TITLE
docs: correct identifiability claims in choice-only tutorial

### DIFF
--- a/docs/tutorials/choice_only_models.ipynb
+++ b/docs/tutorials/choice_only_models.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "In practice this manifests as a **ridge in the joint posterior**: $\\beta$ and the logits trade off against each other, producing strong negative correlations, slow mixing (low ESS), and posteriors that are wider than one might expect. The pair plots in this tutorial will make this clearly visible.\n",
     "\n",
-    "**Dealing with the tradeoff.** Two strategies genuinely restore identification by pinning the scale:\n",
+    "**Dealing with the tradeoff.** Two strategies handle the scale tradeoff — one removes the redundancy from the likelihood itself, the other sets the scale through the posterior:\n",
     "\n",
     "1. **Fix $\\beta$** (e.g., $\\beta = 1$) and let the logits absorb the full scale. This eliminates the redundancy entirely and is the simplest approach when only relative preferences matter.\n",
     "2. **Use informative priors** on $\\beta$ or the logits to deliberately set the scale. The likelihood stays flat along the ridge, but the posterior no longer is.\n",
@@ -139,7 +139,7 @@
     "3. **Add more choices.** With $K \\geq 3$ options the flat direction becomes a one-dimensional curve in a higher-dimensional parameter space; sampling geometry changes and diagnostics may improve, but $\\beta' = c \\, \\beta$, $\\ell_k' = \\ell_k / c$ still leaves the likelihood untouched.\n",
     "4. **Introduce covariates** that modulate logits across trials. The composite products (e.g., $\\beta \\times$ intercept and $\\beta \\times$ slope) are identified and sampling can improve, but $\\beta$ and the coefficients individually still trade off exactly.\n",
     "\n",
-    "We will encounter this tradeoff throughout the tutorial. The summary to keep in mind: **only the composite products $\\beta \\, \\ell_k$ are identified unless $\\beta$ is fixed or a prior deliberately sets the scale.**\n"
+    "We will encounter this tradeoff throughout the tutorial. The summary to keep in mind: **the data identify only the composite products $\\beta \\, \\ell_k$.** Fixing $\\beta$ removes the redundancy from the likelihood; an informative prior leaves the likelihood flat but pins the scale through the posterior — individual-parameter inference then inherits that prior choice.\n"
    ]
   },
   {
@@ -857,7 +857,7 @@
    "source": [
     "### Taking Stock\n",
     "\n",
-    "The pair plot makes the **$\\beta$–logit identifiability tradeoff** from the introduction concrete: the posterior concentrates along a ridge of constant $\\beta \\cdot \\ell_1$ that passes through the true values ($\\beta = 2.0$, $\\ell_1 = 0.5$) — not around the true values themselves. Only the product is identified by the data; where the posterior sits *along* the ridge is determined by the priors. The divergences, $\\hat{R}$ warnings, and low ESS in the summary above are the sampler reporting exactly this flat direction.\n",
+    "The pair plot makes the **$\\beta$–logit identifiability tradeoff** from the introduction concrete: the posterior concentrates along a ridge of constant $\\beta \\cdot \\ell_1$ that passes through the true values ($\\beta = 2.0$, $\\ell_1 = 0.5$) — not around the true values themselves. Only the product is identified by the data; where the posterior sits *along* the ridge is determined by the priors. The divergences, $\\hat{R}$ warnings, and low ESS in the summary above are diagnostics consistent with this flat direction (they are not unique to it, but here the pair plot shows its source).\n",
     "\n",
     "Note that the API is identical to RT-based HSSM models — only the `model` string and the absence of an `rt` column differ. In the next sections we will see how **covariates** (Model 2) and **more choices** (Model 4) change the sampling geometry — and why only **fixing $\\beta$** (Model 3) actually resolves the degeneracy.\n"
    ]

--- a/docs/tutorials/choice_only_models.ipynb
+++ b/docs/tutorials/choice_only_models.ipynb
@@ -18,7 +18,7 @@
     "We will:\n",
     "\n",
     "1. Review the softmax inverse-temperature model and its likelihood\n",
-    "2. Recover known parameters from simulated 2-choice data\n",
+    "2. Fit simulated 2-choice data and examine what the data do (and do not) identify\n",
     "3. Add a trial-level covariate that modulates choice\n",
     "4. Extend to a hierarchical (multi-subject) setting\n",
     "5. Demonstrate the 3-choice variant"
@@ -129,14 +129,17 @@
     "\n",
     "In practice this manifests as a **ridge in the joint posterior**: $\\beta$ and the logits trade off against each other, producing strong negative correlations, slow mixing (low ESS), and posteriors that are wider than one might expect. The pair plots in this tutorial will make this clearly visible.\n",
     "\n",
-    "**Dealing with the tradeoff.** There are several strategies:\n",
+    "**Dealing with the tradeoff.** Two strategies genuinely restore identification by pinning the scale:\n",
     "\n",
     "1. **Fix $\\beta$** (e.g., $\\beta = 1$) and let the logits absorb the full scale. This eliminates the redundancy entirely and is the simplest approach when only relative preferences matter.\n",
-    "2. **Use informative priors** on $\\beta$ or the logits to constrain the scale.\n",
-    "3. **Add more choices.** With $K \\geq 3$ options, $\\beta$ must simultaneously scale *all* logits, which partially breaks the degeneracy — the ridge becomes a narrower manifold. Identifiability improves, though correlations remain.\n",
-    "4. **Introduce covariates** that modulate logits across trials. Trial-level variation in the logits constrains $\\beta$ more tightly, since $\\beta$ acts as a global scaling factor on a varying signal.\n",
+    "2. **Use informative priors** on $\\beta$ or the logits to deliberately set the scale. The likelihood stays flat along the ridge, but the posterior no longer is.\n",
     "\n",
-    "We will encounter this tradeoff throughout the tutorial and demonstrate several of these strategies."
+    "Two further changes are often expected to help, and we examine both in this tutorial — but neither removes the scale invariance, which holds exactly for any number of choices and with trial-level covariates (the reparameterization above simply rescales every logit or regression coefficient together):\n",
+    "\n",
+    "3. **Add more choices.** With $K \\geq 3$ options the flat direction becomes a one-dimensional curve in a higher-dimensional parameter space; sampling geometry changes and diagnostics may improve, but $\\beta' = c \\, \\beta$, $\\ell_k' = \\ell_k / c$ still leaves the likelihood untouched.\n",
+    "4. **Introduce covariates** that modulate logits across trials. The composite products (e.g., $\\beta \\times$ intercept and $\\beta \\times$ slope) are identified and sampling can improve, but $\\beta$ and the coefficients individually still trade off exactly.\n",
+    "\n",
+    "We will encounter this tradeoff throughout the tutorial. The summary to keep in mind: **only the composite products $\\beta \\, \\ell_k$ are identified unless $\\beta$ is fixed or a prior deliberately sets the scale.**\n"
    ]
   },
   {
@@ -854,9 +857,9 @@
    "source": [
     "### Taking Stock\n",
     "\n",
-    "The posterior concentrates around the true parameter values ($\\beta = 2.0$, $\\ell_1 = 0.5$), confirming basic parameter recovery. Note that the API is identical to RT-based HSSM models — only the `model` string and the absence of an `rt` column differ.\n",
+    "The pair plot makes the **$\\beta$–logit identifiability tradeoff** from the introduction concrete: the posterior concentrates along a ridge of constant $\\beta \\cdot \\ell_1$ that passes through the true values ($\\beta = 2.0$, $\\ell_1 = 0.5$) — not around the true values themselves. Only the product is identified by the data; where the posterior sits *along* the ridge is determined by the priors. The divergences, $\\hat{R}$ warnings, and low ESS in the summary above are the sampler reporting exactly this flat direction.\n",
     "\n",
-    "However, the diagnostics reveal the **$\\beta$–logit identifiability tradeoff** discussed in the introduction. The pair plot shows a clear ridge: $\\beta$ and $\\ell_1$ are negatively correlated, because only their product $\\beta \\cdot \\ell_1$ is identified by the data. This manifests as low ESS, divergences, and posteriors that are wider than one might expect. In the next sections we will see how **covariates** (Model 2), **fixing $\\beta$** (Model 3), and **more choices** (Model 4) each help mitigate this issue."
+    "Note that the API is identical to RT-based HSSM models — only the `model` string and the absence of an `rt` column differ. In the next sections we will see how **covariates** (Model 2) and **more choices** (Model 4) change the sampling geometry — and why only **fixing $\\beta$** (Model 3) actually resolves the degeneracy.\n"
    ]
   },
   {
@@ -1565,9 +1568,9 @@
    "source": [
     "### Taking Stock\n",
     "\n",
-    "The intercept and slope on `logit1` are well recovered, and the predicted choice probability curve tracks the observed data closely. Regression on choice-only model parameters works exactly as for RT-based HSSM models — via the `include` argument.\n",
+    "The predicted choice-probability curve tracks the observed data closely — the curve depends only on the identified products, so it is well determined even though the individual parameters are not. Regression on choice-only model parameters works exactly as for RT-based HSSM models — via the `include` argument.\n",
     "\n",
-    "Notice the identifiability tradeoff at work again: $\\beta$ is estimated well above its true value (~5.5 vs. 2.0), while the logit coefficients are proportionally scaled down. This is expected — **covariates help** (strategy 4 from the introduction) by providing trial-level variation that constrains $\\beta$, and indeed ESS has improved substantially compared to Model 1. But with $\\beta$ still free, the tradeoff persists: the *products* $\\beta \\cdot \\ell_{1,i}$ are what the data actually identify, not $\\beta$ and the logit coefficients individually. In the hierarchical model next, we fix $\\beta$ to eliminate this redundancy entirely."
+    "The identifiability tradeoff itself is fully intact: $\\beta$ is estimated well above its true value (~5.5 vs. 2.0) while the intercept and slope on `logit1` are proportionally scaled down — the posterior simply settled at a different point on the same ridge. Trial-level covariates do **not** constrain the scale: rescaling $\\beta$ against both regression coefficients together leaves the likelihood unchanged, so what the data identify are the products $\\beta \\times$ intercept and $\\beta \\times$ slope. Strategy 4 changes the sampling geometry — ESS has indeed improved substantially compared to Model 1 — but not what is identified. In the hierarchical model next, we fix $\\beta$ to eliminate the redundancy entirely.\n"
    ]
   },
   {
@@ -3453,9 +3456,9 @@
    "source": [
     "### Taking Stock\n",
     "\n",
-    "The 3-choice model recovers $\\beta$, $\\ell_1$, and $\\ell_2$. The API is unchanged — switching from 2 to 3 choices only requires changing the model string to `\"softmax_inv_temperature_3\"` and providing data with the appropriate choice labels (`[0, 1, 2]`). Recall that $\\ell_0 = 0$ serves as the reference: all estimated logits are relative to option 0.\n",
+    "What the 3-choice model recovers are the composite products $\\beta \\cdot \\ell_1$ and $\\beta \\cdot \\ell_2$ — adding options does **not** break the exact scale degeneracy: rescaling $\\beta$ against both logits together leaves the likelihood unchanged, for any $K$. Where diagnostics look somewhat better than in the 2-choice Model 1, that reflects prior information and a changed posterior geometry (the flat direction is now a single curve in a larger parameter space), not restored identifiability — note that the $\\beta$–logit correlations remain.\n",
     "\n",
-    "With $K = 3$ choices, $\\beta$ must simultaneously scale *two* logits, which partially breaks the scale degeneracy (strategy 3 from the introduction). Notice that ESS and convergence diagnostics are somewhat improved compared to the 2-choice Model 1, though correlations between $\\beta$ and the logits remain. For best results in practice, consider combining multiple strategies — e.g., fixing $\\beta$ or using informative priors alongside the richer signal from multiple choice options."
+    "The API is unchanged — switching from 2 to 3 choices only requires changing the model string to `\"softmax_inv_temperature_3\"` and providing data with the appropriate choice labels (`[0, 1, 2]`). Recall that $\\ell_0 = 0$ serves as the reference: all estimated logits are relative to option 0. For inference on individual parameters in practice, pin the scale — fix $\\beta$ or use a deliberately informative prior — and combine that with the richer signal from multiple options as needed.\n"
    ]
   },
   {


### PR DESCRIPTION
- The softmax likelihood is invariant under β → cβ, ℓ_k → ℓ_k/c for any K and with trial-level covariates — only the products β·ℓ_k are identified unless β is fixed or a prior sets the scale.
- Intro: strategies 3 (more choices) and 4 (covariates) reframed as sampling-geometry aids that do **not** remove the scale invariance; strategies 1–2 remain the identification-restoring ones.
- Model 1 "Taking Stock": no longer calls individual β/ℓ₁ recovery "confirmed"; the divergence/R-hat/ESS output is now cited as evidence of the flat direction.
- Model 2 "Taking Stock": removes the claim that covariates constrain the scale (also resolves its internal contradiction — β ≈ 5.5 vs. true 2.0 with proportionally shrunken coefficients *is* the ridge); identifies β×intercept and β×slope as the recovered quantities.
- Model 4 "Taking Stock": three choices do not partially break the exact degeneracy; recovery claims restated in terms of composite products.
- Markdown cells only — no outputs changed, no re-execution needed (the stored diagnostics already illustrate the corrected narrative).

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the choice-only models tutorial to document exact beta–logit scale invariance.
  - Clarified that only composite parameter products are identifiable.
  - Explained that additional choices and covariates change model geometry but do not remove the degeneracy.
  - Added guidance to fix or constrain parameter scales, including through informative priors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->