### PR TITLE
ci: install the graphviz binary for notebook checks

### DIFF
--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -11,6 +11,14 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    # The `graphviz` Python package is a binding, not a bundle: it shells out
+    # to the `dot` binary, which ubuntu-latest does not ship. Without this,
+    # every notebook that renders a model graph dies on
+    # `ExecutableNotFound: PosixPath('dot')`.
+    - name: Install graphviz
+      run: sudo apt-get update && sudo apt-get install -y graphviz
+      shell: bash
+
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:


### PR DESCRIPTION
- The first scheduled notebook drift run ([31734899653](https://github.com/lnccbrown/HSSM/actions/runs/31734899653)) failed **13 tutorial notebooks** across 3 of 4 shards.
- Dominant cause is not upstream drift: `graphviz` in the `notebook` group is a *binding*, not a bundle — it shells out to the `dot` executable, which `ubuntu-latest` does not ship. Every notebook rendering a model graph dies on `ExecutableNotFound: failed to execute PosixPath('dot')` (55 occurrences in the logs).
- `setup-env-notebooks` installs no system packages at all, unlike `setup-env` which installs BLAS/LAPACK — so nothing ever provided it.
- Fix: one `apt-get install -y graphviz` step in the composite action.

**Two unrelated failures remain in that run and are deliberately not touched here:**

| Notebook | Error |
|---|---|
| (protobuf path) | `TypeError: cannot pickle 'google._upb._message.EnumDescriptor' object` |
| `rlssm_hssm_custom_models.ipynb` | `ValueError: theta is missing required params: ['v']. Expected all of: ['rl_alpha', 'rl_alpha_neg', 'v', 'a', 'z', 't', 'theta']` |

Both need judgment rather than a mechanical fix; the RLSSM one looks like a genuine param-mapping regression worth its own issue.

Found by the spine's scheduled drift detection — this was the notebook job's first-ever run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Graphviz installation during notebook environment setup.
  * Notebook workflows can now use Graphviz-based visualizations without additional manual configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->