### PR TITLE
Support continuous and circular response domains

### DIFF
--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -307,6 +307,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             else None
         )
         self.choices = self.model_config.choices  # type: ignore[assignment]
+        self.response_kind = self.model_config.response_kind
+        self.response_bounds = self.model_config.response_bounds
         self.model_name = self.model_config.model_name
         self.loglik = self.model_config.loglik
         self.loglik_kind = self.model_config.loglik_kind
@@ -315,11 +317,6 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         # TODO: add to HSSMBase
         self.is_choice_only: bool = self.model_config.is_choice_only
-
-        if self.choices is None:
-            raise ValueError(
-                "`choices` must be provided either in `model_config` or as an argument."
-            )
 
         self._validate_choices()
 
@@ -330,7 +327,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
             )
         # endregion
 
-        self.n_choices = len(self.choices)  # type: ignore[arg-type]
+        self.n_choices = len(self.choices) if self.choices is not None else None
 
         self._pre_check_data_sanity()
 
@@ -1907,6 +1904,11 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         if self.has_lapse:
             if lapse is None:
                 if self.is_choice_only:
+                    if self.n_choices is None:
+                        raise ValueError(
+                            "The default choice-only lapse requires categorical "
+                            "responses with `choices`."
+                        )
                     self.lapse = 1 / self.n_choices
                 else:
                     self.lapse = bmb.Prior("Uniform", lower=0.0, upper=20.0)

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args
 
 from bambi import Prior
@@ -32,6 +33,7 @@ DEFAULT_SSM_OBSERVED_DATA = ["rt", "response"]
 DEFAULT_SSM_CHOICES = (0, 1)
 
 ParamSpec = Union[float, dict[str, Any], Prior, None]
+ResponseKind = Literal["categorical", "continuous", "circular"]
 
 
 @dataclass
@@ -45,6 +47,8 @@ class BaseModelConfig(ABC):
     # Data specification
     response: list[str] | None = field(default_factory=DEFAULT_SSM_OBSERVED_DATA.copy)
     choices: tuple[int, ...] | None = DEFAULT_SSM_CHOICES
+    response_kind: ResponseKind = "categorical"
+    response_bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
 
     # Parameter specification
     list_params: list[str] | None = None
@@ -85,6 +89,60 @@ class BaseModelConfig(ABC):
     def is_choice_only(self) -> bool:
         """Return whether the model is choice-only (no RT)."""
         return self.response is not None and len(self.response) == 1
+
+    def validate_response(self) -> None:
+        """Validate the response-domain metadata shared by HSSM model configs.
+
+        Bounds are keyed by observed response column. Continuous bounds are
+        optional and closed when present. Circular bounds are required, finite,
+        and interpreted as a lower-inclusive, upper-exclusive interval.
+        """
+        if self.response is None:
+            raise ValueError("Please provide `response` columns in the configuration.")
+
+        if self.response_kind not in {"categorical", "continuous", "circular"}:
+            raise ValueError(
+                "`response_kind` must be one of 'categorical', 'continuous', or "
+                "'circular'."
+            )
+
+        if self.response_kind == "categorical":
+            if self.choices is None:
+                raise ValueError("Please provide `choices` for categorical responses.")
+            return
+
+        if self.choices is not None:
+            raise ValueError(
+                "`choices` must be None for continuous or circular responses."
+            )
+
+        response_columns = self.response if self.is_choice_only else self.response[1:]
+        unexpected_columns = set(self.response_bounds) - set(response_columns)
+        if unexpected_columns:
+            names = ", ".join(sorted(unexpected_columns))
+            raise ValueError(
+                f"Response bounds were provided for unrecognized column(s): {names}."
+            )
+
+        if self.response_kind == "circular":
+            missing_columns = set(response_columns) - set(self.response_bounds)
+            if missing_columns:
+                names = ", ".join(sorted(missing_columns))
+                raise ValueError(
+                    f"Circular response bounds are required for column(s): {names}."
+                )
+
+        for column, (lower, upper) in self.response_bounds.items():
+            if lower >= upper:
+                raise ValueError(
+                    f"Response bounds for {column!r} must satisfy lower < upper."
+                )
+            if self.response_kind == "circular" and not (
+                isfinite(lower) and isfinite(upper)
+            ):
+                raise ValueError(
+                    f"Circular response bounds for {column!r} must be finite."
+                )
 
 
 @dataclass
