### PR TITLE
docs: titles, goal-first intros, cross-links (phase 3, PR-B)

### DIFF
--- a/docs/archive/hssm_tutorial_workshop_1.ipynb
+++ b/docs/archive/hssm_tutorial_workshop_1.ipynb
@@ -15,7 +15,7 @@
    "id": "2bf587e4-1620-41d6-b1ab-b89a4abd88ba",
    "metadata": {},
    "source": [
-    "# HSSM Tutorial Winterbrain 2025\n",
+    "# HSSM Tutorial Winterbrain 2025 (event snapshot)\n",
     "### Nadja R. Ging-Jehli\n",
     "#### Brown University\n",
     "#### LNCC Lab (Michael J. Frank)\n",

--- a/docs/archive/hssm_tutorial_workshop_2.ipynb
+++ b/docs/archive/hssm_tutorial_workshop_2.ipynb
@@ -15,7 +15,7 @@
    "id": "ecc341d8-b0af-4238-be49-07f704159234",
    "metadata": {},
    "source": [
-    "# Getting Started with Drift Diffusion Models: A Python Tutorial"
+    "# Getting Started with Drift Diffusion Models: A Python Tutorial (event snapshot)"
    ]
   },
   {

--- a/docs/archive/pymc_to_hssm.ipynb
+++ b/docs/archive/pymc_to_hssm.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# HSSM MathPsych 2025\n",
+    "# HSSM MathPsych 2025 (event snapshot)\n",
     "\n",
     "<center> <img src=\"pymc_to_hssm/images/rv_to_hssm.png\"> </center>"
    ]

