### PR TITLE
Execute the repeated JEAM recovery protocol

### DIFF
--- a/scripts/benchmark_jeam_repeated_recovery.py
+++ b/scripts/benchmark_jeam_repeated_recovery.py
@@ -1,20 +1,32 @@
-"""Define the JEAM/HSSM four-scenario deterministic recovery-smoke protocol.
+"""Run the JEAM/HSSM four-scenario deterministic recovery smoke.
+
+Run its module with the ``jeam-prototype`` dependency group installed; ``--output``
+accepts the schema-v2 result path.
 
 The frozen scenarios span opposing drifts and different threshold/nondecision-time
 scales. Fixed-budget JEAM estimates remain distinct from HSSM posterior means; the
 compiled optimizer checks objective preservation only. This is a non-calibration
-protocol definition, not durable evidence or an execution entry point.
+protocol runner, not durable evidence. Its schema-v2 evidence is generated separately.
+The command emits JSON and exits nonzero when a predeclared gate fails.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import math
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass, is_dataclass
+from datetime import UTC, datetime
 from numbers import Real
+from pathlib import Path
+from time import perf_counter
+from typing import Literal, cast
 
 import numpy as np
+import pytensor
 
+import hssm
 from scripts import benchmark_jeam_bayesian_recovery as bayesian
 from scripts import benchmark_jeam_objective_parity as objective
 
@@ -257,6 +269,151 @@ def _mcse_sd_ratio(mcse_mean: float, posterior_sd: float) -> float:
     return mcse_mean / posterior_sd if posterior_sd > 0.0 else math.inf
 
 
