### PR TITLE
Add a JEAM Bayesian recovery gate

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - "pyproject.toml"
       - ".github/workflows/jeam_prototype.yml"
+      - "src/hssm/base.py"
       - "src/hssm/distribution_utils/blackbox.py"
       - "src/hssm/distribution_utils/dist.py"
+      - "src/hssm/hssm.py"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"

--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -9,7 +9,9 @@ on:
       - "src/hssm/distribution_utils/dist.py"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
+      - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
+      - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
       - "tests/integration/test_jeam_objective_parity.py"
@@ -44,3 +46,9 @@ jobs:
           tests/integration/test_jeam_objective_parity.py
           tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py
+
+      - name: Run the marked-slow Bayesian recovery gate
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/integration/test_jeam_bayesian_recovery.py
+          -m slow

--- a/scripts/benchmark_jeam_bayesian_recovery.py
+++ b/scripts/benchmark_jeam_bayesian_recovery.py
@@ -152,10 +152,14 @@ def run_recovery(
         model="circular_diffusion",
         p_outlier=None,
     )
+    slice_steps = [
+        pm.Slice(vars=[model.pymc_model[name]], model=model.pymc_model)
+        for name in PARAMETER_ORDER
+    ]
     started = perf_counter()
     traces = model.sample(
         sampler="pymc",
-        step=pm.Slice(model=model.pymc_model),
+        step=slice_steps,
         chains=chains,
         cores=1,
         tune=tune,
@@ -238,7 +242,7 @@ def run_recovery(
         data_seed=data_seed,
         jeam_revision=_installed_jeam_revision(),
         pytensor_floatx=pytensor.config.floatX,
-        sampler="pymc.Slice",
+        sampler="pymc.Slice[a,t,v_x,v_y]",
         chains=chains,
         tune=tune,
         draws=draws,

--- a/scripts/benchmark_jeam_bayesian_recovery.py
+++ b/scripts/benchmark_jeam_bayesian_recovery.py
@@ -1,0 +1,279 @@
+"""Run the marked-slow Bayesian recovery benchmark for circular JEAM in HSSM.
+
+Run from the HSSM repository with the prototype dependency group installed::
+
+    uv run --group jeam-prototype python -m scripts.benchmark_jeam_bayesian_recovery
+
+The result is emitted as JSON. It includes recovery, convergence, sampler-step,
+posterior-predictive, runtime, and ESS-per-second diagnostics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from time import perf_counter
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor
+import xarray as xr
+
+import hssm
+from scripts.benchmark_jeam_objective_parity import (
+    DEFAULT_DATA_SEED,
+    DEFAULT_TRIALS,
+    DEFAULT_TRUTH,
+    PARAMETER_ORDER,
+    _installed_jeam_revision,
+    simulate_dataset,
+)
+
+DEFAULT_CHAINS = 4
+DEFAULT_TUNE = 1_500
+DEFAULT_DRAWS = 1_500
+DEFAULT_PREDICTIVE_DRAWS = 100
+DEFAULT_CHAIN_SEEDS = (3101, 3102, 3103, 3104)
+DEFAULT_PREDICTIVE_SEED = 7291
+RT_QUANTILES = np.array([0.1, 0.5, 0.9])
+
+
+@dataclass(frozen=True)
+class ParameterRecovery:
+    """Diagnostics for one recovered model parameter."""
+
+    name: str
+    truth: float
+    posterior_mean: float
+    mean_error: float
+    interval_lower: float
+    interval_upper: float
+    rhat: float
+    ess_bulk: float
+    ess_tail: float
+    mcse_mean: float
+    ess_bulk_per_second: float
+
+
+@dataclass(frozen=True)
+class PredictiveRecovery:
+    """Observed-versus-predictive RT and circular summaries."""
+
+    rt_probabilities: tuple[float, ...]
+    observed_rt_quantiles: tuple[float, ...]
+    predictive_rt_quantiles: tuple[float, ...]
+    observed_mean_angle: float
+    predictive_mean_angle: float
+    mean_angle_distance: float
+    observed_resultant_length: float
+    predictive_resultant_length: float
+
+
+@dataclass(frozen=True)
+class SliceDiagnostics:
+    """Sampler-specific step statistics proving Slice, rather than NUTS, ran."""
+
+    sample_stats: tuple[str, ...]
+    mean_steps_in: float
+    mean_steps_out: float
+
+
+@dataclass(frozen=True)
+class RecoveryResult:
+    """Machine-readable HSSM Bayesian recovery benchmark."""
+
+    parameter_order: tuple[str, ...]
+    truth: tuple[float, ...]
+    trials: int
+    data_seed: int
+    jeam_revision: str
+    pytensor_floatx: str
+    sampler: str
+    chains: int
+    tune: int
+    draws: int
+    chain_seeds: tuple[int, ...]
+    sampling_seconds: float
+    predictive_seconds: float
+    parameters: tuple[ParameterRecovery, ...]
+    slice_diagnostics: SliceDiagnostics
+    predictive: PredictiveRecovery
+
+
+def _circular_summary(angles: np.ndarray) -> tuple[float, float]:
+    """Return circular mean direction and mean resultant length."""
+    resultant = np.mean(np.exp(1j * np.asarray(angles)))
+    return float(np.angle(resultant)), float(np.abs(resultant))
+
+
+def _circular_distance(first: float, second: float) -> float:
+    """Return the absolute shortest angular distance in radians."""
+    return float(abs(np.angle(np.exp(1j * (first - second)))))
+
+
+def _summary_interval_columns(summary: pd.DataFrame) -> tuple[str, str]:
+    """Find ArviZ's version-specific HDI column labels."""
+    lower = [
+        column
+        for column in summary.columns
+        if column.startswith("hdi") and column.endswith("_lb")
+    ]
+    upper = [
+        column
+        for column in summary.columns
+        if column.startswith("hdi") and column.endswith("_ub")
+    ]
+    if len(lower) != 1 or len(upper) != 1:
+        raise RuntimeError("Expected one lower and one upper HDI column from ArviZ.")
+    return lower[0], upper[0]
+
+
+def run_recovery(
+    *,
+    trials: int = DEFAULT_TRIALS,
+    data_seed: int = DEFAULT_DATA_SEED,
+    chains: int = DEFAULT_CHAINS,
+    tune: int = DEFAULT_TUNE,
+    draws: int = DEFAULT_DRAWS,
+    chain_seeds: tuple[int, ...] = DEFAULT_CHAIN_SEEDS,
+    predictive_draws: int = DEFAULT_PREDICTIVE_DRAWS,
+    predictive_seed: int = DEFAULT_PREDICTIVE_SEED,
+) -> RecoveryResult:
+    """Fit the fixed circular model and collect recovery diagnostics."""
+    if len(chain_seeds) != chains:
+        raise ValueError("Provide exactly one random seed per MCMC chain.")
+
+    data = simulate_dataset(trials=trials, seed=data_seed)
+    model = hssm.HSSM(
+        data=pd.DataFrame(data, columns=["rt", "response"]),
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+    started = perf_counter()
+    traces = model.sample(
+        sampler="pymc",
+        step=pm.Slice(model=model.pymc_model),
+        chains=chains,
+        cores=1,
+        tune=tune,
+        draws=draws,
+        random_seed=list(chain_seeds),
+        progressbar=False,
+        idata_kwargs={"log_likelihood": False},
+    )
+    sampling_seconds = perf_counter() - started
+    if not isinstance(traces, xr.DataTree):
+        raise RuntimeError("Expected PyMC sampling to return an xarray DataTree.")
+
+    summary = az.summary(
+        traces,
+        var_names=list(PARAMETER_ORDER),
+        ci_prob=0.94,
+        ci_kind="hdi",
+        round_to=8,
+    )
+    interval_lower, interval_upper = _summary_interval_columns(summary)
+    truth_by_name = dict(zip(PARAMETER_ORDER, DEFAULT_TRUTH, strict=True))
+    parameter_recovery = tuple(
+        ParameterRecovery(
+            name=name,
+            truth=float(truth_by_name[name]),
+            posterior_mean=float(summary.loc[name, "mean"]),
+            mean_error=float(summary.loc[name, "mean"] - truth_by_name[name]),
+            interval_lower=float(summary.loc[name, interval_lower]),
+            interval_upper=float(summary.loc[name, interval_upper]),
+            rhat=float(summary.loc[name, "r_hat"]),
+            ess_bulk=float(summary.loc[name, "ess_bulk"]),
+            ess_tail=float(summary.loc[name, "ess_tail"]),
+            mcse_mean=float(summary.loc[name, "mcse_mean"]),
+            ess_bulk_per_second=float(summary.loc[name, "ess_bulk"] / sampling_seconds),
+        )
+        for name in PARAMETER_ORDER
+    )
+
+    sample_stats = traces["sample_stats"]
+    sample_stat_names = tuple(sorted(str(name) for name in sample_stats.data_vars))
+    slice_diagnostics = SliceDiagnostics(
+        sample_stats=sample_stat_names,
+        mean_steps_in=float(np.asarray(sample_stats["nstep_in"]).mean()),
+        mean_steps_out=float(np.asarray(sample_stats["nstep_out"]).mean()),
+    )
+
+    started = perf_counter()
+    predictive = model.sample_posterior_predictive(
+        dt=traces,
+        inplace=False,
+        kind="response",
+        draws=predictive_draws,
+        safe_mode=True,
+        random_seed=predictive_seed,
+    )
+    predictive_seconds = perf_counter() - started
+    if predictive is None:
+        raise RuntimeError("Expected non-inplace posterior predictive output.")
+    predictive_dataset = predictive["posterior_predictive"].to_dataset()
+    values = predictive_dataset["rt,response"].values
+    observed_angle, observed_resultant = _circular_summary(data[:, 1])
+    predictive_angle, predictive_resultant = _circular_summary(values[..., 1])
+    observed_rt = np.quantile(data[:, 0], RT_QUANTILES)
+    predictive_rt = np.quantile(values[..., 0], RT_QUANTILES)
+    predictive_recovery = PredictiveRecovery(
+        rt_probabilities=tuple(float(value) for value in RT_QUANTILES),
+        observed_rt_quantiles=tuple(float(value) for value in observed_rt),
+        predictive_rt_quantiles=tuple(float(value) for value in predictive_rt),
+        observed_mean_angle=observed_angle,
+        predictive_mean_angle=predictive_angle,
+        mean_angle_distance=_circular_distance(observed_angle, predictive_angle),
+        observed_resultant_length=observed_resultant,
+        predictive_resultant_length=predictive_resultant,
+    )
+
+    return RecoveryResult(
+        parameter_order=PARAMETER_ORDER,
+        truth=tuple(float(value) for value in DEFAULT_TRUTH),
+        trials=trials,
+        data_seed=data_seed,
+        jeam_revision=_installed_jeam_revision(),
+        pytensor_floatx=pytensor.config.floatX,
+        sampler="pymc.Slice",
+        chains=chains,
+        tune=tune,
+        draws=draws,
+        chain_seeds=chain_seeds,
+        sampling_seconds=sampling_seconds,
+        predictive_seconds=predictive_seconds,
+        parameters=parameter_recovery,
+        slice_diagnostics=slice_diagnostics,
+        predictive=predictive_recovery,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
+    parser.add_argument("--tune", type=int, default=DEFAULT_TUNE)
+    parser.add_argument("--draws", type=int, default=DEFAULT_DRAWS)
+    parser.add_argument(
+        "--predictive-draws", type=int, default=DEFAULT_PREDICTIVE_DRAWS
+    )
+    parser.add_argument("--compact", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the recovery benchmark and emit JSON."""
+    args = _parse_args()
+    result = run_recovery(
+        trials=args.trials,
+        tune=args.tune,
+        draws=args.draws,
+        predictive_draws=args.predictive_draws,
+    )
+    print(json.dumps(asdict(result), indent=None if args.compact else 2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_jeam_bayesian_recovery.py
+++ b/scripts/benchmark_jeam_bayesian_recovery.py
@@ -96,6 +96,8 @@ class RecoveryResult:
     tune: int
     draws: int
     chain_seeds: tuple[int, ...]
+    predictive_draws: int
+    predictive_seed: int
     sampling_seconds: float
     predictive_seconds: float
     parameters: tuple[ParameterRecovery, ...]
@@ -247,6 +249,8 @@ def run_recovery(
         tune=tune,
         draws=draws,
         chain_seeds=chain_seeds,
+        predictive_draws=predictive_draws,
+        predictive_seed=predictive_seed,
         sampling_seconds=sampling_seconds,
         predictive_seconds=predictive_seconds,
         parameters=parameter_recovery,

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -86,9 +86,13 @@ def test_recovery_report_records_provenance_and_efficiency(recovery_result):
     assert recovery_result.jeam_revision == PINNED_JEAM_REVISION
     assert recovery_result.pytensor_floatx == "float64"
     assert recovery_result.trials == 300
+    assert recovery_result.predictive_draws == 100
+    assert recovery_result.predictive_seed == 7291
     assert recovery_result.sampling_seconds > 0.0
     assert recovery_result.predictive_seconds > 0.0
 
     payload = json.loads(json.dumps(asdict(recovery_result)))
     assert payload["sampler"] == "pymc.Slice[a,t,v_x,v_y]"
     assert payload["jeam_revision"] == PINNED_JEAM_REVISION
+    assert payload["predictive_draws"] == 100
+    assert payload["predictive_seed"] == 7291

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -1,0 +1,94 @@
+"""Marked-slow Bayesian recovery gate for the circular JEAM handshake."""
+
+import json
+from dataclasses import asdict
+
+import numpy as np
+import pytensor
+import pytest
+
+import hssm
+
+pytest.importorskip("jeam")
+pytestmark = pytest.mark.slow
+
+from scripts.benchmark_jeam_bayesian_recovery import run_recovery
+
+PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+MEAN_ERROR_LIMITS = {"a": 0.10, "t": 0.04, "v_x": 0.15, "v_y": 0.15}
+MAX_RHAT = 1.01
+MIN_ESS = 1_000.0
+MAX_MCSE_MEAN = 0.005
+MAX_RT_QUANTILE_ERROR = 0.12
+MAX_MEAN_ANGLE_ERROR = 0.10
+MAX_RESULTANT_LENGTH_ERROR = 0.08
+
+
+@pytest.fixture(scope="module")
+def recovery_result():
+    """Run one default-float64 recovery benchmark and restore global precision."""
+    original_floatx = pytensor.config.floatX
+    hssm.set_floatX("float64")
+    try:
+        result = run_recovery()
+        print(json.dumps(asdict(result), sort_keys=True))
+        return result
+    finally:
+        hssm.set_floatX(original_floatx)
+
+
+def test_truth_is_recovered_with_converged_slice_chains(recovery_result):
+    """Every truth should be covered with small bias and reliable diagnostics."""
+    for parameter in recovery_result.parameters:
+        assert abs(parameter.mean_error) <= MEAN_ERROR_LIMITS[parameter.name]
+        assert parameter.interval_lower <= parameter.truth <= parameter.interval_upper
+        assert parameter.rhat <= MAX_RHAT
+        assert parameter.ess_bulk >= MIN_ESS
+        assert parameter.ess_tail >= MIN_ESS
+        assert parameter.mcse_mean <= MAX_MCSE_MEAN
+        assert np.isfinite(parameter.ess_bulk_per_second)
+        assert parameter.ess_bulk_per_second > 0.0
+
+
+def test_recovery_uses_the_declared_gradient_free_sampler(recovery_result):
+    """The integration must use PyMC Slice and expose no NUTS statistics."""
+    diagnostics = recovery_result.slice_diagnostics
+
+    assert recovery_result.sampler == "pymc.Slice"
+    assert diagnostics.sample_stats == ("nstep_in", "nstep_out")
+    assert diagnostics.mean_steps_in > 0.0
+    assert diagnostics.mean_steps_out > 0.0
+    assert recovery_result.chains == 4
+    assert recovery_result.tune == recovery_result.draws == 1_500
+
+
+def test_posterior_predictive_recovers_rt_and_circular_summaries(recovery_result):
+    """Predictive RT quantiles and circular moments should reproduce the data."""
+    predictive = recovery_result.predictive
+    np.testing.assert_allclose(
+        predictive.predictive_rt_quantiles,
+        predictive.observed_rt_quantiles,
+        rtol=0.0,
+        atol=MAX_RT_QUANTILE_ERROR,
+    )
+    assert predictive.mean_angle_distance <= MAX_MEAN_ANGLE_ERROR
+    assert (
+        abs(
+            predictive.predictive_resultant_length
+            - predictive.observed_resultant_length
+        )
+        <= MAX_RESULTANT_LENGTH_ERROR
+    )
+
+
+def test_recovery_report_records_provenance_and_efficiency(recovery_result):
+    """The scientific gate should remain reproducible and machine-readable."""
+    assert recovery_result.jeam_revision == PINNED_JEAM_REVISION
+    assert recovery_result.pytensor_floatx == "float64"
+    assert recovery_result.trials == 300
+    assert recovery_result.sampling_seconds > 0.0
+    assert recovery_result.predictive_seconds > 0.0
+
+    payload = json.loads(json.dumps(asdict(recovery_result)))
+    assert payload["sampler"] == "pymc.Slice"
+    assert payload["jeam_revision"] == PINNED_JEAM_REVISION

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -54,7 +54,7 @@ def test_recovery_uses_the_declared_gradient_free_sampler(recovery_result):
     """The integration must use PyMC Slice and expose no NUTS statistics."""
     diagnostics = recovery_result.slice_diagnostics
 
-    assert recovery_result.sampler == "pymc.Slice"
+    assert recovery_result.sampler == "pymc.Slice[a,t,v_x,v_y]"
     assert diagnostics.sample_stats == ("nstep_in", "nstep_out")
     assert diagnostics.mean_steps_in > 0.0
     assert diagnostics.mean_steps_out > 0.0
@@ -90,5 +90,5 @@ def test_recovery_report_records_provenance_and_efficiency(recovery_result):
     assert recovery_result.predictive_seconds > 0.0
 
     payload = json.loads(json.dumps(asdict(recovery_result)))
-    assert payload["sampler"] == "pymc.Slice"
+    assert payload["sampler"] == "pymc.Slice[a,t,v_x,v_y]"
     assert payload["jeam_revision"] == PINNED_JEAM_REVISION


### PR DESCRIPTION
# Context

HSSM #1200 is merged into `dev` at `a6aef022`. This branch replays only #1201's four unique recovery-gate commits onto that accepted base; it does not carry the stale descendant stack.

Three historical patches are range-diff identical. The workflow patch required a union resolution because #1200 added adjacent dependency filters; it preserves the same eight additions while retaining #1200's filters.

## Scope

- simulate one deterministic 300-trial fixed-CDM dataset at truth `[a=1.2, t=0.15, v_x=0.8, v_y=-0.5]`
- fit the ordinary `hssm.HSSM` model with four explicitly ordered univariate PyMC Slice steps: `[a, t, v_x, v_y]`
- use four chains with 1,500 tuning and 1,500 retained draws per chain
- emit a machine-readable recovery report containing posterior, convergence, Slice-step, runtime, ESS/second, precision, JEAM revision, and posterior-predictive provenance
- gate posterior-predictive RT quantiles and circular summaries in addition to parameter recovery
- run the marked-slow recovery gate in the optional JEAM workflow

## Predeclared gates

- absolute posterior-mean error: `a <= 0.10`, `t <= 0.04`, each drift `<= 0.15`
- every truth inside its 94% HDI
- R-hat `<= 1.01`
- bulk and tail ESS `>= 1,000`
- posterior-mean MCSE `<= 0.005`
- RT-quantile error `<= 0.12 s`
- circular-mean error `<= 0.10 rad`
- resultant-length error `<= 0.08`
- sample statistics exactly `nstep_in` and `nstep_out`, excluding a silent NUTS path

## Fixed-seed result

The historical calibrated run produced posterior means `[1.2459, 0.1294, 0.8313, -0.5846]`. Every truth was inside its 94% HDI; maximum R-hat was `1.0024`, minimum bulk/tail ESS were `1729.7`/`2202.5`, and maximum mean MCSE was `0.0010`.

The maximum RT-quantile discrepancy was `0.0568 s`, circular-mean discrepancy `0.0026 rad`, and resultant-length discrepancy `0.0041`. Efficiency remains descriptive rather than a wall-clock assertion.

## Review repairs on the replay

- record and assert the posterior-predictive draw count and seed used by the scientific gate
- trigger the optional lane when either the concrete `HSSM` constructor or base sampling/predictive implementation changes

## Commands run

- exact worktree import proof against JEAM `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`
- marked-slow recovery gate: 4 passed in 48.54 seconds
- remaining optional JEAM integration selection: 18 passed in 5.65 seconds
- affected-file Ruff check and repository-wide Ruff format check
- affected-file Pyrefly check: 0 errors
- `mypy src/hssm`: success on 85 source files
- workflow YAML parse and `git diff --check`

The repository-wide local Ruff/Pyrefly runs also expose unrelated findings in unchanged current-`dev` notebook/prior files; this PR does not modify those files.

## Claim boundary

This is a deterministic one-dataset fixed-CDM recovery smoke. It is not repeated-simulation calibration, general JEAM-family support, a sampler comparison, or a claim that Slice should become HSSM's default. It does not retain raw traces or add prior-predictive evidence; later artifact/repeated-recovery slices own those claims.
