### PR TITLE
Add the JEAM circular simulator adapter

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/jeam_prototype.yml"
       - "src/hssm/integrations/jeam.py"
       - "tests/integration/test_jeam.py"
+      - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
 
 jobs:
@@ -28,5 +29,8 @@ jobs:
       - name: Smoke-test optional imports
         run: uv run --group jeam-prototype python -c "import hssm; import jeam"
 
-      - name: Verify the JEAM likelihood handshake
-        run: uv run --group jeam-prototype pytest tests/integration/test_jeam.py
+      - name: Verify the JEAM likelihood and simulator handshake
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/integration/test_jeam.py
+          tests/integration/test_jeam_simulator.py

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -124,4 +124,102 @@ def logp_circular_diffusion(
     return logp
 
 
-__all__ = ["logp_circular_diffusion"]
+def _normalize_simulator_theta(theta: np.ndarray) -> np.ndarray:
+    """Normalize HSSM simulator parameters to one ``[v_x, v_y, a, t]`` row."""
+    try:
+        parameters = np.asarray(theta, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "JEAM simulator parameters must be a numeric array with columns "
+            "[v_x, v_y, a, t]."
+        ) from exc
+
+    if parameters.ndim == 1:
+        if parameters.shape != (4,):
+            raise ValueError(
+                "JEAM simulator parameters must have shape (4,) or "
+                "(n_trials, 4) with columns [v_x, v_y, a, t]."
+            )
+        parameters = parameters[np.newaxis, :]
+    elif parameters.ndim != 2 or parameters.shape[1] != 4 or parameters.shape[0] == 0:
+        raise ValueError(
+            "JEAM simulator parameters must have shape (4,) or (n_trials, 4) "
+            "with columns [v_x, v_y, a, t]."
+        )
+
+    if not np.all(np.isfinite(parameters)):
+        raise ValueError("JEAM simulator parameters must contain only finite values.")
+
+    return parameters
+
+
+def simulate_circular_diffusion(
+    theta: np.ndarray,
+    random_state: int | np.random.Generator | None,
+    n_replicas: int,
+) -> np.ndarray:
+    """Simulate fixed-boundary JEAM circular diffusion observations for HSSM.
+
+    ``theta`` follows HSSM's ``[v_x, v_y, a, t]`` parameter order. Replicas are
+    contiguous within each trial so ``ssms.hssm_support.rng_fn`` can reshape the
+    returned rows to ``(..., n_trials, n_replicas, 2)`` without changing their
+    association. The final two columns are always ``[rt, response]``.
+    """
+    parameters = _normalize_simulator_theta(theta)
+    if (
+        isinstance(n_replicas, (bool, np.bool_))
+        or not isinstance(n_replicas, (int, np.integer))
+        or n_replicas < 1
+    ):
+        raise ValueError("n_replicas must be a positive integer.")
+
+    replicated = np.repeat(parameters, int(n_replicas), axis=0)
+    model_type = _load_circular_diffusion_model()
+    model = model_type(threshold_dynamic="fixed")
+    simulated = model.simulate(
+        drift_vec=replicated[:, :2],
+        ndt=replicated[:, 3],
+        threshold=replicated[:, 2],
+        decay=0.0,
+        threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+        n_sample=replicated.shape[0],
+        random_state=random_state,
+    )
+
+    try:
+        observations = np.asarray(
+            simulated.loc[:, ["rt", "response"]], dtype=np.float64
+        )
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "JEAM simulator output must expose numeric columns [rt, response]."
+        ) from exc
+
+    expected_shape = (replicated.shape[0], 2)
+    if observations.shape != expected_shape:
+        raise RuntimeError(
+            "JEAM returned an unexpected simulator output shape: "
+            f"expected {expected_shape}, got {observations.shape}."
+        )
+    if not np.all(np.isfinite(observations)):
+        raise RuntimeError("JEAM simulator output must contain only finite values.")
+    if np.any(observations[:, 0] <= 0.0):
+        raise RuntimeError("JEAM simulator response times must be positive.")
+    angles = observations[:, 1]
+    if np.any((angles < -np.pi) | (angles >= np.pi)):
+        raise RuntimeError("JEAM simulator responses must lie in [-pi, pi).")
+
+    return observations
+
+
+setattr(simulate_circular_diffusion, "model_name", "circular_diffusion")
+# Required by ssms.hssm_support for compatibility. Circular responses are continuous,
+# so there are deliberately no categorical choices to enumerate.
+setattr(simulate_circular_diffusion, "choices", [])
+setattr(simulate_circular_diffusion, "obs_dim", 2)
+
+
+__all__ = ["logp_circular_diffusion", "simulate_circular_diffusion"]

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -21,6 +21,10 @@ BOUNDS = {
     "a": (0.1, 3.0),
     "t": (0.0, 2.0),
 }
