### PR TITLE
Register the experimental JEAM circular model

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -6,7 +6,9 @@ on:
       - "pyproject.toml"
       - ".github/workflows/jeam_prototype.yml"
       - "src/hssm/integrations/jeam.py"
+      - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "tests/integration/test_jeam.py"
+      - "tests/integration/test_jeam_model.py"
       - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
 
@@ -33,4 +35,5 @@ jobs:
         run: >-
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam.py
+          tests/integration/test_jeam_model.py
           tests/integration/test_jeam_simulator.py

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -1,7 +1,7 @@
 """Type definitions for the HSSM package."""
 
 from os import PathLike
-from typing import Any, Callable, Literal, Optional, TypedDict, Union
+from typing import Any, Callable, Literal, NotRequired, Optional, TypedDict, Union
 
 import bambi as bmb
 import numpy as np
@@ -30,6 +30,8 @@ SupportedModels = Literal[
     "softmax_inv_temperature_3",
 ]
 
+ResponseKind = Literal["categorical", "continuous", "circular"]
+
 
 LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
 
@@ -52,7 +54,10 @@ class DefaultConfig(TypedDict):
 
     response: list[str]
     list_params: list[str]
-    choices: list[int]
+    choices: list[int] | None
+    response_kind: NotRequired[ResponseKind]
+    response_bounds: NotRequired[dict[str, tuple[float, float]]]
+    rv: NotRequired[Any]
     description: Optional[str]
     likelihoods: LoglikConfigs
 

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -28,6 +28,7 @@ SupportedModels = Literal[
     "poisson_race",
     "softmax_inv_temperature_2",
     "softmax_inv_temperature_3",
+    "circular_diffusion",
 ]
 
 ResponseKind = Literal["categorical", "continuous", "circular"]

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -338,6 +338,16 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         )
 
         # region ===== Process lapse distribution =====
+        if self.response_kind != "categorical" and p_outlier is not None:
+            if self.is_choice_only:
+                raise ValueError(
+                    "The default choice-only lapse requires categorical responses "
+                    "with `choices`. Set `p_outlier=None`."
+                )
+            raise ValueError(
+                "`p_outlier` is not supported for continuous or circular "
+                "responses. Set `p_outlier=None`."
+            )
         self.has_lapse = p_outlier is not None and p_outlier != 0
         self._check_lapse(lapse)
         # endregion

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -3,27 +3,22 @@
 # This is necessary to enable forward looking
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from math import isfinite
-from typing import TYPE_CHECKING, Any, Literal, Union, cast, get_args
+from typing import Any, Literal, Union, cast, get_args
 
 from bambi import Prior
+from ssms.config import model_config as ssms_model_config
 
-from ._types import LogLik, LoglikKind, SupportedModels
+from ._types import DefaultConfig, LogLik, LoglikKind, ResponseKind, SupportedModels
 from .defaults import (
     default_model_config,
 )
 from .modelconfig import get_default_model_config
 from .register import register_model
-
-if TYPE_CHECKING:
-    from pytensor.tensor.random.op import RandomVariable
-
-import logging
-
-from ssms.config import model_config as ssms_model_config
 
 _logger = logging.getLogger("hssm")
 
@@ -33,7 +28,6 @@ DEFAULT_SSM_OBSERVED_DATA = ["rt", "response"]
 DEFAULT_SSM_CHOICES = (0, 1)
 
 ParamSpec = Union[float, dict[str, Any], Prior, None]
-ResponseKind = Literal["categorical", "continuous", "circular"]
 
 
 @dataclass
@@ -149,7 +143,7 @@ class BaseModelConfig(ABC):
 class Config(BaseModelConfig):
     """Config class that stores the configurations for models."""
 
-    rv: RandomVariable | None = None
+    rv: Any | None = None
     # Fields with dictionaries are automatically deepcopied
     default_priors: dict[str, ParamSpec] = field(default_factory=dict)
 
@@ -194,16 +188,8 @@ class Config(BaseModelConfig):
                 default_config = deepcopy(default_model_config[model_name])
                 if kind in default_config["likelihoods"]:
                     kind = cast("LoglikKind", kind)
