### PR TITLE
Verify seeded JEAM predictive sampling

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -9,6 +9,7 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
+      - "tests/integration/test_jeam_predictive.py"
       - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
 
@@ -36,4 +37,5 @@ jobs:
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam.py
           tests/integration/test_jeam_model.py
+          tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py

--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -205,6 +205,7 @@ class aDDM(HSSMBase):
         kind: Literal["response", "response_params"] = "response",
         draws: int | float | list[int] | np.ndarray | None = None,
         safe_mode: bool = True,
+        random_seed: int | np.random.Generator | None = None,
         continuation_mode: str | None = None,
         continuation_params: dict | None = None,
     ) -> DataTree | None:
@@ -234,7 +235,14 @@ class aDDM(HSSMBase):
         self._continuation_override: tuple[str, dict | None] | None = (mode, params)
         try:
             return super().sample_posterior_predictive(
-                dt, data, inplace, include_group_specific, kind, draws, safe_mode
+                dt=dt,
+                data=data,
+                inplace=inplace,
+                include_group_specific=include_group_specific,
+                kind=kind,
+                draws=draws,
+                safe_mode=safe_mode,
+                random_seed=random_seed,
             )
         finally:
             self._continuation_override = None

--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -207,6 +207,7 @@ class aDDM(HSSMBase):
         safe_mode: bool = True,
         continuation_mode: str | None = None,
         continuation_params: dict | None = None,
+        *,
         random_seed: int | np.random.Generator | None = None,
     ) -> DataTree | None:
         """Posterior-predictive draws with a per-call fixation-continuation policy.

--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -205,9 +205,9 @@ class aDDM(HSSMBase):
         kind: Literal["response", "response_params"] = "response",
         draws: int | float | list[int] | np.ndarray | None = None,
         safe_mode: bool = True,
-        random_seed: int | np.random.Generator | None = None,
         continuation_mode: str | None = None,
         continuation_params: dict | None = None,
+        random_seed: int | np.random.Generator | None = None,
     ) -> DataTree | None:
         """Posterior-predictive draws with a per-call fixation-continuation policy.
 

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -988,6 +988,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         kind: Literal["response", "response_params"] = "response",
         draws: int | float | list[int] | np.ndarray | None = None,
         safe_mode: bool = True,
+        *,
         random_seed: int | np.random.Generator | None = None,
     ) -> DataTree | None:
         """Perform posterior predictive sampling from the HSSM model.

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -988,6 +988,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         kind: Literal["response", "response_params"] = "response",
         draws: int | float | list[int] | np.ndarray | None = None,
         safe_mode: bool = True,
+        random_seed: int | np.random.Generator | None = None,
     ) -> DataTree | None:
         """Perform posterior predictive sampling from the HSSM model.
 
@@ -1028,6 +1029,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         safe_mode: bool
             If True, the function will split the draws into chunks of 10 to avoid memory
             issues. Defaults to True.
+        random_seed
+            Seed or NumPy Generator for reproducible posterior predictive draws. A
+            single Generator stream is advanced across safe-mode chunks.
 
         Raises
         ------
@@ -1075,6 +1079,10 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
         assert isinstance(draws, np.ndarray)
 
+        predict_kwargs: dict[str, Any] = {}
+        if random_seed is not None:
+            predict_kwargs["random_seed"] = np.random.default_rng(random_seed)
+
         # Make a copy of dt, set the `posterior` group to be a random sub-sample
         # of the original (draw dimension gets sub-sampled)
 
@@ -1099,7 +1107,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     tmp_posterior = dt["posterior"].sel(draw=samples_tmp)
                     dt_copy["posterior"] = tmp_posterior
                     self.model.predict(
-                        dt_copy, kind, data, True, include_group_specific
+                        dt_copy,
+                        kind,
+                        data,
+                        True,
+                        include_group_specific,
+                        **predict_kwargs,
                     )
                     posterior_predictive_list.append(dt_copy["posterior_predictive"])
 
@@ -1130,7 +1143,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     # .predict() is called on the copy of dt
                     # since we still subsampled (or assigned) the draws
                     self.model.predict(
-                        dt_copy, kind, data, True, include_group_specific
+                        dt_copy,
+                        kind,
+                        data,
+                        True,
+                        include_group_specific,
+                        **predict_kwargs,
                     )
 
                     # posterior predictive group added to dt
