### PR TITLE
Document the black-box JEAM circular workflow

### DIFF
--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -8,8 +8,9 @@ notebook with::
         marimo edit docs/tutorials/jeam_circular_diffusion.py
 
 The default two-chain fit is intentionally small enough for an interactive tutorial.
-For a longer local run, set ``FULL_RUN=1`` before starting marimo. The repeated-recovery
-benchmark in ``docs/tutorials/jeam_repeated_recovery.py`` remains the scientific gate.
+For a longer local run, set ``FULL_RUN=1`` before starting marimo. The artifact-backed,
+four-scenario report in ``docs/tutorials/jeam_repeated_recovery.py`` provides the broader
+recovery smoke evidence; it is not simulation-based calibration.
 """
 
 # ruff: noqa: B018, D401, E501, PLR1711
@@ -63,7 +64,7 @@ def _(mo):
     mo.md(r"""
     # Fit a circular diffusion model with HSSM and JEAM
 
-    This tutorial exercises the complete prototype handshake: simulate angular
+    This tutorial exercises the complete black-box prototype handshake: simulate angular
     responses with JEAM, construct an **ordinary `hssm.HSSM` object**, verify its
     likelihood numerically against JEAM, fit it with a gradient-free sampler, and
     perform posterior predictive checks.
@@ -106,6 +107,10 @@ def _(mo):
     FULL_RUN=1 uv run --group docs --group jeam-prototype \
       marimo edit docs/tutorials/jeam_circular_diffusion.py
     ```
+
+    `FULL_RUN=1` only lengthens this one illustrative two-chain analysis. It does
+    not reproduce the artifact-backed four-scenario recovery smoke or establish
+    simulation-based calibration.
     """)
     return
 
@@ -275,6 +280,7 @@ def _(data, hssm):
     circular_model = hssm.HSSM(
         data=data,
         model="circular_diffusion",
+        loglik_kind="blackbox",
         p_outlier=None,
     )
     return (circular_model,)
@@ -287,7 +293,9 @@ def _(mo):
 
     No `HSSMCircular` subclass is involved. HSSM discovers the likelihood,
     simulator, bounds, and response semantics from the registered
-    `circular_diffusion` model configuration.
+    `circular_diffusion` model configuration. This walkthrough selects the
+    `blackbox` likelihood explicitly so its sampler guidance remains local to
+    that route.
     """)
     return
 
@@ -321,6 +329,7 @@ def _(RUN_CONFIG, data, hssm):
     _prior_check_model = hssm.HSSM(
         data=data,
         model="circular_diffusion",
+        loglik_kind="blackbox",
         p_outlier=None,
     )
     prior_predictive = _prior_check_model.sample_prior_predictive(
@@ -490,18 +499,18 @@ def _(mo):
     mo.md(r"""
     ## 4. Fit with explicit PyMC Slice steps
 
-    This likelihood crosses a Python/NumPy black-box boundary and does **not** provide
-    gradients to PyTensor. Consequently:
+    This explicitly selected `blackbox` likelihood crosses a Python/NumPy boundary and
+    does **not** provide gradients to PyTensor. Consequently, for this route:
 
     - this tutorial uses one explicit PyMC `Slice` step per parameter;
     - NUTS, JAX NUTS (`numpyro`, `blackjax`, or `nutpie`), and variational inference
-      are not supported by this prototype;
+      are not available;
     - `cores=1` keeps the notebook portable and reproducible; and
     - `p_outlier=None` is required because HSSM's categorical lapse mixture is not a
       density over continuous angles.
 
     The short default run demonstrates the workflow. It is not a replacement for the
-    four-scenario, predeclared recovery benchmark in
+    artifact-backed, schema-v2 four-scenario deterministic recovery smoke in
     `docs/tutorials/jeam_repeated_recovery.py`.
     """)
     return
@@ -946,12 +955,13 @@ def _(mo):
     1. run `FULL_RUN=1` and require satisfactory diagnostics for your data;
     2. choose and justify domain-specific priors;
     3. compare posterior predictions to all scientifically important summaries;
-    4. consult `docs/tutorials/jeam_repeated_recovery.py` for the predeclared
-       multi-dataset recovery evidence; and
+    4. consult `docs/tutorials/jeam_repeated_recovery.py` for the artifact-backed,
+       four-scenario deterministic recovery smoke (not calibration); and
     5. retain the exact JEAM revision in the analysis environment.
 
     The integration remains deliberately narrow: fixed CDM, two-dimensional angular
-    responses, no lapse mixture, and gradient-free PyMC sampling.
+    responses, no lapse mixture, and a black-box likelihood with gradient-free PyMC
+    Slice sampling.
     """)
     return
 

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -1,0 +1,960 @@
+"""Fit JEAM's circular diffusion model through ordinary HSSM.
+
+From the HSSM repository root, install the pinned prototype and open this marimo
+notebook with::
+
+    uv sync --group docs --group jeam-prototype
+    uv run --group docs --group jeam-prototype \
+        marimo edit docs/tutorials/jeam_circular_diffusion.py
+
+The default two-chain fit is intentionally small enough for an interactive tutorial.
+For a longer local run, set ``FULL_RUN=1`` before starting marimo. The repeated-recovery
+benchmark in ``docs/tutorials/jeam_repeated_recovery.py`` remains the scientific gate.
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import importlib.metadata
+    import json
+    import os
+    import warnings
+    from time import perf_counter
+
+    import arviz as az
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import pymc as pm
+    import pytensor
+    from jeam.Models.Circular import CircularDiffusionModel
+
+    import hssm
+    from hssm.integrations.jeam import simulate_circular_diffusion
+
+    return (
+        CircularDiffusionModel,
+        az,
+        hssm,
+        importlib,
+        json,
+        mo,
+        np,
+        os,
+        pd,
+        perf_counter,
+        plt,
+        pm,
+        pytensor,
+        simulate_circular_diffusion,
+        warnings,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Fit a circular diffusion model with HSSM and JEAM
+
+    This tutorial exercises the complete prototype handshake: simulate angular
+    responses with JEAM, construct an **ordinary `hssm.HSSM` object**, verify its
+    likelihood numerically against JEAM, fit it with a gradient-free sampler, and
+    perform posterior predictive checks.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    > **Experimental integration.** The current handshake covers JEAM's
+    > **two-dimensional, fixed-boundary circular diffusion model (CDM)** only.
+    > Responses are angles in radians on the half-open interval $[-\pi, \pi)$.
+    > The prototype fixes $\sigma=1$, $s_v=0$, $s_t=0$, and threshold decay to
+    > zero. It does not yet register spherical, hyperspherical, projected,
+    > categorical, or ordinary continuous-response JEAM models in HSSM.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Install the pinned prototype
+
+    In an HSSM checkout, the exact install command is:
+
+    ```bash
+    uv sync --group docs --group jeam-prototype
+    ```
+
+    The dependency group resolves the HSSM fork of JEAM at commit
+    `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`. This is a VCS-pinned prototype,
+    not a released HSSM runtime dependency.
+
+    The default run below uses 120 trials and two short chains. Start marimo with
+    `FULL_RUN=1` to use 300 trials and longer chains:
+
+    ```bash
+    FULL_RUN=1 uv run --group docs --group jeam-prototype \
+      marimo edit docs/tutorials/jeam_circular_diffusion.py
+    ```
+    """)
+    return
+
+
+@app.cell
+def _(hssm, os, pytensor, warnings):
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Numba will use object mode to run .*",
+        category=UserWarning,
+        module=r"pytensor\.link\.numba\.dispatch\.basic",
+    )
+    hssm.set_floatX("float64")
+    FULL_RUN = os.getenv("FULL_RUN", "0") == "1"
+    RUN_CONFIG = {
+        "mode": "full" if FULL_RUN else "tutorial",
+        "trials": 300 if FULL_RUN else 120,
+        "chains": 2,
+        "tune": 1_500 if FULL_RUN else 500,
+        "draws": 1_500 if FULL_RUN else 500,
+        "prior_draws": 20 if FULL_RUN else 8,
+        "predictive_draws": 100 if FULL_RUN else 30,
+        "data_seed": 1_492,
+        "chain_seeds": (3_101, 3_102),
+        "prior_seed": 6_101,
+        "predictive_seed": 7_291,
+    }
+    TRUTH = {"a": 1.20, "t": 0.15, "v_x": 0.80, "v_y": -0.50}
+    PARAMETER_ORDER = ("a", "t", "v_x", "v_y")
+    HSSM_PARAMETER_ORDER = ("v_x", "v_y", "a", "t")
+    assert pytensor.config.floatX == "float64"
+    return (
+        FULL_RUN,
+        HSSM_PARAMETER_ORDER,
+        PARAMETER_ORDER,
+        RUN_CONFIG,
+        TRUTH,
+    )
+
+
+@app.cell
+def _(importlib, json, mo):
+    expected_jeam_revision = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+    _distribution = importlib.metadata.distribution("jeam")
+    _direct_url_text = _distribution.read_text("direct_url.json")
+    if _direct_url_text is None:
+        raise RuntimeError("JEAM installation has no direct-url provenance metadata.")
+    installed_jeam_revision = (
+        json.loads(_direct_url_text).get("vcs_info", {}).get("commit_id")
+    )
+    if installed_jeam_revision != expected_jeam_revision:
+        raise RuntimeError(
+            "This tutorial requires JEAM revision "
+            f"{expected_jeam_revision}, but found {installed_jeam_revision!r}. "
+            "Run `uv sync --group docs --group jeam-prototype --locked`."
+        )
+    mo.callout(
+        f"Verified installed JEAM revision `{installed_jeam_revision}`.",
+        kind="success",
+    )
+    return expected_jeam_revision, installed_jeam_revision
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 1. Simulate a known circular dataset
+
+    The data-generating values deliberately create an asymmetric drift direction.
+    The seeds are fixed so rerunning this notebook is deterministic.
+    """)
+    return
+
+
+@app.cell
+def _(RUN_CONFIG, mo, pd):
+    _configuration = pd.DataFrame(
+        [
+            {"setting": key.replace("_", " "), "value": value}
+            for key, value in RUN_CONFIG.items()
+        ]
+    )
+    mo.ui.table(_configuration, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(RUN_CONFIG, TRUTH, np, pd, simulate_circular_diffusion):
+    simulator_theta = np.array(
+        [TRUTH["v_x"], TRUTH["v_y"], TRUTH["a"], TRUTH["t"]],
+        dtype=np.float64,
+    )
+    observations = simulate_circular_diffusion(
+        theta=simulator_theta,
+        random_state=RUN_CONFIG["data_seed"],
+        n_replicas=RUN_CONFIG["trials"],
+    )
+    data = pd.DataFrame(observations, columns=["rt", "response"])
+    assert np.all(data["rt"] > 0.0)
+    assert np.all((-np.pi <= data["response"]) & (data["response"] < np.pi))
+    return data, observations, simulator_theta
+
+
+@app.cell
+def _(RUN_CONFIG, mo):
+    point_count = mo.ui.slider(
+        start=20,
+        stop=RUN_CONFIG["trials"],
+        step=10,
+        value=min(120, RUN_CONFIG["trials"]),
+        label="Trials shown",
+    )
+    point_count
+    return (point_count,)
+
+
+@app.cell
+def _(TRUTH, data, np, plt, point_count):
+    _visible = data.iloc[: point_count.value]
+    _figure = plt.figure(figsize=(8.5, 4.1))
+    _polar = _figure.add_subplot(1, 2, 1, projection="polar")
+    _polar.scatter(
+        _visible["response"],
+        _visible["rt"],
+        s=24,
+        alpha=0.65,
+        color="#4472C4",
+    )
+    _drift_angle = np.arctan2(TRUTH["v_y"], TRUTH["v_x"])
+    _polar.axvline(
+        _drift_angle,
+        color="#B22222",
+        linewidth=2,
+        label="drift direction",
+    )
+    _polar.set_title("Each response is an angle and an RT")
+    _polar.legend(loc="lower left", bbox_to_anchor=(-0.15, -0.18), fontsize=8)
+    _rt_axis = _figure.add_subplot(1, 2, 2)
+    _rt_axis.hist(data["rt"], bins=20, color="#9DC3E6", edgecolor="white")
+    _rt_axis.axvline(TRUTH["t"], color="#B22222", linestyle="--", label="true t")
+    _rt_axis.set(xlabel="response time", ylabel="trials", title="RT marginal")
+    _rt_axis.legend()
+    _figure.suptitle("Observed fixed-CDM data")
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    HSSM expects two columns in this order:
+
+    | column | meaning | allowed values |
+    |---|---|---|
+    | `rt` | ordinary response time | finite and strictly positive |
+    | `response` | angular coordinate in radians | $[-\pi, \pi)$ |
+
+    The model has no finite list of choices: an angle is a circular continuous
+    response, not a categorical label.
+    """)
+    return
+
+
+@app.cell
+def _(data, hssm):
+    circular_model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+    return (circular_model,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2. Build an ordinary HSSM model
+
+    No `HSSMCircular` subclass is involved. HSSM discovers the likelihood,
+    simulator, bounds, and response semantics from the registered
+    `circular_diffusion` model configuration.
+    """)
+    return
+
+
+@app.cell
+def _(circular_model, hssm, mo, np, pd):
+    model_contract = pd.DataFrame(
+        [
+            {"property": "Python class", "value": type(circular_model).__name__},
+            {"property": "model name", "value": circular_model.model_name},
+            {"property": "likelihood", "value": circular_model.loglik_kind},
+            {"property": "response kind", "value": circular_model.response_kind},
+            {
+                "property": "angle bounds",
+                "value": str(circular_model.response_bounds["response"]),
+            },
+            {"property": "parameters", "value": ", ".join(circular_model.list_params)},
+            {"property": "categorical choices", "value": str(circular_model.choices)},
+            {"property": "p_outlier", "value": "None (required)"},
+        ]
+    )
+    assert type(circular_model) is hssm.HSSM
+    assert circular_model.response_bounds == {"response": (-np.pi, np.pi)}
+    mo.ui.table(model_contract, selection=None, pagination=False)
+    return (model_contract,)
+
+
+@app.cell
+def _(RUN_CONFIG, data, hssm):
+    # Keep prior draws separate from the HSSM object that will hold posterior traces.
+    _prior_check_model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+    prior_predictive = _prior_check_model.sample_prior_predictive(
+        draws=RUN_CONFIG["prior_draws"],
+        random_seed=RUN_CONFIG["prior_seed"],
+    )
+    prior_values = prior_predictive["prior_predictive"]["rt,response"].values
+    return prior_predictive, prior_values
+
+
+@app.cell
+def _(data, np, plt, prior_values):
+    _figure, _axes = plt.subplots(1, 2, figsize=(8.5, 3.7))
+    _rt_limit = np.quantile(
+        np.concatenate([data["rt"].to_numpy(), prior_values[..., 0].ravel()]),
+        0.98,
+    )
+    _rt_bins = np.linspace(0.0, _rt_limit, 28)
+    _axes[0].hist(
+        prior_values[..., 0].ravel(),
+        bins=_rt_bins,
+        density=True,
+        alpha=0.45,
+        color="#ED7D31",
+        label="prior predictive",
+    )
+    _axes[0].hist(
+        data["rt"],
+        bins=_rt_bins,
+        density=True,
+        histtype="step",
+        linewidth=2,
+        color="#111111",
+        label="observed",
+    )
+    _axes[0].set(xlabel="response time", ylabel="density", title="RT scale")
+    _axes[0].legend(fontsize=8)
+    _angle_bins = np.linspace(-np.pi, np.pi, 25)
+    _axes[1].hist(
+        prior_values[..., 1].ravel(),
+        bins=_angle_bins,
+        density=True,
+        alpha=0.45,
+        color="#ED7D31",
+        label="prior predictive",
+    )
+    _axes[1].hist(
+        data["response"],
+        bins=_angle_bins,
+        density=True,
+        histtype="step",
+        linewidth=2,
+        color="#111111",
+        label="observed",
+    )
+    _axes[1].set(
+        xlabel="response angle (radians)",
+        ylabel="density",
+        title="Circular response",
+        xlim=(-np.pi, np.pi),
+    )
+    _axes[1].set_xticks([-np.pi, 0.0, np.pi], [r"$-\pi$", "0", r"$\pi$"])
+    _axes[1].legend(fontsize=8)
+    _figure.suptitle("Prior predictive check")
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    The prior predictive plot is the first model check. It asks whether the default
+    priors and simulator produce values on plausible RT and angular scales before the
+    observed likelihood is used. For an applied analysis, replace default priors with
+    domain-informed priors rather than treating this picture as a one-time ritual.
+
+    ## 3. Verify the numerical handshake
+
+    The next cell evaluates every observation twice at the known parameters:
+
+    1. directly through JEAM's `CircularDiffusionModel.joint_lpdf`, and
+    2. through the distribution constructed by this exact HSSM object.
+
+    Agreement checks the objective itself, not merely whether both APIs return finite
+    numbers.
+    """)
+    return
+
+
+@app.cell
+def _(
+    CircularDiffusionModel,
+    TRUTH,
+    circular_model,
+    np,
+    observations,
+    pd,
+):
+    direct_jeam = CircularDiffusionModel(threshold_dynamic="fixed")
+    direct_logp = np.asarray(
+        direct_jeam.joint_lpdf(
+            rt=observations[:, 0],
+            theta=observations[:, 1],
+            drift_vec=np.column_stack(
+                (
+                    np.full(len(observations), TRUTH["v_x"]),
+                    np.full(len(observations), TRUTH["v_y"]),
+                )
+            ),
+            ndt=np.full(len(observations), TRUTH["t"]),
+            threshold=TRUTH["a"],
+            decay=0.0,
+            threshold_function=None,
+            dt_threshold_function=None,
+            s_v=0.0,
+            s_t=0.0,
+            sigma=1.0,
+        ),
+        dtype=np.float64,
+    )
+    hssm_logp = np.asarray(
+        circular_model.model_distribution.logp(
+            observations,
+            TRUTH["v_x"],
+            TRUTH["v_y"],
+            TRUTH["a"],
+            TRUTH["t"],
+        ).eval(),
+        dtype=np.float64,
+    )
+    logp_absolute_error = np.abs(hssm_logp - direct_logp)
+    logp_comparison = pd.DataFrame(
+        [
+            {
+                "quantity": "summed log likelihood",
+                "direct JEAM": direct_logp.sum(),
+                "HSSM distribution": hssm_logp.sum(),
+                "absolute error": abs(hssm_logp.sum() - direct_logp.sum()),
+            },
+            {
+                "quantity": "largest pointwise absolute error",
+                "direct JEAM": np.nan,
+                "HSSM distribution": np.nan,
+                "absolute error": logp_absolute_error.max(),
+            },
+        ]
+    )
+    np.testing.assert_allclose(hssm_logp, direct_logp, rtol=1e-6, atol=5e-5)
+    return (
+        direct_jeam,
+        direct_logp,
+        hssm_logp,
+        logp_absolute_error,
+        logp_comparison,
+    )
+
+
+@app.cell
+def _(logp_comparison, mo):
+    mo.ui.table(logp_comparison.round(8), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 4. Fit with explicit PyMC Slice steps
+
+    This likelihood crosses a Python/NumPy black-box boundary and does **not** provide
+    gradients to PyTensor. Consequently:
+
+    - this tutorial uses one explicit PyMC `Slice` step per parameter;
+    - NUTS, JAX NUTS (`numpyro`, `blackjax`, or `nutpie`), and variational inference
+      are not supported by this prototype;
+    - `cores=1` keeps the notebook portable and reproducible; and
+    - `p_outlier=None` is required because HSSM's categorical lapse mixture is not a
+      density over continuous angles.
+
+    The short default run demonstrates the workflow. It is not a replacement for the
+    four-scenario, predeclared recovery benchmark in
+    `docs/tutorials/jeam_repeated_recovery.py`.
+    """)
+    return
+
+
+@app.cell
+def _(PARAMETER_ORDER, RUN_CONFIG, circular_model, perf_counter, pm):
+    slice_steps = [
+        pm.Slice(
+            vars=[circular_model.pymc_model[name]],
+            model=circular_model.pymc_model,
+        )
+        for name in PARAMETER_ORDER
+    ]
+    sampling_started = perf_counter()
+    traces = circular_model.sample(
+        sampler="pymc",
+        step=slice_steps,
+        chains=RUN_CONFIG["chains"],
+        cores=1,
+        tune=RUN_CONFIG["tune"],
+        draws=RUN_CONFIG["draws"],
+        random_seed=list(RUN_CONFIG["chain_seeds"]),
+        progressbar=False,
+        idata_kwargs={"log_likelihood": False},
+    )
+    sampling_seconds = perf_counter() - sampling_started
+    return sampling_seconds, slice_steps, traces
+
+
+@app.cell
+def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
+    posterior_summary = az.summary(
+        traces,
+        var_names=list(PARAMETER_ORDER),
+        ci_prob=0.94,
+        ci_kind="hdi",
+        round_to=8,
+    )
+    lower_column = next(
+        column
+        for column in posterior_summary.columns
+        if column.startswith("hdi") and column.endswith("_lb")
+    )
+    upper_column = next(
+        column
+        for column in posterior_summary.columns
+        if column.startswith("hdi") and column.endswith("_ub")
+    )
+    recovery_table = posterior_summary.reset_index(names="parameter")
+    recovery_table.insert(
+        1,
+        "truth",
+        recovery_table["parameter"].map(TRUTH),
+    )
+    recovery_table["mean error"] = recovery_table["mean"] - recovery_table["truth"]
+    recovery_table["truth in 94% HDI"] = (
+        recovery_table[lower_column] <= recovery_table["truth"]
+    ) & (recovery_table["truth"] <= recovery_table[upper_column])
+    sample_stat_names = tuple(
+        sorted(str(name) for name in traces["sample_stats"].data_vars)
+    )
+    maximum_rhat = float(posterior_summary["r_hat"].max())
+    minimum_bulk_ess = float(posterior_summary["ess_bulk"].min())
+    diagnostic_limits = {
+        "maximum R-hat": 1.01 if FULL_RUN else 1.05,
+        "minimum bulk ESS": 400.0 if FULL_RUN else 100.0,
+    }
+    diagnostics_ok = (
+        np.isfinite(maximum_rhat)
+        and maximum_rhat <= diagnostic_limits["maximum R-hat"]
+        and minimum_bulk_ess >= diagnostic_limits["minimum bulk ESS"]
+    )
+    sampling_report = pd.DataFrame(
+        [
+            {"diagnostic": "sampler statistics", "observed": str(sample_stat_names)},
+            {"diagnostic": "sampling seconds", "observed": sampling_seconds},
+            {"diagnostic": "maximum R-hat", "observed": maximum_rhat},
+            {"diagnostic": "minimum bulk ESS", "observed": minimum_bulk_ess},
+            {
+                "diagnostic": "mode-specific diagnostic screen",
+                "observed": diagnostics_ok,
+            },
+        ]
+    )
+    assert sample_stat_names == ("nstep_in", "nstep_out")
+    return (
+        diagnostic_limits,
+        diagnostics_ok,
+        lower_column,
+        maximum_rhat,
+        minimum_bulk_ess,
+        posterior_summary,
+        recovery_table,
+        sample_stat_names,
+        sampling_report,
+        upper_column,
+    )
+
+
+@app.cell
+def _(diagnostic_limits, diagnostics_ok, maximum_rhat, minimum_bulk_ess, mo):
+    _message = (
+        f"The diagnostic screen passed: maximum R-hat is {maximum_rhat:.3f} "
+        f"(limit {diagnostic_limits['maximum R-hat']:.2f}) and minimum bulk ESS "
+        f"is {minimum_bulk_ess:.0f} "
+        f"(limit {diagnostic_limits['minimum bulk ESS']:.0f})."
+        if diagnostics_ok
+        else f"Treat the posterior as provisional: maximum R-hat is "
+        f"{maximum_rhat:.3f} and minimum bulk ESS is {minimum_bulk_ess:.0f}. "
+        "Run FULL_RUN=1, inspect the chains, and revise the model before "
+        "substantive interpretation."
+    )
+    mo.callout(_message, kind="success" if diagnostics_ok else "warn")
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ### Diagnose before interpreting
+    """)
+    return
+
+
+@app.cell
+def _(mo, sampling_report):
+    mo.ui.table(sampling_report.round(4), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ### Parameter recovery in this one illustrative dataset
+    """)
+    return
+
+
+@app.cell
+def _(lower_column, mo, recovery_table, upper_column):
+    mo.ui.table(
+        recovery_table[
+            [
+                "parameter",
+                "truth",
+                "mean",
+                "mean error",
+                lower_column,
+                upper_column,
+                "truth in 94% HDI",
+                "ess_bulk",
+                "r_hat",
+            ]
+        ].round(4),
+        selection=None,
+        pagination=False,
+    )
+    return
+
+
+@app.cell
+def _(PARAMETER_ORDER, TRUTH, lower_column, posterior_summary, plt, upper_column):
+    _positions = list(range(len(PARAMETER_ORDER)))
+    _means = posterior_summary.loc[list(PARAMETER_ORDER), "mean"].to_numpy()
+    _lower = posterior_summary.loc[list(PARAMETER_ORDER), lower_column].to_numpy()
+    _upper = posterior_summary.loc[list(PARAMETER_ORDER), upper_column].to_numpy()
+    _truth = [TRUTH[name] for name in PARAMETER_ORDER]
+    _figure, _axis = plt.subplots(figsize=(8, 3.8))
+    _axis.errorbar(
+        _means,
+        _positions,
+        xerr=[_means - _lower, _upper - _means],
+        fmt="s",
+        capsize=3,
+        color="#4472C4",
+        label="posterior mean and 94% HDI",
+    )
+    _axis.scatter(
+        _truth,
+        _positions,
+        marker="x",
+        s=80,
+        linewidth=2,
+        color="#B22222",
+        label="generating truth",
+        zorder=4,
+    )
+    _axis.set_yticks(_positions, PARAMETER_ORDER)
+    _axis.invert_yaxis()
+    _axis.set(xlabel="parameter value", title="Recovery in one simulated dataset")
+    _axis.grid(axis="x", alpha=0.2)
+    _axis.legend(loc="best")
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(RUN_CONFIG, circular_model, perf_counter, traces):
+    predictive_started = perf_counter()
+    posterior_predictive = circular_model.sample_posterior_predictive(
+        dt=traces,
+        inplace=False,
+        kind="response",
+        draws=RUN_CONFIG["predictive_draws"],
+        safe_mode=True,
+        random_seed=RUN_CONFIG["predictive_seed"],
+    )
+    predictive_seconds = perf_counter() - predictive_started
+    if posterior_predictive is None:
+        raise RuntimeError("Expected non-inplace posterior predictive output.")
+    posterior_predictive_values = posterior_predictive["posterior_predictive"][
+        "rt,response"
+    ].values
+    return posterior_predictive, posterior_predictive_values, predictive_seconds
+
+
+@app.cell
+def _(mo):
+    predictive_view = mo.ui.dropdown(
+        options={
+            "Response time and angle": "both",
+            "Response time only": "rt",
+            "Angle only": "angle",
+        },
+        value="Response time and angle",
+        label="Posterior predictive view",
+    )
+    predictive_view
+    return (predictive_view,)
+
+
+@app.cell
+def _(data, np, plt, posterior_predictive_values, predictive_view):
+    _show_rt = predictive_view.value in {"both", "rt"}
+    _show_angle = predictive_view.value in {"both", "angle"}
+    _panels = int(_show_rt) + int(_show_angle)
+    _figure, _axes_array = plt.subplots(1, _panels, figsize=(4.4 * _panels, 3.7))
+    _axes = np.atleast_1d(_axes_array)
+    _axis_index = 0
+    if _show_rt:
+        _axis = _axes[_axis_index]
+        _rt_limit = np.quantile(
+            np.concatenate(
+                [data["rt"].to_numpy(), posterior_predictive_values[..., 0].ravel()]
+            ),
+            0.99,
+        )
+        _bins = np.linspace(0.0, _rt_limit, 30)
+        _axis.hist(
+            posterior_predictive_values[..., 0].ravel(),
+            bins=_bins,
+            density=True,
+            alpha=0.5,
+            color="#4472C4",
+            label="posterior predictive",
+        )
+        _axis.hist(
+            data["rt"],
+            bins=_bins,
+            density=True,
+            histtype="step",
+            linewidth=2,
+            color="#111111",
+            label="observed",
+        )
+        _axis.set(xlabel="response time", ylabel="density", title="RT distribution")
+        _axis.legend(fontsize=8)
+        _axis_index += 1
+    if _show_angle:
+        _axis = _axes[_axis_index]
+        _bins = np.linspace(-np.pi, np.pi, 25)
+        _axis.hist(
+            posterior_predictive_values[..., 1].ravel(),
+            bins=_bins,
+            density=True,
+            alpha=0.5,
+            color="#4472C4",
+            label="posterior predictive",
+        )
+        _axis.hist(
+            data["response"],
+            bins=_bins,
+            density=True,
+            histtype="step",
+            linewidth=2,
+            color="#111111",
+            label="observed",
+        )
+        _axis.set(
+            xlabel="response angle (radians)",
+            ylabel="density",
+            title="Circular response",
+            xlim=(-np.pi, np.pi),
+        )
+        _axis.set_xticks([-np.pi, 0.0, np.pi], [r"$-\pi$", "0", r"$\pi$"])
+        _axis.legend(fontsize=8)
+    _figure.suptitle("Posterior predictive check")
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(data, np, pd, posterior_predictive_values, predictive_seconds):
+    def _circular_summary(values):
+        _resultant = np.mean(np.exp(1j * np.asarray(values)))
+        return float(np.angle(_resultant)), float(np.abs(_resultant))
+
+    _observed_angle, _observed_length = _circular_summary(data["response"])
+    _predictive_angle, _predictive_length = _circular_summary(
+        posterior_predictive_values[..., 1]
+    )
+    _probabilities = np.array([0.1, 0.5, 0.9])
+    _observed_rt = np.quantile(data["rt"], _probabilities)
+    _predictive_rt = np.quantile(posterior_predictive_values[..., 0], _probabilities)
+    predictive_summary = pd.DataFrame(
+        [
+            *[
+                {
+                    "quantity": f"RT q{int(probability * 100)}",
+                    "observed": observed,
+                    "posterior predictive": predicted,
+                    "absolute difference": abs(observed - predicted),
+                }
+                for probability, observed, predicted in zip(
+                    _probabilities, _observed_rt, _predictive_rt, strict=True
+                )
+            ],
+            {
+                "quantity": "circular mean angle",
+                "observed": _observed_angle,
+                "posterior predictive": _predictive_angle,
+                "absolute difference": abs(
+                    np.angle(np.exp(1j * (_observed_angle - _predictive_angle)))
+                ),
+            },
+            {
+                "quantity": "mean resultant length",
+                "observed": _observed_length,
+                "posterior predictive": _predictive_length,
+                "absolute difference": abs(_observed_length - _predictive_length),
+            },
+            {
+                "quantity": "predictive runtime (seconds)",
+                "observed": np.nan,
+                "posterior predictive": predictive_seconds,
+                "absolute difference": np.nan,
+            },
+        ]
+    )
+    return (predictive_summary,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 5. Check posterior predictions
+
+    The visual check compares both components of the joint response. The table adds
+    RT quantiles and circular summaries; an arithmetic mean of angles would be wrong
+    near the minus-pi/pi seam.
+    """)
+    return
+
+
+@app.cell
+def _(mo, predictive_summary):
+    mo.ui.table(predictive_summary.round(4), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(
+    HSSM_PARAMETER_ORDER,
+    circular_model,
+    hssm,
+    logp_absolute_error,
+    np,
+    pd,
+    posterior_predictive_values,
+    sample_stat_names,
+):
+    predictive_support_ok = bool(
+        np.all(np.isfinite(posterior_predictive_values))
+        and np.all(posterior_predictive_values[..., 0] > 0.0)
+        and np.all(posterior_predictive_values[..., 1] >= -np.pi)
+        and np.all(posterior_predictive_values[..., 1] < np.pi)
+    )
+    validation_table = pd.DataFrame(
+        [
+            {
+                "workflow gate": "ordinary HSSM class",
+                "result": type(circular_model) is hssm.HSSM,
+            },
+            {
+                "workflow gate": "registered parameter order",
+                "result": tuple(circular_model.list_params) == HSSM_PARAMETER_ORDER,
+            },
+            {
+                "workflow gate": "direct JEAM vs HSSM logp",
+                "result": float(logp_absolute_error.max()) <= 5e-5,
+            },
+            {
+                "workflow gate": "explicit Slice statistics",
+                "result": sample_stat_names == ("nstep_in", "nstep_out"),
+            },
+            {
+                "workflow gate": "posterior predictive support",
+                "result": predictive_support_ok,
+            },
+        ]
+    )
+    assert validation_table["result"].all()
+    return predictive_support_ok, validation_table
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## What this run established
+    """)
+    return
+
+
+@app.cell
+def _(mo, validation_table):
+    mo.ui.table(validation_table, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    The notebook has now exercised the same registered likelihood and random variable
+    in both directions: inference consumed JEAM log densities, and predictive sampling
+    called JEAM's simulator through HSSM.
+
+    Before using this prototype for substantive work:
+
+    1. run `FULL_RUN=1` and require satisfactory diagnostics for your data;
+    2. choose and justify domain-specific priors;
+    3. compare posterior predictions to all scientifically important summaries;
+    4. consult `docs/tutorials/jeam_repeated_recovery.py` for the predeclared
+       multi-dataset recovery evidence; and
+    5. retain the exact JEAM revision in the analysis environment.
+
+    The integration remains deliberately narrow: fixed CDM, two-dimensional angular
+    responses, no lapse mixture, and gradient-free PyMC sampling.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
           - A complete scientific workflow: tutorials/scientific_workflow_hssm.ipynb
       - Model walkthroughs:
           - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
+          - Circular diffusion with JEAM: tutorials/jeam_circular_diffusion.py
           - Choice-only models: tutorials/choice_only_models.ipynb
           - Poisson race models: tutorials/poisson_race.ipynb
           - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
@@ -122,6 +123,7 @@ plugins:
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
         - tutorials/attentional_ddm.py
+        - tutorials/jeam_circular_diffusion.py
         - tutorials/jeam_repeated_recovery.py
         - tutorials/hsgp_regression.ipynb
         - tutorials/ddm_hierarchical_tutorial.ipynb


### PR DESCRIPTION
## Purpose

- add an executable marimo walkthrough for the fixed circular-diffusion prototype through the ordinary `hssm.HSSM` API
- connect the user workflow to the schema-v2, artifact-backed recovery report merged in #1204

## Changes

- simulate fixed-CDM data, verify direct JEAM/HSSM pointwise likelihood parity, and fit the explicitly selected `blackbox` route with PyMC Slice
- demonstrate prior and posterior predictive checks for RTs and circular responses
- add the tutorial to the public documentation navigation while keeping documentation builds from rerunning inference

## Verification

- strict marimo check and Ruff check/format
- default two-chain headless export: all five workflow gates passed; max R-hat 1.006; minimum bulk ESS 298
- exported HTML host-path/error scan and visual inspection of all four figures
- documentation-weight check and strict MkDocs build

## Scope

- fixed two-dimensional CDM only, with `sigma=1`, `s_v=0`, `s_t=0`, and no threshold decay or lapse mixture
- `FULL_RUN=1` lengthens one illustrative black-box/Slice fit; it is not the four-scenario recovery smoke or simulation-based calibration