+def _scenario_parameters(
+    recovery: bayesian.RecoveryResult,
+    optimizer_estimate: Sequence[float],
+) -> tuple[ScenarioParameterResult, ...]:
+    """Combine the fixed-budget estimate and posterior without conflating them."""
+    return tuple(
+        ScenarioParameterResult(
+            name=parameter.name,
+            truth=parameter.truth,
+            jeam_fixed_budget_estimate=float(estimate),
+            posterior_mean=parameter.posterior_mean,
+            posterior_sd=parameter.posterior_sd,
+            interval_lower=parameter.interval_lower,
+            interval_upper=parameter.interval_upper,
+            hdi_contains_truth=parameter.interval_lower
+            <= parameter.truth
+            <= parameter.interval_upper,
+            rhat=parameter.rhat,
+            ess_bulk=parameter.ess_bulk,
+            ess_tail=parameter.ess_tail,
+            mcse_mean=parameter.mcse_mean,
+            mcse_sd_ratio=_mcse_sd_ratio(parameter.mcse_mean, parameter.posterior_sd),
+            ess_bulk_per_second=parameter.ess_bulk_per_second,
+        )
+        for parameter, estimate in zip(
+            recovery.parameters, optimizer_estimate, strict=True
+        )
+    )
+
+
+def run_scenario(
+    scenario: Scenario,
+    *,
+    trials: int,
+    tune: int,
+    draws: int,
+    prior_draws: int,
+    predictive_draws: int,
+    optimizer_maxiter: int,
+    optimizer_popsize: int,
+) -> ScenarioResult:
+    """Run fixed-budget objective parity and HSSM posterior recovery."""
+    truth = np.asarray(scenario.truth, dtype=np.float64)
+    data = objective.simulate_dataset(
+        truth=truth, trials=trials, seed=scenario.data_seed
+    )
+    direct_objective = objective.make_direct_objective(data)
+    compiled_objective = objective.make_compiled_hssm_objective(data)
+    bounds = objective.optimization_bounds(data)
+
+    direct_started = perf_counter()
+    direct_optimizer = objective._fit(
+        direct_objective,
+        bounds,
+        seed=scenario.optimizer_seed,
+        maxiter=optimizer_maxiter,
+        popsize=optimizer_popsize,
+    )
+    direct_seconds = perf_counter() - direct_started
+    compiled_started = perf_counter()
+    compiled_optimizer = objective._fit(
+        compiled_objective,
+        bounds,
+        seed=scenario.optimizer_seed,
+        maxiter=optimizer_maxiter,
+        popsize=optimizer_popsize,
+    )
+    compiled_seconds = perf_counter() - compiled_started
+
+    candidates = (
+        tuple(float(value) for value in truth),
+        direct_optimizer.parameters,
+        compiled_optimizer.parameters,
+    )
+    candidate_arrays = tuple(np.asarray(candidate) for candidate in candidates)
+    direct_objectives = tuple(
+        direct_objective(candidate) for candidate in candidate_arrays
+    )
+    compiled_objectives = tuple(
+        compiled_objective(candidate) for candidate in candidate_arrays
+    )
+
+    recovery = bayesian.run_recovery(
+        truth=scenario.truth,
+        trials=trials,
+        data_seed=scenario.data_seed,
+        chains=len(scenario.chain_seeds),
+        tune=tune,
+        draws=draws,
+        chain_seeds=scenario.chain_seeds,
+        prior_draws=prior_draws,
+        prior_seed=scenario.prior_seed,
+        predictive_draws=predictive_draws,
+        predictive_seed=scenario.predictive_seed,
+    )
+    if recovery.sampler != "pymc.Slice[a,t,v_x,v_y]":
+        raise RuntimeError(f"Unexpected sampler: {recovery.sampler}")
+    if recovery.hdi_probability != HDI_PROBABILITY:
+        raise RuntimeError(f"Unexpected HDI probability: {recovery.hdi_probability}")
+
+    objective_error = float(
+        np.max(np.abs(np.subtract(direct_objectives, compiled_objectives)))
+    )
+    optimizer_parameter_error = float(
+        np.max(
+            np.abs(
+                np.subtract(direct_optimizer.parameters, compiled_optimizer.parameters)
+            )
+        )
+    )
+    return ScenarioResult(
+        name=scenario.name,
+        truth=scenario.truth,
+        data_seed=scenario.data_seed,
+        optimizer_seed=scenario.optimizer_seed,
+        chain_seeds=scenario.chain_seeds,
+        prior_seed=scenario.prior_seed,
+        predictive_seed=scenario.predictive_seed,
+        direct_objectives=direct_objectives,
+        compiled_objectives=compiled_objectives,
+        objective_candidates=candidates,
+        maximum_objective_absolute_error=objective_error,
+        direct_jeam_fixed_budget_optimizer=direct_optimizer,
+        compiled_hssm_fixed_budget_optimizer=compiled_optimizer,
+        maximum_optimizer_parameter_absolute_error=optimizer_parameter_error,
+        optimizer_objective_absolute_error=abs(
+            direct_optimizer.objective - compiled_optimizer.objective
+        ),
+        minimum_observed_rt=recovery.minimum_observed_rt,
+        initial_point=recovery.initial_point,
+        initial_logp=recovery.initial_logp,
+        parameters=_scenario_parameters(recovery, direct_optimizer.parameters),
+        slice_diagnostics=recovery.slice_diagnostics,
+        prior_predictive=recovery.prior_predictive,
+        predictive=recovery.predictive,
+        runtime=ScenarioRuntime(
+            direct_jeam_fixed_budget_optimizer_seconds=direct_seconds,
+            compiled_hssm_fixed_budget_optimizer_seconds=compiled_seconds,
+            hssm_prior_predictive_seconds=recovery.prior_predictive_seconds,
+            hssm_sampling_seconds=recovery.sampling_seconds,
+            hssm_predictive_seconds=recovery.predictive_seconds,
+        ),
+    )
+
+
 def aggregate_results(
     scenarios: Sequence[ScenarioResult],
 ) -> tuple[AggregateParameterResult, ...]:
@@ -463,3 +620,101 @@ def evaluate_gate(
         for path in _nonfinite_metric_paths(finite_metrics, "result")
     )
     return GateResult(passed=not failures, failures=tuple(failures))
