### PR TITLE
fix: narrow compute_deterministics return type for pyrefly

### DIFF
--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -380,7 +380,7 @@ def compute_merge_necessary_deterministics(
     """Compute the necessary deterministic variables for the model."""
     # Get the list of deterministic variables
     necessary_params, _ = _cartoon_model_meta(model)
-    deterministics_list = []
+    deterministics_list: list[xr.Dataset] = []
     group_ds = dt[dt_group].to_dataset()
     dt_group_keys = list(group_ds.data_vars)
     # Compute the deterministic variables
@@ -390,8 +390,13 @@ def compute_merge_necessary_deterministics(
                 deterministic.name for deterministic in model.pymc_model.deterministics
             ]:
                 deterministics_list.append(
-                    pm.compute_deterministics(
-                        group_ds, model=model.pymc_model, var_names=[param]
+                    # compute_deterministics is annotated Dataset | DataTree;
+                    # it returns a Dataset when given one (group_ds)
+                    cast(
+                        "xr.Dataset",
+                        pm.compute_deterministics(
+                            group_ds, model=model.pymc_model, var_names=[param]
+                        ),
                     )
                 )
 


### PR DESCRIPTION
- pymc 6.3.0 annotates `compute_deterministics` as `Dataset | DataTree`; the inferred `list[DataTree | Dataset]` no longer matches either `xr.merge` overload under pyrefly, failing `run_tests` on every branch (unpinned CI resolves fresh).
- We always pass a `Dataset` (`.to_dataset()` upstream), so the runtime type is `Dataset`: `cast("xr.Dataset", ...)` + explicit list annotation.
- pyrefly 0 errors, mypy clean, ruff clean locally.

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of plotting computations for greater consistency and reliability.
  * No changes to the user-facing plotting experience or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->