### PR TITLE
Document schema-v2 JEAM repeated-recovery evidence

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,10 +2,26 @@ name: Docs
 
 on:
   pull_request:
-    paths: ["docs/**", "mkdocs.yml", "pyproject.toml", "src/hssm/**"]
+    paths:
+      - ".github/workflows/build_docs.yml"
+      - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "scripts/jeam_repeated_recovery_report.py"
+      - "scripts/verify_jeam_repeated_recovery_evidence.py"
+      - "src/hssm/**"
   push:
     branches: [main]
-    paths: ["docs/**", "mkdocs.yml", "pyproject.toml", "src/hssm/**"]
+    paths:
+      - ".github/workflows/build_docs.yml"
+      - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "scripts/jeam_repeated_recovery_report.py"
+      - "scripts/verify_jeam_repeated_recovery_evidence.py"
+      - "src/hssm/**"
   release:
     types: [published]
   schedule:
@@ -28,6 +44,26 @@ jobs:
       # re-execution adds a permanent blob. Catch growth at review time.
       - name: Check docs weight
         run: python scripts/check_docs_weight.py
+      - name: Validate JEAM repeated-recovery report
+        env:
+          MPLCONFIGDIR: /tmp/hssm-jeam-report-matplotlib
+          XDG_CACHE_HOME: /tmp/hssm-jeam-report-cache
+        run: |
+          mkdir -p "$MPLCONFIGDIR" "$XDG_CACHE_HOME"
+          uv run --group docs marimo check --strict docs/tutorials/jeam_repeated_recovery.py
+          uv run --group docs marimo export html docs/tutorials/jeam_repeated_recovery.py \
+            -o /tmp/jeam-repeated-recovery.html --force --no-include-code \
+            > /tmp/jeam-repeated-recovery-export.log 2>&1
+          cat /tmp/jeam-repeated-recovery-export.log
+          grep -Fq "16/16" /tmp/jeam-repeated-recovery.html
+          grep -Fq "not simulation-based calibration" /tmp/jeam-repeated-recovery.html
+          grep -Fq "d8a5c458d2194f1fb7031f6bc5ca5add3cd67afabd028880dc0bfed887ef9972" \
+            /tmp/jeam-repeated-recovery.html
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            /tmp/jeam-repeated-recovery.html /tmp/jeam-repeated-recovery-export.log; then
+            echo "JEAM recovery report contains a host path or execution error"
+            exit 1
+          fi
       - name: Build docs (strict)
         run: uv run --group notebook --group docs mkdocs build --strict
 