+
+
+def run_benchmark() -> MultiScenarioRecoveryResult:
+    """Run the frozen four-scenario protocol under float64."""
+    started = perf_counter()
+    original_floatx = cast("Literal['float32', 'float64']", pytensor.config.floatX)
+    hssm.set_floatX("float64")
+    try:
+        results = tuple(
+            run_scenario(
+                scenario,
+                trials=DEFAULT_TRIALS,
+                tune=DEFAULT_REPEATED_TUNE,
+                draws=DEFAULT_REPEATED_DRAWS,
+                prior_draws=DEFAULT_REPEATED_PRIOR_DRAWS,
+                predictive_draws=DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+                optimizer_maxiter=DEFAULT_MAXITER,
+                optimizer_popsize=DEFAULT_POPSIZE,
+            )
+            for scenario in DEFAULT_SCENARIOS
+        )
+    finally:
+        hssm.set_floatX(original_floatx)
+    aggregate = aggregate_results(results)
+    total_runtime_seconds = perf_counter() - started
+    gate = evaluate_gate(
+        results,
+        aggregate,
+        DEFAULT_THRESHOLDS,
+        total_runtime_seconds=total_runtime_seconds,
+    )
+    return MultiScenarioRecoveryResult(
+        schema_version=2,
+        benchmark=(
+            "JEAM fixed circular diffusion four-scenario deterministic recovery smoke"
+        ),
+        interpretation=(
+            "This protocol smoke is not a calibration study or durable evidence; "
+            "committed schema-v2 evidence is generated separately."
+        ),
+        generated_at_utc=datetime.now(UTC).isoformat(),
+        reproduction_command=(
+            "uv run --group jeam-prototype python "
+            "-m scripts.benchmark_jeam_repeated_recovery "
+            "--output benchmarks/results/jeam_repeated_recovery_v2.json"
+        ),
+        parameter_order=objective.PARAMETER_ORDER,
+        jeam_revision=objective._installed_jeam_revision(),
+        pytensor_floatx="float64",
+        sampler="pymc.Slice[a,t,v_x,v_y]",
+        trials_per_scenario=DEFAULT_TRIALS,
+        chains=len(DEFAULT_SCENARIOS[0].chain_seeds),
+        tune=DEFAULT_REPEATED_TUNE,
+        draws=DEFAULT_REPEATED_DRAWS,
+        hdi_probability=HDI_PROBABILITY,
+        prior_draws=DEFAULT_REPEATED_PRIOR_DRAWS,
+        predictive_draws=DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+        optimizer_maxiter=DEFAULT_MAXITER,
+        optimizer_popsize=DEFAULT_POPSIZE,
+        thresholds=DEFAULT_THRESHOLDS,
+        scenarios=results,
+        aggregate=aggregate,
+        total_runtime_seconds=total_runtime_seconds,
+        gate=gate,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--compact", action="store_true")
+    return parser.parse_args()
+
+
+def _json_payload(result: MultiScenarioRecoveryResult, *, compact: bool) -> str:
+    """Serialize a finite standards-compliant result payload."""
+    return json.dumps(asdict(result), indent=None if compact else 2, allow_nan=False)
+
+
+def main() -> None:
+    """Run the protocol, write optional JSON, and enforce its gate."""
+    args = _parse_args()
+    result = run_benchmark()
+    payload = _json_payload(result, compact=args.compact)
+    if args.output is None:
+        print(payload)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(f"{payload}\n", encoding="utf-8")
+        print(args.output)
+    if not result.gate.passed:
+        raise SystemExit(
+            "Multi-scenario recovery gate failed: " + "; ".join(result.gate.failures)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -1,12 +1,15 @@
 """Fast contracts for the multi-scenario JEAM recovery protocol."""
 
+import json
 from dataclasses import asdict, astuple, replace
+from inspect import signature
 
 import numpy as np
 import pytest
 
 pytest.importorskip("jeam")
 
+import scripts.benchmark_jeam_repeated_recovery as repeated
 from scripts.benchmark_jeam_bayesian_recovery import (
     PredictiveRecovery,
     PriorPredictiveCheck,
@@ -330,3 +333,105 @@ def test_gate_rejects_invalid_slice_mcse_and_nonfinite_metrics():
     )
     # fmt: on
     assert all(expected in failure_text for expected in expected_failures)
+
+
+@pytest.fixture
+def benchmark_execution(monkeypatch):
+    """Run canonical orchestration with every expensive scenario stubbed."""
+    template = _scenario("serialized")
+    calls = []
+
+    def fake_run_scenario(scenario, **kwargs):
+        calls.append((scenario, kwargs))
+        return replace(template, name=scenario.name)
+
+    monkeypatch.setattr(repeated, "run_scenario", fake_run_scenario)
+    monkeypatch.setattr(
+        repeated.objective, "_installed_jeam_revision", lambda: "revision"
+    )
+    return repeated.run_benchmark(), calls
+
+
+def test_schema_v2_serialization_is_canonical_and_finite(
+    benchmark_execution, monkeypatch
+):
+    """The schema must state and serialize the exact canonical execution."""
+    result, calls = benchmark_execution
+    assert not signature(repeated.run_benchmark).parameters
+    assert tuple(scenario.name for scenario, _ in calls) == tuple(
+        scenario.name for scenario in DEFAULT_SCENARIOS
+    )
+    expected_kwargs = {
+        "trials": DEFAULT_TRIALS,
+        "tune": DEFAULT_REPEATED_TUNE,
+        "draws": DEFAULT_REPEATED_DRAWS,
+        "prior_draws": DEFAULT_REPEATED_PRIOR_DRAWS,
+        "predictive_draws": DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+        "optimizer_maxiter": DEFAULT_MAXITER,
+        "optimizer_popsize": DEFAULT_POPSIZE,
+    }
+    assert all(kwargs == expected_kwargs for _, kwargs in calls)
+
+    monkeypatch.setattr("sys.argv", ["benchmark"])
+    assert vars(repeated._parse_args()) == {"output": None, "compact": False}
+    monkeypatch.setattr("sys.argv", ["benchmark", "--scenario", "baseline"])
+    with pytest.raises(SystemExit):
+        repeated._parse_args()
+
+    payload = json.loads(repeated._json_payload(result, compact=True))
+    assert [
+        payload[name]
+        for name in (
+            "schema_version",
+            "trials_per_scenario",
+            "chains",
+            "tune",
+            "draws",
+            "hdi_probability",
+            "prior_draws",
+            "predictive_draws",
+            "optimizer_maxiter",
+            "optimizer_popsize",
+        )
+    ] == [2, 300, 4, 1_000, 1_000, 0.94, 100, 40, 14, 15]
+    assert "four-scenario deterministic recovery smoke" in payload["benchmark"]
+    assert "not a calibration study" in payload["interpretation"]
+    assert payload["reproduction_command"].endswith(
+        "benchmarks/results/jeam_repeated_recovery_v2.json"
+    )
+    assert tuple(item["name"] for item in payload["scenarios"]) == tuple(
+        scenario.name for scenario in DEFAULT_SCENARIOS
+    )
+    serialized = payload["scenarios"][0]
+    assert (serialized["prior_seed"], serialized["predictive_seed"]) == (501, 401)
+    assert serialized["initial_point"] == [1.0, 0.1, 0.0, 0.0]
+    assert {"prior_predictive", "predictive", "slice_diagnostics"} <= serialized.keys()
+    assert "mle" not in json.dumps(payload).lower()
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        repeated._json_payload(
+            replace(result, total_runtime_seconds=np.nan), compact=True
+        )
+    assert "posterior_sd" in asdict(result.scenarios[0].parameters[0])
+
+
+def test_cli_writes_compact_output_and_enforces_the_gate(
+    benchmark_execution, monkeypatch, tmp_path, capsys
+):
+    """The CLI must write strict JSON before reporting a failed gate."""
+    result, _ = benchmark_execution
+    output = tmp_path / "nested" / "recovery.json"
+    monkeypatch.setattr(repeated, "run_benchmark", lambda: result)
+    monkeypatch.setattr("sys.argv", ["benchmark", "--output", str(output), "--compact"])
+
+    repeated.main()
+
+    text = output.read_text(encoding="utf-8")
+    assert capsys.readouterr().out.strip() == str(output)
+    assert text.endswith("\n") and text.count("\n") == 1
+    assert json.loads(text)["gate"] == {"passed": True, "failures": []}
+
+    failed = replace(result, gate=GateResult(False, ("forced failure",)))
+    monkeypatch.setattr(repeated, "run_benchmark", lambda: failed)
+    with pytest.raises(SystemExit, match="forced failure"):
+        repeated.main()

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -435,3 +435,8 @@ def test_cli_writes_compact_output_and_enforces_the_gate(
     monkeypatch.setattr(repeated, "run_benchmark", lambda: failed)
     with pytest.raises(SystemExit, match="forced failure"):
         repeated.main()
+
+    assert json.loads(output.read_text(encoding="utf-8"))["gate"] == {
+        "passed": False,
+        "failures": ["forced failure"],
+    }


### PR DESCRIPTION
#1240 is merged into `dev`.

## Purpose

- execute the already frozen four-scenario JEAM recovery protocol
- compose the direct JEAM objective, compiled HSSM objective, supported initialization, prior preflight, Slice recovery, and posterior predictive checks
- serialize a strict schema-v2 result without changing any scenario, seed, budget, probability grid, or acceptance threshold defined in #1240

## Scope

- add the scenario executor and zero-argument canonical benchmark runner
- force float64 for the run and restore the caller's PyTensor/JAX precision state, including after failures
- add strict finite JSON serialization and a compact CLI with only `--output` and `--compact`
- write failed finite gates before exiting nonzero
- test exact four-scenario orchestration, frozen execution arguments, schema-v2 serialization, output replacement on a failed gate, and the absence of a scenario-selection escape hatch

The diff is limited to the runner and its integration test (`+367/-2`). It does not change HSSM package code, dependencies, lockfiles, workflows, protocol thresholds, or committed benchmark artifacts. The optional workflow coverage landed through #1240.

## Canonical execution

The single canonical run was performed only after #1240 published the frozen protocol. HSSM was imported from this executor worktree, and JEAM resolved to exact revision `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`.

- gate: passed with no failures
- scenarios: 4; trials per scenario: 300
- sampling: 4 Slice chains, 1,000 tune and 1,000 posterior draws per chain
- 94% HDI inclusion: 16/16 parameter-scenario intervals
- maximum R-hat: 1.0076487
- minimum bulk/tail ESS: 786.1347 / 1279.9919
- maximum MCSE/posterior-SD ratio: 0.0356850
- maximum direct-versus-compiled objective error: 2.274e-13
- maximum optimizer-parameter error: 0.0
- maximum optimizer-objective error: 2.274e-13
- prior-to-observed RT quantile ratios: 2.3102 to 6.8147
- maximum posterior-predictive RT-quantile error: 0.08219
- maximum circular mean-angle distance: 0.00980
- maximum resultant-length error: 0.01449
- total runtime: 111.97 seconds

The transient JSON payload was written outside the repository and had SHA-256 `b457208afbff765a0e707e8c61800cd1e3039bd8e2f4cfe38d19aaa49d280be8`. It is not presented as a durable scientific artifact.

## Interpretation

This is a deterministic four-scenario recovery smoke, not a repeated-simulation calibration study. The differential-evolution outputs are deliberately described as fixed-budget optimizer estimates, not converged MLEs. A later evidence PR owns retained datasets and traces, environment and source hashes, and an independently bound verifier; the obsolete schema-v1 artifact is not reused or overwritten here.

## Verification

- canonical schema-v2 execution: passed
- focused repeated-protocol tests: 8 passed
- complete optional-JEAM fast lane: 26 passed before the final test-only assertion
- independent executor review: 17 passed, 5 slow deselected; no scientific or execution blocker
- all three reviewed commits are patch-identical after replay onto `dev` (`range-diff` reports `=`)
- Ruff check and format check
- focused mypy
- CLI `--help`
- `git diff --check`
