### PR TITLE
Checkpoint durable JEAM recovery evidence

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -13,7 +13,9 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
+      - "scripts/benchmark_jeam_recovery_evidence.py"
       - "scripts/benchmark_jeam_repeated_recovery.py"
+      - "tests/test_jeam_recovery_evidence_io.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
@@ -60,3 +62,8 @@ jobs:
         run: >-
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam_repeated_recovery.py
+
+      - name: Verify durable recovery checkpoints
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/test_jeam_recovery_evidence_io.py

--- a/scripts/benchmark_jeam_recovery_evidence.py
+++ b/scripts/benchmark_jeam_recovery_evidence.py
@@ -1,0 +1,226 @@
+"""Atomic on-disk checkpoints for one JEAM recovery scenario."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import xarray as xr
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+_PRIOR_GROUPS = ("prior", "prior_predictive", "observed_data")
+_POSTERIOR_GROUPS = ("posterior", "sample_stats")
+_RAW_GROUPS = (*_PRIOR_GROUPS, *_POSTERIOR_GROUPS, "posterior_predictive")
+_COMPRESSION = {"zlib": True, "complevel": 4, "shuffle": True}
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the hexadecimal SHA256 digest of one file."""
+    with path.open("rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def _canonical_json_bytes(value: Mapping[str, object]) -> bytes:
+    """Encode finite JSON deterministically with a terminating newline."""
+    payload = json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return f"{payload}\n".encode()
+
+
+def _atomic_write(
+    target: Path,
+    write: Callable[[Path], object],
+    *,
+    replace: bool = False,
+) -> None:
+    """Write through a same-directory temporary and atomically install it."""
+    if target.exists() and not replace:
+        raise FileExistsError(target)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=target.parent, prefix=f".{target.name}.", suffix=".tmp"
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        write(temporary)
+        with temporary.open("rb") as staged:
+            os.fsync(staged.fileno())
+        install = os.replace if replace else os.link
+        install(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_bytes(target: Path, payload: bytes) -> None:
+    """Atomically create one byte-exact file without overwriting."""
+
+    def write(temporary: Path) -> None:
+        temporary.write_bytes(payload)
+        if temporary.read_bytes() != payload:
+            raise RuntimeError(f"{target.name} failed its byte round trip.")
+
+    _atomic_write(target, write)
+
+
+def _group_dataset(tree: xr.DataTree, group: str) -> xr.Dataset:
+    """Load an owned copy of one required, non-inherited DataTree group."""
+    try:
+        node = tree[group]
+    except KeyError as error:
+        raise ValueError(f"DataTree is missing required group {group!r}.") from error
+    if not isinstance(node, xr.DataTree):
+        raise ValueError(f"DataTree path {group!r} is not a group.")
+    return node.to_dataset(inherit=False).load().copy(deep=True)
+
+
+def _assert_same_group(
+    expected: xr.DataTree, candidate: xr.DataTree, group: str
+) -> None:
+    """Reject duplicate groups differing beyond the volatile creation timestamp."""
+    datasets = (_group_dataset(expected, group), _group_dataset(candidate, group))
+    for dataset in datasets:
+        dataset.attrs.pop("created_at", None)
+    try:
+        xr.testing.assert_identical(*datasets)
+    except AssertionError as error:
+        raise ValueError(f"Duplicate {group!r} group is not identical.") from error
+
+
+def _compression_encoding(tree: xr.DataTree) -> dict[str, dict[str, dict[str, object]]]:
+    """Return h5netcdf compression settings for all non-scalar data variables."""
+    encoding: dict[str, dict[str, dict[str, object]]] = {}
+    for node in tree.subtree:
+        if any(not isinstance(name, str) for name in node.data_vars):
+            raise TypeError("Evidence variable names must be strings.")
+        variables: dict[str, dict[str, object]] = {
+            str(name): dict(_COMPRESSION)
+            for name, variable in node.data_vars.items()
+            if variable.ndim
+        }
+        if node.path != "/" and variables:
+            encoding[node.path] = variables
+    return encoding
+
+
+def _arrays_identical(first: np.ndarray, second: np.ndarray) -> bool:
+    """Compare concrete dtype, shape, values, and NaN positions."""
+    return (
+        first.dtype == second.dtype
+        and first.shape == second.shape
+        and bool(
+            np.array_equal(first, second, equal_nan=first.dtype.kind in {"c", "f"})
+        )
+    )
+
+
+class ScenarioEvidenceWriter:
+    """Build one scenario directory through durable ordered checkpoints."""
+
+    def __init__(self, directory: str | Path) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir()
+        self.dataset_path = self.directory / "dataset.npy"
+        self.raw_path = self.directory / "raw.nc"
+        self.measurements_path = self.directory / "measurements.json"
+
+    def record_dataset(self, data: np.ndarray) -> Path:
+        """Record data, accepting only an identical repeated attestation."""
+        array = np.array(data, copy=True, subok=False)
+        if array.dtype.hasobject:
+            raise TypeError("The evidence dataset cannot use an object dtype.")
+        if self.dataset_path.exists():
+            if _arrays_identical(np.load(self.dataset_path, allow_pickle=False), array):
+                return self.dataset_path
+            raise FileExistsError(
+                f"{self.dataset_path} already records different data."
+            )
+
+        def write(temporary: Path) -> None:
+            with temporary.open("wb") as target:
+                np.save(target, array, allow_pickle=False)
+            if not _arrays_identical(np.load(temporary, allow_pickle=False), array):
+                raise RuntimeError("The dataset checkpoint failed its round trip.")
+
+        _atomic_write(self.dataset_path, write)
+        return self.dataset_path
+
+    def record_prior(self, tree: xr.DataTree) -> Path:
+        """Create the first raw checkpoint from prior and observed groups."""
+        return self._checkpoint(tree, _PRIOR_GROUPS)
+
+    def record_posterior(self, tree: xr.DataTree) -> Path:
+        """Extend the raw checkpoint with posterior and sampler groups."""
+        return self._checkpoint(tree, _POSTERIOR_GROUPS, ("observed_data",))
+
+    def record_predictive(self, tree: xr.DataTree) -> Path:
+        """Complete the raw checkpoint with posterior-predictive draws."""
+        return self._checkpoint(tree, _RAW_GROUPS[-1:], ("observed_data", "posterior"))
+
+    def write_measurements(self, measurements: Mapping[str, object]) -> Path:
+        """Write the final strict canonical measurements document."""
+        self._require_dataset()
+        self._read_raw(_RAW_GROUPS)
+        _atomic_bytes(self.measurements_path, _canonical_json_bytes(measurements))
+        return self.measurements_path
+
+    def _require_dataset(self) -> None:
+        if not self.dataset_path.is_file():
+            raise RuntimeError("record_dataset() must complete first.")
+
+    def _read_raw(self, expected_groups: Sequence[str]) -> xr.DataTree:
+        if not self.raw_path.is_file():
+            raise RuntimeError("record_prior() must complete first.")
+        loaded = xr.load_datatree(self.raw_path, engine="h5netcdf")
+        actual = tuple(loaded.children)
+        if actual != tuple(expected_groups):
+            raise RuntimeError(
+                f"Unexpected raw checkpoint groups: expected {tuple(expected_groups)}, "
+                f"found {actual}."
+            )
+        return loaded
+
+    def _checkpoint(
+        self,
+        source: xr.DataTree,
+        additions: Sequence[str],
+        duplicates: Sequence[str] = (),
+    ) -> Path:
+        start = _RAW_GROUPS.index(additions[0])
+        existing = _RAW_GROUPS[:start]
+        self._require_dataset()
+        if not existing and self.raw_path.exists():
+            raise FileExistsError(self.raw_path)
+        current = self._read_raw(existing) if existing else None
+        if current is not None:
+            for group in duplicates:
+                _assert_same_group(current, source, group)
+        base = source if current is None else current
+        datasets = {group: _group_dataset(base, group) for group in existing}
+        datasets.update({group: _group_dataset(source, group) for group in additions})
+        self._write_raw(xr.DataTree.from_dict(datasets), replace=bool(existing))
+        return self.raw_path
+
+    def _write_raw(self, tree: xr.DataTree, *, replace: bool) -> None:
+        def write(temporary: Path) -> None:
+            tree.to_netcdf(
+                temporary,
+                engine="h5netcdf",
+                encoding=_compression_encoding(tree),
+            )
+            xr.testing.assert_identical(
+                tree, xr.load_datatree(temporary, engine="h5netcdf")
+            )
+
+        _atomic_write(self.raw_path, write, replace=replace)

--- a/scripts/benchmark_jeam_recovery_evidence.py
+++ b/scripts/benchmark_jeam_recovery_evidence.py
@@ -1,4 +1,4 @@
-"""Atomic on-disk checkpoints for one JEAM recovery scenario."""
+"""POSIX-durable on-disk checkpoints for one JEAM recovery scenario."""
 
 from __future__ import annotations
 
@@ -59,8 +59,28 @@ def _atomic_write(
             os.fsync(staged.fileno())
         install = os.replace if replace else os.link
         install(temporary, target)
+        _fsync_directory(target.parent)
     finally:
-        temporary.unlink(missing_ok=True)
+        if temporary.exists():
+            temporary.unlink()
+            _fsync_directory(target.parent)
+
+
+def _require_posix_durability() -> None:
+    if os.name != "posix":
+        raise RuntimeError(
+            "Durable recovery evidence requires POSIX directory fsync support."
+        )
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Flush an installed directory entry so the checkpoint survives a crash."""
+    _require_posix_durability()
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _atomic_bytes(target: Path, payload: bytes) -> None:
@@ -129,8 +149,10 @@ class ScenarioEvidenceWriter:
     """Build one scenario directory through durable ordered checkpoints."""
 
     def __init__(self, directory: str | Path) -> None:
+        _require_posix_durability()
         self.directory = Path(directory)
         self.directory.mkdir()
+        _fsync_directory(self.directory.parent)
         self.dataset_path = self.directory / "dataset.npy"
         self.raw_path = self.directory / "raw.nc"
         self.measurements_path = self.directory / "measurements.json"
@@ -158,6 +180,7 @@ class ScenarioEvidenceWriter:
 
     def record_prior(self, tree: xr.DataTree) -> Path:
         """Create the first raw checkpoint from prior and observed groups."""
+        self._attest_observed_data(tree)
         return self._checkpoint(tree, _PRIOR_GROUPS)
 
     def record_posterior(self, tree: xr.DataTree) -> Path:
@@ -178,6 +201,16 @@ class ScenarioEvidenceWriter:
     def _require_dataset(self) -> None:
         if not self.dataset_path.is_file():
             raise RuntimeError("record_dataset() must complete first.")
+
+    def _attest_observed_data(self, tree: xr.DataTree) -> None:
+        self._require_dataset()
+        observed = _group_dataset(tree, "observed_data")
+        if tuple(observed.data_vars) != ("rt,response",):
+            raise ValueError("observed_data must contain the canonical 'rt,response'.")
+        stored = np.load(self.dataset_path, allow_pickle=False)
+        values = np.asarray(observed["rt,response"].values)
+        if not _arrays_identical(stored, values):
+            raise ValueError("observed_data does not match the recorded dataset.")
 
     def _read_raw(self, expected_groups: Sequence[str]) -> xr.DataTree:
         if not self.raw_path.is_file():

--- a/tests/test_jeam_recovery_evidence_io.py
+++ b/tests/test_jeam_recovery_evidence_io.py
@@ -1,0 +1,185 @@
+"""Durability contracts for one JEAM recovery evidence scenario."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5netcdf
+import numpy as np
+import pytest
+import xarray as xr
+
+from scripts.benchmark_jeam_recovery_evidence import (
+    ScenarioEvidenceWriter,
+    _canonical_json_bytes,
+    _sha256_file,
+)
+
+GROUPS = tuple(
+    "prior prior_predictive observed_data posterior sample_stats "
+    "posterior_predictive".split()
+)
+DATA = np.array([[0.3, -0.2], [0.7, 0.4]], dtype=np.float64)
+
+
+def _trees() -> tuple[xr.DataTree, xr.DataTree, xr.DataTree]:
+    datasets = {
+        "prior": xr.Dataset({"a": ("draw", [0.8, 1.0])}),
+        "prior_predictive": xr.Dataset(
+            {"response": (("draw", "obs"), [[0.2, 0.4], [0.3, 0.5]])}
+        ),
+        "observed_data": xr.Dataset({"rt,response": (("obs", "response_dim"), DATA)}),
+        "posterior": xr.Dataset({"a": (("chain", "draw"), [[1.0, 1.1], [0.9, 1.0]])}),
+        "sample_stats": xr.Dataset({"nstep_in": (("chain", "draw"), [[2, 3], [4, 5]])}),
+        "posterior_predictive": xr.Dataset(
+            {"response": (("chain", "draw", "obs"), np.arange(8).reshape(2, 2, 2))}
+        ),
+    }
+
+    def tree(groups, created_at):
+        selected = {group: datasets[group] for group in groups}
+        for duplicate in {"observed_data", "posterior"} & selected.keys():
+            selected[duplicate] = selected[duplicate].assign_attrs(
+                created_at=created_at
+            )
+        return xr.DataTree.from_dict(selected)
+
+    return (
+        tree(GROUPS[:3], "prior"),
+        tree(("posterior", "sample_stats", "observed_data"), "sampling"),
+        tree(("posterior", "observed_data", "posterior_predictive"), "predictive"),
+    )
+
+
+def test_raw_checkpoint_progresses_exactly_and_is_compressed(tmp_path: Path) -> None:
+    """Every stage extends one compressed tree and accepts volatile timestamps."""
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    writer.record_dataset(DATA)
+    trees = _trees()
+
+    for method, tree, expected_groups in (
+        (writer.record_prior, trees[0], GROUPS[:3]),
+        (writer.record_posterior, trees[1], GROUPS[:5]),
+        (writer.record_predictive, trees[2], GROUPS),
+    ):
+        method(tree)
+        with xr.open_datatree(writer.raw_path, engine="h5netcdf") as checkpoint:
+            checkpoint.load()
+            assert tuple(checkpoint.children) == expected_groups
+
+    with h5netcdf.File(writer.raw_path, "r") as raw_file:
+        for group in GROUPS:
+            for variable in raw_file.groups[group].variables.values():
+                if variable.dimensions:
+                    filters = variable.filters()
+                    assert (
+                        filters["zlib"],
+                        filters["complevel"],
+                        filters["shuffle"],
+                    ) == (
+                        True,
+                        4,
+                        True,
+                    )
+
+
+def test_dataset_and_final_json_round_trip_strictly_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    """Round-trip arrays and strict JSON while refusing replacement."""
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    assert writer.record_dataset(DATA) == writer.dataset_path
+    assert writer.record_dataset(DATA.copy()) == writer.dataset_path
+    np.testing.assert_array_equal(
+        np.load(writer.dataset_path, allow_pickle=False), DATA
+    )
+
+    with pytest.raises(FileExistsError, match="different data"):
+        writer.record_dataset(DATA.astype(np.float32))
+    with pytest.raises(TypeError, match="object dtype"):
+        ScenarioEvidenceWriter(tmp_path / "object").record_dataset(
+            np.array([object()], dtype=object)
+        )
+
+    for method, tree in zip(
+        (writer.record_prior, writer.record_posterior, writer.record_predictive),
+        _trees(),
+        strict=True,
+    ):
+        method(tree)
+    with pytest.raises(ValueError, match="Out of range"):
+        writer.write_measurements({"bad": np.nan})
+    assert not writer.measurements_path.exists()
+
+    value = {"z": 3, "a": {"unicode": "μ", "finite": 1.25}}
+    expected = b'{"a":{"finite":1.25,"unicode":"\xce\xbc"},"z":3}\n'
+    writer.write_measurements(value)
+    assert writer.measurements_path.read_bytes() == expected
+    with pytest.raises(FileExistsError):
+        writer.write_measurements({"z": 4})
+    with pytest.raises(FileExistsError):
+        ScenarioEvidenceWriter(writer.directory)
+    assert _canonical_json_bytes(value) == expected
+
+
+def test_invalid_order_or_group_never_creates_a_raw_checkpoint(tmp_path: Path) -> None:
+    """Reject invalid progression without leaving a partial checkpoint."""
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    prior, posterior, _ = _trees()
+    with pytest.raises(RuntimeError, match="record_dataset"):
+        writer.record_prior(prior)
+    writer.record_dataset(DATA)
+    with pytest.raises(RuntimeError, match="record_prior"):
+        writer.record_posterior(posterior)
+    with pytest.raises(ValueError, match="observed_data"):
+        writer.record_prior(
+            xr.DataTree.from_dict(
+                {group: prior[group].to_dataset() for group in GROUPS[:2]}
+            )
+        )
+    assert not writer.raw_path.exists()
+    assert not tuple(writer.directory.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize("group", ["observed_data", "posterior"])
+def test_substantive_duplicate_group_mismatch_preserves_checkpoint(
+    group: str, tmp_path: Path
+) -> None:
+    """Reject value changes while tolerating only volatile timestamps."""
+    prior, posterior, predictive = _trees()
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    writer.record_dataset(DATA)
+    writer.record_prior(prior)
+    if group == "observed_data":
+        posterior[group]["rt,response"][0, 0] = 99.0
+        action = lambda: writer.record_posterior(posterior)
+    else:
+        writer.record_posterior(posterior)
+        predictive[group]["a"][0, 0] = 99.0
+        action = lambda: writer.record_predictive(predictive)
+    original = _sha256_file(writer.raw_path)
+
+    with pytest.raises(ValueError, match=group):
+        action()
+    assert _sha256_file(writer.raw_path) == original
+
+
+def test_failed_serialization_preserves_checkpoint_and_removes_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep the last valid checkpoint when serialization fails."""
+    prior, posterior, _ = _trees()
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    writer.record_dataset(DATA)
+    writer.record_prior(prior)
+    original = _sha256_file(writer.raw_path)
+
+    def fail(self, path, *args, **kwargs):
+        Path(path).write_bytes(b"partial")
+        raise OSError("injected failure")
+
+    monkeypatch.setattr(xr.DataTree, "to_netcdf", fail)
+    with pytest.raises(OSError, match="injected failure"):
+        writer.record_posterior(posterior)
+    assert _sha256_file(writer.raw_path) == original
+    assert not tuple(writer.directory.glob(".*.tmp"))

--- a/tests/test_jeam_recovery_evidence_io.py
+++ b/tests/test_jeam_recovery_evidence_io.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+import scripts.benchmark_jeam_recovery_evidence as evidence
 from scripts.benchmark_jeam_recovery_evidence import (
     ScenarioEvidenceWriter,
     _canonical_json_bytes,
@@ -28,7 +29,9 @@ def _trees() -> tuple[xr.DataTree, xr.DataTree, xr.DataTree]:
         "prior_predictive": xr.Dataset(
             {"response": (("draw", "obs"), [[0.2, 0.4], [0.3, 0.5]])}
         ),
-        "observed_data": xr.Dataset({"rt,response": (("obs", "response_dim"), DATA)}),
+        "observed_data": xr.Dataset(
+            {"rt,response": (("obs", "response_dim"), DATA.copy())}
+        ),
         "posterior": xr.Dataset({"a": (("chain", "draw"), [[1.0, 1.1], [0.9, 1.0]])}),
         "sample_stats": xr.Dataset({"nstep_in": (("chain", "draw"), [[2, 3], [4, 5]])}),
         "posterior_predictive": xr.Dataset(
@@ -122,6 +125,27 @@ def test_dataset_and_final_json_round_trip_strictly_without_overwrite(
     assert _canonical_json_bytes(value) == expected
 
 
+def test_atomic_install_flushes_the_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Flush the directory entry after installing a durable checkpoint."""
+    synced = []
+    fsync_directory = evidence._fsync_directory
+    monkeypatch.setattr(evidence, "_fsync_directory", synced.append)
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+
+    writer.record_dataset(DATA)
+
+    assert synced[0] == tmp_path
+    assert writer.directory in synced[1:]
+
+    monkeypatch.setattr(evidence, "_fsync_directory", fsync_directory)
+    monkeypatch.setattr(evidence.os, "name", "nt")
+    with pytest.raises(RuntimeError, match="POSIX directory fsync"):
+        ScenarioEvidenceWriter(tmp_path / "unsupported")
+    assert not (tmp_path / "unsupported").exists()
+
+
 def test_invalid_order_or_group_never_creates_a_raw_checkpoint(tmp_path: Path) -> None:
     """Reject invalid progression without leaving a partial checkpoint."""
     writer = ScenarioEvidenceWriter(tmp_path / "scenario")
@@ -139,6 +163,32 @@ def test_invalid_order_or_group_never_creates_a_raw_checkpoint(tmp_path: Path) -
         )
     assert not writer.raw_path.exists()
     assert not tuple(writer.directory.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize("fault", ["values", "name"])
+def test_prior_rejects_observed_data_that_contradicts_the_dataset(
+    fault: str,
+    tmp_path: Path,
+) -> None:
+    """Bind the exact dataset bytes semantically to PyMC's observed-data group."""
+    writer = ScenarioEvidenceWriter(tmp_path / "scenario")
+    writer.record_dataset(DATA)
+    prior, _, _ = _trees()
+    if fault == "values":
+        prior["observed_data"]["rt,response"][0, 0] = 9.9
+    else:
+        datasets = {
+            group: prior[group].to_dataset(inherit=False) for group in GROUPS[:3]
+        }
+        datasets["observed_data"] = datasets["observed_data"].rename(
+            {"rt,response": "wrong_name"}
+        )
+        prior = xr.DataTree.from_dict(datasets)
+
+    with pytest.raises(ValueError, match="observed_data"):
+        writer.record_prior(prior)
+
+    assert not writer.raw_path.exists()
 
 
 @pytest.mark.parametrize("group", ["observed_data", "posterior"])


### PR DESCRIPTION
## Purpose

Replace the obsolete summary-only recovery artifact root with the first durable-evidence layer for the schema-v2 JEAM recovery protocol.

## Scope

- add a scenario-local writer for exact `dataset.npy`, staged `raw.nc`, and strict `measurements.json` checkpoints
- preserve PyMC 6/xarray DataTree groups in the order `prior`, `prior_predictive`, `observed_data`, `posterior`, `sample_stats`, and `posterior_predictive`
- compress non-scalar NetCDF variables losslessly with h5netcdf
- write through same-directory temporary files, refuse accidental overwrite, and retain the last valid checkpoint after a failed write
- flush file and directory entries on POSIX before reporting a checkpoint complete
- require the exact saved NumPy dataset to match PyMC's canonical `observed_data/rt,response` values, dtype, and shape
- permit only the known volatile `created_at` difference when attesting duplicated PyMC groups
- run the focused checkpoint contract in the optional JEAM workflow

## Review boundary

This PR does not change HSSM model behavior, run inference, define bundle provenance, or commit scientific evidence. The next stacked units attach these checkpoints to the Bayesian runner, bind the bundle manifest, and orchestrate the frozen four-scenario run. The canonical run occurs only after all capture code is reviewed and merged.

## Verification

- `9 passed` in `tests/test_jeam_recovery_evidence_io.py` on Python 3.12 and 3.14
- focused Ruff check and format check
- focused mypy
- workflow YAML parse
- `git diff --check`

The complete assembled stack additionally passes the optional JEAM fast lane (`66 passed`, `5 deselected`).
