### PR TITLE
Adapt the fixed JEAM circular likelihood

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Smoke-test optional imports
         run: uv run --group jeam-prototype python -c "import hssm; import jeam"
+
+      - name: Verify the JEAM likelihood handshake
+        run: uv run --group jeam-prototype pytest tests/integration/test_jeam.py

--- a/src/hssm/integrations/__init__.py
+++ b/src/hssm/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Optional integrations with packages outside HSSM's core dependencies."""

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -1,0 +1,127 @@
+"""Adapters for the experimental JEAM circular diffusion integration."""
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+
+def _load_circular_diffusion_model() -> Callable[..., Any]:
+    """Load JEAM's circular model without making it a core HSSM dependency."""
+    try:
+        from jeam.Models.Circular import CircularDiffusionModel
+    except ModuleNotFoundError as exc:
+        if exc.name == "jeam" or (
+            exc.name is not None and exc.name.startswith("jeam.")
+        ):
+            raise ImportError(
+                "The experimental JEAM integration requires the "
+                "`jeam-prototype` dependency group. Install it with "
+                "`uv sync --group jeam-prototype`."
+            ) from exc
+        raise
+
+    return CircularDiffusionModel
+
+
+def _broadcast_parameter(
+    value: float | np.ndarray, name: str, n_observations: int
+) -> np.ndarray:
+    """Return one finite float64 value per observation."""
+    try:
+        values = np.asarray(value, dtype=np.float64)
+        broadcast = np.broadcast_to(values, (n_observations,))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Parameter {name!r} must be scalar or broadcastable to "
+            f"{n_observations} observations."
+        ) from exc
+
+    if not np.all(np.isfinite(broadcast)):
+        raise ValueError(f"Parameter {name!r} must contain only finite values.")
+
+    return broadcast
+
+
+def _validate_observations(data: np.ndarray) -> np.ndarray:
+    """Validate and normalize ``[rt, response]`` observations."""
+    try:
+        observations = np.asarray(data, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "JEAM observations must be a numeric two-column array."
+        ) from exc
+
+    if observations.ndim != 2 or observations.shape[1] != 2:
+        raise ValueError(
+            "JEAM observations must have shape (n_observations, 2) with columns "
+            "[rt, response]."
+        )
+    if not np.all(np.isfinite(observations)):
+        raise ValueError("JEAM observations must contain only finite values.")
+
+    angles = observations[:, 1]
+    if np.any((angles < -np.pi) | (angles >= np.pi)):
+        raise ValueError("JEAM circular responses must lie in [-pi, pi).")
+
+    return observations
+
+
+def logp_circular_diffusion(
+    data: np.ndarray,
+    v_x: float | np.ndarray,
+    v_y: float | np.ndarray,
+    a: float | np.ndarray,
+    t: float | np.ndarray,
+) -> np.ndarray:
+    """Evaluate the fixed-boundary JEAM circular diffusion log density.
+
+    The two data columns are response time and response angle in radians. Angles use
+    the half-open interval ``[-pi, pi)``. The adapter fixes JEAM's diffusion scale to
+    one and both drift and nondecision-time variability to zero.
+
+    Parameters may be scalars or arrays broadcastable to the number of observations.
+    JEAM currently evaluates a single threshold value per call, so observations with
+    different trial-wise thresholds are partitioned without altering their order.
+    """
+    observations = _validate_observations(data)
+    n_observations = observations.shape[0]
+    v_x_values = _broadcast_parameter(v_x, "v_x", n_observations)
+    v_y_values = _broadcast_parameter(v_y, "v_y", n_observations)
+    threshold_values = _broadcast_parameter(a, "a", n_observations)
+    ndt_values = _broadcast_parameter(t, "t", n_observations)
+
+    model_type = _load_circular_diffusion_model()
+    model = model_type(threshold_dynamic="fixed")
+    logp = np.empty(n_observations, dtype=np.float64)
+    thresholds, threshold_groups = np.unique(threshold_values, return_inverse=True)
+
+    for group, threshold in enumerate(thresholds):
+        selection = threshold_groups == group
+        drift = np.column_stack((v_x_values[selection], v_y_values[selection]))
+        group_logp = model.joint_lpdf(
+            rt=observations[selection, 0],
+            theta=observations[selection, 1],
+            drift_vec=drift,
+            ndt=ndt_values[selection],
+            threshold=float(threshold),
+            decay=0.0,
+            threshold_function=None,
+            dt_threshold_function=None,
+            s_v=0.0,
+            s_t=0.0,
+            sigma=1.0,
+        )
+        group_logp = np.asarray(group_logp, dtype=np.float64)
+        expected_shape = (int(np.count_nonzero(selection)),)
+        if group_logp.shape != expected_shape:
+            raise RuntimeError(
+                "JEAM returned an unexpected pointwise log-density shape: "
+                f"expected {expected_shape}, got {group_logp.shape}."
+            )
+        logp[selection] = group_logp
+
+    return logp
+
+
+__all__ = ["logp_circular_diffusion"]

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -1,0 +1,100 @@
+"""Numerical handshake tests against the pinned JEAM implementation."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+from jeam.Models.Circular import CircularDiffusionModel
+
+from hssm.integrations.jeam import logp_circular_diffusion
+
+
+def _direct_trialwise_jeam(
+    data: np.ndarray,
+    v_x: np.ndarray,
+    v_y: np.ndarray,
+    a: np.ndarray,
+    t: np.ndarray,
+) -> np.ndarray:
+    """Evaluate JEAM row by row when every parameter may be trial-wise."""
+    model = CircularDiffusionModel(threshold_dynamic="fixed")
+    return np.array(
+        [
+            model.joint_lpdf(
+                rt=data[index : index + 1, 0],
+                theta=data[index : index + 1, 1],
+                drift_vec=np.array([[v_x[index], v_y[index]]]),
+                ndt=np.array([t[index]]),
+                threshold=float(a[index]),
+                decay=0.0,
+                threshold_function=None,
+                dt_threshold_function=None,
+                s_v=0.0,
+                s_t=0.0,
+                sigma=1.0,
+            )[0]
+            for index in range(data.shape[0])
+        ],
+        dtype=np.float64,
+    )
+
+
+def test_adapter_matches_direct_jeam_at_asymmetric_scalar_parameters():
+    """The adapter should preserve JEAM values across RT and angle locations."""
+    data = np.array([[0.18, -2.1], [0.37, 0.35], [0.82, 2.4]], dtype=np.float64)
+    v_x = 0.45
+    v_y = -0.30
+    threshold = 1.20
+    ndt = 0.08
+    model = CircularDiffusionModel(threshold_dynamic="fixed")
+
+    expected = model.joint_lpdf(
+        rt=data[:, 0],
+        theta=data[:, 1],
+        drift_vec=np.column_stack(
+            (np.full(data.shape[0], v_x), np.full(data.shape[0], v_y))
+        ),
+        ndt=np.full(data.shape[0], ndt),
+        threshold=threshold,
+        decay=0.0,
+        threshold_function=None,
+        dt_threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+    )
+    observed = logp_circular_diffusion(data, v_x, v_y, threshold, ndt)
+
+    np.testing.assert_allclose(observed, expected, rtol=1e-12, atol=1e-12)
+    assert observed.shape == (3,)
+    assert observed.dtype == np.float64
+
+
+def test_adapter_matches_direct_jeam_with_trialwise_parameters():
+    """All four HSSM parameters should support one value per observation."""
+    data = np.array([[0.21, -1.7], [0.46, 0.2], [0.91, 2.2]], dtype=np.float64)
+    v_x = np.array([0.55, -0.20, 0.35])
+    v_y = np.array([-0.25, 0.45, -0.15])
+    threshold = np.array([1.00, 1.25, 1.00])
+    ndt = np.array([0.04, 0.11, 0.17])
+
+    expected = _direct_trialwise_jeam(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+    observed = logp_circular_diffusion(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+
+    np.testing.assert_allclose(observed, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_adapter_preserves_jeam_impossible_rt_support_value():
+    """An RT at or below NDT should retain JEAM's pointwise support result."""
+    data = np.array([[0.05, 0.2], [0.10, -0.4]], dtype=np.float64)
+    v_x = np.array([0.45, -0.10])
+    v_y = np.array([-0.30, 0.25])
+    threshold = np.array([1.20, 1.20])
+    ndt = np.array([0.10, 0.10])
+
+    expected = _direct_trialwise_jeam(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+    observed = logp_circular_diffusion(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+
+    np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(observed, np.log(1e-14), rtol=0.0, atol=1e-12)

--- a/tests/test_jeam_adapter.py
+++ b/tests/test_jeam_adapter.py
@@ -1,0 +1,165 @@
+"""Dependency-free contract tests for the experimental JEAM adapter."""
+
+import builtins
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from hssm.integrations import jeam as jeam_integration
+
+
+class _RecordingCircularModel:
+    calls: list[dict] = []
+
+    def __init__(self, threshold_dynamic):
+        assert threshold_dynamic == "fixed"
+
+    def joint_lpdf(self, **kwargs):
+        self.calls.append(kwargs)
+        return (
+            kwargs["rt"]
+            + kwargs["theta"]
+            + kwargs["drift_vec"][:, 0]
+            + kwargs["drift_vec"][:, 1]
+            + kwargs["ndt"]
+            + kwargs["threshold"]
+        )
+
+
+@pytest.fixture
+def _fake_jeam(monkeypatch):
+    _RecordingCircularModel.calls = []
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_circular_diffusion_model",
+        lambda: _RecordingCircularModel,
+    )
+
+
+def test_adapter_broadcasts_scalars_and_fixes_jeam_settings(_fake_jeam):
+    """Scalar parameters should reach JEAM as fixed trial-wise settings."""
+    data = np.array([[0.2, -np.pi], [0.5, 0.25], [0.9, np.pi - 1e-12]])
+
+    observed = jeam_integration.logp_circular_diffusion(
+        data, v_x=0.4, v_y=-0.2, a=1.1, t=0.05
+    )
+
+    expected = data[:, 0] + data[:, 1] + 0.4 - 0.2 + 1.1 + 0.05
+    np.testing.assert_allclose(observed, expected)
+    assert observed.dtype == np.float64
+
+    assert len(_RecordingCircularModel.calls) == 1
+    call = _RecordingCircularModel.calls[0]
+    np.testing.assert_array_equal(call["drift_vec"], [[0.4, -0.2]] * 3)
+    np.testing.assert_array_equal(call["ndt"], [0.05] * 3)
+    assert call["threshold"] == 1.1
+    assert call["decay"] == 0.0
+    assert call["threshold_function"] is None
+    assert call["dt_threshold_function"] is None
+    assert call["s_v"] == 0.0
+    assert call["s_t"] == 0.0
+    assert call["sigma"] == 1.0
+
+
+def test_adapter_preserves_order_with_trialwise_thresholds(_fake_jeam):
+    """Threshold grouping should preserve the original observation order."""
+    data = np.array([[0.2, -0.5], [0.4, 0.0], [0.6, 0.5]])
+    v_x = np.array([0.1, 0.2, 0.3])
+    v_y = np.array([-0.4, -0.5, -0.6])
+    thresholds = np.array([1.2, 0.8, 1.2])
+    ndt = np.array([0.01, 0.02, 0.03])
+
+    observed = jeam_integration.logp_circular_diffusion(
+        data, v_x=v_x, v_y=v_y, a=thresholds, t=ndt
+    )
+
+    expected = data.sum(axis=1) + v_x + v_y + thresholds + ndt
+    np.testing.assert_allclose(observed, expected)
+    assert [call["threshold"] for call in _RecordingCircularModel.calls] == [0.8, 1.2]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.array([0.2, 0.1]),
+        np.ones((2, 1)),
+        np.ones((2, 3)),
+    ],
+)
+def test_adapter_rejects_invalid_data_shapes(data):
+    """Only the HSSM two-column observation contract should be accepted."""
+    with pytest.raises(ValueError, match=r"shape \(n_observations, 2\)"):
+        jeam_integration.logp_circular_diffusion(data, 0.1, 0.2, 1.0, 0.05)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        np.array([[0.2, np.nan]]),
+        np.array([[np.inf, 0.1]]),
+    ],
+)
+def test_adapter_rejects_nonfinite_data(data):
+    """Nonfinite RTs and angles should fail before JEAM evaluation."""
+    with pytest.raises(ValueError, match="only finite values"):
+        jeam_integration.logp_circular_diffusion(data, 0.1, 0.2, 1.0, 0.05)
+
+
+@pytest.mark.parametrize("angle", [np.pi, np.nextafter(-np.pi, -np.inf)])
+def test_adapter_rejects_angles_outside_half_open_interval(angle):
+    """Circular responses should use the declared half-open radian interval."""
+    with pytest.raises(ValueError, match=r"\[-pi, pi\)"):
+        jeam_integration.logp_circular_diffusion(
+            np.array([[0.2, angle]]), 0.1, 0.2, 1.0, 0.05
+        )
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("v_x", np.ones(3)),
+        ("v_y", np.array([np.inf, 0.2])),
+        ("a", np.array([1.0, np.nan])),
+        ("t", "not-a-number"),
+    ],
+)
+def test_adapter_rejects_invalid_parameter_arrays(parameter, value):
+    """Parameters must provide one finite value for every observation."""
+    parameters = {"v_x": 0.1, "v_y": 0.2, "a": 1.0, "t": 0.05}
+    parameters[parameter] = value
+
+    with pytest.raises(ValueError, match=parameter):
+        jeam_integration.logp_circular_diffusion(
+            np.array([[0.2, -0.1], [0.3, 0.1]]), **parameters
+        )
+
+
+def test_adapter_rejects_an_unexpected_jeam_output_shape(monkeypatch):
+    """A producer shape-contract regression should fail explicitly."""
+    bad_model = SimpleNamespace(joint_lpdf=lambda **kwargs: np.ones((1, 1)))
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_circular_diffusion_model",
+        lambda: lambda **kwargs: bad_model,
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected pointwise log-density shape"):
+        jeam_integration.logp_circular_diffusion(
+            np.array([[0.2, 0.1]]), 0.1, 0.2, 1.0, 0.05
+        )
+
+
+def test_loader_explains_how_to_install_the_optional_dependency(monkeypatch):
+    """A missing JEAM install should report the prototype-group command."""
+    real_import = builtins.__import__
+
+    def import_without_jeam(name, *args, **kwargs):
+        if name.startswith("jeam"):
+            raise ModuleNotFoundError("No module named 'jeam'", name="jeam")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_jeam)
+
+    with pytest.raises(ImportError, match="uv sync --group jeam-prototype"):
+        jeam_integration._load_circular_diffusion_model()


