### PR TITLE
Pin the JEAM prototype dependency

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -1,0 +1,29 @@
+name: JEAM prototype dependency
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - ".github/workflows/jeam_prototype.yml"
+      - "src/hssm/integrations/jeam.py"
+      - "tests/integration/test_jeam.py"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup environment
+        uses: ./.github/setup-env
+        with:
+          python-version: "3.12"
+
+      - name: Sync JEAM prototype group
+        run: uv sync --group jeam-prototype --locked
+
+      - name: Smoke-test optional imports
+        run: uv run --group jeam-prototype python -c "import hssm; import jeam"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ cuda12 = ["jax[cuda12]>=0.7.0"]
 cuda13 = ["jax[cuda13]>=0.7.0"]
 
 [dependency-groups]
+jeam-prototype = ["jeam"]
+
 dev = [
     "coverage>=7.6.4",
     "mypy>=2.1",
@@ -256,6 +258,7 @@ publish-url = "https://test.pypi.org/legacy/"
 
 [tool.uv.sources]
 hssm = { workspace = true }
+jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "6a945654ea36917eaa22acca54c0fca718bbe275" }
 
 [tool.pyrefly]
 preset = "legacy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ publish-url = "https://test.pypi.org/legacy/"
 
 [tool.uv.sources]
 hssm = { workspace = true }
-jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "6a945654ea36917eaa22acca54c0fca718bbe275" }
+jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99" }
 
 [tool.pyrefly]
 preset = "legacy"


### PR DESCRIPTION
Depends on #1193. This PR is stacked on `codex/jeam-handshake` and must remain based there until the response-domain foundation is ready to merge.

## Summary

- add a dedicated `jeam-prototype` uv dependency group
- pin the working JEAM fork to merged commit `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`
- add a path-filtered CI smoke test that installs the group and imports both packages
- keep JEAM out of HSSM's published wheel metadata and ordinary development environment

## Dependency policy

HSSM currently gitignores `uv.lock`, so this PR does not force-add a lockfile. The JEAM source itself is reproducible because `[tool.uv.sources]` uses an exact immutable commit SHA rather than a moving branch or tag.

The pinned revision is the merge commit of [JEAM PR #5](https://github.com/AlexanderFengler/JEAM/pull/5), which adds the accepted deterministic fixed-CDM simulator contract. The dependency remains a development dependency group, not a project dependency or published extra, so the experimental repository does not become part of HSSM's installation contract.

## Verification

- `uv sync --group dev --group notebook --group docs --group jeam-prototype --python 3.12`
- verified JEAM's installed `direct_url.json` resolves to commit `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`
- verified the installed `CircularDiffusionModel.simulate` exposes `random_state`
- verified ordinary development sync and HSSM wheel metadata do not publish or require JEAM
- parsed `.github/workflows/jeam_prototype.yml` as YAML
- `ruff check src/hssm`
- `ruff format --check .`
- `git diff --check`

## Next stack

#1195 adds the fixed-CDM likelihood adapter and #1196 verifies the compiled distribution path. After both child branches are rebased onto this refreshed pin, the next stacked PR adds the HSSM simulator adapter.