@@ -1143,7 +1161,12 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                     # .predict(). It just operates on the
                     # dt_copy object
                     return self.model.predict(
-                        dt_copy, kind, data, False, include_group_specific
+                        dt_copy,
+                        kind,
+                        data,
+                        False,
+                        include_group_specific,
+                        **predict_kwargs,
                     )
         elif kind == "response_params":
             # If kind == 'response_params', we don't need to run the RV directly,
@@ -1154,7 +1177,14 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 "The kind argument is set to 'mean', but 'draws' argument "
                 + "is not None: The draws argument will be ignored!"
             )
-            return self.model.predict(dt, kind, data, inplace, include_group_specific)
+            return self.model.predict(
+                dt,
+                kind,
+                data,
+                inplace,
+                include_group_specific,
+                **predict_kwargs,
+            )
         else:
             raise ValueError("`kind` must be either 'response' or 'response_params'.")
 
@@ -1241,7 +1271,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         draws: int = 500,
         var_names: str | list[str] | None = None,
         omit_offsets: bool = True,
-        random_seed: np.random.Generator | None = None,
+        random_seed: int | np.random.Generator | None = None,
     ) -> DataTree:
         """Generate samples from the prior predictive distribution.
 

--- a/tests/addm/test_addm_continuation.py
+++ b/tests/addm/test_addm_continuation.py
@@ -34,8 +34,46 @@ needs_addm_continuation = pytest.mark.skipif(
 
 import hssm  # noqa: E402
 from hssm.addm.config import aDDMConfig  # noqa: E402
+from hssm.base import HSSMBase  # noqa: E402
 
 _GAMMA = {"dist": "gamma", "dist_params": {"a": 2.0, "scale": 0.3}}
+
+
+def test_addm_ppc_preserves_positional_continuation_arguments(monkeypatch):
+    """Adding ``random_seed`` must not change existing positional bindings."""
+    model = object.__new__(hssm.aDDM)
+    model.model_config = aDDMConfig()
+    received: dict = {}
+
+    def fake_sample_posterior_predictive(self, **kwargs):
+        received.update(kwargs)
+        received["continuation_override"] = self._continuation_override
+
+    monkeypatch.setattr(
+        HSSMBase, "sample_posterior_predictive", fake_sample_posterior_predictive
+    )
+
+    # Keep the pre-random_seed positional order intact: the established continuation
+    # arguments remain positions 8 and 9, and the new seed is appended at position 10.
+    model.sample_posterior_predictive(
+        None,
+        None,
+        True,
+        False,
+        "response",
+        4,
+        False,
+        "sample_continuation",
+        _GAMMA,
+        519,
+    )
+
+    assert received["continuation_override"] == ("sample_continuation", _GAMMA)
+    assert received["random_seed"] == 519
+    assert received["include_group_specific"] is False
+    assert received["draws"] == 4
+    assert received["safe_mode"] is False
+    assert model._continuation_override is None
 
 
 @needs_addm_continuation

--- a/tests/addm/test_addm_continuation.py
+++ b/tests/addm/test_addm_continuation.py
@@ -9,6 +9,7 @@ Requires the ssm-simulators build with ``cssm.addm`` AND the ``fixation_continua
 module; skips otherwise (like the aDDM PPC tests).
 """
 
+import inspect
 import sys
 from pathlib import Path
 
@@ -45,6 +46,19 @@ def test_addm_ppc_preserves_positional_continuation_arguments(monkeypatch):
     model.model_config = aDDMConfig()
     received: dict = {}
 