--- a/docs/getting_started/getting_started.ipynb
+++ b/docs/getting_started/getting_started.ipynb
@@ -5,7 +5,7 @@
    "id": "3abbdcc2",
    "metadata": {},
    "source": [
-    "# HSSM Quickstart\n",
+    "# Quickstart\n",
     "\n",
     "Fit and check your first HSSM model in about 15 minutes: simulate data, build a model, sample the posterior, and run a posterior predictive check.\n",
     "\n",

--- a/docs/getting_started/hierarchical_modeling.ipynb
+++ b/docs/getting_started/hierarchical_modeling.ipynb
@@ -5,7 +5,7 @@
    "id": "0aec427c-56d5-48bb-83c6-6bdc0c445ba2",
    "metadata": {},
    "source": [
-    "# Hierarchical Modeling\n",
+    "# Hierarchical modeling\n",
     "\n",
     "This tutorial demonstrates how to take advantage of HSSM's hierarchical modeling capabilities. We will cover the following:\n",
     "\n",

--- a/docs/how_to/compare_models.ipynb
+++ b/docs/how_to/compare_models.ipynb
@@ -5,7 +5,7 @@
    "id": "35e6afeb",
    "metadata": {},
    "source": [
-    "# How to compare and interpret models\n",
+    "# Compare and interpret models\n",
     "\n",
     "Fitting one model is rarely the end of an analysis — the real question is usually *which of several candidate models best explains the data*. This page shows the HSSM pattern for that question:\n",
     "\n",

--- a/docs/how_to/specify_priors.ipynb
+++ b/docs/how_to/specify_priors.ipynb
@@ -5,7 +5,7 @@
    "id": "c0a6ef2d",
    "metadata": {},
    "source": [
-    "# How to specify priors and fix parameters\n",
+    "# Specify priors and fix parameters\n",
     "\n",
     "Every HSSM model accepts custom priors — and fixed (non-sampled) parameter values — through the same small set of patterns. This page is the reference walkthrough for all of them: the `include` argument (dictionaries and `hssm.Param`), `hssm.Prior`, bounds, the shortcut keyword syntax, and coefficient priors in regressions.\n",
     "\n",

--- a/docs/tutorials/bayesflow_lre_integration.ipynb
+++ b/docs/tutorials/bayesflow_lre_integration.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Integrating BayesFlow Likelihood Ratio Estimation into HSSM\n",
+    "# Integrate a BayesFlow LRE (JAX callable)\n",
     "\n",
-    "This tutorial demonstrates how to use a trained [BayesFlow](https://github.com/bayesflow-org/bayesflow) `RatioApproximator` as a custom likelihood within HSSM. \n",
+    "Use a trained [BayesFlow](https://github.com/bayesflow-org/bayesflow) `RatioApproximator` as a custom likelihood within HSSM. \n",
     "\n",
     "**Background.** BayesFlow's *Likelihood Ratio Estimation* (LRE) trains a neural classifier to approximate the log-likelihood-to-evidence ratio for a simulator-based model. Once trained, this approximator produces a differentiable, pure-JAX function that can serve as a drop-in likelihood for MCMC sampling.\n",
     "\n",

--- a/docs/tutorials/bayesflow_nle_onnx_integration.ipynb
+++ b/docs/tutorials/bayesflow_nle_onnx_integration.ipynb
@@ -5,7 +5,7 @@
    "id": "ef64c208",
    "metadata": {},
    "source": [
-    "# Integrating bayesflow-trained likelihoods into HSSM (NLE via ONNX)\n",
+    "# Integrate a BayesFlow NLE (ONNX)\n",
     "\n",
     "This notebook covers the bayesflow version of the ONNX-based NLE integration workflow in HSSM. Once you've trained a [bayesflow](https://github.com/bayesflow-org/bayesflow) `ContinuousApproximator` (NLE) or `RatioApproximator` (NRE), you can export it to a single ONNX file and hand the path to HSSM. From HSSM's side, the file is consumed identically to a LAN export or an sbi export — same `loglik=\"file.onnx\"` gesture, no library-specific glue.\n",
     "\n",

--- a/docs/tutorials/blackbox_contribution_onnx_example.ipynb
+++ b/docs/tutorials/blackbox_contribution_onnx_example.ipynb
@@ -4,9 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Custom models from ONNX files (blackbox route)\n",
+    "# Custom models from ONNX files (blackbox)\n",
     "\n",
-    "In this tutorial we build a `HSSM` model directly from an `onnx` file. For our purposes, the `onnx` file-format provides nice translation layer from deep learning frameworks into a common layer from which we can then reconstruct computation graph to use through **PyMC**."
+    "Build an `HSSM` model directly from an `onnx` file, via the blackbox route. For our purposes, the `onnx` file-format provides nice translation layer from deep learning frameworks into a common layer from which we can then reconstruct computation graph to use through **PyMC**.\n",
+    "\n",
+    "> New to HSSM's likelihood kinds? [Understanding likelihoods in HSSM](https://lnccbrown.github.io/HSSM/tutorials/likelihoods/) explains how analytical, `approx_differentiable`, and blackbox likelihoods differ."
    ]
   },
   {

--- a/docs/tutorials/centered_vs_noncentered_basic_logic.ipynb
+++ b/docs/tutorials/centered_vs_noncentered_basic_logic.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Centered vs. non-centered parameterizations: basic logic\n",
+    "# Centered vs. non-centered parameterizations\n",
     "\n",
     "When you fit a hierarchical model in HSSM you implicitly choose between two parameterizations of the group-specific (random) effects. They are statistically equivalent, but **the node names in the underlying PyMC graph differ**, and that difference interacts with the way you specify priors. Misalignment between the two leads to a subtle footgun: a prior you supplied can be silently dropped, leaving a *disconnected* free RV in the graph.\n",
     "\n",

--- a/docs/tutorials/choice_only_models.ipynb
+++ b/docs/tutorials/choice_only_models.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Choice-Only Models in HSSM"
+    "# Choice-only models"
    ]
   },
   {

--- a/docs/tutorials/choice_only_rlssm.ipynb
+++ b/docs/tutorials/choice_only_rlssm.ipynb
@@ -5,7 +5,7 @@
    "id": "choice-only-rlssm-00",
    "metadata": {},
    "source": [
-    "# Choice-only RLSSM tutorial\n",
+    "# Choice-only RLSSM\n",
     "\n",
     "This tutorial is for readers who already know the basics of HSSM models and want to fit a reinforcement-learning model when the data contain choices and rewards, but no reaction times.\n",
     "\n",

--- a/docs/tutorials/compile_logp.ipynb
+++ b/docs/tutorials/compile_logp.ipynb
@@ -4,6 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Compile a log-likelihood function\n",
+    "\n",
+    "Compile a fitted HSSM model's log-likelihood into a plain callable — useful for profiling, for custom optimizers, and for handing the model's density to a third-party sampler.\n",
+    "\n",
     "## Compile log-likelihood function"
    ]
   },

--- a/docs/tutorials/ddm_hierarchical_tutorial.ipynb
+++ b/docs/tutorials/ddm_hierarchical_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "intro",
    "metadata": {},
    "source": [
-    "# DDM with hierarchical regressions\n",
+    "# Hierarchical DDM regressions\n",
     "\n",
     " This tutorial walks you through fitting hierarchical Drift Diffusion Models (DDMs) with HSSM. If you're new to HSSM, please click this [link](https://lnccbrown.github.io/HSSM/getting_started/getting_started/). For background on hierarchical modeling in HSSM, please click this [link](https://lnccbrown.github.io/HSSM/getting_started/hierarchical_modeling/).\n",
     "We'll move through four progressively more complex scenarios, each demonstrating a different real-world experimental design and the kind of regression formula you'd use to capture it.\n",

--- a/docs/tutorials/do_operator.ipynb
+++ b/docs/tutorials/do_operator.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using the `do-operator` to simulate data\n",
+    "# Simulate data with the do-operator\n",
     "\n",
-    "This tutorial illustrates how we can use the underlying `PyMC` model of a given HSSM model, to forward simulate datasets that you may use for numerical studies."
+    "Use the underlying `PyMC` model of an HSSM model to forward-simulate datasets that you may use for numerical studies."
    ]
   },
   {

--- a/docs/tutorials/hmm_ddm_regime_switching.ipynb
+++ b/docs/tutorials/hmm_ddm_regime_switching.ipynb
@@ -5,7 +5,9 @@
    "id": "965b9774",
    "metadata": {},
    "source": [
-    "# Joint Modeling of Latent Cognitive States and Decision Processes: HMM with DDM Emissions\n",
+    "# HMM with DDM emissions\n",
+    "\n",
+    "*Joint modeling of latent cognitive states and decision processes*\n",
     "\n",
     "This tutorial demonstrates how to build a **Hidden Markov Model (HMM)** whose emission distribution is a **Drift Diffusion Model (DDM)**, using HSSM's low-level API.\n",
     "\n",

--- a/docs/tutorials/hsgp_regression.ipynb
+++ b/docs/tutorials/hsgp_regression.ipynb
@@ -5,7 +5,7 @@
    "id": "2a13f28d",
    "metadata": {},
    "source": [
-    "# Smooth effects on SSM parameters with `hsgp()`\n",
+    "# Add smooth effects with hsgp()\n",
     "\n",
     "Sometimes a model parameter varies with a covariate in a way you do not want\n",
     "to commit to parametrically — drift that drifts over trial time, a threshold\n",
@@ -14,7 +14,7 @@
     "Gaussian process) covers exactly this, and it works in any HSSM regression\n",
     "formula.\n",
     "\n",
-    "In this tutorial we simulate a DDM whose drift follows $v(s) = A\\,\\sin(s)$ in\n",
+    "Below we simulate a DDM whose drift follows $v(s) = A\\,\\sin(s)$ in\n",
     "a stimulus variable, then recover that curve with\n",
     "\n",
     "```python\n",

--- a/docs/tutorials/initial_values.ipynb
+++ b/docs/tutorials/initial_values.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initial Values"
+    "# Set initial values"
    ]
   },
   {

--- a/docs/tutorials/jax_callable_contribution_onnx_example.ipynb
+++ b/docs/tutorials/jax_callable_contribution_onnx_example.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Custom models from JAX callables\n",
     "\n",
-    "This how-to shows the `approx_differentiable`/JAX route: a differentiable JAX network forward function used directly as an HSSM likelihood — no ONNX file involved. For the ONNX-based variants, see [The ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/) and the [blackbox route](https://lnccbrown.github.io/HSSM/tutorials/blackbox_contribution_onnx_example/)."
+    "This how-to shows the `approx_differentiable`/JAX route: a differentiable JAX network forward function used directly as an HSSM likelihood — no ONNX file involved. For the ONNX-based variants, see [The ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/) and the [blackbox route](https://lnccbrown.github.io/HSSM/tutorials/blackbox_contribution_onnx_example/).\n",
+    "\n",
+    "> New to HSSM's likelihood kinds? [Understanding likelihoods in HSSM](https://lnccbrown.github.io/HSSM/tutorials/likelihoods/) explains how analytical, `approx_differentiable`, and blackbox likelihoods differ."
    ]
   },
   {

--- a/docs/tutorials/lapse_prob_and_dist.ipynb
+++ b/docs/tutorials/lapse_prob_and_dist.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "01dd12ae-9f74-4ad3-bad5-5fd3b8559476",
+   "metadata": {},
+   "source": [
+    "# Using lapse probabilities and distributions in HSSM\n",
+    "\n",
+    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c34be9dd",
    "metadata": {},
    "source": [
@@ -27,16 +37,6 @@
    "outputs": [],
    "source": [
     "# %pip install hssm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "01dd12ae-9f74-4ad3-bad5-5fd3b8559476",
-   "metadata": {},
-   "source": [
-    "# Using lapse probabilities and distributions in HSSM\n",
-    "\n",
-    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works."
    ]
   },
   {

--- a/docs/tutorials/lapse_prob_and_dist.ipynb
+++ b/docs/tutorials/lapse_prob_and_dist.ipynb
@@ -5,9 +5,11 @@
    "id": "01dd12ae-9f74-4ad3-bad5-5fd3b8559476",
    "metadata": {},
    "source": [
-    "# Using lapse probabilities and distributions in HSSM\n",
+    "# Model outliers with lapse probabilities\n",
     "\n",
-    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works."
+    "Since v0.1.2, HSSM has added the ability to model outliers in the distribution with lapse probabilities and distributions. Let's see how it works.\n",
+    "\n",
+    "> To make `p_outlier` itself the target of a regression, see [Regress on p_outlier](https://lnccbrown.github.io/HSSM/tutorials/tutorial_p_outlier_regression/)."
    ]
   },
   {

--- a/docs/tutorials/likelihoods.ipynb
+++ b/docs/tutorials/likelihoods.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Understanding likelihood functions in HSSM\n",
+    "# Understanding likelihoods in HSSM\n",
     "\n",
     "One of the design goals of HSSM is its flexibility. It is built from ground up to support many types of likelihood functions out-of-the-box. For more tailored applications, HSSM provides a convenient toolbox. This allows users to create their own likelihood functions, which can seamlessly integrate with the HSSM class, facilitating a highly customizable analysis environment. This notebook focuses on explaining how to use different types of likelihoods with HSSM."
    ]

--- a/docs/tutorials/main_tutorial.ipynb
+++ b/docs/tutorials/main_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "9ecc15b5-726f-4065-a095-26117b8a4f9c",
    "metadata": {},
    "source": [
-    "# The HSSM Tutorial\n",
+    "# The HSSM tutorial\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
     "  <img src=\"images/HSSM_logo.png\" alt=\"HSSM logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",

--- a/docs/tutorials/parameterization_per_parameter.ipynb
+++ b/docs/tutorials/parameterization_per_parameter.ipynb
@@ -5,7 +5,7 @@
    "id": "e93eb83e",
    "metadata": {},
    "source": [
-    "# Per-parameter centered vs. non-centered parameterization\n",
+    "# Choosing a parameterization per parameter\n",
     "\n",
     "Hierarchical models can express a group-specific (random) effect in one of two\n",
     "equivalent ways:\n",

--- a/docs/tutorials/plotting.ipynb
+++ b/docs/tutorials/plotting.ipynb
@@ -5,13 +5,15 @@
    "id": "9169028c-f35c-458a-b9c3-67f406d3b2d4",
    "metadata": {},
    "source": [
-    "# Plotting in HSSM\n",
+    "# Plot posteriors and predictions\n",
     "\n",
-    "This tutorial demonstrates the plotting functionalities in HSSM.\n",
+    "Inspect a fitted HSSM model visually: posterior summaries, traces, posterior predictives, and model cartoons.\n",
     "\n",
     "While the `ArviZ` package provides many plotting utilities, HSSM aims complement the `ArviZ` package with additional types of plots specific for hierarchical sequential sampling models. In addition, HSSM also provides some plotting API directly from the `HSSM` model object with some additional tweaks for convenience.\n",
     "\n",
-    "Most of the plotting and summary functionalities can be found in `hssm.plotting` module, and additional convenience functions are exposed through the top-level `HSSM` model as well."
+    "Most of the plotting and summary functionalities can be found in `hssm.plotting` module, and additional convenience functions are exposed through the top-level `HSSM` model as well.\n",
+    "\n",
+    "> Looking for one specific option? The [posterior predictive plot gallery](https://lnccbrown.github.io/HSSM/tutorials/ppc_gallery/) and the [model cartoon plot gallery](https://lnccbrown.github.io/HSSM/tutorials/cartoon_gallery/) catalogue the rendering options one at a time."
    ]
   },
   {

--- a/docs/tutorials/poisson_race.ipynb
+++ b/docs/tutorials/poisson_race.ipynb
@@ -5,7 +5,7 @@
    "id": "c6ec77a6",
    "metadata": {},
    "source": [
-    "# Poisson Race Model Tutorial\n",
+    "# Poisson race models\n",
     "\n",
     "This short tutorial shows how to (1) simulate synthetic reaction times with the Poisson race simulator from `ssms-simulators`, (2) fit the analytical Poisson race likelihood provided by HSSM, and (3) inspect the recovered parameters with ArviZ.\n"
    ]

--- a/docs/tutorials/pymc.ipynb
+++ b/docs/tutorials/pymc.ipynb
@@ -5,11 +5,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using the low-level API from HSSM directly with PyMC\n",
+    "# Use the low-level API with PyMC\n",
     "\n",
     "This is a tutorial for advanced users who prefer to use the convenience functions and classes in HSSM to create models and sample in PyMC without using `bambi`. We assume that the readers of this tutorial are familiar with the internals of `PyMC`, `pytensor`, and/or `JAX`.\n",
     "\n",
-    "In addition to the high-level API that relies on `bambi` for model creation, HSSM also features a low-level API that it internally calls for creating `pytensor` `Op`s and `pm.Distribution`s. Experienced users can use the low-level API directly with `PyMC` to create even more customized models. This tutorial shows how advanced users can utilize the low-level API and convenience functions that HSSM provides to interface with PyMC.\n",
+    "In addition to the high-level API that relies on `bambi` for model creation, HSSM also features a low-level API that it internally calls for creating `pytensor` `Op`s and `pm.Distribution`s. Experienced users can use the low-level API directly with `PyMC` to create even more customized models. This guide shows how to use the low-level API and convenience functions HSSM provides to interface with PyMC directly.\n",
     "\n",
     "## When to drop to the low-level API\n",
     "\n",

--- a/docs/tutorials/rlssm_advanced.ipynb
+++ b/docs/tutorials/rlssm_advanced.ipynb
@@ -5,7 +5,7 @@
    "id": "b19b5854",
    "metadata": {},
    "source": [
-    "# RLSSM Advanced Tutorial: Build a Custom Model with `ssms.rl`\n",
+    "# Custom RLSSMs with ssms.rl\n",
     "\n",
     "The [basic RLSSM tutorial](rlssm_basic.ipynb) used the ready-made\n",
     "`2AB_RW_Angle` preset. A preset is convenient because it already bundles the task,\n",

--- a/docs/tutorials/rlssm_basic.ipynb
+++ b/docs/tutorials/rlssm_basic.ipynb
@@ -5,7 +5,7 @@
    "id": "416c9a6f",
    "metadata": {},
    "source": [
-    "# RLSSM — Basic tutorial\n",
+    "# RLSSM basics\n",
     "\n",
     "**Reinforcement-Learning Sequential Sampling Models (RLSSMs)** join two ideas that\n",
     "cognitive scientists usually study separately:\n",

--- a/docs/tutorials/rlssm_hssm_custom_models.ipynb
+++ b/docs/tutorials/rlssm_hssm_custom_models.ipynb
@@ -5,7 +5,7 @@
    "id": "78f2f8ed",
    "metadata": {},
    "source": [
-    "# Registering custom RLSSM models in HSSM\n",
+    "# Registering custom RLSSMs in HSSM\n",
     "\n",
     "This is the shortest tutorial in the RLSSM suite. It teaches the **HSSM-native\n",
     "registry path** for building a reinforcement-learning sequential-sampling model\n",

--- a/docs/tutorials/rlssm_restless_learner.ipynb
+++ b/docs/tutorials/rlssm_restless_learner.ipynb
@@ -5,7 +5,9 @@
    "id": "3aaf30d2",
    "metadata": {},
    "source": [
-    "# RLSSM Restless Learner Tutorial: One Learner, Two Decision Parameters\n",
+    "# A restless learner\n",
+    "\n",
+    "*One learner driving two decision parameters*\n",
     "\n",
     "The [basic](rlssm_basic.ipynb) and [advanced](rlssm_advanced.ipynb) tutorials each\n",
     "let a learner shape **one** part of the decision: the trial-wise drift rate `v`. The\n",

--- a/docs/tutorials/save_load_tutorial.ipynb
+++ b/docs/tutorials/save_load_tutorial.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Saving and loading models\n",
+    "# Saving and loading models\n",
     "\n",
     "In this short how-to, tutorial, we show how to save a HSSM model instance and its inference results to disk and then re-instantiate the model from the saved files."
    ]
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load data and instantiate HSSM model"
+    "## Load data and instantiate HSSM model"
    ]
   },
   {
@@ -66,9 +66,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate inference results\n",
+    "## Generate inference results\n",
     "\n",
-    "#### MCMC"
+    "### MCMC"
    ]
   },
   {
@@ -514,7 +514,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### VI"
+    "### VI"
    ]
   },
   {
@@ -594,7 +594,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Saving and Loading the model"
+    "## Saving and Loading the model"
    ]
   },
   {

--- a/docs/tutorials/save_load_tutorial.ipynb
+++ b/docs/tutorials/save_load_tutorial.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Saving and loading models\n",
+    "# Save and load models\n",
     "\n",
-    "In this short how-to, tutorial, we show how to save a HSSM model instance and its inference results to disk and then re-instantiate the model from the saved files."
+    "Save a HSSM model instance and its inference results to disk and then re-instantiate the model from the saved files."
    ]
   },
   {

--- a/docs/tutorials/sbi_nre_integration.ipynb
+++ b/docs/tutorials/sbi_nre_integration.ipynb
@@ -5,7 +5,7 @@
    "id": "c5b5342c",
    "metadata": {},
    "source": [
-    "# Integrating sbi-trained likelihoods into HSSM (NRE via ONNX)\n",
+    "# Integrate an sbi NRE (ONNX)\n",
     "\n",
     "This tutorial mirrors the structure of `bayesflow_lre_integration.ipynb` for the\n",
     "third major SBI library in the HSSM ecosystem: **[sbi](https://github.com/sbi-dev/sbi)**\n",

--- a/docs/tutorials/scientific_workflow_hssm.ipynb
+++ b/docs/tutorials/scientific_workflow_hssm.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Scientific Workflow with HSSM"
+    "# A complete scientific workflow\n",
+    "\n",
+    "*An end-to-end case study, from raw behavior to a defended model*"
    ]
   },
   {

--- a/docs/tutorials/tutorial_bayesian_t_test.ipynb
+++ b/docs/tutorials/tutorial_bayesian_t_test.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian t-tests\n",
+    "# Run Bayesian t-tests on the posterior\n",
     "\n",
     "In this quick tutorial we illustrate how to use posterior samples to perform Bayesian hypothesis testing. \n"
    ]

--- a/docs/tutorials/tutorial_bayeux.ipynb
+++ b/docs/tutorials/tutorial_bayeux.ipynb
@@ -6,9 +6,9 @@
     "id": "6Yg1KB_Zi49y"
    },
    "source": [
-    "# Sampling with Bayeux\n",
+    "# Use alternative samplers (Bayeux)\n",
     "\n",
-    "This tutorial demonstrates how to use the `bayeux-ml` package with models defined with HSSM.\n",
+    "Sample an HSSM model with an alternative sampler from the `bayeux-ml` package instead of HSSM's defaults.\n",
     "\n",
     "## Install `bayeux-ml` with pip\n",
     "\n",
@@ -20,7 +20,9 @@
     "pip install hssm bayeux-ml flowMC==0.3.4 jax[cuda12]==0.4.38 jaxlib==0.4.38\n",
     "```\n",
     "\n",
-    "Bayeux has some conflicts with some dependencies because it has not been updated for a while. You might also need to install other packages that it depends on for samplers, such as `blackjax`."
+    "Bayeux has some conflicts with some dependencies because it has not been updated for a while. You might also need to install other packages that it depends on for samplers, such as `blackjax`.\n",
+    "\n",
+    "> If sampling fails to start rather than failing to converge, see [Set initial values](https://lnccbrown.github.io/HSSM/tutorials/initial_values/)."
    ]
   },
   {

--- a/docs/tutorials/tutorial_p_outlier_regression.ipynb
+++ b/docs/tutorials/tutorial_p_outlier_regression.ipynb
@@ -4,10 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Regression on \"p_outlier\"\n",
+    "# Regress on p_outlier\n",
     "\n",
-    "This small tutorial illustrates how we can define a regression directly on the `p_outlier` parameter.\n",
-    "The way we define the regression follows the basic pattern we establish in the `include` argument."
+    "Define a regression directly on the `p_outlier` parameter.\n",
+    "The way we define the regression follows the basic pattern we establish in the `include` argument.\n",
+    "\n",
+    "> For fixing `p_outlier` or choosing the lapse distribution itself, see [Model outliers with lapse probabilities](https://lnccbrown.github.io/HSSM/tutorials/lapse_prob_and_dist/)."
    ]
   },
   {

--- a/docs/tutorials/tutorial_stim_coding.ipynb
+++ b/docs/tutorials/tutorial_stim_coding.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Stimulus Coding Example\n",
+    "# Use stimulus coding\n",
     "\n",
-    "In this tutorial we illustrate how to use the regression approach to model the effect of stimulus coding on the drift rate parameter of the DDM."
+    "Model stimulus-coded data with a regression on the drift rate, rather than recoding responses as accuracy."
    ]
   },
   {

--- a/docs/tutorials/tutorial_trial_wise_parameters.ipynb
+++ b/docs/tutorials/tutorial_trial_wise_parameters.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Attach trial wise parameters to idata post-hoc\n",
+    "# Get trial-wise parameters\n",
     "\n",
     "HSSM automatically cleans up the idata object we return from samplers, to avoid unnecessarily huge objects from being passed around (the decision was taken after having observed many inadvertent *out of memory* errors).\n",
     "\n",

--- a/docs/tutorials/variational_inference.ipynb
+++ b/docs/tutorials/variational_inference.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Variational Inference with HSSM\n",
+    "# Run variational inference\n",
     "\n",
-    "Through our [PyMC](https://www.pymc.io/welcome.html) interface, we also gain access to approximate posteriors via Variational Inference. This tutorial illustrates how to perform variational inference via HSSM.\n",
+    "Through our [PyMC](https://www.pymc.io/welcome.html) interface, we also gain access to approximate posteriors via Variational Inference. This guide shows how to run variational inference through HSSM, and when to prefer it over MCMC.\n",
     "\n",
     "This guide covers four things: the **basics** of running VI through HSSM (`.vi()`, its outputs, convergence checks), **when to prefer VI over MCMC**, a **hierarchical case study** comparing both under centered and non-centered parameterizations, and an **appendix** driving PyMC's VI machinery directly."
    ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,24 +19,63 @@ nav:
       - Credits: credits.md
       - License: license.md
       - Changelog: changelog.md
-  - Getting Started:
-      - Getting HSSM:
+      - Archive:
+          - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
+          - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
+          - PyMC to HSSM — MathPsych 2025 (snapshot): archive/pymc_to_hssm.ipynb
+  - Learn:
+      - Get started:
           - Installation: getting_started/installation.md
-      - Learn HSSM:
           - Quickstart: getting_started/getting_started.ipynb
           - The HSSM tutorial: tutorials/main_tutorial.ipynb
           - Hierarchical modeling: getting_started/hierarchical_modeling.ipynb
           - A complete scientific workflow: tutorials/scientific_workflow_hssm.ipynb
+      - Model walkthroughs:
+          - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
+          - Choice-only models: tutorials/choice_only_models.ipynb
+          - Poisson race models: tutorials/poisson_race.ipynb
+          - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
+      - Reinforcement learning models:
+          - RLSSM basics: tutorials/rlssm_basic.ipynb
+          - Choice-only RLSSM: tutorials/choice_only_rlssm.ipynb
+          - Custom RLSSMs with ssms.rl: tutorials/rlssm_advanced.ipynb
+          - A restless learner: tutorials/rlssm_restless_learner.ipynb
+          - Registering custom RLSSMs in HSSM: tutorials/rlssm_hssm_custom_models.ipynb
   - How-to guides:
-      - Specify priors and fix parameters: how_to/specify_priors.ipynb
-      - Compare and interpret models: how_to/compare_models.ipynb
-      - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.ipynb
-      - Bring your own likelihood (external trainers): how_to/external_trainers.md
-      - Custom models from JAX callables: tutorials/jax_callable_contribution_onnx_example.ipynb
-      - Custom models from ONNX files (blackbox): tutorials/blackbox_contribution_onnx_example.ipynb
-      - Using HSSM low-level API directly with PyMC: tutorials/pymc.ipynb
-      - Using compiled log-likelihood functions: tutorials/compile_logp.ipynb
-  - API References:
+      - Building models:
+          - Specify priors and fix parameters: how_to/specify_priors.ipynb
+          - Model outliers with lapse probabilities: tutorials/lapse_prob_and_dist.ipynb
+          - Regress on p_outlier: tutorials/tutorial_p_outlier_regression.ipynb
+          - Use stimulus coding: tutorials/tutorial_stim_coding.ipynb
+          - Add smooth effects with hsgp(): tutorials/hsgp_regression.ipynb
+      - Sampling and diagnostics:
+          - Set initial values: tutorials/initial_values.ipynb
+          - Use alternative samplers (Bayeux): tutorials/tutorial_bayeux.ipynb
+          - Run variational inference: tutorials/variational_inference.ipynb
+      - Working with results:
+          - Plot posteriors and predictions: tutorials/plotting.ipynb
+          - Posterior predictive plot gallery: tutorials/ppc_gallery.ipynb
+          - Model cartoon plot gallery: tutorials/cartoon_gallery.ipynb
+          - Compare and interpret models: how_to/compare_models.ipynb
+          - Get trial-wise parameters: tutorials/tutorial_trial_wise_parameters.ipynb
+          - Run Bayesian t-tests on the posterior: tutorials/tutorial_bayesian_t_test.ipynb
+          - Simulate data with the do-operator: tutorials/do_operator.ipynb
+          - Save and load models: tutorials/save_load_tutorial.ipynb
+      - Custom likelihoods and models:
+          - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.ipynb
+          - Bring your own likelihood (external trainers): how_to/external_trainers.md
+          - Custom models from JAX callables: tutorials/jax_callable_contribution_onnx_example.ipynb
+          - Custom models from ONNX files (blackbox): tutorials/blackbox_contribution_onnx_example.ipynb
+          - Integrate an sbi NRE (ONNX): tutorials/sbi_nre_integration.ipynb
+          - Integrate a BayesFlow NLE (ONNX): tutorials/bayesflow_nle_onnx_integration.ipynb
+          - Integrate a BayesFlow LRE (JAX callable): tutorials/bayesflow_lre_integration.ipynb
+          - Use the low-level API with PyMC: tutorials/pymc.ipynb
+          - Compile a log-likelihood function: tutorials/compile_logp.ipynb
+  - Explanations:
+      - Understanding likelihoods in HSSM: tutorials/likelihoods.ipynb
+      - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
+      - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
+  - Reference:
       - HSSM core classes:
           - hssm.HSSM: api/hssm.md
           - hssm.Param: api/param.md
@@ -56,41 +95,6 @@ nav:
           - hssm.distribution_utils: api/distribution_utils.md
       - Plotting:
           - hssm.plotting: api/plotting.md
-  - Tutorials:
-      - Hierarchical DDM: tutorials/ddm_hierarchical_tutorial.ipynb
-      - Choice-only models: tutorials/choice_only_models.ipynb
-      - Understanding likelihood functions in HSSM: tutorials/likelihoods.ipynb
-      - Plotting: tutorials/plotting.ipynb
-      - Posterior predictive plot gallery: tutorials/ppc_gallery.ipynb
-      - Model cartoon plot gallery: tutorials/cartoon_gallery.ipynb
-      - Using lapse probabilities: tutorials/lapse_prob_and_dist.ipynb
-      - Variational inference: tutorials/variational_inference.ipynb
-      - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
-      - Per-parameter centered vs. non-centered parameterization: tutorials/parameterization_per_parameter.ipynb
-      - Smooth effects with HSGP regressions: tutorials/hsgp_regression.ipynb
-      - RLSSM — Basic tutorial: tutorials/rlssm_basic.ipynb
-      - RLSSM — Choice-only: tutorials/choice_only_rlssm.ipynb
-      - RLSSM — Custom models with ssms.rl: tutorials/rlssm_advanced.ipynb
-      - RLSSM — Restless learner: tutorials/rlssm_restless_learner.ipynb
-      - RLSSM — Registering custom models in HSSM: tutorials/rlssm_hssm_custom_models.ipynb
-      - BayesFlow LRE Integration: tutorials/bayesflow_lre_integration.ipynb
-      - BayesFlow NLE Integration (ONNX): tutorials/bayesflow_nle_onnx_integration.ipynb
-      - sbi NRE Integration (ONNX): tutorials/sbi_nre_integration.ipynb
-      - Saving and loading models: tutorials/save_load_tutorial.ipynb
-      - Bayesian t-test: tutorials/tutorial_bayesian_t_test.ipynb
-      - Using the do-operator: tutorials/do_operator.ipynb
-      - Getting trial-wise parameters: tutorials/tutorial_trial_wise_parameters.ipynb
-      - Stim Coding: tutorials/tutorial_stim_coding.ipynb
-      - P-outlier Regression: tutorials/tutorial_p_outlier_regression.ipynb
-      - Sampling with Bayeux: tutorials/tutorial_bayeux.ipynb
-      - Hidden Markov Models with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
-      - Setting initial values: tutorials/initial_values.ipynb
-      - Poisson race models: tutorials/poisson_race.ipynb
-  - Archive:
-      - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
-      - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
-      - PyMC to HSSM — MathPsych 2025 (snapshot): archive/pymc_to_hssm.ipynb
-
   - Contributing:
       - Developing locally: local_development.md
       - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
Stacked on #1180 (targets that branch; retarget to main after it merges). Prose and metadata only — no code cells touched, no re-execution, all stored outputs untouched.

- **38 notebook titles aligned with their nav labels.** mkdocs-jupyter takes a notebook's own H1 as the sidebar title, so phase-3's task-first labels were inert for notebooks until now ("Attach trial wise parameters to idata post-hoc" → "Get trial-wise parameters", "Integrating BayesFlow Likelihood Ratio Estimation…" → "Integrate a BayesFlow LRE (JAX callable)"). Where the old title carried information the label drops, it survives as an italic subtitle (HMM, restless learner, scientific workflow).
- **Archive pages keep their authentic event titles** with an "(event snapshot)" marker appended, so the sidebar states their status even where the banner isn't visible.
- **`compile_logp` had no H1 at all** — added, with a goal-first opening line.
- **11 intros reframed** from tutorial voice to goal-first ("This tutorial demonstrates the plotting functionalities" → "Inspect a fitted HSSM model visually: posterior summaries, traces, posterior predictives, and model cartoons"). Includes fixing "In this short how-to, tutorial, we show".
- **Cross-links** for the gaps the audit found: the two `p_outlier` pages now reference each other (same parameter, previously no link); plotting links forward to the two option galleries (they already linked back); the two custom-likelihood how-tos link the likelihood-kinds explanation; Bayeux links "Set initial values" for the fails-to-start case.

Verified: `mkdocs build --strict` green, ruff clean, 9 sample sidebar labels confirmed rendering from the built site, no markdown cell carries code-cell fields, and a fence-aware sweep confirms every live notebook has exactly one H1 (the single exception is an archived snapshot, frozen by policy).

Note: a classifier claim that `likelihoods.ipynb` emitted bogus H1s into the ToC was checked and is a false positive — those `#` lines sit inside a closed code fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and standardized titles across archived, getting-started, how-to, and tutorial notebooks.
  * Improved introductory descriptions for model simulation, inference, integrations, visualization, and scientific workflows.
  * Added helpful cross-links to related tutorials and likelihood guidance.
  * Added introductory guidance for compiling model log-likelihoods into callable functions.
  * No computational logic or notebook outputs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->