--- a/docs/tutorials/jeam_repeated_recovery.py
+++ b/docs/tutorials/jeam_repeated_recovery.py
@@ -1,0 +1,532 @@
+"""Inspect the durable schema-v2 JEAM repeated-recovery evidence.
+
+The notebook authenticates the committed evidence bundle and independently
+recomputes its scientific summaries from retained datasets and raw draws. It
+does not import JEAM or HSSM, access the network, optimize, or run MCMC.
+
+Open it from the HSSM repository root::
+
+    uv run --group docs marimo edit docs/tutorials/jeam_repeated_recovery.py
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+
+    _repository = Path(__file__).resolve().parents[2]
+    if str(_repository) not in sys.path:
+        sys.path.insert(0, str(_repository))
+
+    from scripts.jeam_repeated_recovery_report import load_report, summarize_science
+    from scripts.verify_jeam_repeated_recovery_evidence import MANIFEST_SHA256
+
+    return MANIFEST_SHA256, load_report, mo, np, pd, plt, summarize_science
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Repeated recovery for the JEAM–HSSM handshake
+
+    This report asks a narrow question: **for four deterministic datasets from JEAM's
+    fixed circular diffusion model, does the HSSM black-box integration preserve the
+    numerical objective and recover the generating parameters?**
+
+    Each dataset contains 300 trials. HSSM uses four explicitly seeded PyMC Slice
+    chains with 1,000 tuning and 1,000 retained draws per chain. The direct JEAM and
+    compiled HSSM optimizers use the same deliberately fixed differential-evolution
+    budget. They are therefore **fixed-budget estimates**, not claimed converged MLEs.
+
+    The report is built from the committed evidence bundle for the schema-v2 result.
+    Before anything below is displayed, the verifier authenticates all 14 payloads and independently
+    recomputes posterior, prior-predictive, posterior-predictive, convergence, and gate
+    summaries from the retained datasets and raw draws. It never imports JEAM or HSSM,
+    accesses the network, optimizes, or samples.
+    """)
+    return
+
+
+@app.cell
+def _(load_report, summarize_science):
+    manifest, science, report_frames = load_report()
+    headline = summarize_science(science)
+    return headline, manifest, report_frames, science
+
+
+@app.cell
+def _(headline, mo, science):
+    _status = "PASS" if headline["passed"] else "FAIL"
+    mo.md(f"""
+    ## Result at a glance
+
+    | Independent gate | Scenarios | 94% HDIs containing truth | Maximum R-hat | Minimum bulk ESS | Minimum tail ESS | Maximum MCSE / SD |
+    |---|---:|---:|---:|---:|---:|---:|
+    | **{_status}** | {headline["scenarios"]} | {headline["hdi_inclusions"]}/{headline["hdi_total"]} | {headline["maximum_rhat"]:.4f} | {headline["minimum_bulk_ess"]:.1f} | {headline["minimum_tail_ess"]:.1f} | {headline["maximum_mcse_sd_ratio"]:.4f} |
+
+    Numerical parity is also inside its frozen gate: the largest direct-versus-compiled
+    objective difference is `{headline["maximum_objective_error"]:.2e}`, and the two
+    fixed-budget optimizers return parameter vectors differing by at most
+    `{headline["maximum_optimizer_parameter_error"]:.1e}`. PyTensor ran in
+    `{science["pytensor_floatx"]}` precision.
+    """)
+    return
+
+
+@app.cell
+def _(mo, report_frames, science):
+    _first_scenario = report_frames["scenarios"].iloc[0]["scenario"]
+    scenario_selector = mo.ui.dropdown(
+        options={
+            name.replace("_", " ").title(): name
+            for name in report_frames["scenarios"]["scenario"]
+        },
+        value=_first_scenario.replace("_", " ").title(),
+        label="Scenario",
+    )
+    parameter_selector = mo.ui.dropdown(
+        options={name: name for name in science["parameter_order"]},
+        value=science["parameter_order"][0],
+        label="Parameter",
+    )
+    mo.hstack([scenario_selector, parameter_selector], justify="start", gap=2)
+    return parameter_selector, scenario_selector
+
+
+@app.cell
+def _(report_frames, scenario_selector, science):
+    selected_science = next(
+        row for row in science["scenarios"] if row["name"] == scenario_selector.value
+    )
+    selected_parameters = report_frames["parameters"].loc[
+        report_frames["parameters"]["scenario"] == scenario_selector.value
+    ]
+    selected_scenario = (
+        report_frames["scenarios"]
+        .loc[report_frames["scenarios"]["scenario"] == scenario_selector.value]
+        .iloc[0]
+    )
+    return selected_parameters, selected_scenario, selected_science
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Inspect one dataset
+
+    The direct fixed-budget estimate and HSSM posterior answer different questions;
+    equality between them is not a gate. The interval and convergence columns show the
+    evidence used for the Bayesian recovery claim.
+    """)
+    return
+
+
+@app.cell
+def _(mo, selected_parameters):
+    _columns = {
+        "name": "parameter",
+        "truth": "truth",
+        "jeam_fixed_budget_estimate": "JEAM fixed-budget estimate",
+        "posterior_mean": "HSSM posterior mean",
+        "interval_lower": "94% HDI lower",
+        "interval_upper": "94% HDI upper",
+        "hdi_contains_truth": "contains truth",
+        "rhat": "R-hat",
+        "ess_bulk": "bulk ESS",
+        "ess_tail": "tail ESS",
+        "mcse_sd_ratio": "MCSE / SD",
+    }
+    _table = selected_parameters.loc[:, list(_columns)].rename(columns=_columns)
+    mo.ui.table(_table.round(4), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Recovery across all four datasets
+
+    Choose a parameter above. Crosses are generating truths, open circles are direct
+    JEAM fixed-budget estimates, squares are HSSM posterior means, and horizontal lines
+    are 94% HSSM HDIs. This exposes every recovery case instead of hiding it behind an
+    aggregate score.
+    """)
+    return
+
+
+@app.cell
+def _(parameter_selector, plt, report_frames):
+    _selected = (
+        report_frames["parameters"]
+        .loc[report_frames["parameters"]["name"] == parameter_selector.value]
+        .reset_index(drop=True)
+    )
+    _positions = list(range(len(_selected)))
+    _figure, _axis = plt.subplots(figsize=(8.2, 4.2))
+    for _position, _row in _selected.iterrows():
+        _axis.hlines(
+            _position,
+            _row["interval_lower"],
+            _row["interval_upper"],
+            color="#4472C4",
+            linewidth=4,
+            alpha=0.4,
+            label="HSSM 94% HDI" if _position == 0 else None,
+        )
+    _axis.scatter(
+        _selected["truth"],
+        _positions,
+        marker="x",
+        s=80,
+        linewidth=2.2,
+        color="#111111",
+        label="generating truth",
+        zorder=4,
+    )
+    _axis.scatter(
+        _selected["jeam_fixed_budget_estimate"],
+        _positions,
+        marker="o",
+        s=54,
+        facecolors="white",
+        edgecolors="#E67E22",
+        linewidth=1.8,
+        label="JEAM fixed-budget estimate",
+        zorder=3,
+    )
+    _axis.scatter(
+        _selected["posterior_mean"],
+        _positions,
+        marker="s",
+        s=48,
+        color="#4472C4",
+        label="HSSM posterior mean",
+        zorder=3,
+    )
+    _axis.set_yticks(
+        _positions,
+        [name.replace("_", " ") for name in _selected["scenario"]],
+    )
+    _axis.invert_yaxis()
+    _axis.set_xlabel(parameter_selector.value)
+    _axis.set_title(f"Recovery of {parameter_selector.value}")
+    _axis.grid(axis="x", alpha=0.2)
+    _axis.legend(loc="best", fontsize=8)
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Frozen aggregate gate
+
+    Bias and RMSE have parameter-specific units, so each bar is divided by its
+    verifier-owned limit. Every bar must remain at or below one. HDI inclusion and
+    sampler diagnostics are evaluated separately in the table below.
+
+    Four out of four inclusions per parameter are reassuring for these deterministic
+    cases, but they are **not** an estimate of long-run 94% coverage. This is a
+    repeated scientific regression smoke, not simulation-based calibration.
+    """)
+    return
+
+
+@app.cell
+def _(np, plt, report_frames):
+    _aggregate = report_frames["aggregate"]
+    _x = np.arange(len(_aggregate))
+    _width = 0.19
+    _figure, _axis = plt.subplots(figsize=(8.5, 4.2))
+    _series = (
+        ("jeam_fixed_budget_bias_ratio", "JEAM |bias| / limit", "#F4B183"),
+        ("jeam_fixed_budget_rmse_ratio", "JEAM RMSE / limit", "#E67E22"),
+        ("hssm_posterior_bias_ratio", "HSSM |bias| / limit", "#9DC3E6"),
+        ("hssm_posterior_rmse_ratio", "HSSM RMSE / limit", "#4472C4"),
+    )
+    for _index, (_column, _label, _color) in enumerate(_series):
+        _axis.bar(
+            _x + (_index - 1.5) * _width,
+            _aggregate[_column],
+            _width,
+            label=_label,
+            color=_color,
+        )
+    _axis.axhline(1.0, color="#B22222", linestyle="--", label="frozen limit")
+    _axis.set_xticks(_x, _aggregate["name"])
+    _axis.set_ylabel("observed metric / allowed limit")
+    _axis.set_title("Both estimators remain inside the recovery gate")
+    _axis.set_ylim(0.0, 1.08)
+    _axis.grid(axis="y", alpha=0.2)
+    _axis.legend(ncol=2, fontsize=8)
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo, report_frames, science):
+    _thresholds = science["thresholds"]
+    _diagnostics = report_frames["aggregate"][
+        [
+            "name",
+            "hdi_inclusion_fraction",
+            "maximum_rhat",
+            "minimum_bulk_ess",
+            "minimum_tail_ess",
+            "maximum_mcse_sd_ratio",
+        ]
+    ].copy()
+    _diagnostics["HDI floor"] = _thresholds["minimum_hdi_inclusion_fraction"]
+    _diagnostics["R-hat ceiling"] = _thresholds["maximum_rhat"]
+    _diagnostics["bulk ESS floor"] = _thresholds["minimum_bulk_ess"]
+    _diagnostics["tail ESS floor"] = _thresholds["minimum_tail_ess"]
+    _diagnostics["MCSE / SD ceiling"] = _thresholds["maximum_mcse_sd_ratio"]
+    mo.ui.table(_diagnostics.round(4), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Numerical handshake
+
+    Each scenario evaluates three frozen parameter vectors through direct JEAM and the
+    compiled HSSM objective, then runs both optimizers with the same seed and fixed
+    budget. The table shows machine-precision agreement and identical returned vectors.
+
+    These objective evaluations, optimizer outputs, and initial log densities are
+    authenticated primary measurements. The verifier checks their finiteness and
+    internal parity, but intentionally does not rerun JEAM, HSSM, or optimization.
+    """)
+    return
+
+
+@app.cell
+def _(mo, report_frames):
+    _columns = {
+        "scenario": "scenario",
+        "objective_error": "maximum objective error",
+        "optimizer_parameter_error": "optimizer parameter error",
+        "optimizer_objective_error": "optimizer objective error",
+        "initial_logp": "initial log density",
+    }
+    _table = report_frames["scenarios"].loc[:, list(_columns)].rename(columns=_columns)
+    mo.ui.table(_table, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo, scenario_selector):
+    mo.md(f"""
+    ## Predictive checks: {scenario_selector.value.replace("_", " ")}
+
+    The posterior-predictive RT quantiles are compared directly with the observed
+    quantiles. Circular predictions are evaluated using angular distance and resultant
+    length, avoiding an invalid ordinary mean across the `-π`/`π` seam. Prior-predictive
+    RT ratios guard against a pathologically narrow or diffuse prior before fitting.
+    """)
+    return
+
+
+@app.cell
+def _(np, plt, selected_science):
+    _predictive = selected_science["predictive"]
+    _observed = np.asarray(_predictive["observed_rt_quantiles"])
+    _simulated = np.asarray(_predictive["predictive_rt_quantiles"])
+    _lower = min(_observed.min(), _simulated.min())
+    _upper = max(_observed.max(), _simulated.max())
+    _padding = max(0.05, 0.08 * (_upper - _lower))
+    _figure, (_rt_axis, _circular_axis) = plt.subplots(1, 2, figsize=(9.0, 4.2))
+    _rt_axis.plot(
+        [_lower - _padding, _upper + _padding],
+        [_lower - _padding, _upper + _padding],
+        linestyle="--",
+        color="#777777",
+        label="observed = predictive",
+    )
+    _rt_axis.scatter(_observed, _simulated, s=65, color="#4472C4", zorder=3)
+    for _probability, _x, _y in zip(
+        _predictive["rt_probabilities"], _observed, _simulated, strict=True
+    ):
+        _rt_axis.annotate(
+            f"p={_probability:.1f}", (_x, _y), xytext=(5, 5), textcoords="offset points"
+        )
+    _rt_axis.set_xlabel("observed RT quantile (s)")
+    _rt_axis.set_ylabel("posterior-predictive RT quantile (s)")
+    _rt_axis.set_title("RT quantiles")
+    _rt_axis.grid(alpha=0.2)
+    _rt_axis.legend(fontsize=8)
+
+    _circle = np.linspace(-np.pi, np.pi, 300)
+    _circular_axis.plot(np.cos(_circle), np.sin(_circle), color="#BBBBBB")
+    for _label, _mean_key, _length_key, _color, _style in (
+        (
+            "posterior predictive",
+            "predictive_mean_angle",
+            "predictive_resultant_length",
+            "#4472C4",
+            "-",
+        ),
+        (
+            "observed",
+            "observed_mean_angle",
+            "observed_resultant_length",
+            "#111111",
+            "--",
+        ),
+    ):
+        _angle = _predictive[_mean_key]
+        _length = _predictive[_length_key]
+        _circular_axis.plot(
+            [0.0, _length * np.cos(_angle)],
+            [0.0, _length * np.sin(_angle)],
+            color=_color,
+            linestyle=_style,
+            linewidth=2.5,
+            marker="o",
+            markevery=[1],
+            label=_label,
+        )
+    _circular_axis.axhline(0.0, color="#DDDDDD", linewidth=0.8)
+    _circular_axis.axvline(0.0, color="#DDDDDD", linewidth=0.8)
+    _circular_axis.set_xlim(-1.08, 1.08)
+    _circular_axis.set_ylim(-1.08, 1.08)
+    _circular_axis.set_aspect("equal")
+    _circular_axis.set_title("Circular resultant vectors")
+    _circular_axis.legend(loc="lower right", fontsize=8)
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo, pd, selected_scenario, selected_science, science):
+    _predictive = selected_science["predictive"]
+    _prior = selected_science["prior_predictive"]
+    _thresholds = science["thresholds"]
+    _predictive_table = pd.DataFrame(
+        [
+            {
+                "check": "maximum RT quantile error",
+                "observed": selected_scenario["maximum_rt_quantile_error"],
+                "allowed": _thresholds["maximum_rt_quantile_absolute_error"],
+            },
+            {
+                "check": "circular mean distance",
+                "observed": _predictive["mean_angle_distance"],
+                "allowed": _thresholds["maximum_mean_angle_distance"],
+            },
+            {
+                "check": "resultant-length error",
+                "observed": selected_scenario["resultant_length_error"],
+                "allowed": _thresholds["maximum_resultant_length_absolute_error"],
+            },
+        ]
+    )
+    _prior_table = pd.DataFrame(
+        {
+            "RT quantile": [f"p={value:.1f}" for value in _prior["rt_probabilities"]],
+            "observed (s)": _prior["observed_rt_quantiles"],
+            "prior predictive (s)": _prior["prior_rt_quantiles"],
+            "prior / observed": _prior["prior_to_observed_rt_ratios"],
+        }
+    )
+    mo.vstack(
+        [
+            mo.md(
+                f"Prior/observed ratios must stay in the frozen interval "
+                f"`[{_thresholds['minimum_prior_to_observed_rt_ratio']}, "
+                f"{_thresholds['maximum_prior_to_observed_rt_ratio']}]`."
+            ),
+            mo.ui.table(_prior_table.round(4), selection=None, pagination=False),
+            mo.ui.table(_predictive_table.round(4), selection=None, pagination=False),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Runtime and Slice behavior
+
+    These values describe this one run; they are hash-bound but deliberately excluded
+    from the scientific pass/fail gate. Wall time is hardware dependent. Slice step
+    counts help characterize the gradient-free sampler without turning performance into
+    a scientific claim.
+    """)
+    return
+
+
+@app.cell
+def _(mo, report_frames):
+    _columns = {
+        "scenario": "scenario",
+        "prior_predictive_seconds": "prior predictive (s)",
+        "sampling_seconds": "sampling (s)",
+        "posterior_predictive_seconds": "posterior predictive (s)",
+        "mean_steps_in": "mean Slice steps in",
+        "mean_steps_out": "mean Slice steps out",
+    }
+    _table = report_frames["scenarios"].loc[:, list(_columns)].rename(columns=_columns)
+    mo.ui.table(_table.round(3), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(MANIFEST_SHA256, manifest, mo, science):
+    _provenance = manifest["provenance"]
+    _platform = _provenance["platform"]
+    mo.md(f"""
+    ## Integrity, provenance, and limits
+
+    | Evidence field | Frozen value |
+    |---|---|
+    | Manifest schema | `{manifest["schema_version"]}` |
+    | Result schema | `{science["schema_version"]}` |
+    | Manifest SHA-256 | `{MANIFEST_SHA256}` |
+    | Protocol SHA-256 | `{manifest["protocol_sha256"]}` |
+    | Authenticated payloads | `{len(manifest["artifacts"])}` |
+    | JEAM revision | `{_provenance["jeam_revision"]}` |
+    | HSSM producer revision | `{_provenance["producer_revision"]}` |
+    | HSSM producer tree | `{_provenance["producer_tree"]}` |
+    | Python | `{_provenance["python"]["implementation"]} {_provenance["python"]["version"]}` |
+    | Platform | `{_platform["system"]} {_platform["release"]} ({_platform["machine"]})` |
+
+    The evidence supports the **fixed two-dimensional circular diffusion black-box
+    prototype** for these four generating configurations with `s_v = 0` and `s_t = 0`.
+    It does not establish calibrated long-run coverage, support the remaining JEAM model
+    families, validate drift/nondecision variability, or make a default-sampler claim.
+
+    Objective evaluations, optimizer execution, and the initial log density remain
+    authenticated producer measurements rather than independently rerun calculations.
+    All posterior, predictive, convergence, aggregate, and gate values shown here are
+    recomputed from the retained raw evidence. The exact model producer is JEAM
+    `{science["jeam_revision"]}`; this historical provenance must not be rewritten when
+    the optional dependency pin advances later.
+
+    To verify the bundle without opening marimo:
+
+    ```bash
+    uv run --group docs python scripts/verify_jeam_repeated_recovery_evidence.py
+    ```
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ validation:
   # phase-2 consolidation targets, deliberately unlisted until then
 not_in_nav: |
   tutorials/attentional_ddm.py
+  tutorials/jeam_repeated_recovery.py
   absolute_links: warn
   unrecognized_links: warn
   anchors: warn
@@ -121,6 +122,7 @@ plugins:
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
         - tutorials/attentional_ddm.py
+        - tutorials/jeam_repeated_recovery.py
         - tutorials/hsgp_regression.ipynb
         - tutorials/ddm_hierarchical_tutorial.ipynb
         - tutorials/choice_only_models.ipynb

--- a/scripts/jeam_repeated_recovery_report.py
+++ b/scripts/jeam_repeated_recovery_report.py
@@ -1,0 +1,122 @@
+"""Build concise report views from verified JEAM repeated-recovery evidence."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+
+from scripts.verify_jeam_repeated_recovery_evidence import (
+    DEFAULT_BUNDLE,
+    load_verified_evidence,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+
+def summarize_science(science: Mapping[str, Any]) -> dict[str, float | int | bool]:
+    """Reduce verified science to the headline recovery and parity diagnostics."""
+    scenarios = science["scenarios"]
+    parameters = [row for scenario in scenarios for row in scenario["parameters"]]
+    aggregate = science["aggregate"]
+    return {
+        "passed": science["gate"] == {"passed": True, "failures": []},
+        "scenarios": len(scenarios),
+        "hdi_inclusions": sum(row["hdi_contains_truth"] for row in parameters),
+        "hdi_total": len(parameters),
+        "maximum_rhat": max(row["maximum_rhat"] for row in aggregate),
+        "minimum_bulk_ess": min(row["minimum_bulk_ess"] for row in aggregate),
+        "minimum_tail_ess": min(row["minimum_tail_ess"] for row in aggregate),
+        "maximum_mcse_sd_ratio": max(row["maximum_mcse_sd_ratio"] for row in aggregate),
+        "maximum_objective_error": max(
+            row["maximum_objective_absolute_error"] for row in scenarios
+        ),
+        "maximum_optimizer_parameter_error": max(
+            row["maximum_optimizer_parameter_absolute_error"] for row in scenarios
+        ),
+    }
+
+
+def build_report_frames(
+    science: Mapping[str, Any],
+) -> dict[str, pd.DataFrame]:
+    """Create presentation frames without changing scientific values or thresholds."""
+    parameter_rows = [
+        {"scenario": scenario["name"], **parameter}
+        for scenario in science["scenarios"]
+        for parameter in scenario["parameters"]
+    ]
+    scenario_rows = []
+    for scenario in science["scenarios"]:
+        predictive = scenario["predictive"]
+        prior = scenario["prior_predictive"]
+        runtime = scenario["runtime"]
+        scenario_rows.append(
+            {
+                "scenario": scenario["name"],
+                "objective_error": scenario["maximum_objective_absolute_error"],
+                "optimizer_parameter_error": scenario[
+                    "maximum_optimizer_parameter_absolute_error"
+                ],
+                "optimizer_objective_error": scenario[
+                    "optimizer_objective_absolute_error"
+                ],
+                "initial_logp": scenario["initial_logp"],
+                "sampling_seconds": runtime["hssm_sampling_seconds"],
+                "prior_predictive_seconds": runtime["hssm_prior_predictive_seconds"],
+                "posterior_predictive_seconds": runtime["hssm_predictive_seconds"],
+                "mean_steps_in": scenario["slice_diagnostics"]["mean_steps_in"],
+                "mean_steps_out": scenario["slice_diagnostics"]["mean_steps_out"],
+                "maximum_rt_quantile_error": float(
+                    np.max(
+                        np.abs(
+                            np.asarray(predictive["observed_rt_quantiles"])
+                            - np.asarray(predictive["predictive_rt_quantiles"])
+                        )
+                    )
+                ),
+                "mean_angle_distance": predictive["mean_angle_distance"],
+                "resultant_length_error": abs(
+                    predictive["observed_resultant_length"]
+                    - predictive["predictive_resultant_length"]
+                ),
+                "minimum_prior_rt_ratio": min(prior["prior_to_observed_rt_ratios"]),
+                "maximum_prior_rt_ratio": max(prior["prior_to_observed_rt_ratios"]),
+            }
+        )
+
+    thresholds = science["thresholds"]
+    aggregate_rows = []
+    for row in science["aggregate"]:
+        name = row["name"]
+        bias_limit = thresholds["maximum_absolute_bias"][name]
+        rmse_limit = thresholds["maximum_rmse"][name]
+        aggregate_rows.append(
+            {
+                **row,
+                "jeam_fixed_budget_bias_ratio": abs(row["jeam_fixed_budget_bias"])
+                / bias_limit,
+                "jeam_fixed_budget_rmse_ratio": row["jeam_fixed_budget_rmse"]
+                / rmse_limit,
+                "hssm_posterior_bias_ratio": abs(row["hssm_posterior_bias"])
+                / bias_limit,
+                "hssm_posterior_rmse_ratio": row["hssm_posterior_rmse"] / rmse_limit,
+            }
+        )
+
+    return {
+        "parameters": pd.DataFrame(parameter_rows),
+        "scenarios": pd.DataFrame(scenario_rows),
+        "aggregate": pd.DataFrame(aggregate_rows),
+    }
+
+
+def load_report(
+    root: str | Path = DEFAULT_BUNDLE,
+) -> tuple[dict[str, object], dict[str, Any], dict[str, pd.DataFrame]]:
+    """Authenticate the evidence once and return its recomputed report views."""
+    manifest, science = load_verified_evidence(root)
+    return manifest, science, build_report_frames(science)

--- a/scripts/verify_jeam_repeated_recovery_evidence.py
+++ b/scripts/verify_jeam_repeated_recovery_evidence.py
@@ -1059,13 +1059,21 @@ def verify_integrity(root: str | Path = DEFAULT_BUNDLE) -> dict[str, object]:
     return manifest
 
 
-def verify_evidence(root: str | Path = DEFAULT_BUNDLE) -> dict[str, object]:
-    """Authenticate the bundle, recompute its science, and enforce every gate."""
-    _, stored, measurements, datasets, groups = _load_verified_bundle(Path(root))
+def load_verified_evidence(
+    root: str | Path = DEFAULT_BUNDLE,
+) -> tuple[dict[str, object], dict[str, Any]]:
+    """Return the authenticated manifest and independently recomputed science."""
+    manifest, stored, measurements, datasets, groups = _load_verified_bundle(Path(root))
     science = _recompute_science(measurements, datasets, groups)
     _assert_same_science(scientific_projection(science), scientific_projection(stored))
     if failures := science["gate"]["failures"]:
         _fail(f"Scientific gate failed: {'; '.join(failures)}")
+    return manifest, science
+
+
+def verify_evidence(root: str | Path = DEFAULT_BUNDLE) -> dict[str, object]:
+    """Authenticate the bundle, recompute its science, and enforce every gate."""
+    _, science = load_verified_evidence(root)
     inclusions = sum(
         parameter["hdi_contains_truth"]
         for scenario in science["scenarios"]

--- a/tests/test_jeam_repeated_recovery_report.py
+++ b/tests/test_jeam_repeated_recovery_report.py
@@ -1,0 +1,177 @@
+"""Tests for the schema-v2 JEAM repeated-recovery report views."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scripts.jeam_repeated_recovery_report import (
+    build_report_frames,
+    load_report,
+    summarize_science,
+)
+from scripts.verify_jeam_repeated_recovery_evidence import (
+    MANIFEST_SHA256,
+    SCENARIOS,
+    EvidenceMismatch,
+)
+
+BUNDLE = (
+    Path(__file__).parents[1] / "benchmarks" / "evidence" / "jeam_repeated_recovery_v2"
+)
+
+
+@pytest.fixture(scope="module")
+def report():
+    """Load the authenticated canonical report once."""
+    return load_report(BUNDLE)
+
+
+def test_report_loads_authenticated_recomputed_science(report) -> None:
+    """The report must inherit the verifier's manifest root and independent gate."""
+    manifest, science, _ = report
+
+    assert MANIFEST_SHA256 == (
+        "d8a5c458d2194f1fb7031f6bc5ca5add3cd67afabd028880dc0bfed887ef9972"
+    )
+    assert manifest["provenance"]["jeam_revision"] == science["jeam_revision"]
+    assert manifest["protocol"]["thresholds"] == science["thresholds"]
+    assert science["gate"] == {"passed": True, "failures": []}
+
+
+def test_report_summary_pins_the_canonical_outcome(report) -> None:
+    """Headline numbers must remain derived from all scenarios and parameters."""
+    _, science, _ = report
+    summary = summarize_science(science)
+
+    assert summary == {
+        "passed": True,
+        "scenarios": 4,
+        "hdi_inclusions": 16,
+        "hdi_total": 16,
+        "maximum_rhat": pytest.approx(1.0076487),
+        "minimum_bulk_ess": pytest.approx(786.13471011),
+        "minimum_tail_ess": pytest.approx(1279.99191356),
+        "maximum_mcse_sd_ratio": pytest.approx(0.03568501073939003),
+        "maximum_objective_error": pytest.approx(2.2737367544323206e-13),
+        "maximum_optimizer_parameter_error": 0.0,
+    }
+
+
+def test_report_frames_preserve_order_terminology_and_gate_math(report) -> None:
+    """Presentation reshaping must retain all rows and fixed-budget terminology."""
+    _, science, frames = report
+    parameters = frames["parameters"]
+    scenarios = frames["scenarios"]
+    aggregate = frames["aggregate"]
+
+    expected_scenarios = [name for name, *_ in SCENARIOS]
+    assert scenarios["scenario"].tolist() == expected_scenarios
+    assert parameters["scenario"].tolist() == [
+        name for name in expected_scenarios for _ in science["parameter_order"]
+    ]
+    assert parameters["name"].tolist() == science["parameter_order"] * 4
+    assert len(parameters) == 16
+    assert "jeam_fixed_budget_estimate" in parameters
+    assert not any("mle" in column.lower() for column in parameters.columns)
+
+    ratio_columns = [
+        "jeam_fixed_budget_bias_ratio",
+        "jeam_fixed_budget_rmse_ratio",
+        "hssm_posterior_bias_ratio",
+        "hssm_posterior_rmse_ratio",
+    ]
+    assert np.all(aggregate[ratio_columns].to_numpy() <= 1.0)
+
+
+def test_report_scenario_metrics_are_recomputed_from_predictive_rows(report) -> None:
+    """Flattened predictive metrics must remain exact functions of verified science."""
+    _, science, frames = report
+    first = science["scenarios"][0]
+    predictive = first["predictive"]
+    row = frames["scenarios"].iloc[0]
+
+    expected_rt_error = np.max(
+        np.abs(
+            np.asarray(predictive["observed_rt_quantiles"])
+            - np.asarray(predictive["predictive_rt_quantiles"])
+        )
+    )
+    assert row["maximum_rt_quantile_error"] == pytest.approx(expected_rt_error)
+    assert row["resultant_length_error"] == pytest.approx(
+        abs(
+            predictive["observed_resultant_length"]
+            - predictive["predictive_resultant_length"]
+        )
+    )
+    assert row["mean_angle_distance"] == pytest.approx(
+        predictive["mean_angle_distance"]
+    )
+
+
+def test_report_ratios_use_inclusive_frozen_limits(report) -> None:
+    """Presentation ratios equal one exactly at each verifier-owned boundary."""
+    _, science, _ = report
+    altered = copy.deepcopy(science)
+    row = altered["aggregate"][0]
+    name = row["name"]
+    bias_limit = science["thresholds"]["maximum_absolute_bias"][name]
+    rmse_limit = science["thresholds"]["maximum_rmse"][name]
+    row.update(
+        jeam_fixed_budget_bias=-bias_limit,
+        jeam_fixed_budget_rmse=rmse_limit,
+        hssm_posterior_bias=bias_limit,
+        hssm_posterior_rmse=rmse_limit,
+        maximum_rhat=1.5,
+    )
+
+    aggregate = build_report_frames(altered)["aggregate"].iloc[0]
+    assert aggregate[
+        [
+            "jeam_fixed_budget_bias_ratio",
+            "jeam_fixed_budget_rmse_ratio",
+            "hssm_posterior_bias_ratio",
+            "hssm_posterior_rmse_ratio",
+        ]
+    ].tolist() == pytest.approx([1.0, 1.0, 1.0, 1.0])
+    assert summarize_science(altered)["maximum_rhat"] == pytest.approx(1.5)
+
+
+def test_report_helper_cannot_run_inference_or_read_compact_results() -> None:
+    """The helper may only present the public network-free verifier result."""
+    source = (
+        Path(__file__).parents[1] / "scripts" / "jeam_repeated_recovery_report.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+
+    assert imports.isdisjoint({"hssm", "jeam", "pymc", "socket", "subprocess"})
+    assert "result.json" not in source
+    assert "FULL_RUN" not in source
+    assert "run_button" not in source
+    assert not any(
+        prefix in source
+        for prefix in ("/Users/", "/home/", "/private/", "/var/folders/", "file://")
+    )
+
+
+def test_report_fails_closed_with_the_verifier(tmp_path: Path) -> None:
+    """The presentation entry point may not bypass bundle authentication."""
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(EvidenceMismatch, match="inventory mismatch"):
+        load_report(tmp_path)

--- a/tests/test_jeam_repeated_recovery_report.py
+++ b/tests/test_jeam_repeated_recovery_report.py
@@ -141,11 +141,18 @@ def test_report_ratios_use_inclusive_frozen_limits(report) -> None:
     assert summarize_science(altered)["maximum_rhat"] == pytest.approx(1.5)
 
 
-def test_report_helper_cannot_run_inference_or_read_compact_results() -> None:
-    """The helper may only present the public network-free verifier result."""
-    source = (
-        Path(__file__).parents[1] / "scripts" / "jeam_repeated_recovery_report.py"
-    ).read_text(encoding="utf-8")
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "scripts/jeam_repeated_recovery_report.py",
+        "docs/tutorials/jeam_repeated_recovery.py",
+    ),
+)
+def test_report_surface_cannot_run_inference_or_read_compact_results(
+    relative_path: str,
+) -> None:
+    """The report may only present the public network-free verifier result."""
+    source = (Path(__file__).parents[1] / relative_path).read_text(encoding="utf-8")
     tree = ast.parse(source)
     imports = {
         alias.name.split(".")[0]


### PR DESCRIPTION
## Purpose

- replace the historical schema-v1 notebook with a schema-v2 report backed by the manifest-bound evidence merged through #1255 and #1256
- make the fixed circular-diffusion recovery result inspectable without importing JEAM/HSSM, accessing the network, optimizing, or rerunning MCMC

## Changes

- authenticate all 14 payloads and independently recompute posterior, predictive, convergence, aggregate, and gate summaries from retained datasets and raw draws
- report all four scenarios, 16/16 truth-in-HDI checks, diagnostics, objective/optimizer parity, predictive checks, runtime, and immutable provenance
- add focused report tests and strict CI checks for marimo export, required content, manifest identity, execution errors, and host-path leakage

## Verification

- `uv run pytest tests/test_jeam_repeated_recovery_report.py tests/test_jeam_repeated_recovery_evidence_verifier.py` — 38 passed
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run --group docs marimo check --strict docs/tutorials/jeam_repeated_recovery.py`
- headless marimo HTML export and content/path/error checks
- `uv run --group notebook --group docs mkdocs build --strict`

## Scope

- supports the fixed two-dimensional circular-diffusion black-box prototype for four deterministic configurations with `s_v = 0` and `s_t = 0`
- does not establish simulation-based calibration, cover other JEAM families or variability, or make a default-sampler claim
- objective and optimizer results remain authenticated producer measurements rather than independently rerun calculations