### PR DESCRIPTION
Depends on #1194, now merged into `dev` at `4a88dbd9`; #1193 is also present on `dev`. This branch was patch-identically restacked onto that integration tip, and this PR now targets `dev`.

## Summary

- add a lazily imported adapter for JEAM's fixed-boundary `CircularDiffusionModel`
- expose the HSSM blackbox signature `logp(data, v_x, v_y, a, t)`
- accept scalar or trial-wise values for all four parameters
- enforce two-column `[rt, response]` data and response angles in `[-pi, pi)`
- keep JEAM mathematical and numerical behavior in JEAM rather than duplicating it in HSSM
- execute direct HSSM-adapter-versus-JEAM comparisons in the dedicated prototype workflow

## Fixed prototype contract

The adapter assembles `drift_vec=[v_x, v_y]`, maps `a` to JEAM's threshold and `t` to nondecision time, and fixes:

- `threshold_dynamic="fixed"`
- `sigma=1`
- `s_v=0`
- `s_t=0`
- `decay=0`
- no custom threshold function

The pinned JEAM API accepts a scalar threshold per `joint_lpdf` call. For trial-wise `a`, HSSM groups observations by exact threshold, calls JEAM once per group, and restores original pointwise order. It does not reproduce JEAM's density formula or alter/floor JEAM results.