+    assert (
+        inspect.signature(HSSMBase.sample_posterior_predictive)
+        .parameters["random_seed"]
+        .kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert (
+        inspect.signature(hssm.aDDM.sample_posterior_predictive)
+        .parameters["random_seed"]
+        .kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+
     def fake_sample_posterior_predictive(self, **kwargs):
         received.update(kwargs)
         received["continuation_override"] = self._continuation_override
@@ -53,8 +67,8 @@ def test_addm_ppc_preserves_positional_continuation_arguments(monkeypatch):
         HSSMBase, "sample_posterior_predictive", fake_sample_posterior_predictive
     )
 
-    # Keep the pre-random_seed positional order intact: the established continuation
-    # arguments remain positions 8 and 9, and the new seed is appended at position 10.
+    # Keep the established continuation arguments in positions 8 and 9 while the
+    # newly introduced seed is keyword-only in both the base and subclass methods.
     model.sample_posterior_predictive(
         None,
         None,
@@ -65,7 +79,7 @@ def test_addm_ppc_preserves_positional_continuation_arguments(monkeypatch):
         False,
         "sample_continuation",
         _GAMMA,
-        519,
+        random_seed=519,
     )
 
     assert received["continuation_override"] == ("sample_continuation", _GAMMA)

--- a/tests/integration/test_jeam_predictive.py
+++ b/tests/integration/test_jeam_predictive.py
@@ -1,0 +1,129 @@
+"""Predictive-path tests for the registered JEAM circular model."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+pytest.importorskip("jeam")
+
+import hssm
+from hssm.integrations.jeam import simulate_circular_diffusion
+
+OBSERVED_NAME = "rt,response"
+OBSERVATION_DIM = "__obs__"
+RESPONSE_DIM = "rt,response_dim"
+
+
+@pytest.fixture(scope="module")
+def circular_model():
+    """Build one ordinary HSSM model from deterministic JEAM observations."""
+    observations = simulate_circular_diffusion(
+        theta=np.array([0.70, -0.35, 0.40, 0.08]),
+        random_state=1947,
+        n_replicas=6,
+    )
+    return hssm.HSSM(
+        data=pd.DataFrame(observations, columns=["rt", "response"]),
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+
+
+def _assert_predictive_contract(values: np.ndarray) -> None:
+    """Check the common final-axis, support, and numeric predictive contract."""
+    assert values.shape[-1] == 2
+    assert values.dtype == np.float64
+    assert np.all(np.isfinite(values))
+    assert np.all(values[..., 0] > 0.0)
+    assert np.all(values[..., 1] >= -np.pi)
+    assert np.all(values[..., 1] < np.pi)
+
+
+def _fixed_posterior(n_draws: int = 12) -> xr.DataTree:
+    """Return identical parameter draws to isolate simulator RNG behavior."""
+    coords = {"chain": [0], "draw": np.arange(n_draws)}
+    posterior = xr.Dataset(
+        {
+            name: (("chain", "draw"), np.full((1, n_draws), value))
+            for name, value in {
+                "v_x": 0.70,
+                "v_y": -0.35,
+                "a": 0.40,
+                "t": 0.08,
+            }.items()
+        },
+        coords=coords,
+    )
+    return xr.DataTree.from_dict({"posterior": posterior})
+
+
+def test_prior_predictive_preserves_shape_support_and_seed(circular_model):
+    """Prior draws should retain `[rt, response]` and repeat exactly by seed."""
+    first = circular_model.sample_prior_predictive(draws=3, random_seed=519)
+    second = circular_model.sample_prior_predictive(draws=3, random_seed=519)
+    different = circular_model.sample_prior_predictive(draws=3, random_seed=520)
+
+    first_values = first["prior_predictive"][OBSERVED_NAME].values
+    second_values = second["prior_predictive"][OBSERVED_NAME].values
+    different_values = different["prior_predictive"][OBSERVED_NAME].values
+
+    np.testing.assert_array_equal(first_values, second_values)
+    assert not np.array_equal(first_values, different_values)
+    assert first["prior_predictive"][OBSERVED_NAME].dims == (
+        "chain",
+        "draw",
+        OBSERVATION_DIM,
+        RESPONSE_DIM,
+    )
+    assert first_values.shape == (1, 3, 6, 2)
+    np.testing.assert_array_equal(
+        first["prior_predictive"].coords[RESPONSE_DIM].values,
+        np.array([0, 1]),
+    )
+    _assert_predictive_contract(first_values)
+
+
+def test_posterior_predictive_advances_one_seeded_safe_mode_stream(circular_model):
+    """Chunked posterior draws should repeat by seed without repeating chunks."""
+    first = circular_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=997,
+    )
+    second = circular_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=997,
+    )
+    different = circular_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=998,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert different is not None
+    first_values = first["posterior_predictive"][OBSERVED_NAME].values
+    second_values = second["posterior_predictive"][OBSERVED_NAME].values
+    different_values = different["posterior_predictive"][OBSERVED_NAME].values
+
+    np.testing.assert_array_equal(first_values, second_values)
+    assert not np.array_equal(first_values, different_values)
+    assert not np.array_equal(first_values[:, 0], first_values[:, 10])
+    assert first["posterior_predictive"][OBSERVED_NAME].dims == (
+        "chain",
+        "draw",
+        OBSERVATION_DIM,
+        RESPONSE_DIM,
+    )
+    assert first_values.shape == (1, 12, 6, 2)
+    np.testing.assert_array_equal(
+        first["posterior_predictive"].coords["draw"].values,
+        np.arange(12),
+    )
+    _assert_predictive_contract(first_values)

--- a/tests/integration/test_jeam_predictive.py
+++ b/tests/integration/test_jeam_predictive.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytensor
 import pytest
 import xarray as xr
 
@@ -38,7 +39,7 @@ def circular_model():
 def _assert_predictive_contract(values: np.ndarray) -> None:
     """Check the common final-axis, support, and numeric predictive contract."""
     assert values.shape[-1] == 2
-    assert values.dtype == np.float64
+    assert values.dtype == np.dtype(pytensor.config.floatX)
     assert np.all(np.isfinite(values))
     assert np.all(values[..., 0] > 0.0)
     assert np.all(values[..., 1] >= -np.pi)

--- a/tests/integration/test_jeam_predictive.py
+++ b/tests/integration/test_jeam_predictive.py
@@ -15,9 +15,8 @@ OBSERVATION_DIM = "__obs__"
 RESPONSE_DIM = "rt,response_dim"
 
 
-@pytest.fixture(scope="module")
-def circular_model():
-    """Build one ordinary HSSM model from deterministic JEAM observations."""
+def _build_circular_model():
+    """Build an ordinary HSSM model from deterministic JEAM observations."""
     observations = simulate_circular_diffusion(
         theta=np.array([0.70, -0.35, 0.40, 0.08]),
         random_state=1947,
@@ -28,6 +27,12 @@ def circular_model():
         model="circular_diffusion",
         p_outlier=None,
     )
+
+
+@pytest.fixture(scope="module")
+def circular_model():
+    """Share one circular model across the predictive-path tests."""
+    return _build_circular_model()
 
 
 def _assert_predictive_contract(values: np.ndarray) -> None:
@@ -127,3 +132,34 @@ def test_posterior_predictive_advances_one_seeded_safe_mode_stream(circular_mode
         np.arange(12),
     )
     _assert_predictive_contract(first_values)
+
+
+def test_circular_model_round_trip_reconstructs_predictive_state(tmp_path):
+    """Existing HSSM persistence should reconstruct the config and custom RV."""
+    model = _build_circular_model()
+    model.save_model(
+        model_name="circular_round_trip",
+        base_path=tmp_path,
+        allow_absolute_base_path=True,
+    )
+
+    model_path = tmp_path / "circular_round_trip"
+    restored = hssm.HSSM.load_model(model_path)
+
+    assert isinstance(restored, hssm.HSSM)
+    assert restored.model_name == "circular_diffusion"
+    assert restored._init_args["model"] == "circular_diffusion"
+    assert restored._init_args["p_outlier"] is None
+    assert restored.model_config.rv is simulate_circular_diffusion
+    assert restored.data.equals(model.data)
+    assert (model_path / "model.pkl").is_file()
+    assert not (model_path / "traces.nc").exists()
+
+    original_draws = model.sample_prior_predictive(draws=2, random_seed=1623)[
+        "prior_predictive"
+    ][OBSERVED_NAME].values
+    restored_draws = restored.sample_prior_predictive(draws=2, random_seed=1623)[
+        "prior_predictive"
+    ][OBSERVED_NAME].values
+    np.testing.assert_array_equal(original_draws, restored_draws)
+    _assert_predictive_contract(restored_draws)

--- a/tests/test_predictive_random_seed.py
+++ b/tests/test_predictive_random_seed.py
@@ -1,0 +1,53 @@
+"""Tests for deterministic HSSM predictive-stream forwarding."""
+
+import numpy as np
+import xarray as xr
+
+import hssm
+
+
+def test_posterior_predictive_reuses_one_generator_across_safe_chunks(
+    data_ddm,
+    minimal_posterior_datatree,
+    monkeypatch,
+):
+    """Safe-mode chunks should advance one stream rather than restart a seed."""
+    model = hssm.HSSM(data=data_ddm, p_outlier=None)
+    posterior = (
+        minimal_posterior_datatree()["posterior"].isel(draw=np.zeros(12, dtype=int)).ds
+    )
+    posterior = posterior.assign_coords(draw=np.arange(12))
+    traces = xr.DataTree.from_dict({"posterior": posterior})
+    received_seeds = []
+
+    def fake_predict(
+        dt,
+        kind,
+        data,
+        inplace,
+        include_group_specific,
+        random_seed=None,
+    ):
+        del kind, data, inplace, include_group_specific
+        received_seeds.append(random_seed)
+        draws = dt["posterior"].coords["draw"].values
+        dt["posterior_predictive"] = xr.Dataset(
+            {"response": (("chain", "draw"), np.zeros((1, len(draws))))},
+            coords={"chain": [0], "draw": draws},
+        )
+
+    monkeypatch.setattr(model.model, "predict", fake_predict)
+
+    result = model.sample_posterior_predictive(
+        dt=traces,
+        draws=12,
+        safe_mode=True,
+        inplace=False,
+        random_seed=519,
+    )
+
+    assert result is not None
+    assert result["posterior_predictive"].sizes["draw"] == 12
+    assert len(received_seeds) == 2
+    assert isinstance(received_seeds[0], np.random.Generator)
+    assert received_seeds[0] is received_seeds[1]


### PR DESCRIPTION
# Dependency

HSSM #1198 is merged into `dev` at `a626c178`. This branch starts directly from that integration commit.

## Scope

- add a keyword-only `random_seed` argument to posterior predictive sampling
- create one NumPy `Generator` per predictive request and advance it across safe-mode chunks
- preserve the established positional `aDDM` continuation arguments while forwarding the seed by keyword
- verify JEAM circular predictive shape, support, precision, seeded repeatability, and save/load behavior
- run the predictive tests in the optional JEAM workflow

## Why one generator

Safe mode splits posterior draws into chunks. Reusing an integer seed for every chunk would restart the stream and duplicate simulated chunks. One request-scoped generator makes the complete request deterministic while each chunk consumes the next part of the stream.

The seed is keyword-only because it is new API. This preserves the positional meaning of `aDDM`'s existing `continuation_mode` and `continuation_params` arguments and keeps the subclass signature compatible with `HSSMBase`.

## Regression coverage

- dependency-free safe-mode regression proves both chunks receive the same generator object
- fixed-parameter JEAM regression proves equal seeds reproduce, unequal seeds differ, and opposite sides of a chunk boundary are not duplicates
- `aDDM` regression calls the existing continuation arguments positionally, passes the seed by keyword, and verifies the effective continuation override and seed forwarding
- signature assertions keep the new seed keyword-only in both the base and subclass APIs
- integration checks cover `(chain, draw, __obs__, rt,response_dim)`, `[rt, response]` order, positive RTs, `[-pi, pi)` support, active precision, and model-state round-tripping

## Verification after restacking

- `git range-diff`: the original six commits are patch-identical to the reviewed stack; `fb668014` and `33e0059c` are focused compatibility follow-ups
- Python 3.12 non-slow suite before the compatibility follow-ups: 703 passed, 371 deselected
- focused predictive, JEAM, persistence, and `aDDM` slice before the compatibility follow-ups: 29 passed
- focused continuation and predictive-RNG regression after the final follow-up: 3 passed, 1 slow deselected
- focused Pyrefly on `base.py` and `addm.py`: 0 errors
- Ruff check and format checks on changed Python files
- `mypy src/hssm`: 85 source files checked before the compatibility follow-ups
- wheel and source distribution builds before the compatibility follow-ups
- `git diff --check`

Hosted checks are rerunning for the final two compatibility commits.

## Deferred

This PR establishes reproducible generative behavior. Objective parity, recovery, and the analytical likelihood remain in later review units.
