### PR TITLE
Benchmark JEAM and HSSM objective parity

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -7,8 +7,10 @@ on:
       - ".github/workflows/jeam_prototype.yml"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
+      - "scripts/benchmark_jeam_objective_parity.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
+      - "tests/integration/test_jeam_objective_parity.py"
       - "tests/integration/test_jeam_predictive.py"
       - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
@@ -37,5 +39,6 @@ jobs:
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam.py
           tests/integration/test_jeam_model.py
+          tests/integration/test_jeam_objective_parity.py
           tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py

--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "pyproject.toml"
       - ".github/workflows/jeam_prototype.yml"
+      - "src/hssm/distribution_utils/blackbox.py"
+      - "src/hssm/distribution_utils/dist.py"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "scripts/benchmark_jeam_objective_parity.py"

--- a/scripts/benchmark_jeam_objective_parity.py
+++ b/scripts/benchmark_jeam_objective_parity.py
@@ -1,0 +1,325 @@
+"""Benchmark direct JEAM against the compiled HSSM circular likelihood.
+
+Run from the HSSM repository with the prototype dependency group installed::
+
+    uv run --group jeam-prototype python scripts/benchmark_jeam_objective_parity.py
+
+The command writes one JSON object to stdout. Runtime values are descriptive only; the
+scientific invariant is numerical objective and bounded-optimizer parity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+from dataclasses import asdict, dataclass
+from time import perf_counter
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+from jeam.Models.Circular import CircularDiffusionModel
+from scipy.optimize import differential_evolution
+
+from hssm.distribution_utils.dist import make_distribution, make_likelihood_callable
+from hssm.integrations.jeam import (
+    logp_circular_diffusion,
+    simulate_circular_diffusion,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+PARAMETER_ORDER = ("a", "t", "v_x", "v_y")
+DEFAULT_TRUTH = np.array([1.20, 0.15, 0.80, -0.50], dtype=np.float64)
+DEFAULT_DATA_SEED = 1492
+DEFAULT_OPTIMIZER_SEED = 8675309
+DEFAULT_TRIALS = 300
+DEFAULT_MAXITER = 14
+DEFAULT_POPSIZE = 15
+
+HSSM_PARAMETER_ORDER = ["v_x", "v_y", "a", "t"]
+HSSM_BOUNDS = {
+    "v_x": (-3.0, 3.0),
+    "v_y": (-3.0, 3.0),
+    "a": (0.1, 3.0),
+    "t": (0.0, 2.0),
+}
+
+
+@dataclass(frozen=True)
+class FitSummary:
+    """Serializable optimizer result."""
+
+    parameters: tuple[float, ...]
+    objective: float
+    evaluations: int
+    iterations: int
+
+
+@dataclass(frozen=True)
+class RuntimeSummary:
+    """Descriptive median pointwise objective runtimes in milliseconds."""
+
+    direct_jeam_ms: float
+    compiled_hssm_ms: float
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Machine-readable objective and optimizer parity result."""
+
+    parameter_order: tuple[str, ...]
+    truth: tuple[float, ...]
+    trials: int
+    data_seed: int
+    optimizer_seed: int
+    jeam_revision: str
+    candidate_parameters: tuple[tuple[float, ...], ...]
+    direct_objectives: tuple[float, ...]
+    compiled_objectives: tuple[float, ...]
+    direct_fit: FitSummary
+    compiled_fit: FitSummary
+    runtime: RuntimeSummary
+
+
+def _installed_jeam_revision() -> str:
+    """Return the installed VCS revision when direct-url metadata is available."""
+    distribution = importlib.metadata.distribution("jeam")
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text is not None:
+        direct_url = json.loads(direct_url_text)
+        commit_id = direct_url.get("vcs_info", {}).get("commit_id")
+        if isinstance(commit_id, str):
+            return commit_id
+    return distribution.version
+
+
+def simulate_dataset(
+    truth: np.ndarray = DEFAULT_TRUTH,
+    *,
+    trials: int = DEFAULT_TRIALS,
+    seed: int = DEFAULT_DATA_SEED,
+) -> np.ndarray:
+    """Simulate one deterministic fixed-CDM dataset through pinned JEAM."""
+    a, t, v_x, v_y = np.asarray(truth, dtype=np.float64)
+    theta = np.array([v_x, v_y, a, t], dtype=np.float64)
+    return simulate_circular_diffusion(
+        theta=theta,
+        random_state=seed,
+        n_replicas=trials,
+    )
+
+
+def make_direct_objective(data: np.ndarray) -> Callable[[np.ndarray], float]:
+    """Return the negative summed log likelihood evaluated directly by JEAM."""
+    observations = np.asarray(data, dtype=np.float64)
+    model = CircularDiffusionModel(threshold_dynamic="fixed")
+
+    def objective(parameters: np.ndarray) -> float:
+        a, t, v_x, v_y = np.asarray(parameters, dtype=np.float64)
+        logp = model.joint_lpdf(
+            rt=observations[:, 0],
+            theta=observations[:, 1],
+            drift_vec=np.column_stack(
+                (
+                    np.full(observations.shape[0], v_x),
+                    np.full(observations.shape[0], v_y),
+                )
+            ),
+            ndt=np.full(observations.shape[0], t),
+            threshold=float(a),
+            decay=0.0,
+            threshold_function=None,
+            dt_threshold_function=None,
+            s_v=0.0,
+            s_t=0.0,
+            sigma=1.0,
+        )
+        return -float(np.sum(logp, dtype=np.float64))
+
+    return objective
+
+
+def make_compiled_hssm_objective(
+    data: np.ndarray,
+) -> Callable[[np.ndarray], float]:
+    """Compile the actual HSSM distribution into a scalar objective."""
+    likelihood = make_likelihood_callable(
+        loglik=logp_circular_diffusion,
+        loglik_kind="blackbox",
+        backend="pytensor",
+    )
+    distribution = make_distribution(
+        rv=simulate_circular_diffusion,
+        loglik=likelihood,
+        list_params=HSSM_PARAMETER_ORDER.copy(),
+        bounds=HSSM_BOUNDS,
+    )
+    parameters = pt.dvector("parameters")
+    a, t, v_x, v_y = (parameters[index] for index in range(4))
+    pointwise = distribution.logp(  # pyrefly: ignore[missing-attribute]
+        pt.as_tensor_variable(np.asarray(data, dtype=np.float64)),
+        v_x,
+        v_y,
+        a,
+        t,
+    )
+    compiled = pytensor.function([parameters], -pt.sum(pointwise))
+
+    def objective(values: np.ndarray) -> float:
+        return float(compiled(np.asarray(values, dtype=np.float64)))
+
+    return objective
+
+
+def optimization_bounds(data: np.ndarray) -> tuple[tuple[float, float], ...]:
+    """Return bounds wholly inside both HSSM and dataset-specific RT support."""
+    min_rt = float(np.min(np.asarray(data)[:, 0]))
+    t_upper = np.nextafter(min_rt, -np.inf)
+    if t_upper <= 0.05:
+        raise ValueError(
+            "The simulated dataset leaves no valid optimization range for t."
+        )
+    return ((0.60, 1.80), (0.05, t_upper), (-1.50, 1.50), (-1.50, 1.50))
+
+
+def _fit(
+    objective: Callable[[np.ndarray], float],
+    bounds: Sequence[tuple[float, float]],
+    *,
+    seed: int,
+    maxiter: int,
+    popsize: int,
+) -> FitSummary:
+    """Run a deterministic fixed-budget differential-evolution fit."""
+    fit: Any = differential_evolution(
+        objective,
+        bounds=bounds,
+        seed=seed,
+        maxiter=maxiter,
+        popsize=popsize,
+        polish=False,
+        tol=0.0,
+        atol=0.0,
+        workers=1,
+        updating="immediate",
+    )
+    return FitSummary(
+        parameters=tuple(float(value) for value in fit.x),
+        objective=float(fit.fun),
+        evaluations=int(fit.nfev),
+        iterations=int(fit.nit),
+    )
+
+
+def _median_runtime_ms(
+    objective: Callable[[np.ndarray], float],
+    parameters: np.ndarray,
+    *,
+    repeats: int,
+) -> float:
+    """Measure a warmed objective without turning speed into an assertion."""
+    objective(parameters)
+    durations = np.empty(repeats, dtype=np.float64)
+    for index in range(repeats):
+        start = perf_counter()
+        objective(parameters)
+        durations[index] = perf_counter() - start
+    return float(np.median(durations) * 1_000.0)
+
+
+def run_benchmark(
+    *,
+    trials: int = DEFAULT_TRIALS,
+    data_seed: int = DEFAULT_DATA_SEED,
+    optimizer_seed: int = DEFAULT_OPTIMIZER_SEED,
+    maxiter: int = DEFAULT_MAXITER,
+    popsize: int = DEFAULT_POPSIZE,
+    timing_repeats: int = 51,
+) -> BenchmarkResult:
+    """Run objective-grid, optimizer, and descriptive runtime comparisons."""
+    data = simulate_dataset(trials=trials, seed=data_seed)
+    direct = make_direct_objective(data)
+    compiled = make_compiled_hssm_objective(data)
+    candidates = (
+        tuple(float(value) for value in DEFAULT_TRUTH),
+        (1.00, 0.10, 0.40, -0.30),
+        (1.50, 0.12, 1.10, -0.80),
+    )
+    candidate_arrays = tuple(np.asarray(candidate) for candidate in candidates)
+    direct_objectives = tuple(direct(candidate) for candidate in candidate_arrays)
+    compiled_objectives = tuple(compiled(candidate) for candidate in candidate_arrays)
+    bounds = optimization_bounds(data)
+    direct_fit = _fit(
+        direct,
+        bounds,
+        seed=optimizer_seed,
+        maxiter=maxiter,
+        popsize=popsize,
+    )
+    compiled_fit = _fit(
+        compiled,
+        bounds,
+        seed=optimizer_seed,
+        maxiter=maxiter,
+        popsize=popsize,
+    )
+    runtime = RuntimeSummary(
+        direct_jeam_ms=_median_runtime_ms(
+            direct,
+            np.asarray(direct_fit.parameters),
+            repeats=timing_repeats,
+        ),
+        compiled_hssm_ms=_median_runtime_ms(
+            compiled,
+            np.asarray(compiled_fit.parameters),
+            repeats=timing_repeats,
+        ),
+    )
+    return BenchmarkResult(
+        parameter_order=PARAMETER_ORDER,
+        truth=tuple(float(value) for value in DEFAULT_TRUTH),
+        trials=trials,
+        data_seed=data_seed,
+        optimizer_seed=optimizer_seed,
+        jeam_revision=_installed_jeam_revision(),
+        candidate_parameters=candidates,
+        direct_objectives=direct_objectives,
+        compiled_objectives=compiled_objectives,
+        direct_fit=direct_fit,
+        compiled_fit=compiled_fit,
+        runtime=runtime,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
+    parser.add_argument("--data-seed", type=int, default=DEFAULT_DATA_SEED)
+    parser.add_argument("--optimizer-seed", type=int, default=DEFAULT_OPTIMIZER_SEED)
+    parser.add_argument("--maxiter", type=int, default=DEFAULT_MAXITER)
+    parser.add_argument("--popsize", type=int, default=DEFAULT_POPSIZE)
+    parser.add_argument("--timing-repeats", type=int, default=51)
+    parser.add_argument("--compact", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the benchmark and print machine-readable JSON."""
+    args = _parse_args()
+    result = run_benchmark(
+        trials=args.trials,
+        data_seed=args.data_seed,
+        optimizer_seed=args.optimizer_seed,
+        maxiter=args.maxiter,
+        popsize=args.popsize,
+        timing_repeats=args.timing_repeats,
+    )
+    print(json.dumps(asdict(result), indent=None if args.compact else 2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_jeam_objective_parity.py
+++ b/scripts/benchmark_jeam_objective_parity.py
@@ -39,6 +39,7 @@ DEFAULT_OPTIMIZER_SEED = 8675309
 DEFAULT_TRIALS = 300
 DEFAULT_MAXITER = 14
 DEFAULT_POPSIZE = 15
+NDT_SUPPORT_MARGIN = 1e-12
 
 HSSM_PARAMETER_ORDER = ["v_x", "v_y", "a", "t"]
 HSSM_BOUNDS = {
@@ -178,7 +179,9 @@ def make_compiled_hssm_objective(
 def optimization_bounds(data: np.ndarray) -> tuple[tuple[float, float], ...]:
     """Return bounds wholly inside both HSSM and dataset-specific RT support."""
     min_rt = float(np.min(np.asarray(data)[:, 0]))
-    t_upper = np.nextafter(min_rt, -np.inf)
+    # HSSM excludes rt - t <= 1e-15 before evaluating the model likelihood.
+    # Keep the optimizer endpoint comfortably inside that shared support.
+    t_upper = min(HSSM_BOUNDS["t"][1], min_rt - NDT_SUPPORT_MARGIN)
     if t_upper <= 0.05:
         raise ValueError(
             "The simulated dataset leaves no valid optimization range for t."
@@ -244,15 +247,21 @@ def run_benchmark(
     data = simulate_dataset(trials=trials, seed=data_seed)
     direct = make_direct_objective(data)
     compiled = make_compiled_hssm_objective(data)
+    bounds = optimization_bounds(data)
     candidates = (
         tuple(float(value) for value in DEFAULT_TRUTH),
         (1.00, 0.10, 0.40, -0.30),
         (1.50, 0.12, 1.10, -0.80),
+        (
+            float(DEFAULT_TRUTH[0]),
+            bounds[1][1],
+            float(DEFAULT_TRUTH[2]),
+            float(DEFAULT_TRUTH[3]),
+        ),
     )
     candidate_arrays = tuple(np.asarray(candidate) for candidate in candidates)
     direct_objectives = tuple(direct(candidate) for candidate in candidate_arrays)
     compiled_objectives = tuple(compiled(candidate) for candidate in candidate_arrays)
-    bounds = optimization_bounds(data)
     direct_fit = _fit(
         direct,
         bounds,

--- a/tests/integration/test_jeam_objective_parity.py
+++ b/tests/integration/test_jeam_objective_parity.py
@@ -1,0 +1,74 @@
+"""Fast deterministic objective and optimizer parity for the JEAM handshake."""
+
+import json
+from dataclasses import asdict
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+from scripts.benchmark_jeam_objective_parity import (
+    DEFAULT_MAXITER,
+    DEFAULT_POPSIZE,
+    PARAMETER_ORDER,
+    run_benchmark,
+)
+
+PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+OBJECTIVE_RTOL = 1e-6
+OBJECTIVE_ATOL = 5e-5
+
+
+@pytest.fixture(scope="module")
+def parity_result():
+    """Run the fixed 300-trial benchmark once for all parity assertions."""
+    return run_benchmark(timing_repeats=3)
+
+
+def test_objective_grid_matches_direct_jeam(parity_result):
+    """Compiled HSSM should preserve direct JEAM objectives away from one point."""
+    np.testing.assert_allclose(
+        parity_result.compiled_objectives,
+        parity_result.direct_objectives,
+        rtol=OBJECTIVE_RTOL,
+        atol=OBJECTIVE_ATOL,
+    )
+    assert len(parity_result.candidate_parameters) == 3
+    assert parity_result.parameter_order == PARAMETER_ORDER
+
+
+def test_fixed_budget_optimizer_follows_the_same_path(parity_result):
+    """Equal seeds and objectives should produce the same bounded DE estimate."""
+    direct = parity_result.direct_fit
+    compiled = parity_result.compiled_fit
+    expected_evaluations = (
+        (DEFAULT_MAXITER + 1) * DEFAULT_POPSIZE * len(PARAMETER_ORDER)
+    )
+
+    np.testing.assert_allclose(
+        compiled.parameters,
+        direct.parameters,
+        rtol=0.0,
+        atol=1e-12,
+    )
+    assert compiled.objective == pytest.approx(
+        direct.objective,
+        rel=OBJECTIVE_RTOL,
+        abs=OBJECTIVE_ATOL,
+    )
+    assert direct.evaluations == compiled.evaluations == expected_evaluations
+    assert direct.iterations == compiled.iterations == DEFAULT_MAXITER
+    assert direct.objective < parity_result.direct_objectives[0]
+
+
+def test_benchmark_records_provenance_and_machine_readable_output(parity_result):
+    """The benchmark output should identify its producer and serialize as JSON."""
+    assert parity_result.jeam_revision == PINNED_JEAM_REVISION
+    assert parity_result.trials == 300
+    assert parity_result.runtime.direct_jeam_ms > 0.0
+    assert parity_result.runtime.compiled_hssm_ms > 0.0
+
+    payload = json.loads(json.dumps(asdict(parity_result)))
+    assert payload["jeam_revision"] == PINNED_JEAM_REVISION
+    assert payload["parameter_order"] == list(PARAMETER_ORDER)

--- a/tests/integration/test_jeam_objective_parity.py
+++ b/tests/integration/test_jeam_objective_parity.py
@@ -11,8 +11,11 @@ pytest.importorskip("jeam")
 from scripts.benchmark_jeam_objective_parity import (
     DEFAULT_MAXITER,
     DEFAULT_POPSIZE,
+    HSSM_BOUNDS,
     PARAMETER_ORDER,
+    optimization_bounds,
     run_benchmark,
+    simulate_dataset,
 )
 
 PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
@@ -27,15 +30,20 @@ def parity_result():
 
 
 def test_objective_grid_matches_direct_jeam(parity_result):
-    """Compiled HSSM should preserve direct JEAM objectives away from one point."""
+    """Compiled HSSM should preserve direct JEAM objectives through the bounds."""
     np.testing.assert_allclose(
         parity_result.compiled_objectives,
         parity_result.direct_objectives,
         rtol=OBJECTIVE_RTOL,
         atol=OBJECTIVE_ATOL,
     )
-    assert len(parity_result.candidate_parameters) == 3
+    assert len(parity_result.candidate_parameters) == 4
     assert parity_result.parameter_order == PARAMETER_ORDER
+
+    data = simulate_dataset()
+    ndt_upper = optimization_bounds(data)[1][1]
+    assert np.min(data[:, 0]) - ndt_upper > 1e-15
+    assert parity_result.candidate_parameters[-1][1] == ndt_upper
 
 
 def test_fixed_budget_optimizer_follows_the_same_path(parity_result):
@@ -60,6 +68,15 @@ def test_fixed_budget_optimizer_follows_the_same_path(parity_result):
     assert direct.evaluations == compiled.evaluations == expected_evaluations
     assert direct.iterations == compiled.iterations == DEFAULT_MAXITER
     assert direct.objective < parity_result.direct_objectives[0]
+
+
+def test_optimization_bounds_respect_hssm_ndt_upper_bound():
+    """High-RT datasets must not expand the optimizer beyond HSSM support."""
+    data = np.array([[2.5, 0.0], [3.0, 0.5]], dtype=np.float64)
+    ndt_upper = optimization_bounds(data)[1][1]
+
+    assert ndt_upper == HSSM_BOUNDS["t"][1]
+    assert ndt_upper < np.min(data[:, 0])
 
 
 def test_benchmark_records_provenance_and_machine_readable_output(parity_result):


### PR DESCRIPTION
Depends on #1199, now merged into `dev` at `846878cd`.

## Summary

- add a reusable JSON benchmark for direct JEAM versus the compiled HSSM circular likelihood
- compare four pointwise objectives and identical seeded, fixed-budget differential-evolution fits on one 300-trial dataset
- record the exact JEAM revision and descriptive runtimes without asserting wall-clock speed
- run the benchmark in the optional JEAM CI lane

## Result

- both paths use 900 evaluations and return `[1.242234, 0.131519, 0.832853, -0.581627]`
- both fitted objectives are `554.6065039285276` in the final local run
- the four candidate objectives, including the NDT upper-bound endpoint, agree within `1.2e-13` absolute error

## Replay provenance

- replayed only this PR's three unique commits onto current `dev`; `git range-diff` marks all three patches identical to the original stack
- added two focused review commits after replay
- corrected an NDT upper bound that was one ULP below the minimum RT but still inside HSSM's `1e-15` support mask; the old endpoint differed by `33.86` objective units
- cap that dataset-dependent bound at HSSM's configured `t <= 2.0` support and cover high-RT datasets explicitly
- added the corrected endpoint to the regression grid and added workflow triggers for the two compiled-distribution modules it exercises
- final diff is exactly three files with 430 insertions

## Verification

- optional JEAM workflow slice: 18 passed
- Ruff check and format check pass for both Python files
- `git diff --check` passes
- hosted Python 3.12--3.14, lint/type, and optional JEAM lanes pass

## Deferred

- this proves likelihood-objective and optimizer parity, not Bayesian recovery
- the next stacked PR adds the predeclared marked-slow gradient-free recovery gate
