### PR TITLE
docs: fix vi() niter docstring default to match signature

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -754,7 +754,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         Parameters
         ----------
         niter : int
-            The number of iterations to run the VI algorithm. Defaults to 3000.
+            The number of iterations to run the VI algorithm. Defaults to 10000.
         method : str
             The method to use for VI. Can be one of "advi" or "fullrank_advi", "svgd",
             "asvgd".Defaults to "advi".


### PR DESCRIPTION
- Fix `HSSM.vi()` docstring: `niter` default corrected from 3000 to 10000, matching the signature and `pm.fit`'s own default
- Docstring-only change; no behavior change

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `vi` method documentation to accurately reflect its default of 10,000 iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->