@@ -226,6 +284,12 @@ class Config(BaseModelConfig):
         """
         if user_config.response is not None:
             self.response = list(user_config.response)  # type: ignore[assignment]
+        if user_config.response_kind is not None:
+            self.response_kind = user_config.response_kind
+            if self.response_kind != "categorical" and user_config.choices is None:
+                self.choices = None
+        if user_config.response_bounds is not None:
+            self.response_bounds = deepcopy(user_config.response_bounds)
         if user_config.list_params is not None:
             self.list_params = user_config.list_params
         if user_config.choices is not None:
@@ -245,12 +309,9 @@ class Config(BaseModelConfig):
 
     def validate(self) -> None:
         """Ensure that mandatory fields are not None."""
-        if self.response is None:
-            raise ValueError("Please provide `response` columns in the configuration.")
+        self.validate_response()
         if self.list_params is None:
             raise ValueError("Please provide `list_params`.")
-        if self.choices is None:
-            raise ValueError("Please provide `choices`.")
         if self.loglik is None:
             raise ValueError("Please provide a log-likelihood function via `loglik`.")
         if self.loglik_kind == "approx_differentiable" and self.backend is None:
@@ -324,6 +385,8 @@ class ModelConfig:
     """Representation for model_config provided by the user."""
 
     response: tuple[str, ...] | None = None
+    response_kind: ResponseKind | None = None
+    response_bounds: dict[str, tuple[float, float]] | None = None
     list_params: list[str] | None = None
     choices: tuple[int, ...] | None = None
     default_priors: dict[str, ParamSpec] = field(default_factory=dict)

--- a/src/hssm/data_validator.py
+++ b/src/hssm/data_validator.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_bool_dtype, is_numeric_dtype
 
 _logger = logging.getLogger("hssm")
 
@@ -14,8 +15,10 @@ class DataValidatorMixin:
 
     data: pd.DataFrame
     response: list[str]
-    choices: list[int]
-    n_choices: int
+    choices: list[int] | tuple[int, ...] | None
+    response_kind: str
+    response_bounds: dict[str, tuple[float, float]]
+    n_choices: int | None
     extra_fields: list[str] | None
     deadline: bool
     deadline_name: str
@@ -49,31 +52,42 @@ class DataValidatorMixin:
     def _post_check_data_sanity(self):
         """Check if the data is clean enough for the model."""
         if self.is_choice_only:
-            return
-        if self.deadline or self.missing_data:
-            if -999.0 not in self.data["rt"].unique():
-                raise ValueError(
-                    "You have no missing data in your dataset, "
-                    + "which is not allowed when `missing_data` or `deadline` is set to"
-                    + " True."
-                )
-            rt_filtered = self.data.rt[self.data.rt != -999.0]
+            if self.response_kind == "categorical":
+                return
+            valid_data = self.data
         else:
-            rt_filtered = self.data.rt
+            if self.deadline or self.missing_data:
+                if -999.0 not in self.data["rt"].unique():
+                    raise ValueError(
+                        "You have no missing data in your dataset, "
+                        + "which is not allowed when `missing_data` or `deadline` is "
+                        + "set to True."
+                    )
+                rt_filtered = self.data.rt[self.data.rt != -999.0]
+            else:
+                rt_filtered = self.data.rt
 
-        if np.any(rt_filtered.isna(), axis=None):
-            raise ValueError(
-                "You have NaN response times in your dataset, "
-                + "which is not allowed."
-            )
+            if np.any(rt_filtered.isna(), axis=None):
+                raise ValueError(
+                    "You have NaN response times in your dataset, "
+                    + "which is not allowed."
+                )
 
-        if not np.all(rt_filtered >= 0):
-            raise ValueError(
-                "You have negative response times in your dataset, "
-                + "which is not allowed."
-            )
+            if not np.all(rt_filtered >= 0):
+                raise ValueError(
+                    "You have negative response times in your dataset, "
+                    + "which is not allowed."
+                )
 
-        valid_responses = self.data.loc[self.data["rt"] != -999.0, "response"]
+            valid_data = self.data.loc[self.data["rt"] != -999.0]
+
+        if self.response_kind != "categorical":
+            self._validate_non_categorical_responses(valid_data)
+            return
+
+        assert self.choices is not None
+        assert self.n_choices is not None
+        valid_responses = valid_data["response"]
         unique_responses = valid_responses.unique().astype(int)
 
         if np.any(~np.isin(unique_responses, self.choices)):
@@ -96,6 +110,46 @@ class DataValidatorMixin:
                 UserWarning,
                 stacklevel=2,
             )
+
+    def _validate_non_categorical_responses(self, data: pd.DataFrame) -> None:
+        """Validate continuous or circular response columns without coercion."""
+        response_columns = list(self.response)
+        if self.deadline and self.deadline_name in response_columns:
+            response_columns.remove(self.deadline_name)
+        if not self.is_choice_only:
+            response_columns = response_columns[1:]
+
+        for column in response_columns:
+            values = data[column]
+            if is_bool_dtype(values.dtype) or not is_numeric_dtype(values.dtype):
+                raise ValueError(
+                    f"Response column {column!r} must contain numeric, finite values."
+                )
+
+            values_array = values.to_numpy()
+            if not np.all(np.isfinite(values_array)):
+                raise ValueError(
+                    f"Response column {column!r} must contain numeric, finite values."
+                )
+
+            if column not in self.response_bounds:
+                continue
+
+            lower, upper = self.response_bounds[column]
+            upper_invalid = (
+                values_array >= upper
+                if self.response_kind == "circular"
+                else values_array > upper
+            )
+            invalid = (values_array < lower) | upper_invalid
+            if np.any(invalid):
+                interval_end = ")" if self.response_kind == "circular" else "]"
+                invalid_values = np.unique(values_array[invalid]).tolist()
+                raise ValueError(
+                    f"{self.response_kind.capitalize()} responses in column "
+                    f"{column!r} must lie in [{lower}, {upper}{interval_end}. "
+                    f"Invalid values: {invalid_values}"
+                )
 
     # AF-TODO: We probably want to incorporate some of the
     # remaining check on missing data
@@ -124,12 +178,12 @@ class DataValidatorMixin:
             ]
 
     def _validate_choices(self):
-        """
-        Ensure that `choices` is provided (not None).
-
-        Raises ValueError if choices is None.
-        """
-        if self.choices is None:
+        """Validate that categorical response metadata includes choices."""
+        if self.response_kind == "categorical" and self.choices is None:
             raise ValueError(
                 "`choices` must be provided either in `model_config` or as an argument."
+            )
+        if self.response_kind != "categorical" and self.choices is not None:
+            raise ValueError(
+                "`choices` must be None for continuous or circular responses."
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,12 @@
 import logging
+from copy import deepcopy
+from dataclasses import asdict
 
-import pytest
 import numpy as np
+import pytest
 
-from hssm.config import Config, ModelConfig
 import hssm
+from hssm.config import Config, ModelConfig
 
 
 hssm.set_floatX("float32")
@@ -19,6 +21,9 @@ def test_from_defaults():
     assert config1.list_params == ["v", "a", "z", "t"]
     assert config1.loglik_kind == "analytical"
     assert config1.loglik is not None
+    assert config1.response_kind == "categorical"
+    assert config1.response_bounds == {}
+    assert config1.choices == (-1, 1)
     assert "t" in config1.default_priors
     assert "v" in config1.bounds
     assert not config1.is_choice_only
@@ -90,6 +95,84 @@ def test_update_config():
 
     assert v_prior.name == "Normal"
     assert v_bounds == (-np.inf, np.inf)
+
+
+def test_non_categorical_response_metadata_round_trips():
+    bounds = {"response": (-np.pi, np.pi)}
+    user_config = ModelConfig(
+        response=("rt", "response"),
+        response_kind="circular",
+        response_bounds=bounds,
+        list_params=["v_x", "v_y", "a", "t"],
+    )
+
+    config = Config.from_defaults("custom", "blackbox")
+    config.update_config(deepcopy(user_config))
+    config.update_loglik(lambda *args: None)
+    config.validate()
+
+    assert config.response_kind == "circular"
+    assert config.response_bounds == bounds
+    assert config.choices is None
+    assert asdict(config)["response_bounds"] == bounds
+    assert user_config.response_bounds == bounds
+
+    config.response_bounds["response"] = (-1.0, 1.0)
+    assert user_config.response_bounds == bounds
+
+
+@pytest.mark.parametrize("response_kind", ["continuous", "circular"])
+def test_non_categorical_responses_reject_choices(response_kind):
+    config = Config(
+        model_name="custom",
+        response_kind=response_kind,
+        response_bounds={"response": (-np.pi, np.pi)},
+        choices=(0, 1),
+        list_params=["v"],
+        loglik_kind="blackbox",
+        loglik=lambda *args: None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="`choices` must be None for continuous or circular responses",
+    ):
+        config.validate()
+
+
+def test_categorical_responses_require_choices():
+    config = Config(
+        model_name="custom",
+        choices=None,
+        list_params=["v"],
+        loglik_kind="blackbox",
+        loglik=lambda *args: None,
+    )
+
+    with pytest.raises(ValueError, match="choices.*categorical responses"):
+        config.validate()
+
+
+def test_circular_responses_require_valid_bounds():
+    config = Config(
+        model_name="custom",
+        response_kind="circular",
+        choices=None,
+        list_params=["v"],
+        loglik_kind="blackbox",
+        loglik=lambda *args: None,
+    )
+
+    with pytest.raises(ValueError, match="bounds are required.*response"):
+        config.validate()
+
+    config.response_bounds = {"response": (np.pi, -np.pi)}
+    with pytest.raises(ValueError, match="lower < upper"):
+        config.validate()
+
+    config.response_bounds = {"response": (-np.inf, np.inf)}
+    with pytest.raises(ValueError, match="must be finite"):
+        config.validate()
 
 
 class TestConfigBuildModelConfigExtraLogic:

--- a/tests/test_data_sanity.py
+++ b/tests/test_data_sanity.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 import numpy as np
+import pandas as pd
 
 import hssm
 
@@ -59,6 +60,95 @@ def test_invalid_responses(data_ddm):
         data_ddm_miscoded["response"] = np.random.choice([0, 1, 2], data_ddm.shape[0])
 
         hssm.HSSM(data=data_ddm_miscoded, model="ddm", choices=[1, 2, 3])
+
+
+def test_circular_response_validation_reaches_distribution_construction(monkeypatch):
+    data = np.array([[0.4, -2.75], [0.8, -0.125], [1.2, 1.875]], dtype=np.float64)
+    data = pd.DataFrame(data, columns=["rt", "response"])
+    observed = {}
+
+    def stop_after_validation(model):
+        observed["response"] = model.data["response"].to_numpy(copy=True)
+        observed["choices"] = model.choices
+        observed["n_choices"] = model.n_choices
+        raise RuntimeError("distribution construction reached")
+
+    monkeypatch.setattr(hssm.HSSM, "_make_model_distribution", stop_after_validation)
+
+    def circular_logp(data, v):
+        return np.zeros(len(data), dtype=np.float64)
+
+    model_config = {
+        "response_kind": "circular",
+        "response_bounds": {"response": (-np.pi, np.pi)},
+        "list_params": ["v"],
+        "bounds": {"v": (-np.inf, np.inf)},
+    }
+    with pytest.raises(RuntimeError, match="distribution construction reached"):
+        hssm.HSSM(
+            data=data,
+            model="custom",
+            model_config=model_config,
+            loglik=circular_logp,
+            loglik_kind="blackbox",
+            p_outlier=None,
+            v={"prior": {"name": "Normal", "mu": 0.0, "sigma": 1.0}},
+        )
+
+    np.testing.assert_array_equal(observed["response"], data["response"].to_numpy())
+    assert observed["choices"] is None
+    assert observed["n_choices"] is None
+
+
+def test_circular_response_validation_precedes_distribution_construction(monkeypatch):
+    data = pd.DataFrame({"rt": [0.4, 0.8], "response": [0.0, np.pi]})
+    distribution_was_built = False
+
+    def record_distribution_construction(model):
+        nonlocal distribution_was_built
+        distribution_was_built = True
+
+    monkeypatch.setattr(
+        hssm.HSSM, "_make_model_distribution", record_distribution_construction
+    )
+
+    with pytest.raises(ValueError, match=r"Circular responses.*must lie in .*\)"):
+        hssm.HSSM(
+            data=data,
+            model="custom",
+            model_config={
+                "response_kind": "circular",
+                "response_bounds": {"response": (-np.pi, np.pi)},
+                "list_params": ["v"],
+                "bounds": {"v": (-np.inf, np.inf)},
+            },
+            loglik=lambda data, v: np.zeros(len(data)),
+            loglik_kind="blackbox",
+            p_outlier=None,
+            v={"prior": {"name": "Normal", "mu": 0.0, "sigma": 1.0}},
+        )
+
+    assert not distribution_was_built
+
+
+def test_continuous_choice_only_lapse_requires_categorical_choices():
+    data = pd.DataFrame({"response": [-0.5, 0.25]})
+
+    with pytest.raises(ValueError, match="choice-only lapse requires categorical"):
+        hssm.HSSM(
+            data=data,
+            model="custom",
+            model_config={
+                "response": ("response",),
+                "response_kind": "continuous",
+                "response_bounds": {"response": (-1.0, 1.0)},
+                "list_params": ["v"],
+                "bounds": {"v": (-np.inf, np.inf)},
+            },
+            loglik=lambda data, v: np.zeros(len(data)),
+            loglik_kind="blackbox",
+            v={"prior": {"name": "Normal", "mu": 0.0, "sigma": 1.0}},
+        )
 
 
 @pytest.mark.slow  # as model needs to be built

--- a/tests/test_data_validator.py
+++ b/tests/test_data_validator.py
@@ -18,11 +18,21 @@ class DataValidatorTester(DataValidatorMixin):
         missing_data: bool = False,
         choices: list[int] | None = None,
         n_choices: int | None = None,
+        response_kind: str = "categorical",
+        response_bounds: dict[str, tuple[float, float]] | None = None,
     ):
         self.data = data
         self.response = ["rt", "response"]
-        self.choices = choices if choices is not None else [0, 1]
-        self.n_choices = n_choices if n_choices is not None else len(self.choices)
+        self.response_kind = response_kind
+        self.response_bounds = response_bounds or {}
+        self.choices = (
+            [0, 1] if choices is None and response_kind == "categorical" else choices
+        )
+        self.n_choices = (
+            n_choices
+            if n_choices is not None
+            else (len(self.choices) if self.choices is not None else None)
+        )
         self.extra_fields = extra_fields
         self.deadline = deadline
         self.deadline_name = "deadline"
@@ -197,3 +207,93 @@ def test_validate_choices():
     dv.choices = None  # type: ignore[assignment]
     with pytest.raises(ValueError, match="`choices` must be provided*."):
         dv._validate_choices()
+
+    circular_dv = DataValidatorTester(
+        data=_base_data(),
+        response_kind="circular",
+        response_bounds={"response": (-np.pi, np.pi)},
+    )
+    circular_dv._validate_choices()
+    assert circular_dv.choices is None
+    assert circular_dv.n_choices is None
+
+
+def test_circular_responses_remain_fractional():
+    responses = np.array([-np.pi, -1.25, 0.125, np.nextafter(np.pi, -np.inf)])
+    data = _base_data()
+    data["response"] = responses
+    original = data["response"].to_numpy(copy=True)
+    dv = DataValidatorTester(
+        data=data,
+        deadline=False,
+        response_kind="circular",
+        response_bounds={"response": (-np.pi, np.pi)},
+    )
+
+    dv._post_check_data_sanity()
+
+    np.testing.assert_array_equal(dv.data["response"].to_numpy(), original)
+
+
+@pytest.mark.parametrize("invalid_response", [np.pi, np.nextafter(-np.pi, -np.inf)])
+def test_circular_responses_enforce_half_open_bounds(invalid_response):
+    data = _base_data()
+    data["response"] = data["response"].astype(float)
+    data.loc[0, "response"] = invalid_response
+    dv = DataValidatorTester(
+        data=data,
+        deadline=False,
+        response_kind="circular",
+        response_bounds={"response": (-np.pi, np.pi)},
+    )
+
+    with pytest.raises(ValueError, match=r"must lie in \[-3.*3.*\)"):
+        dv._post_check_data_sanity()
+
+
+@pytest.mark.parametrize("invalid_response", [np.nan, np.inf, "not-a-number"])
+def test_non_categorical_responses_must_be_numeric_and_finite(invalid_response):
+    data = _base_data()
+    data["response"] = data["response"].astype(object)
+    data.loc[0, "response"] = invalid_response
+    if invalid_response != "not-a-number":
+        data["response"] = pd.to_numeric(data["response"])
+    dv = DataValidatorTester(
+        data=data,
+        deadline=False,
+        response_kind="continuous",
+    )
+
+    with pytest.raises(ValueError, match="must contain numeric, finite values"):
+        dv._post_check_data_sanity()
+
+
+def test_continuous_response_bounds_are_closed():
+    data = _base_data()
+    data["response"] = [-1.0, -0.25, 0.25, 1.0]
+    dv = DataValidatorTester(
+        data=data,
+        deadline=False,
+        response_kind="continuous",
+        response_bounds={"response": (-1.0, 1.0)},
+    )
+    dv._post_check_data_sanity()
+
+    dv.data.loc[0, "response"] = np.nextafter(-1.0, -np.inf)
+    with pytest.raises(ValueError, match=r"must lie in \[-1.0, 1.0\]"):
+        dv._post_check_data_sanity()
+
+
+def test_circular_responses_preserve_deadline_and_missing_row_handling():
+    data = base_data_with_missing()
+    data["response"] = [-2.5, 0.125, -999.0, 2.25]
+    dv = DataValidatorTester(
+        data=data,
+        deadline=True,
+        missing_data=True,
+        response_kind="circular",
+        response_bounds={"response": (-np.pi, np.pi)},
+    )
+    dv.response.append("deadline")
+
+    dv._post_check_data_sanity()


### PR DESCRIPTION
## Summary

- add backwards-compatible response-domain metadata to `BaseModelConfig` and `ModelConfig`
- keep categorical responses and built-in choices as the default
- allow continuous and circular models to use `choices=None`
- validate non-categorical observations without integer coercion
- enforce finite values, closed continuous bounds, and half-open circular bounds
- make categorical-only `n_choices` behavior fail explicitly when it is unavailable

## Motivation

HSSM currently assumes every response is categorical and casts observed response values to integers during validation. That prevents a continuous angular response from reaching likelihood construction safely.

This PR is the dependency-free H01/H02 foundation for the fixed circular-diffusion JEAM handshake. It does not import or depend on JEAM. The next stacked work will pin the merged JEAM fork commit and add the likelihood adapter.

## Response-domain contract

| `response_kind` | `choices` | Accepted observations | Bounds |
| --- | --- | --- | --- |
| `categorical` | required | Existing HSSM behavior is unchanged: unique values are cast to integers, then checked for membership in `choices`. | Not used. |
| `continuous` | must be `None` | Numeric, non-boolean, finite values. | Optional per response column; a declared interval is closed: `[lower, upper]`. |
| `circular` | must be `None` | Numeric, non-boolean, finite values. | Required and finite for every circular response column; lower-inclusive and upper-exclusive: `[lower, upper)`. |

The generic circular metadata does not assume angle units or require an interval width of `2π`. The JEAM follow-up will declare radians on `[-π, π)`. For an RT-bearing model, the first configured column is RT and subsequent configured columns are response columns. Missing rows identified by `rt == -999` are excluded before response validation.

## Compatibility

Existing model configs remain categorical by default and retain their existing choice validation. Missing-data, deadline, and reaction-time checks continue to run before response-domain validation.

## Verification

- focused config and validation suite: 32 passed, 2 slow tests deselected
- full fast suite: 645 passed, 371 deselected
- `pyrefly check`
- `mypy --no-strict-optional --ignore-missing-imports src/hssm`
- `ruff check src/hssm`
- `ruff format --check .`
- `git diff --check`