+# HSSM test modules may select float32 globally during collection. Allow several
+# float32 ULPs while keeping the direct adapter comparisons at float64 precision.
+COMPILED_RTOL = 5e-7
+COMPILED_ATOL = 5e-7
 
 
 @pytest.fixture(scope="module")
@@ -146,7 +150,7 @@ def test_compiled_hssm_distribution_matches_adapter_and_direct_jeam(
     )
 
     np.testing.assert_allclose(adapted, direct, rtol=1e-12, atol=1e-12)
-    np.testing.assert_allclose(compiled, direct, rtol=1e-7, atol=1e-7)
+    np.testing.assert_allclose(compiled, direct, rtol=COMPILED_RTOL, atol=COMPILED_ATOL)
 
 
 def test_compiled_hssm_distribution_accepts_a_trialwise_drift(
@@ -166,7 +170,7 @@ def test_compiled_hssm_distribution_accepts_a_trialwise_drift(
     )
 
     np.testing.assert_allclose(adapted, direct, rtol=1e-12, atol=1e-12)
-    np.testing.assert_allclose(compiled, direct, rtol=1e-7, atol=1e-7)
+    np.testing.assert_allclose(compiled, direct, rtol=COMPILED_RTOL, atol=COMPILED_ATOL)
 
 
 def test_hssm_distribution_applies_standard_ndt_support_mask(circular_distribution):
@@ -180,7 +184,9 @@ def test_hssm_distribution_applies_standard_ndt_support_mask(circular_distributi
     )
     lower_bound = float(np.asarray(LOGP_LB))
 
-    assert compiled[0] == pytest.approx(adapted[0], rel=1e-7)
+    assert compiled[0] == pytest.approx(
+        adapted[0], rel=COMPILED_RTOL, abs=COMPILED_ATOL
+    )
     np.testing.assert_array_equal(compiled[1:], lower_bound)
     np.testing.assert_allclose(adapted[1:], np.log(1e-14), atol=1e-12)
 
@@ -198,5 +204,10 @@ def test_hssm_distribution_applies_parameter_bounds_pointwise(
     )
     lower_bound = float(np.asarray(LOGP_LB))
 
-    np.testing.assert_allclose(compiled[[0, 2]], adapted[[0, 2]], rtol=1e-7)
+    np.testing.assert_allclose(
+        compiled[[0, 2]],
+        adapted[[0, 2]],
+        rtol=COMPILED_RTOL,
+        atol=COMPILED_ATOL,
+    )
     assert compiled[1] == lower_bound

--- a/tests/integration/test_jeam_simulator.py
+++ b/tests/integration/test_jeam_simulator.py
@@ -1,0 +1,93 @@
+"""Real-producer tests for the JEAM-to-HSSM simulator handshake."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+from jeam.Models.Circular import CircularDiffusionModel
+
+from hssm.distribution_utils.dist import make_hssm_rv
+from hssm.integrations.jeam import simulate_circular_diffusion
+
+PARAMETERS = ["v_x", "v_y", "a", "t"]
+
+
+def _assert_circular_observations(observations: np.ndarray) -> None:
+    """Check the fixed two-column predictive-data contract."""
+    assert observations.shape[-1] == 2
+    assert observations.dtype == np.float64
+    assert np.all(np.isfinite(observations))
+    assert np.all(observations[..., 0] > 0.0)
+    assert np.all(observations[..., 1] >= -np.pi)
+    assert np.all(observations[..., 1] < np.pi)
+
+
+def test_simulator_adapter_matches_direct_seeded_jeam():
+    """The adapter should only map parameters, replicas, and output columns."""
+    theta = np.array(
+        [
+            [0.70, -0.35, 0.40, 0.08],
+            [-0.20, 0.55, 0.32, 0.12],
+        ],
+        dtype=np.float64,
+    )
+    replicated = np.repeat(theta, 3, axis=0)
+    model = CircularDiffusionModel(threshold_dynamic="fixed")
+
+    expected = model.simulate(
+        drift_vec=replicated[:, :2],
+        ndt=replicated[:, 3],
+        threshold=replicated[:, 2],
+        decay=0.0,
+        threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+        n_sample=replicated.shape[0],
+        random_state=1947,
+    )[["rt", "response"]].to_numpy(dtype=np.float64)
+    observed = simulate_circular_diffusion(theta, random_state=1947, n_replicas=3)
+
+    np.testing.assert_array_equal(observed, expected)
+    _assert_circular_observations(observed)
+
+
+def test_hssm_random_variable_repeats_scalar_draws_exactly_by_seed():
+    """An HSSM RNG seed should deterministically control a scalar-parameter draw."""
+    random_variable = make_hssm_rv(simulate_circular_diffusion, PARAMETERS.copy())
+
+    first = random_variable.rng_fn(
+        np.random.default_rng(519), 0.70, -0.35, 0.40, 0.08, size=6
+    )
+    second = random_variable.rng_fn(
+        np.random.default_rng(519), 0.70, -0.35, 0.40, 0.08, size=6
+    )
+    different_seed = random_variable.rng_fn(
+        np.random.default_rng(520), 0.70, -0.35, 0.40, 0.08, size=6
+    )
+
+    np.testing.assert_array_equal(first, second)
+    assert not np.array_equal(first, different_seed)
+    assert first.shape == (6, 2)
+    _assert_circular_observations(first)
+
+
+def test_hssm_random_variable_shapes_trialwise_replicas():
+    """Trial-wise parameters should retain a separate replica axis."""
+    random_variable = make_hssm_rv(simulate_circular_diffusion, PARAMETERS.copy())
+    v_x = np.array([0.70, -0.20, 0.35])
+    v_y = np.array([-0.35, 0.55, -0.10])
+    threshold = np.array([0.40, 0.32, 0.36])
+    ndt = np.array([0.08, 0.12, 0.05])
+
+    first = random_variable.rng_fn(
+        np.random.default_rng(997), v_x, v_y, threshold, ndt, size=6
+    )
+    second = random_variable.rng_fn(
+        np.random.default_rng(997), v_x, v_y, threshold, ndt, size=6
+    )
+
+    np.testing.assert_array_equal(first, second)
+    assert first.shape == (3, 2, 2)
+    _assert_circular_observations(first)

--- a/tests/test_jeam_simulator.py
+++ b/tests/test_jeam_simulator.py
@@ -1,0 +1,162 @@
+"""Dependency-free contract tests for the experimental JEAM simulator adapter."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+from ssms.hssm_support import validate_simulator_fun
+
+from hssm.integrations import jeam as jeam_integration
+
+
+class _RecordingCircularModel:
+    calls: list[dict] = []
+
+    def __init__(self, threshold_dynamic):
+        assert threshold_dynamic == "fixed"
+
+    def simulate(self, **kwargs):
+        self.calls.append(kwargs)
+        n_sample = kwargs["n_sample"]
+        return pd.DataFrame(
+            {
+                "rt": np.arange(n_sample, dtype=np.float64) + 0.25,
+                "response": np.linspace(-1.0, 1.0, n_sample),
+                "ignored": np.full(n_sample, 99.0),
+            }
+        )
+
+
+@pytest.fixture
+def _fake_jeam(monkeypatch):
+    _RecordingCircularModel.calls = []
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_circular_diffusion_model",
+        lambda: _RecordingCircularModel,
+    )
+
+
+def test_simulator_advertises_the_hssm_callable_contract():
+    """HSSM should recognize two continuous observation columns."""
+    model_name, choices, obs_dim = validate_simulator_fun(
+        jeam_integration.simulate_circular_diffusion
+    )
+
+    assert model_name == "circular_diffusion"
+    assert choices == []
+    assert obs_dim == 2
+
+
+def test_simulator_maps_and_replicates_one_parameter_row(_fake_jeam):
+    """A one-dimensional theta should produce contiguous JEAM replicas."""
+    observed = jeam_integration.simulate_circular_diffusion(
+        theta=np.array([0.45, -0.30, 1.20, 0.08]),
+        random_state=1947,
+        n_replicas=3,
+    )
+
+    np.testing.assert_array_equal(
+        observed,
+        [[0.25, -1.0], [1.25, 0.0], [2.25, 1.0]],
+    )
+    assert observed.dtype == np.float64
+    assert len(_RecordingCircularModel.calls) == 1
+    call = _RecordingCircularModel.calls[0]
+    np.testing.assert_array_equal(call["drift_vec"], [[0.45, -0.30]] * 3)
+    np.testing.assert_array_equal(call["threshold"], [1.20] * 3)
+    np.testing.assert_array_equal(call["ndt"], [0.08] * 3)
+    assert call["decay"] == 0.0
+    assert call["threshold_function"] is None
+    assert call["s_v"] == 0.0
+    assert call["s_t"] == 0.0
+    assert call["sigma"] == 1.0
+    assert call["n_sample"] == 3
+    assert call["random_state"] == 1947
+
+
+def test_simulator_preserves_trial_major_replica_order(_fake_jeam):
+    """Each trial's replicas should remain adjacent for HSSM's reshape."""
+    theta = np.array(
+        [
+            [0.45, -0.30, 1.20, 0.08],
+            [-0.15, 0.55, 0.90, 0.12],
+        ]
+    )
+
+    observed = jeam_integration.simulate_circular_diffusion(
+        theta=theta, random_state=519, n_replicas=2
+    )
+
+    assert observed.shape == (4, 2)
+    call = _RecordingCircularModel.calls[0]
+    np.testing.assert_array_equal(
+        call["drift_vec"],
+        [[0.45, -0.30], [0.45, -0.30], [-0.15, 0.55], [-0.15, 0.55]],
+    )
+    np.testing.assert_array_equal(call["threshold"], [1.20, 1.20, 0.90, 0.90])
+    np.testing.assert_array_equal(call["ndt"], [0.08, 0.08, 0.12, 0.12])
+
+
+@pytest.mark.parametrize(
+    "theta",
+    [
+        np.ones(3),
+        np.ones(5),
+        np.ones((2, 3)),
+        np.ones((1, 2, 4)),
+        np.empty((0, 4)),
+    ],
+)
+def test_simulator_rejects_invalid_theta_shapes(theta):
+    """The adapter accepts exactly four ordered parameters per trial."""
+    with pytest.raises(ValueError, match=r"shape \(4,\) or \(n_trials, 4\)"):
+        jeam_integration.simulate_circular_diffusion(theta, 11, 1)
+
+
+@pytest.mark.parametrize(
+    "theta",
+    [
+        np.array([0.1, 0.2, np.nan, 0.05]),
+        np.array([[0.1, np.inf, 1.0, 0.05]]),
+        ["not", "numeric", "parameters", "here"],
+    ],
+)
+def test_simulator_rejects_invalid_theta_values(theta):
+    """Invalid parameter values should fail before loading JEAM."""
+    with pytest.raises(ValueError, match="numeric|finite"):
+        jeam_integration.simulate_circular_diffusion(theta, 11, 1)
+
+
+@pytest.mark.parametrize("n_replicas", [0, -1, 1.5, True])
+def test_simulator_rejects_invalid_replica_counts(n_replicas):
+    """Replica counts follow the positive-integer ssms contract."""
+    with pytest.raises(ValueError, match="positive integer"):
+        jeam_integration.simulate_circular_diffusion(
+            np.array([0.1, 0.2, 1.0, 0.05]), 11, n_replicas
+        )
+
+
+@pytest.mark.parametrize(
+    ("frame", "message"),
+    [
+        (pd.DataFrame({"rt": [0.2], "choice": [0.1]}), "columns"),
+        (pd.DataFrame({"rt": [0.2, 0.3], "response": [0.1, 0.2]}), "shape"),
+        (pd.DataFrame({"rt": [np.nan], "response": [0.1]}), "finite"),
+        (pd.DataFrame({"rt": [0.0], "response": [0.1]}), "positive"),
+        (pd.DataFrame({"rt": [0.2], "response": [np.pi]}), r"\[-pi, pi\)"),
+    ],
+)
+def test_simulator_rejects_producer_contract_drift(monkeypatch, frame, message):
+    """Malformed JEAM output should fail at the integration boundary."""
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_circular_diffusion_model",
+        lambda: lambda **kwargs: SimpleNamespace(simulate=lambda **kwargs: frame),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        jeam_integration.simulate_circular_diffusion(
+            np.array([0.1, 0.2, 1.0, 0.05]), 11, 1
+        )


### PR DESCRIPTION
## Dependency

HSSM #1196 is merged into `dev` at `8d0a86c0`. This branch starts from that integration commit.

## Summary

- adapt HSSM's `[v_x, v_y, a, t]` simulator protocol to JEAM's fixed circular diffusion model
- pass HSSM's RNG-derived integer seed through unchanged and preserve trial-major replica ordering
- enforce the two-column `[rt, response]` producer contract, including positive RTs and angles on `[-pi, pi)`
- verify exact equality with direct seeded JEAM plus deterministic scalar and trial-wise HSSM random-variable draws
- run the real-producer simulator checks in the dedicated optional-dependency workflow

## Scope boundary

This PR adds only the fixed-CDM simulator handshake. It does not register a public model, change the generic HSSM simulator contract, or claim cross-backend RNG equality. JEAM remains the simulator implementation and mathematical source of truth.

## Verification

- `git range-diff` marks all four pre-restack and post-restack commits patch-identical
- focused direct, adapter, compiled-likelihood, and predictive suite: 30 passed
- affected Ruff lint and formatting checks pass
- `git diff --check origin/dev...HEAD`

The optional CI workflow installs the immutable JEAM prototype revision and reruns the real-producer checks on GitHub.
