### PR TITLE
ci: run the notebook drift check weekly, and fix its environment

### DIFF
--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -20,6 +20,14 @@ runs:
 
     # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
     # no step with id `cache` exists, so it always evaluated true)
+    # Several tutorials call `model.graph()`, which shells out to Graphviz's
+    # `dot`. The Python wrapper comes from the notebook group; the binary does
+    # not, and without it those notebooks fail with
+    # `FileNotFoundError: PosixPath('dot')`.
+    - name: Install Graphviz
+      run: sudo apt-get update && sudo apt-get install -y graphviz
+      shell: bash
+
     - name: Install hssm
       run: uv sync --group notebook
       shell: bash

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -11,7 +11,7 @@ name: Drift
 on:
   schedule:
     - cron: "0 5 * * 1" # weekly: lint + fast + slow
-    - cron: "0 3 1 * *" # monthly: notebooks
+    - cron: "0 3 * * 2" # weekly: notebooks (Tuesday, off-peak)
   workflow_dispatch:
     inputs:
       force_fail:
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/run_slow_tests.yml
 
   notebooks:
-    if: (github.event_name == 'workflow_dispatch' && inputs.run_notebooks) || github.event.schedule == '0 3 1 * *'
+    if: (github.event_name == 'workflow_dispatch' && inputs.run_notebooks) || github.event.schedule == '0 3 * * 2'
     uses: ./.github/workflows/check_notebooks.yml
 
   report:
@@ -79,7 +79,8 @@ jobs:
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
           # Three outcomes matter separately. `skipped` is neutral by design —
-          # the monthly notebooks job is skipped in every weekly run. But
+          # the two weekly slots run different jobs, so each run skips the
+          # jobs belonging to the other one. But
           # `cancelled` is not evidence of health, and `report` runs under
           # `if: always()`, which includes cancellation: without this
           # distinction a cancelled run would silently close a real drift


### PR DESCRIPTION
Two changes, prompted by the first real dispatch of `drift.yml`'s notebooks job (2026-08-13): **all four shards failed**, and the cause was infrastructure, not drift.

- **Graphviz.** Every failure traces to `FileNotFoundError: PosixPath('dot')`. The Python `graphviz` wrapper ships in the notebook dependency group, but the system binary it shells out to does not — so every tutorial calling `model.graph()` died (~12 notebooks across all four shards). `setup-env-notebooks` now installs it. Without this the freshness budget would have sat permanently red for a reason unrelated to the docs.
- **Weekly instead of monthly.** The notebooks job moves from `0 3 1 * *` to its own weekly slot, `0 3 * * 2` — Tuesday, deliberately not sharing a runner window with Monday's lint/fast/slow. The job-level `if` gate is updated in lockstep (the file's own note warns the cron strings are matched verbatim), and the report job's comment about "the monthly notebooks job" is corrected, since both weekly slots now skip the other's jobs by design.

Companion spine PR updates the `hssm-notebooks` budget to the weekly cadence (40 → 10 days) and clears its `planned` flag, now that the check has been observed.

Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)