JEAM remains a lazy optional import. Requesting this adapter without the prototype group raises an install error containing `uv sync --group jeam-prototype`.

## Numerical regression coverage

The integration tests compare the adapter directly with the pinned JEAM implementation at asymmetric nonzero drifts and multiple RT/angle locations. They cover:

- scalar parameters
- fully trial-wise `v_x`, `v_y`, `a`, and `t`
- repeated and varying thresholds
- one output value per observation in float64
- JEAM's pointwise support value when `rt <= t`

Dependency-free contract tests separately cover broadcasting, threshold grouping and output ordering, every fixed JEAM setting, malformed data/parameter arrays, the half-open angular interval, missing optional dependency guidance, and producer output-shape regressions.

## Verification

- focused adapter and direct-JEAM suite: 18 passed
- full Python 3.12 non-slow HSSM suite with JEAM installed: 663 passed, 371 deselected
- new adapter module coverage: 95%
- `pyrefly check`
- `mypy --no-strict-optional --ignore-missing-imports src/hssm`
- `ruff check src/hssm`
- `ruff format --check .`
- workflow YAML parse
- `git diff --check`

## Deferred

The simulator/RNG bridge, built-in model registration, compiled HSSM distribution comparison, predictive sampling, and gradient-free recovery remain separate later PRs. In particular, the simulator bridge waits for the JEAM deterministic-RNG producer gate rather than adding global RNG workarounds in HSSM.
