### PR TITLE
docs: Diátaxis nav restructure (phase 3, PR-A)

### DIFF
--- a/docs/tutorials/lapse_prob_and_dist.ipynb
+++ b/docs/tutorials/lapse_prob_and_dist.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "01dd12ae-9f74-4ad3-bad5-5fd3b8559476",
+   "metadata": {},
+   "source": [
+    "# Using lapse probabilities and distributions in HSSM\n",
+    "\n",
+    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c34be9dd",
    "metadata": {},
    "source": [
@@ -27,16 +37,6 @@
    "outputs": [],
    "source": [
     "# %pip install hssm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "01dd12ae-9f74-4ad3-bad5-5fd3b8559476",
-   "metadata": {},
-   "source": [
-    "# Using lapse probabilities and distributions in HSSM\n",
-    "\n",
-    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works."
    ]
   },
   {

--- a/docs/tutorials/save_load_tutorial.ipynb
+++ b/docs/tutorials/save_load_tutorial.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Saving and loading models\n",
+    "# Saving and loading models\n",
     "\n",
     "In this short how-to, tutorial, we show how to save a HSSM model instance and its inference results to disk and then re-instantiate the model from the saved files."
    ]
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load data and instantiate HSSM model"
+    "## Load data and instantiate HSSM model"
    ]
   },
   {
@@ -66,9 +66,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate inference results\n",
+    "## Generate inference results\n",
     "\n",
-    "#### MCMC"
+    "### MCMC"
    ]
   },
   {
@@ -514,7 +514,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### VI"
+    "### VI"
    ]
   },
   {
@@ -594,7 +594,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Saving and Loading the model"
+    "## Saving and Loading the model"
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,24 +19,63 @@ nav:
       - Credits: credits.md
       - License: license.md
       - Changelog: changelog.md
-  - Getting Started:
-      - Getting HSSM:
+      - Archive:
+          - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
+          - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
+          - PyMC to HSSM — MathPsych 2025 (snapshot): archive/pymc_to_hssm.ipynb
+  - Learn:
+      - Get started:
           - Installation: getting_started/installation.md
-      - Learn HSSM:
           - Quickstart: getting_started/getting_started.ipynb
           - The HSSM tutorial: tutorials/main_tutorial.ipynb
           - Hierarchical modeling: getting_started/hierarchical_modeling.ipynb
           - A complete scientific workflow: tutorials/scientific_workflow_hssm.ipynb
+      - Model walkthroughs:
+          - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
+          - Choice-only models: tutorials/choice_only_models.ipynb
+          - Poisson race models: tutorials/poisson_race.ipynb
+          - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
+      - Reinforcement learning models:
+          - RLSSM basics: tutorials/rlssm_basic.ipynb
+          - Choice-only RLSSM: tutorials/choice_only_rlssm.ipynb
+          - Custom RLSSMs with ssms.rl: tutorials/rlssm_advanced.ipynb
+          - A restless learner: tutorials/rlssm_restless_learner.ipynb
+          - Registering custom RLSSMs in HSSM: tutorials/rlssm_hssm_custom_models.ipynb
   - How-to guides:
-      - Specify priors and fix parameters: how_to/specify_priors.ipynb
-      - Compare and interpret models: how_to/compare_models.ipynb
-      - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.ipynb
-      - Bring your own likelihood (external trainers): how_to/external_trainers.md
-      - Custom models from JAX callables: tutorials/jax_callable_contribution_onnx_example.ipynb
-      - Custom models from ONNX files (blackbox): tutorials/blackbox_contribution_onnx_example.ipynb
-      - Using HSSM low-level API directly with PyMC: tutorials/pymc.ipynb
-      - Using compiled log-likelihood functions: tutorials/compile_logp.ipynb
-  - API References:
+      - Building models:
+          - Specify priors and fix parameters: how_to/specify_priors.ipynb
+          - Model outliers with lapse probabilities: tutorials/lapse_prob_and_dist.ipynb
+          - Regress on p_outlier: tutorials/tutorial_p_outlier_regression.ipynb
+          - Use stimulus coding: tutorials/tutorial_stim_coding.ipynb
+          - Add smooth effects with hsgp(): tutorials/hsgp_regression.ipynb
+      - Sampling and diagnostics:
+          - Set initial values: tutorials/initial_values.ipynb
+          - Use alternative samplers (Bayeux): tutorials/tutorial_bayeux.ipynb
+          - Run variational inference: tutorials/variational_inference.ipynb
+      - Working with results:
+          - Plot posteriors and predictions: tutorials/plotting.ipynb
+          - Posterior predictive plot gallery: tutorials/ppc_gallery.ipynb
+          - Model cartoon plot gallery: tutorials/cartoon_gallery.ipynb
+          - Compare and interpret models: how_to/compare_models.ipynb
+          - Get trial-wise parameters: tutorials/tutorial_trial_wise_parameters.ipynb
+          - Run Bayesian t-tests on the posterior: tutorials/tutorial_bayesian_t_test.ipynb
+          - Simulate data with the do-operator: tutorials/do_operator.ipynb
+          - Save and load models: tutorials/save_load_tutorial.ipynb
+      - Custom likelihoods and models:
+          - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.ipynb
+          - Bring your own likelihood (external trainers): how_to/external_trainers.md
+          - Custom models from JAX callables: tutorials/jax_callable_contribution_onnx_example.ipynb
+          - Custom models from ONNX files (blackbox): tutorials/blackbox_contribution_onnx_example.ipynb
+          - Integrate an sbi NRE (ONNX): tutorials/sbi_nre_integration.ipynb
+          - Integrate a BayesFlow NLE (ONNX): tutorials/bayesflow_nle_onnx_integration.ipynb
+          - Integrate a BayesFlow LRE (JAX callable): tutorials/bayesflow_lre_integration.ipynb
+          - Use the low-level API with PyMC: tutorials/pymc.ipynb
+          - Compile a log-likelihood function: tutorials/compile_logp.ipynb
+  - Explanations:
+      - Understanding likelihoods in HSSM: tutorials/likelihoods.ipynb
+      - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
+      - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
+  - Reference:
       - HSSM core classes:
           - hssm.HSSM: api/hssm.md
           - hssm.Param: api/param.md
@@ -56,41 +95,6 @@ nav:
           - hssm.distribution_utils: api/distribution_utils.md
       - Plotting:
           - hssm.plotting: api/plotting.md
-  - Tutorials:
-      - Hierarchical DDM: tutorials/ddm_hierarchical_tutorial.ipynb
-      - Choice-only models: tutorials/choice_only_models.ipynb
-      - Understanding likelihood functions in HSSM: tutorials/likelihoods.ipynb
-      - Plotting: tutorials/plotting.ipynb
-      - Posterior predictive plot gallery: tutorials/ppc_gallery.ipynb
-      - Model cartoon plot gallery: tutorials/cartoon_gallery.ipynb
-      - Using lapse probabilities: tutorials/lapse_prob_and_dist.ipynb
-      - Variational inference: tutorials/variational_inference.ipynb
-      - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
-      - Per-parameter centered vs. non-centered parameterization: tutorials/parameterization_per_parameter.ipynb
-      - Smooth effects with HSGP regressions: tutorials/hsgp_regression.ipynb
-      - RLSSM — Basic tutorial: tutorials/rlssm_basic.ipynb
-      - RLSSM — Choice-only: tutorials/choice_only_rlssm.ipynb
-      - RLSSM — Custom models with ssms.rl: tutorials/rlssm_advanced.ipynb
-      - RLSSM — Restless learner: tutorials/rlssm_restless_learner.ipynb
-      - RLSSM — Registering custom models in HSSM: tutorials/rlssm_hssm_custom_models.ipynb
-      - BayesFlow LRE Integration: tutorials/bayesflow_lre_integration.ipynb
-      - BayesFlow NLE Integration (ONNX): tutorials/bayesflow_nle_onnx_integration.ipynb
-      - sbi NRE Integration (ONNX): tutorials/sbi_nre_integration.ipynb
-      - Saving and loading models: tutorials/save_load_tutorial.ipynb
-      - Bayesian t-test: tutorials/tutorial_bayesian_t_test.ipynb
-      - Using the do-operator: tutorials/do_operator.ipynb
-      - Getting trial-wise parameters: tutorials/tutorial_trial_wise_parameters.ipynb
-      - Stim Coding: tutorials/tutorial_stim_coding.ipynb
-      - P-outlier Regression: tutorials/tutorial_p_outlier_regression.ipynb
-      - Sampling with Bayeux: tutorials/tutorial_bayeux.ipynb
-      - Hidden Markov Models with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
-      - Setting initial values: tutorials/initial_values.ipynb
-      - Poisson race models: tutorials/poisson_race.ipynb
-  - Archive:
-      - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
-      - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
-      - PyMC to HSSM — MathPsych 2025 (snapshot): archive/pymc_to_hssm.ipynb
-
   - Contributing:
       - Developing locally: local_development.md
       - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
Phase 3 opens with the structural half. All 59 nav entries preserved (verified programmatically — zero pages lost or gained); file paths unchanged, so no redirects.

- **`Getting Started` + `Tutorials` merge into `Learn`**, with three sub-groups: *Get started* (the phase-2 ladder, installation first), *Model walkthroughs* (hierarchical DDM, choice-only, Poisson race, HMM+DDM), *Reinforcement learning models* (the five-page RLSSM suite, already an internally cross-linked curriculum). The old flat 30-item Tutorials dump is gone.
- **`How-to guides` gains four sub-groups**: Building models · Sampling and diagnostics · Working with results · Custom likelihoods and models. This reunites `external_trainers.md` with the three integration walkthroughs it routes to — they were in different top-level tabs.
- **New `Explanations` section**: likelihood kinds + the centered/non-centered pair.
- `API References` → **`Reference`**; `Archive` moves under Home.
- Rendering fixes found in passing: `save_load_tutorial` had no H1 at all (headings promoted one level); `lapse_prob_and_dist` opened on its Colab badge with the title stranded in cell 2 (reordered).

Verified: `mkdocs build --strict` green, ruff clean, all new sections render in the built sidebar, save_load and lapse now emit a proper `<h1>`.

**Note for review:** mkdocs-jupyter takes a notebook's own H1 as its sidebar title, so the new task-first labels take effect for `.md` pages immediately but notebooks keep their current H1s until PR-B retitles them (e.g. "Saving and loading models" → "Save and load models"). PR-B also carries the 9 intro reframes and the interlinking sweep.

The classification behind these calls: of 25 non-ladder pages in the old Tutorials section, zero are Diátaxis tutorials.

Closes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation navigation into Archive, Learn, How-to, Explanations, and Reference sections.
  * Added and categorized tutorial, archive, and integration pages for easier discovery.
  * Improved heading hierarchy in the save/load tutorial.
  * Clarified the introductory placement in the lapse probability and distribution tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->