### PR TITLE
ci: close the notebook execution gap

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -35,12 +35,13 @@ jobs:
           # full find-produced path — bare filenames never match the loop
           # comparison (the two workshop notebooks executed for months while
           # "skipped").
+          # Only one page is genuinely un-runnable here: bayeux needs
+          # jax[cuda12]==0.4.38, which conflicts with the JAX HSSM is tested
+          # against. The page says so in its own text. Everything else runs —
+          # this workflow is dispatch/drift-only, so "too heavy for the PR
+          # check" no longer applies: there is no PR check.
           SKIP_NOTEBOOKS=(
             "docs/tutorials/tutorial_bayeux.ipynb"
-            "docs/tutorials/hsgp_regression.ipynb"
-            # two hierarchical fits, too heavy for the PR check; outputs
-            # inherited from the archived Winterbrain 2025 workshop run
-            "docs/how_to/compare_models.ipynb"
           )
 
           EXIT_CODE=0

--- a/docs/tutorials/tutorial_bayeux.ipynb
+++ b/docs/tutorials/tutorial_bayeux.ipynb
@@ -20,7 +20,7 @@
     "pip install hssm bayeux-ml flowMC==0.3.4 jax[cuda12]==0.4.38 jaxlib==0.4.38\n",
     "```\n",
     "\n",
-    "Bayeux has some conflicts with some dependencies because it has not been updated for a while. You might also need to install other packages that it depends on for samplers, such as `blackjax`.\n",
+    "Bayeux has some conflicts with some dependencies because it has not been updated for a while. For that reason this page is **not executed by our continuous integration**: the pins above (notably `jax[cuda12]==0.4.38`) conflict with the JAX version HSSM itself is tested against, so the outputs below are from a manual run rather than a scheduled one. Treat the sampler behaviour as illustrative and verify it in your own environment. You might also need to install other packages that it depends on for samplers, such as `blackjax`.\n",
     "\n",
     "> If sampling fails to start rather than failing to converge, see [Set initial values](https://lnccbrown.github.io/HSSM/tutorials/initial_values/)."
    ]


### PR DESCRIPTION
Last Phase-5 item. Three notebooks were skipped by **both** mkdocs and CI, so the `hssm-notebooks` freshness budget could stay green while they rotted. Measured each rather than assuming:

| Notebook | Verdict |
|---|---|
| `hsgp_regression` | **Unskipped** — executes clean in **70 seconds**. The skip was never justified. |
| `compare_models` | **Unskipped** — executes clean in **7m38s**. Its stated rationale ("too heavy for the PR check") is stale: `check_notebooks.yml` is dispatch/`workflow_call`-only, so there is no PR check to be heavy for. |
| `tutorial_bayeux` | **Stays skipped, now honestly.** It needs `jax[cuda12]==0.4.38`/`flowMC==0.3.4`, which conflict with the JAX version HSSM is tested against, and `bayeux-ml` is not a declared dependency. |

Per rubric criterion D1 — every executable page is executed by some pipeline on a stated cadence, *or* says plainly that it is not — the bayeux page now tells readers its outputs come from a manual run rather than a scheduled one, and to verify sampler behaviour in their own environment. The skip list carries the same reason for the next maintainer.

Combined with weekly execution and the graphviz fix (#1188), every executable page in the docs is now covered by a pipeline, and the one exception is labelled on the page itself.

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Bayeux tutorial warning to explain its dependency compatibility limitation.
  * Clarified that displayed notebook outputs are manually generated examples and should be verified locally.

* **Tests**
  * Notebook validation now includes the HSGP regression and model-comparison tutorials.
  * The Bayeux tutorial remains excluded from automated checks due to its JAX dependency conflict.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->