### PR TITLE
docs: landing page with learning paths + ecosystem hub (phase 4)

### DIFF
--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -10,7 +10,7 @@ This page is the map. It is maintained in
 coordination repository, and published here so there is one description of the
 whole rather than three partial ones.
 
-## The packages
+## The packages you install
 
 | Package | Owns | Start here if you want to... |
 |---|---|---|
@@ -66,10 +66,44 @@ library-specific glue on the HSSM side.
 | I trained a network in sbi or BayesFlow — now what? | [HSSM — Bring your own likelihood](https://lnccbrown.github.io/HSSM/how_to/external_trainers/) |
 | How do I track training and data-generation runs? | [Tracking runs with MLflow](#tracking-runs-with-mlflow), below |
 | Which versions work together? | [Version compatibility](#version-compatibility), below |
+| What is this package in my traceback or lockfile? | [Supporting components](#supporting-components), below |
+| How do I contribute across several packages? | [Development and coordination](#development-and-coordination), below |
 
 Each site is organised the same way — **Learn**, **How-to guides**,
 **Explanations**, **Reference** — so the tab you want sits in the same place
 on all three.
+
+## Supporting components
+
+These are not packages you choose — they arrive with HSSM, or hold artifacts
+it fetches. They are listed here because their names show up in tracebacks,
+lockfiles, and download logs.
+
+| Component | What it is |
+|---|---|
+| [`hddm-wfpt`](https://github.com/lnccbrown/hddm-wfpt) | The Cython implementation of the Wiener first-passage-time likelihood, inherited from HDDM. Installed with HSSM, and used for the analytical DDM likelihoods. |
+| [`franklab/HSSM`](https://huggingface.co/franklab/HSSM) | The HuggingFace repository holding trained likelihood networks. HSSM downloads from it on first use of a model without an analytical likelihood. |
+| [`franklab/ssms_gui`](https://huggingface.co/spaces/franklab/ssms_gui) | A HuggingFace Space for exploring SSM behaviour interactively, built on `ssm-simulators`. Useful for building intuition about what a parameter does. |
+| conda-forge feedstocks | `hssm` and `ssm-simulators` are also published on conda-forge; the feedstock repositories carry the recipes. |
+
+Third-party libraries that do real work under the hood — PyMC, Bambi, ArviZ,
+JAX, PyTensor, ONNX Runtime — are dependencies rather than ecosystem
+components, and their own documentation is the right reference for them.
+
+## Development and coordination
+
+Two repositories exist for people working *on* the ecosystem rather than with
+it. You never need them to fit models, and neither is a Python package you
+install alongside HSSM.
+
+| Repository | Role |
+|---|---|
+| [HSSMSpine](https://github.com/lnccbrown/HSSMSpine) | The coordination repository. It holds no library code — it carries cross-repo context, shared development workflows, the release playbook, the shared documentation brand, and this page. Contributors working across two or more packages start here. |
+| [HSSMCortex](https://github.com/lnccbrown/HSSMCortex) | The capability layer: a knowledge base of papers, modeling taxonomies, and curated guides, plus tooling that makes that knowledge queryable during development. |
+
+If you are contributing to a single package, its own contributing guide is the
+place to start; the spine matters when a change spans packages, such as adding
+a model that needs a simulator, a trained network, and an HSSM configuration.
 
 ## Tracking runs with MLflow
 

--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -1,0 +1,119 @@
+# The HSSM ecosystem
+
+HSSM is the user-facing package of a four-part toolchain. Most users never
+leave it: install HSSM, fit models, publish. You end up here when a question
+crosses a package boundary — where does a likelihood network come from, which
+version pairs with which, why does an ONNX file have to look a certain way.
+
+This page is the map. It is maintained in
+[HSSMSpine](https://github.com/lnccbrown/HSSMSpine), the ecosystem's
+coordination repository, and published here so there is one description of the
+whole rather than three partial ones.
+
+## The packages
+
+| Package | Owns | Start here if you want to... |
+|---|---|---|
+| [HSSM](https://lnccbrown.github.io/HSSM/) | Bayesian inference on sequential sampling models — model specification, priors, sampling, diagnostics, model comparison | ...fit a model to behavioral data. This is the default answer. |
+| [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) (`ssms`) | The generative models: simulators for the SSM family, task environments and learning rules for RLSSMs, and the training-data generators | ...simulate from a model, add a new model to the family, or generate training data. |
+| [LANfactory](https://lnccbrown.github.io/LANfactory/) | Training likelihood approximation networks on simulated data, and exporting them to ONNX | ...train your own likelihood network, or export one trained elsewhere. |
+| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Orchestration on a cluster: data generation and network training as scheduled jobs | ...produce networks at scale rather than one at a time. |
+
+## How the pieces connect
+
+The chain runs in one direction, and the handoffs are files rather than
+imports:
+
+```text
+ssm-simulators ──simulated training data──> LANfactory ──ONNX network──> HuggingFace
+                                                                             │
+                                                                             ▼
+                                                                           HSSM
+                                                          (downloads networks at run time)
+```
+
+Two things follow from this shape.
+
+**Networks are artifacts, not code.** Many SSMs have no analytical likelihood.
+For those, a neural network is trained once — offline, on simulated data — to
+approximate the likelihood, and HSSM calls that network during sampling. The
+trained networks live on
+[HuggingFace](https://huggingface.co/franklab/HSSM); HSSM downloads what a
+model needs on first use. You do not need LANfactory installed to use a
+network someone else trained.
+
+**The boundary is a contract, not a convention.** Any ONNX file HSSM loads
+must expose one per-trial forward pass with every input dimension concrete;
+HSSM batches across trials itself. That rule is stated once, with runnable
+checks, in [The ONNX likelihood
+contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/).
+It is what lets networks trained in
+[sbi](https://github.com/sbi-dev/sbi) or
+[BayesFlow](https://github.com/bayesflow-org/bayesflow) drop into HSSM
+unchanged.
+
+## Which package answers your question
+
+| Your question | Where it is answered |
+|---|---|
+| How do I fit this model to my data? | [HSSM — Learn](https://lnccbrown.github.io/HSSM/) |
+| What models exist, and what are their parameters? | [ssm-simulators — Reference](https://lnccbrown.github.io/ssm-simulators/) |
+| How do I simulate data from a model? | [ssm-simulators — Learn](https://lnccbrown.github.io/ssm-simulators/) |
+| How do I add a model that does not exist yet? | [ssm-simulators — Contributing](https://lnccbrown.github.io/ssm-simulators/) |
+| How do I train a likelihood network for it? | [LANfactory — Learn](https://lnccbrown.github.io/LANfactory/) |
+| I trained a network in sbi or BayesFlow — now what? | [HSSM — Bring your own likelihood](https://lnccbrown.github.io/HSSM/how_to/external_trainers/) |
+| How do I track training and data-generation runs? | [Tracking runs with MLflow](#tracking-runs-with-mlflow), below |
+| Which versions work together? | [Version compatibility](#version-compatibility), below |
+
+Each site is organised the same way — **Learn**, **How-to guides**,
+**Explanations**, **Reference** — so the tab you want sits in the same place
+on all three.
+
+## Tracking runs with MLflow
+
+Data generation (`ssms`) and network training (LANfactory) both log to
+[MLflow](https://mlflow.org/), and they log to the *same* tracking store when
+you point them at one. That is what makes a trained network traceable back to
+the data that produced it.
+
+The environment variable is the whole interface:
+
+```bash
+export MLFLOW_TRACKING_URI="file:///absolute/path/to/mlruns"   # or an http:// server
+```
+
+With that set, `ssms` records each generation run (model, output folder, file
+count, config hash) and LANfactory records each training run (model, network
+type, backend, training-data folder, the run UUID that appears in the
+artifact filenames). Joining the two is what lets you answer "which data
+trained this network" months later.
+
+Per-package details — CLI flags, what exactly is logged, how to query it —
+live with the packages:
+[ssm-simulators](https://lnccbrown.github.io/ssm-simulators/core_tutorials/using_mlflow/)
+and [LANfactory](https://lnccbrown.github.io/LANfactory/using_mlflow/).
+
+## Version compatibility
+
+The packages are released independently, in dependency order:
+`ssm-simulators` → `LANfactory` → HSSM. Install floors, rather than pins, are
+what the ecosystem guarantees:
+
+| Consumer | Requires |
+|---|---|
+| HSSM | `ssm-simulators>=0.13.1` |
+| LANfactory | `ssm-simulators>=0.13.1` |
+| LAN_pipeline_minimal | `ssm-simulators>=0.13.2`, `lanfactory>=0.8` |
+
+All released packages require Python 3.12 or newer. `pip install hssm` pulls a
+compatible `ssm-simulators` automatically; you only need to think about this
+when you are pinning an environment or building networks yourself.
+
+## Where to ask
+
+- **Usage questions and modeling advice** —
+  [HSSM Discussions](https://github.com/lnccbrown/HSSM/discussions).
+- **Bugs** — the issue tracker of the package the bug is in. If you are not
+  sure which, HSSM's tracker is the right default and we will move it.
+- **New models** — [ssm-simulators](https://github.com/lnccbrown/ssm-simulators/issues),
+  which is where the model family lives.

--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -47,10 +47,12 @@ must expose one per-trial forward pass with every input dimension concrete;
 HSSM batches across trials itself. That rule is stated once, with runnable
 checks, in [The ONNX likelihood
 contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/).
-It is what lets networks trained in
+It is also what makes the ecosystem open at the edges: a network trained in
 [sbi](https://github.com/sbi-dev/sbi) or
-[BayesFlow](https://github.com/bayesflow-org/bayesflow) drop into HSSM
-unchanged.
+[BayesFlow](https://github.com/bayesflow-org/bayesflow) becomes usable in HSSM
+by exporting it to ONNX with LANfactory's exporters, after which HSSM loads it
+with the same `loglik="model.onnx"` gesture it uses for its own networks — no
+library-specific glue on the HSSM side.
 
 ## Which package answers your question
 
@@ -72,21 +74,26 @@ on all three.
 ## Tracking runs with MLflow
 
 Data generation (`ssms`) and network training (LANfactory) both log to
-[MLflow](https://mlflow.org/), and they log to the *same* tracking store when
-you point them at one. That is what makes a trained network traceable back to
-the data that produced it.
+[MLflow](https://mlflow.org/). Point them at the same tracking store and the
+two halves of a network's history end up in one place.
 
-The environment variable is the whole interface:
+Two environment variables are the interface:
 
 ```bash
-export MLFLOW_TRACKING_URI="file:///absolute/path/to/mlruns"   # or an http:// server
+export MLFLOW_TRACKING_URI="sqlite:////absolute/path/to/tracking.db"
+export MLFLOW_ARTIFACT_LOCATION="/absolute/path/to/artifacts"
 ```
 
-With that set, `ssms` records each generation run (model, output folder, file
-count, config hash) and LANfactory records each training run (model, network
-type, backend, training-data folder, the run UUID that appears in the
-artifact filenames). Joining the two is what lets you answer "which data
-trained this network" months later.
+`ssms` records each generation run — the generator and model configuration,
+the `data_output_folder`, the number of files produced and their total size,
+and tags for the run phase and any SLURM job it ran under. LANfactory records
+each training run's configuration and metrics.
+
+The two are linked explicitly rather than by convention: pass the data
+generation run's experiment id to the trainer with
+`--data-generation-experiment-id`, and LANfactory records the lineage — it can
+also discover the training-data folder from MLflow instead of being told where
+it is.
 
 Per-package details — CLI flags, what exactly is logged, how to query it —
 live with the packages:

--- a/docs/explanations/coming_from_hddm.md
+++ b/docs/explanations/coming_from_hddm.md
@@ -17,8 +17,14 @@ your numbers if you miss it.
 
 This is not a cosmetic difference. If you carry HDDM parameter values across —
 as priors, as simulation ground truth, or when comparing published estimates —
-divide them by two. HSSM's default bounds for `a` are `(0.3, 2.5)`, which is
-the range you should expect posteriors to live in.
+divide them by two.
+
+Halving also matters for a second reason: HSSM's bounds on `a` depend on which
+likelihood you use. The analytical DDM leaves `a` on `(0, inf)`, but the
+neural approximation is only valid over the range it was trained on, which for
+`ddm` is `(0.3, 2.5)`. An HDDM `a` of `2.0` becomes a comfortable `1.0`; an
+HDDM `a` of `6.0` becomes `3.0`, which is outside the trained range and calls
+for the analytical likelihood instead.
 
 You can see the conversion in HSSM's own source: the black-box likelihoods
 wrap HDDM's Cython WFPT implementation and pass `a * 2` when they call it. The
@@ -68,8 +74,8 @@ one per parameter, which covers the same ground and more:
 |---|---|---|
 | Drift varies by condition | `depends_on={'v': 'stim'}` | `include=[{"name": "v", "formula": "v ~ 0 + C(stim)"}]` |
 | Drift varies by a continuous covariate | `HDDMRegressor` with a patsy formula | `"formula": "v ~ 1 + x"` |
-| Per-participant drift | hierarchical by default | `"formula": "v ~ 1 + (1|participant_id)"` |
-| Several parameters, same structure | one specification per parameter | `global_formula="y ~ 1 + (1|participant_id)"` |
+| Per-participant drift | hierarchical by default | `"formula": "v ~ 1 + (1\|participant_id)"` |
+| Several parameters, same structure | one specification per parameter | `global_formula="y ~ 1 + (1\|participant_id)"` |
 
 The [hierarchical modeling tutorial](../getting_started/hierarchical_modeling.ipynb)
 covers the formula syntax; [hierarchical DDM
@@ -94,10 +100,14 @@ explains the tradeoff and when each is the better choice.
 
 ## Concepts with no direct translation
 
-- **Priors.** HSSM applies HDDM-derived default priors for `ddm`, `ddm_sdv`,
-  and `full_ddm` when the likelihood is analytical, so a default model starts
-  from familiar ground. Specifying your own is a different interface — see
-  [Specify priors and fix parameters](../how_to/specify_priors.ipynb).
+- **Priors.** For `ddm`, `ddm_sdv`, and `full_ddm`, HSSM's default priors on
+  regression terms are derived from HDDM's — the settings are carried in
+  `hssm.prior` under names like `HDDM_MU` and `HDDM_SIGMA` — so a regression
+  model on these families starts from familiar ground. The rule is the
+  likelihood: those defaults apply unless you are using the neural
+  (`approx_differentiable`) likelihood, which has its own priors derived from
+  the network's training bounds. Specifying your own is a different interface
+  — see [Specify priors and fix parameters](../how_to/specify_priors.ipynb).
 - **Outliers.** HDDM's `p_outlier` exists in HSSM under the same name, and the
   lapse distribution is configurable rather than fixed. See [Model outliers
   with lapse probabilities](../tutorials/lapse_prob_and_dist.ipynb).

--- a/docs/explanations/coming_from_hddm.md
+++ b/docs/explanations/coming_from_hddm.md
@@ -1,0 +1,119 @@
+# Coming from HDDM
+
+HDDM is HSSM's predecessor, and the workflow will feel familiar: you hand a
+data frame of reaction times and responses to a model object, sample it, and
+inspect the posterior. This page covers what changes, so that an analysis you
+already understand can be rebuilt rather than re-derived.
+
+There are three kinds of differences: the data your model expects, the way a
+model is specified, and one parameter convention that will silently change
+your numbers if you miss it.
+
+## The convention that matters: `a`
+
+**HSSM's `a` is the distance from the starting point to one boundary; HDDM's
+`a` is the distance between the two boundaries.** An HDDM fit reporting
+`a = 2.0` corresponds to `a = 1.0` in HSSM.
+
+This is not a cosmetic difference. If you carry HDDM parameter values across —
+as priors, as simulation ground truth, or when comparing published estimates —
+divide them by two. HSSM's default bounds for `a` are `(0.3, 2.5)`, which is
+the range you should expect posteriors to live in.
+
+You can see the conversion in HSSM's own source: the black-box likelihoods
+wrap HDDM's Cython WFPT implementation and pass `a * 2` when they call it. The
+other parameters — `v`, `z`, `t`, `sv`, `sz`, `st` — carry over unchanged, and
+`z` is a relative starting point in `(0, 1)` in both packages.
+
+## Your data
+
+| HDDM | HSSM | Note |
+|---|---|---|
+| `subj_idx` | `participant_id` | Rename the column. It is the default grouping variable in formulas. |
+| `response` coded `0` / `1` | `response` coded `-1` / `1` | Recode. HSSM's two-choice models use `-1` and `1`. |
+| `rt` | `rt` | Unchanged, in seconds. |
+
+In practice this is two lines before you build the model:
+
+```python
+data = data.rename(columns={"subj_idx": "participant_id"})
+data["response"] = np.where(data["response"] == 0, -1, 1)
+```
+
+Unlike HDDM, HSSM does not require a participant column at all — a model with
+no group-specific terms is fit to the pooled data. The column matters when you
+write a formula that groups by it.
+
+## Specifying a model
+
+HDDM selects a model by class and configures it with keyword arguments
+(`HDDMRegressor`, `depends_on`, `include`). HSSM has one class, and the model
+family is a string:
+
+```python
+model = hssm.HSSM(data=data, model="ddm")
+```
+
+`model=` accepts `ddm`, `ddm_sdv`, `full_ddm`, `angle`, `levy`, `ornstein`,
+`weibull`, and others; `hssm.list_models()` prints the current set. Models
+without an analytical likelihood are served by a neural approximation that
+HSSM downloads on first use, which is why the model family is a string rather
+than a separate class.
+
+The larger change is how effects on parameters are expressed. HDDM's
+`depends_on` splits a parameter by condition; HSSM uses `lmer`-style formulas,
+one per parameter, which covers the same ground and more:
+
+| What you want | HDDM | HSSM |
+|---|---|---|
+| Drift varies by condition | `depends_on={'v': 'stim'}` | `include=[{"name": "v", "formula": "v ~ 0 + C(stim)"}]` |
+| Drift varies by a continuous covariate | `HDDMRegressor` with a patsy formula | `"formula": "v ~ 1 + x"` |
+| Per-participant drift | hierarchical by default | `"formula": "v ~ 1 + (1|participant_id)"` |
+| Several parameters, same structure | one specification per parameter | `global_formula="y ~ 1 + (1|participant_id)"` |
+
+The [hierarchical modeling tutorial](../getting_started/hierarchical_modeling.ipynb)
+covers the formula syntax; [hierarchical DDM
+regressions](../tutorials/ddm_hierarchical_tutorial.ipynb) works through
+within-subject, between-subject, and interaction designs.
+
+## Hierarchy is opt-in, and parameterized differently
+
+HDDM models are hierarchical by default. In HSSM, a model is hierarchical
+exactly when a parameter has a group-specific term in its formula — there is
+no `hierarchical` switch to set.
+
+The parameterization also differs. HDDM's convention is what HSSM calls the
+*centered* form: drop the common intercept (`v ~ 0 + ...`) and let the
+participant-level coefficients come from one group distribution with a free
+mean and standard deviation. HSSM defaults to the *non-centered* form, which
+usually samples better. To reproduce the HDDM specification, set
+`noncentered=False`; the group distributions then appear as
+`v_1|participant_id_mu`-style nodes. [Centered vs. non-centered
+parameterizations](../tutorials/centered_vs_noncentered_basic_logic.ipynb)
+explains the tradeoff and when each is the better choice.
+
+## Concepts with no direct translation
+
+- **Priors.** HSSM applies HDDM-derived default priors for `ddm`, `ddm_sdv`,
+  and `full_ddm` when the likelihood is analytical, so a default model starts
+  from familiar ground. Specifying your own is a different interface — see
+  [Specify priors and fix parameters](../how_to/specify_priors.ipynb).
+- **Outliers.** HDDM's `p_outlier` exists in HSSM under the same name, and the
+  lapse distribution is configurable rather than fixed. See [Model outliers
+  with lapse probabilities](../tutorials/lapse_prob_and_dist.ipynb).
+- **Sampling.** HSSM samples with PyMC and can dispatch to NumPyro and other
+  JAX-based samplers. `model.sample()` passes keyword arguments through to
+  PyMC, so `chains`, `draws`, `tune`, and `target_accept` behave as they do in
+  PyMC rather than as in HDDM's sampler.
+- **Results.** Posterior samples come back as an ArviZ `InferenceData` object
+  rather than an HDDM-specific container, so diagnostics, plots, and model
+  comparison are standard ArviZ from there on.
+
+## Where to start
+
+If you are rebuilding an existing analysis, [the HSSM
+tutorial](../tutorials/main_tutorial.ipynb) is the fastest route to the parts
+you already know, in the new interface. The [Winterbrain 2025 workshop
+snapshot](../archive/hssm_tutorial_workshop_2.ipynb) works through an analysis
+first run in HDDM and then rebuilt in HSSM, including the data preparation
+above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,28 +29,15 @@ collaboration with the
 [Center for Computational Brain Science](https://ccbs.carney.brown.edu/) within
 the [Carney Institute at Brown University](https://www.brown.edu/carney/).
 
-## Citation
+## Installation
 
-Fengler, A., Xu, Y., Bera, K., Omar, A., Frank, M.J. (in preparation). HSSM: A
-generalized toolbox for hierarchical bayesian estimation of computational
-models in cognitive neuroscience.
+```bash
+pip install hssm        # or: uv add hssm
+```
 
-## Features
-
-- Allows approximate hierarchical Bayesian inference via various likelihood
-  approximators.
-- Estimate impact of neural and other trial-by-trial covariates via native
-  hierarchical mixed-regression support.
-- Extensible for users to add novel models with corresponding likelihoods.
-- Built on PyMC with support from the Python Bayesian ecosystem at large.
-- Incorporates Bambi's intuitive `lmer`-like regression parameter specification
-  for within- and between-subject effects.
-- (💥 New in HSSM 0.4.0) Support for reinforcement learning sequential sampling models.
-- Native ArviZ support for plotting and other convenience functions to aid the
-  Bayesian workflow.
-- Utilizes the ONNX format for translation of differentiable likelihood
-  approximators across backends.
-- Broad ecosystem support for differentiable likelihoods sourced from the sbi and BayesFlow libraries.
+HSSM installs on all platforms with Python 3.12–3.14. For GPU sampling (CUDA
+extras), Colab, the dev version, optional dependencies, and troubleshooting,
+see the [Installation guide](getting_started/installation.md).
 
 ## Example
 
@@ -83,35 +70,83 @@ model = hssm.HSSM(
 model.sample()
 ```
 
-To quickly get started with HSSM, please follow
-[the quickstart](getting_started/getting_started.ipynb). For the full guided
-introduction, please follow [the HSSM tutorial](tutorials/main_tutorial.ipynb).
+## Start here
 
-## Installation
+<div class="grid cards" markdown>
 
-```bash
-pip install hssm        # or: uv add hssm
-```
+-   __Fit your first model__
 
-HSSM installs on all platforms with Python 3.12–3.14. For GPU sampling (CUDA
-extras), Colab, the dev version, optional dependencies, and troubleshooting,
-see the [Installation guide](getting_started/installation.md).
+    ---
+
+    From `pip install` to a result you can defend. Six steps, each building on
+    the last:
+
+    1. [Installation](getting_started/installation.md) — a working environment, GPU extras included.
+    2. [Quickstart](getting_started/getting_started.ipynb) — simulate, fit, and check a DDM in about 15 minutes.
+    3. [The HSSM tutorial](tutorials/main_tutorial.ipynb) — the guided introduction: model choice, priors, diagnostics, predictive checks, comparison.
+    4. [Hierarchical modeling](getting_started/hierarchical_modeling.ipynb) — `lmer`-style formulas on any model parameter.
+    5. [Hierarchical DDM regressions](tutorials/ddm_hierarchical_tutorial.ipynb) — map your actual design onto a formula, and recover it.
+    6. [Compare and interpret models](how_to/compare_models.ipynb) — rank candidates, and recognise when the data cannot separate them.
+
+    **Capstone:** [A complete scientific workflow](tutorials/scientific_workflow_hssm.ipynb) — one dataset, start to finish.
+
+-   __Bring your own likelihood or model__
+
+    ---
+
+    For models HSSM does not ship, or likelihoods you trained yourself:
+
+    1. [Understanding likelihoods in HSSM](tutorials/likelihoods.ipynb) — analytical, `approx_differentiable`, and blackbox, and when each applies.
+    2. [The ONNX likelihood contract](how_to/custom_onnx_likelihoods.ipynb) — the rules an ONNX file must satisfy, demonstrated live.
+    3. [Bring your own likelihood](how_to/external_trainers.md) — the route table for networks trained in sbi or BayesFlow.
+    4. Then the walkthrough for your route — [sbi NRE](tutorials/sbi_nre_integration.ipynb), [BayesFlow NLE](tutorials/bayesflow_nle_onnx_integration.ipynb), [BayesFlow LRE](tutorials/bayesflow_lre_integration.ipynb), or [JAX callables](tutorials/jax_callable_contribution_onnx_example.ipynb).
+    5. [Use the low-level API with PyMC](tutorials/pymc.ipynb) — when the formula interface is the constraint.
+
+</div>
+
+Beyond the paths, the docs are organised by what you are doing: **Learn** for
+guided material, **How-to guides** for a specific task, **Explanations** for
+the reasoning behind a choice, and **Reference** for the API.
+
+## Part of a larger toolchain
+
+HSSM is the inference layer of a four-package ecosystem: `ssm-simulators`
+supplies the models and simulated data, LANfactory trains the likelihood
+networks that make otherwise-intractable models estimable, and HSSM consumes
+them. Most users never need the other three. See
+[The HSSM ecosystem](ecosystem/index.md) for the map, including which package
+answers which question and how versions fit together.
+
+## What HSSM gives you
+
+- Hierarchical Bayesian inference for a broad family of sequential sampling
+  models, including those with no analytical likelihood.
+- Parameter-wise mixed-effects regressions in `lmer`-like syntax, so neural and
+  trial-by-trial covariates can enter any model parameter.
+- Reinforcement learning sequential sampling models (RLSSMs), where the
+  decision parameters are driven by a learning process.
+- Custom models and likelihoods: bring an ONNX network, a JAX callable, or a
+  black-box Python function.
+- Built on PyMC, Bambi, and ArviZ, so the wider Python Bayesian ecosystem
+  applies directly.
+
+## Citation
+
+Fengler, A., Xu, Y., Bera, K., Omar, A., Frank, M.J. (in preparation). HSSM: A
+generalized toolbox for hierarchical bayesian estimation of computational
+models in cognitive neuroscience.
+
+## Community
+
+- **Questions and modeling advice** —
+  [open a discussion](https://github.com/lnccbrown/HSSM/discussions).
+- **Bugs and feature requests** —
+  [open an issue](https://github.com/lnccbrown/HSSM/issues) using the
+  corresponding template.
+- **Contributing** — see the
+  [contribution guidelines](CONTRIBUTING.md).
 
 ## License
 
 HSSM is licensed under
 [Copyright 2023, Brown University, Providence, RI](license.md)
-
-## Support
-
-For questions, please feel free to
-[open a discussion](https://github.com/lnccbrown/HSSM/discussions).
-
-For bug reports and feature requests, please feel free to
-[open an issue](https://github.com/lnccbrown/HSSM/issues) using the
-corresponding template.
-
-## Contributing
-
-If you want to contribute to this project, please follow our
-[contribution guidelines](CONTRIBUTING.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,8 @@ model.sample()
 
     **Capstone:** [A complete scientific workflow](tutorials/scientific_workflow_hssm.ipynb) — one dataset, start to finish.
 
+    *Used HDDM before?* [Coming from HDDM](explanations/coming_from_hddm.md) maps what you know onto HSSM.
+
 -   __Bring your own likelihood or model__
 
     ---

--- a/docs/tutorials/scientific_workflow_hssm.ipynb
+++ b/docs/tutorials/scientific_workflow_hssm.ipynb
@@ -25,7 +25,7 @@
     "Along the way we try to achieve the following balance:\n",
     "\n",
     "1. Illustrate how HSSM can be used for real scientific workflows. HSSM helps us with model building, running the stats, and reporting results.\n",
-    "2. Stay readable end to end, shirking conceptually advanced features that are discussed in the many dedicated tutorials you can find in the [documentation](https://lnccbrown.github.io/HSSM/).\n",
+    "2. Stay readable end to end by deferring conceptually advanced features to the dedicated tutorials in the [documentation](https://lnccbrown.github.io/HSSM/).\n",
     "\n",
     "This tutorial is the capstone of the learning path rather than its entry point: it assumes you have already built and sampled a model, as covered in [the HSSM tutorial](https://lnccbrown.github.io/HSSM/tutorials/main_tutorial/). If you are looking for your first look at HSSM, start there."
    ]

--- a/docs/tutorials/scientific_workflow_hssm.ipynb
+++ b/docs/tutorials/scientific_workflow_hssm.ipynb
@@ -25,7 +25,9 @@
     "Along the way we try to achieve the following balance:\n",
     "\n",
     "1. Illustrate how HSSM can be used for real scientific workflows. HSSM helps us with model building, running the stats, and reporting results.\n",
-    "2. Allow this tutorial to be used as a **first** look into HSSM, shirking conceptually advanced features that are discused in the many dedicated tutorials you can find on the [documentation](https://lnccbrown.github.io/HSSM/)"
+    "2. Stay readable end to end, shirking conceptually advanced features that are discussed in the many dedicated tutorials you can find in the [documentation](https://lnccbrown.github.io/HSSM/).\n",
+    "\n",
+    "This tutorial is the capstone of the learning path rather than its entry point: it assumes you have already built and sampled a model, as covered in [the HSSM tutorial](https://lnccbrown.github.io/HSSM/tutorials/main_tutorial/). If you are looking for your first look at HSSM, start there."
    ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
           - Use the low-level API with PyMC: tutorials/pymc.ipynb
           - Compile a log-likelihood function: tutorials/compile_logp.ipynb
   - Explanations:
+      - Coming from HDDM: explanations/coming_from_hddm.md
       - Understanding likelihoods in HSSM: tutorials/likelihoods.ipynb
       - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
       - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Credits: credits.md
       - License: license.md
       - Changelog: changelog.md
+      - The HSSM ecosystem: ecosystem/index.md
       - Archive:
           - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
           - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
@@ -256,6 +257,7 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - attr_list
+  - md_in_html
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
Phase 4. Vendors the spine-authored hub (lnccbrown/HSSMSpine#48) and rebuilds the landing page around the two guided learning paths requested at the start of this workstream.

- **Two learning paths as grid cards** — *Fit your first model* (installation → quickstart → the HSSM tutorial → hierarchical modeling → hierarchical DDM regressions → model comparison, capstone: the scientific workflow) and *Bring your own likelihood or model* (likelihood kinds → ONNX contract → route table → your route's walkthrough → the low-level API). Every step is a page that exists today, each with a one-line promise of what you can do after it.
- **Landing page restructured**: install moves above the fold (it was below a 9-bullet feature list), the two tutorial pointers that were an unheaded paragraph become the path cards, the feature list is rewritten around what you can do rather than what is implemented, and Support/Contributing/License consolidate under **Community**. Logo, badges, both intro paragraphs, the citation block, and the code example are kept verbatim.
- **`/ecosystem/` hub** — HSSM previously never mentioned the ecosystem it belongs to (grep-verified: `ssm-simulators`/`LANfactory` appeared only in the changelog and one how-to). The hub is vendored from the spine and linked under Home.
- **`md_in_html`** added to `markdown_extensions` — required for grid cards, a core Python-Markdown extension, no new dependency (`attr_list` was already enabled and mkdocs-material ships the card CSS).
- **Positioning conflict resolved**: the scientific-workflow tutorial claimed to be a "**first** look into HSSM" while the quickstart routes newcomers to the main tutorial — the path cards would have asserted an order the pages contradicted. It now names itself the capstone and defers to the main tutorial (typo `discused` fixed while there).

Verified: `mkdocs build --strict` green, ruff clean, grid cards render as Material's card structure in the built HTML, hub builds and appears in the sidebar.

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive ecosystem overview covering package roles, data handoffs, workflows, version compatibility, and support resources.
  * Reorganized the documentation homepage with installation guidance, onboarding paths, capability highlights, custom-likelihood guidance, community links, and licensing information.
  * Added an HDDM migration guide covering model setup, data preparation, priors, hierarchies, sampling, and result handling.
  * Clarified the scientific workflow tutorial’s position as an advanced, capstone resource.
  * Updated documentation navigation with the ecosystem and HDDM migration guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->