-                    loglik_config = default_config["likelihoods"][kind]
-
-                    return Config(
-                        model_name=model_name,
-                        loglik_kind=kind,
-                        response=list(default_config["response"]),
-                        choices=tuple(default_config["choices"]),
-                        list_params=default_config["list_params"],
-                        description=default_config["description"],
-                        **loglik_config,
+                    return cls._from_registered_default(
+                        model_name, kind, default_config
                     )
 
             raise ValueError(
@@ -223,23 +209,11 @@ class Config(BaseModelConfig):
                 model_name = cast("SupportedModels", model_name)
                 default_config = deepcopy(default_model_config[model_name])
                 if loglik_kind in default_config["likelihoods"]:
-                    loglik_config = default_config["likelihoods"][loglik_kind]
-                    return Config(
-                        model_name=model_name,
-                        loglik_kind=loglik_kind,
-                        response=list(default_config["response"]),
-                        choices=tuple(default_config["choices"]),
-                        list_params=default_config["list_params"],
-                        description=default_config["description"],
-                        **loglik_config,
+                    return cls._from_registered_default(
+                        model_name, loglik_kind, default_config
                     )
-                return Config(
-                    model_name=model_name,
-                    loglik_kind=loglik_kind,
-                    response=list(default_config["response"]),
-                    choices=tuple(default_config["choices"]),
-                    list_params=default_config["list_params"],
-                    description=default_config["description"],
+                return cls._from_registered_default(
+                    model_name, loglik_kind, default_config
                 )
 
             return Config(
@@ -247,6 +221,31 @@ class Config(BaseModelConfig):
                 loglik_kind=loglik_kind,
                 response=DEFAULT_SSM_OBSERVED_DATA,
             )
+
+    @classmethod
+    def _from_registered_default(
+        cls,
+        model_name: SupportedModels,
+        loglik_kind: LoglikKind,
+        default_config: DefaultConfig,
+    ) -> Config:
+        """Build a Config while preserving optional response and simulator metadata."""
+        choices = default_config["choices"]
+        likelihood = cast(
+            "dict[str, Any]", default_config["likelihoods"].get(loglik_kind, {})
+        )
+        return cls(
+            model_name=model_name,
+            loglik_kind=loglik_kind,
+            response=list(default_config["response"]),
+            choices=None if choices is None else tuple(choices),
+            response_kind=default_config.get("response_kind", "categorical"),
+            response_bounds=deepcopy(default_config.get("response_bounds", {})),
+            list_params=default_config["list_params"],
+            description=default_config["description"],
+            rv=default_config.get("rv"),
+            **likelihood,
+        )
 
     def update_loglik(self, loglik: Any | None) -> None:
         """Update the log-likelihood function from user input.
@@ -392,7 +391,7 @@ class ModelConfig:
     default_priors: dict[str, ParamSpec] = field(default_factory=dict)
     bounds: dict[str, tuple[float, float]] = field(default_factory=dict)
     backend: Literal["jax", "pytensor"] | None = None
-    rv: RandomVariable | None = None
+    rv: Any | None = None
     extra_fields: list[str] | None = None
 
 

--- a/src/hssm/modelconfig/circular_diffusion_config.py
+++ b/src/hssm/modelconfig/circular_diffusion_config.py
@@ -1,0 +1,46 @@
+"""Default configuration for the experimental JEAM circular diffusion model."""
+
+from math import pi
+
+from .._types import DefaultConfig
+from ..integrations.jeam import logp_circular_diffusion, simulate_circular_diffusion
+
+
+def get_circular_diffusion_config() -> DefaultConfig:
+    """Return the fixed-boundary JEAM circular diffusion configuration.
+
+    HSSM parameters ``v_x`` and ``v_y`` form JEAM's Cartesian drift vector, ``a``
+    maps to its fixed threshold, and ``t`` maps to nondecision time. The prototype
+    fixes diffusion scale to one and drift/nondecision-time variability to zero.
+    """
+    return {
+        "response": ["rt", "response"],
+        "response_kind": "circular",
+        "response_bounds": {"response": (-pi, pi)},
+        "list_params": ["v_x", "v_y", "a", "t"],
+        "choices": None,
+        "rv": simulate_circular_diffusion,
+        "description": (
+            "Experimental fixed-boundary JEAM circular diffusion model with "
+            "Cartesian drift"
+        ),
+        "likelihoods": {
+            "blackbox": {
+                "loglik": logp_circular_diffusion,
+                "backend": None,
+                "default_priors": {
+                    "t": {
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
+                    },
+                },
+                "bounds": {
+                    "v_x": (-3.0, 3.0),
+                    "v_y": (-3.0, 3.0),
+                    "a": (0.1, 3.0),
+                    "t": (0.0, 2.0),
+                },
+                "extra_fields": None,
+            }
+        },
+    }

--- a/src/hssm/plotting/model_cartoon.py
+++ b/src/hssm/plotting/model_cartoon.py
@@ -61,6 +61,18 @@ class PlotFunctionProtocol(Protocol):
         ...
 
 
+def _require_categorical_choices(
+    choices: list[int] | tuple[int, ...] | None, model_name: str
+) -> list[int]:
+    """Return model choices or reject non-categorical cartoon requests."""
+    if choices is None:
+        raise ValueError(
+            "Model cartoons currently require categorical responses with explicit "
+            f"choices; model {model_name!r} has non-categorical responses."
+        )
+    return list(choices)
+
+
 def _cartoon_model_meta(model) -> tuple[list[str], list[int]]:
     """Return ``(list_params, choices)`` for a fitted model.
 
@@ -73,9 +85,13 @@ def _cartoon_model_meta(model) -> tuple[list[str], list[int]]:
     """
     cfg = default_model_config.get(model.model_name)
     if cfg is not None:
-        return list(cfg["list_params"]), list(cfg["choices"])
+        return list(cfg["list_params"]), _require_categorical_choices(
+            cfg["choices"], model.model_name
+        )
     mc = model.model_config
-    return list(mc.list_params), list(mc.choices)
+    return list(mc.list_params), _require_categorical_choices(
+        mc.choices, model.model_name
+    )
 
 
 def _resolve_uncertainty_from_legacy(
@@ -191,7 +207,9 @@ def _plot_model_cartoon_1D(
     if list_params is None or choices is None:
         config_tmp = default_model_config[cast("SupportedModels", model_name)]
         list_params = list_params or config_tmp["list_params"]
-        choices = choices or config_tmp["choices"]
+        choices = _require_categorical_choices(
+            choices if choices is not None else config_tmp["choices"], model_name
+        )
     model_params = list_params
 
     n_choices = len(choices)
@@ -2834,6 +2852,7 @@ def plot_func_model_n(
     # fall back to the registry for built-in models called directly.
     if choices is None:
         choices = default_model_config[cast("SupportedModels", model_name)]["choices"]
+    choices = _require_categorical_choices(choices, model_name)
 
     # Shared bin edges for every histogram on this axis (see plot_func_model).
     if bins is None:

--- a/src/hssm/register.py
+++ b/src/hssm/register.py
@@ -61,16 +61,19 @@ def register_model(
     if name in registered_models:
         raise ValueError(f"Model '{name}' already exists")
 
-    _config = {
+    _config: dict[str, Any] = {
         "response": response,
         "list_params": list_params,
         "choices": choices,
-        "response_kind": response_kind,
-        "response_bounds": response_bounds or {},
-        "rv": rv,
         "description": description,
         "likelihoods": likelihoods,
     }
+    if response_kind != "categorical":
+        _config["response_kind"] = response_kind
+    if response_bounds is not None:
+        _config["response_bounds"] = response_bounds
+    if rv is not None:
+        _config["rv"] = rv
     config = cast("DefaultConfig", _config)
 
     # TODO: validate provided configs?

--- a/src/hssm/register.py
+++ b/src/hssm/register.py
@@ -1,11 +1,12 @@
 """Module for registering custom models in HSSM."""
 
 from pprint import pformat, pp
-from typing import cast
+from typing import Any, cast
 
 from ._types import (
     DefaultConfig,
     LoglikConfigs,
+    ResponseKind,
     SupportedModels,
 )
 from .defaults import (
@@ -17,9 +18,12 @@ def register_model(
     name: SupportedModels,
     response: list[str],
     list_params: list[str],
-    choices: list[int],
+    choices: list[int] | None,
     likelihoods: LoglikConfigs,
     description: str | None,
+    response_kind: ResponseKind = "categorical",
+    response_bounds: dict[str, tuple[float, float]] | None = None,
+    rv: Any | None = None,
 ) -> None:
     """Register a new model in HSSM.
 
@@ -31,12 +35,18 @@ def register_model(
         List of response variables
     list_params : list[str]
         List of parameters
-    choices : list[int]
-        List of possible choices
+    choices : list[int] | None
+        List of possible categorical choices, or None for non-categorical responses.
     description : str
         Description of the model
     likelihoods : LoglikConfigs
         Dictionary of likelihood configurations
+    response_kind : ResponseKind
+        Type of observed response. Defaults to categorical.
+    response_bounds : dict[str, tuple[float, float]] | None
+        Optional bounds keyed by non-RT response column.
+    rv : optional
+        RandomVariable or simulator callable used for predictive sampling.
 
     Returns
     -------
@@ -51,7 +61,16 @@ def register_model(
     if name in registered_models:
         raise ValueError(f"Model '{name}' already exists")
 
-    _config = {k: v for k, v in locals().items() if k != "name"}
+    _config = {
+        "response": response,
+        "list_params": list_params,
+        "choices": choices,
+        "response_kind": response_kind,
+        "response_bounds": response_bounds or {},
+        "rv": rv,
+        "description": description,
+        "likelihoods": likelihoods,
+    }
     config = cast("DefaultConfig", _config)
 
     # TODO: validate provided configs?

--- a/tests/integration/test_jeam_model.py
+++ b/tests/integration/test_jeam_model.py
@@ -1,0 +1,35 @@
+"""End-to-end construction tests for the JEAM model registration."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("jeam")
+
+import hssm
+from hssm.integrations.jeam import simulate_circular_diffusion
+
+
+def test_simulated_circular_data_builds_an_ordinary_hssm_model():
+    """The fixed CDM should use HSSM's standard config-driven lifecycle."""
+    observations = simulate_circular_diffusion(
+        theta=np.array([0.70, -0.35, 0.40, 0.08]),
+        random_state=1947,
+        n_replicas=12,
+    )
+    data = pd.DataFrame(observations, columns=["rt", "response"])
+
+    model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+
+    assert type(model) is hssm.HSSM
+    assert model.model_name == "circular_diffusion"
+    assert model.response_kind == "circular"
+    assert model.response_bounds == {"response": (-np.pi, np.pi)}
+    assert model.choices is None
+    assert model.n_choices is None
+    assert model.list_params == ["v_x", "v_y", "a", "t"]
+    assert model.model_config.rv is simulate_circular_diffusion

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -1,0 +1,56 @@
+"""Tests for the experimental built-in JEAM model configuration."""
+
+import numpy as np
+
+import hssm
+from hssm.config import Config
+from hssm.integrations.jeam import (
+    logp_circular_diffusion,
+    simulate_circular_diffusion,
+)
+from hssm.modelconfig import get_default_model_config
+
+
+def test_circular_diffusion_is_a_supported_model():
+    """The prototype should be discoverable through the public model list."""
+    assert "circular_diffusion" in hssm.list_models()
+
+
+def test_get_circular_diffusion_config():
+    """The raw built-in config should expose the complete model contract."""
+    config = get_default_model_config("circular_diffusion")
+
+    assert config["response"] == ["rt", "response"]
+    assert config["response_kind"] == "circular"
+    assert config["response_bounds"] == {"response": (-np.pi, np.pi)}
+    assert config["choices"] is None
+    assert config["list_params"] == ["v_x", "v_y", "a", "t"]
+    assert config["rv"] is simulate_circular_diffusion
+
+    likelihood = config["likelihoods"]["blackbox"]
+    assert likelihood["loglik"] is logp_circular_diffusion
+    assert likelihood["backend"] is None
+    assert likelihood["bounds"] == {
+        "v_x": (-3.0, 3.0),
+        "v_y": (-3.0, 3.0),
+        "a": (0.1, 3.0),
+        "t": (0.0, 2.0),
+    }
+    assert likelihood["default_priors"] == {"t": {"name": "HalfNormal", "sigma": 2.0}}
+    assert likelihood["extra_fields"] is None
+
+
+def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
+    """Lazy registration should produce a validated non-categorical Config."""
+    config = Config.from_defaults("circular_diffusion", None)
+
+    assert config.model_name == "circular_diffusion"
+    assert config.loglik_kind == "blackbox"
+    assert config.response == ["rt", "response"]
+    assert config.response_kind == "circular"
+    assert config.response_bounds == {"response": (-np.pi, np.pi)}
+    assert config.choices is None
+    assert config.list_params == ["v_x", "v_y", "a", "t"]
+    assert config.loglik is logp_circular_diffusion
+    assert config.rv is simulate_circular_diffusion
+    config.validate()

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -11,6 +11,7 @@ from hssm.integrations.jeam import (
     simulate_circular_diffusion,
 )
 from hssm.modelconfig import get_default_model_config
+from hssm.plotting.model_cartoon import _require_categorical_choices
 
 
 def test_circular_diffusion_is_a_supported_model():
@@ -72,3 +73,9 @@ def test_non_categorical_model_requires_explicitly_disabled_lapse(p_outlier):
             model="circular_diffusion",
             p_outlier=p_outlier,
         )
+
+
+def test_model_cartoon_rejects_non_categorical_choices_directly():
+    """Categorical-only plotting should fail before trying to enumerate angles."""
+    with pytest.raises(ValueError, match="Model cartoons.*non-categorical responses"):
+        _require_categorical_choices(None, "circular_diffusion")

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -1,6 +1,8 @@
 """Tests for the experimental built-in JEAM model configuration."""
 
 import numpy as np
+import pandas as pd
+import pytest
 
 import hssm
 from hssm.config import Config
@@ -54,3 +56,19 @@ def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
     assert config.loglik is logp_circular_diffusion
     assert config.rv is simulate_circular_diffusion
     config.validate()
+
+
+@pytest.mark.parametrize("p_outlier", [0.0, 0.05])
+def test_non_categorical_model_requires_explicitly_disabled_lapse(p_outlier):
+    """Continuous-response density measures cannot use HSSM's categorical lapse."""
+    data = pd.DataFrame({"rt": [0.4, 0.8], "response": [-0.2, 0.3]})
+
+    with pytest.raises(
+        ValueError,
+        match=r"`p_outlier` is not supported.*Set `p_outlier=None`",
+    ):
+        hssm.HSSM(
+            data=data,
+            model="circular_diffusion",
+            p_outlier=p_outlier,
+        )

--- a/tests/unit/test_register.py
+++ b/tests/unit/test_register.py
@@ -3,17 +3,59 @@
 import pytest
 
 import hssm
-from hssm.register import register_model, list_registered_models, get_model_info
-from hssm.modelconfig import get_default_model_config
+from hssm.config import Config
 from hssm.defaults import (
     default_model_config as registered_models,
 )
+from hssm.modelconfig import get_default_model_config
+from hssm.register import get_model_info, list_registered_models, register_model
+
+
+def test_register_model_preserves_non_categorical_metadata():
+    """Registration should retain response-domain and simulator metadata."""
+    name = "registered_circular_test_model"
+
+    def logp(data, v):
+        return data[:, 1] * 0.0 + v * 0.0
+
+    def simulator(theta, random_state, n_replicas):
+        del theta, random_state, n_replicas
+
+    try:
+        register_model(
+            name=name,
+            response=["rt", "response"],
+            list_params=["v"],
+            choices=None,
+            response_kind="circular",
+            response_bounds={"response": (-3.14, 3.14)},
+            rv=simulator,
+            description="A registration-contract test model",
+            likelihoods={
+                "blackbox": {
+                    "loglik": logp,
+                    "backend": None,
+                    "bounds": {"v": (-1.0, 1.0)},
+                    "default_priors": {},
+                    "extra_fields": None,
+                }
+            },
+        )
+
+        config = Config.from_defaults(name, "blackbox")
+
+        assert config.choices is None
+        assert config.response_kind == "circular"
+        assert config.response_bounds == {"response": (-3.14, 3.14)}
+        assert config.rv is simulator
+        config.validate()
+    finally:
+        registered_models.pop(name, None)
 
 
 @pytest.mark.slow
 def test_register_model():
-    """Test registering a custom model"""
-
+    """Test registering a custom model."""
     # Test data for registration
     name = "custom_model"
     # get some model metadata for testing purposes


### PR DESCRIPTION
## Dependency

- HSSM #1197 is merged into `dev` at `9897c9d`; this branch starts from that merge commit.

## Summary

- register `circular_diffusion` as a lazy built-in config with `[v_x, v_y, a, t]`, circular responses on `[-pi, pi)`, the pinned JEAM blackbox likelihood, and its seeded simulator
- use the ordinary `hssm.HSSM` lifecycle; no circular subclass is introduced
- preserve categorical registration behavior and reject unsupported non-categorical `p_outlier` mixtures explicitly
- make categorical-only model cartoons fail clearly for non-categorical configs

## Verification

- all six commits are patch-identical to the previously reviewed #1198 stack under `git range-diff`
- Python 3.12 focused config, registration, cartoon, and real JEAM construction slice: 103 passed
- verified the worktree source import and exact JEAM pin `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`
- affected Ruff lint and format checks pass
- `git diff --check`

## Deferred

- predictive and serialization coverage remains in H08
- optimizer parity, Bayesian recovery, and the repeated recovery benchmark remain split across the H09 stack
