### PR TITLE
Verify the compiled JEAM likelihood path

### DIFF
--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -7,7 +7,36 @@ pytest.importorskip("jeam")
 
 from jeam.Models.Circular import CircularDiffusionModel
 
+from hssm.distribution_utils.dist import (
+    LOGP_LB,
+    make_distribution,
+    make_likelihood_callable,
+)
 from hssm.integrations.jeam import logp_circular_diffusion
+
+PARAMETERS = ["v_x", "v_y", "a", "t"]
+BOUNDS = {
+    "v_x": (-3.0, 3.0),
+    "v_y": (-3.0, 3.0),
+    "a": (0.1, 3.0),
+    "t": (0.0, 2.0),
+}
+
+
+@pytest.fixture(scope="module")
+def circular_distribution():
+    """Build the real HSSM blackbox distribution around the JEAM adapter."""
+    likelihood = make_likelihood_callable(
+        loglik=logp_circular_diffusion,
+        loglik_kind="blackbox",
+        backend="pytensor",
+    )
+    return make_distribution(
+        rv="circular_diffusion",
+        loglik=likelihood,
+        list_params=PARAMETERS.copy(),
+        bounds=BOUNDS,
+    )
 
 
 def _direct_trialwise_jeam(
@@ -98,3 +127,76 @@ def test_adapter_preserves_jeam_impossible_rt_support_value():
 
     np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
     np.testing.assert_allclose(observed, np.log(1e-14), rtol=0.0, atol=1e-12)
+
+
+def test_compiled_hssm_distribution_matches_adapter_and_direct_jeam(
+    circular_distribution,
+):
+    """The compiled HSSM blackbox path should preserve pointwise JEAM values."""
+    data = np.array([[0.18, -2.1], [0.37, 0.35], [0.82, 2.4]])
+    v_x = np.full(3, 0.45)
+    v_y = np.full(3, -0.30)
+    threshold = np.full(3, 1.20)
+    ndt = np.full(3, 0.08)
+
+    direct = _direct_trialwise_jeam(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+    adapted = logp_circular_diffusion(data, 0.45, -0.30, 1.20, 0.08)
+    compiled = np.asarray(
+        circular_distribution.logp(data, 0.45, -0.30, 1.20, 0.08).eval()
+    )
+
+    np.testing.assert_allclose(adapted, direct, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(compiled, direct, rtol=1e-7, atol=1e-7)
+
+
+def test_compiled_hssm_distribution_accepts_a_trialwise_drift(
+    circular_distribution,
+):
+    """A regression-shaped drift should remain pointwise through compilation."""
+    data = np.array([[0.21, -1.7], [0.46, 0.2], [0.91, 2.2]])
+    v_x = np.array([0.55, -0.20, 0.35])
+    v_y = np.full(3, -0.25)
+    threshold = np.full(3, 1.15)
+    ndt = np.full(3, 0.07)
+
+    direct = _direct_trialwise_jeam(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
+    adapted = logp_circular_diffusion(data, v_x, -0.25, 1.15, 0.07)
+    compiled = np.asarray(
+        circular_distribution.logp(data, v_x, -0.25, 1.15, 0.07).eval()
+    )
+
+    np.testing.assert_allclose(adapted, direct, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(compiled, direct, rtol=1e-7, atol=1e-7)
+
+
+def test_hssm_distribution_applies_standard_ndt_support_mask(circular_distribution):
+    """HSSM should replace JEAM's finite floor when nondecision time reaches RT."""
+    data = np.array([[0.18, -0.4], [0.37, 0.6], [0.82, 1.2]])
+    ndt = np.array([0.08, 0.37, 0.90])
+
+    adapted = logp_circular_diffusion(data, 0.45, -0.30, 1.20, ndt)
+    compiled = np.asarray(
+        circular_distribution.logp(data, 0.45, -0.30, 1.20, ndt).eval()
+    )
+    lower_bound = float(np.asarray(LOGP_LB))
+
+    assert compiled[0] == pytest.approx(adapted[0], rel=1e-7)
+    np.testing.assert_array_equal(compiled[1:], lower_bound)
+    np.testing.assert_allclose(adapted[1:], np.log(1e-14), atol=1e-12)
+
+
+def test_hssm_distribution_applies_parameter_bounds_pointwise(
+    circular_distribution,
+):
+    """Only trials whose parameter values violate HSSM bounds should be masked."""
+    data = np.array([[0.18, -0.4], [0.37, 0.6], [0.82, 1.2]])
+    v_x = np.array([0.45, 3.01, -0.25])
+
+    adapted = logp_circular_diffusion(data, v_x, -0.30, 1.20, 0.08)
+    compiled = np.asarray(
+        circular_distribution.logp(data, v_x, -0.30, 1.20, 0.08).eval()
+    )
+    lower_bound = float(np.asarray(LOGP_LB))
+
+    np.testing.assert_allclose(compiled[[0, 2]], adapted[[0, 2]], rtol=1e-7)
+    assert compiled[1] == lower_bound


### PR DESCRIPTION
# Dependency

HSSM #1195 is merged into `dev` at `b64967a7`; #1193 and #1194 are also present on that integration branch. This branch was patch-identically restacked onto the merge tip and now targets `dev`.

## Summary

- compile the JEAM adapter through HSSM's real blackbox PyTensor distribution path
- compare direct JEAM, the NumPy adapter, and compiled HSSM pointwise values
- verify scalar parameters and a trial-wise drift vector
- characterize HSSM's standard nondecision-time support mask
- verify that HSSM parameter bounds mask only invalid trials

## Scope boundary

This is a test-only PR. It adds no package source, simulator bridge, model registration, predictive behavior, or sampler support. Those remain separate review units in the JEAM integration stack.

## Three-layer numerical check

For supported observations and parameters, the tests evaluate all three layers:

1. direct `CircularDiffusionModel.joint_lpdf` from the pinned JEAM commit
2. `hssm.integrations.jeam.logp_circular_diffusion`
3. the PyTensor graph produced by HSSM's `make_likelihood_callable` and `make_distribution`

The scalar and trial-wise cases agree pointwise within the stated floating-point tolerances.

The support test also makes one intentional distinction explicit: the JEAM revision pinned by this prototype returns its finite `log(1e-14)` support value for `rt <= t`, while the compiled HSSM distribution applies the ecosystem-wide `LOGP_LB = -66.1` support mask. Likewise, an out-of-bounds trial-wise drift is masked only for the violating row.

## Verification

- exact restack `range-diff`: unique commit is patch-identical
- focused JEAM integration suite: 7 passed on Python 3.12 against pinned JEAM `a9f547b`
- `ruff check tests/integration/test_jeam.py`
- `ruff format --check tests/integration/test_jeam.py`
- `git diff --check origin/dev...HEAD`

The merged parent #1195 separately passed its complete Python 3.12-3.14, lint/type, docs, JEAM dependency, and CodeRabbit checks.
