### PR TITLE
Document the experimental JEAM integration boundary

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -75,7 +75,35 @@ packages installed for additional features such as sampling with `blackjax` or G
 for `JAX`. Please follow the instructions below if you need any of these additional
 features:
 
-### 1. Sampling with JAX through `numpyro`, `nutpie` or `blackjax`
+### Experimental circular diffusion with JEAM
+
+The experimental `circular_diffusion` model is available only from an HSSM source
+checkout that contains the integration. Install its dependency with:
+
+```bash
+uv sync --group jeam-prototype
+```
+
+The group resolves the HSSM fork of JEAM at the immutable commit
+[`a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`](https://github.com/AlexanderFengler/JEAM/commit/a9f547b3630ae8ff31ccec1b904e0c02fdba6d99).
+To run the [circular-diffusion tutorial](../tutorials/jeam_circular_diffusion.py),
+also install the documentation dependencies:
+
+```bash
+uv sync --group docs --group jeam-prototype
+uv run --group docs --group jeam-prototype \
+  marimo edit docs/tutorials/jeam_circular_diffusion.py
+```
+
+This is deliberately a uv dependency group, not a published package extra. JEAM does
+not yet have the versioned release needed for stable HSSM package metadata, so the
+prototype pins the audited Git revision through `[tool.uv.sources]`. Dependency groups
+are source-checkout tooling and are omitted from HSSM's built wheel metadata. Therefore:
+
+- installing ordinary HSSM does not install or import JEAM; and
+- `pip install hssm[jeam]` is not supported yet.
+
+### Sampling with JAX through `numpyro`, `nutpie` or `blackjax`
 
 JAX-based sampling is done through `numpyro`, `nutpie`, or `blackjax`. `numpyro` is installed as
 a dependency by default. You need to have `blackjax` installed if you want to use the
@@ -85,7 +113,7 @@ a dependency by default. You need to have `blackjax` installed if you want to us
 pip install blackjax nutpie
 ```
 
-### 2. Visualizing the model with `graphviz`
+### Visualizing the model with `graphviz`
 
 Model graphs are created with `model.graph()` through `graphviz`. You need to have
 the Graphviz binaries available on your `PATH` (the `dot` command) and then install

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -67,16 +67,18 @@ import hssm
 model = hssm.HSSM(
     data=data,
     model="circular_diffusion",
+    loglik_kind="blackbox",
     p_outlier=None,
 )
 ```
 
 ## Inference and prediction
 
-The JEAM likelihood crosses a NumPy/Python black-box boundary and does not expose
-gradients to PyTensor. Use the PyMC backend with an explicitly gradient-free step method,
-such as one `pm.Slice` step for each parameter. NUTS, the JAX samplers, and variational
-inference are not supported for this model.
+For `loglik_kind="blackbox"`, the JEAM likelihood crosses a NumPy/Python boundary and
+does not expose gradients to PyTensor. Use the PyMC backend with an explicitly
+gradient-free step method. The linked intercept-only tutorial assigns one `pm.Slice`
+step to each free PyMC variable. NUTS, the JAX samplers, and variational inference are
+not available for this black-box route.
 
 Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
 HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.
@@ -98,10 +100,10 @@ not currently provide:
 - higher-dimensional observed responses beyond the two columns `[rt, response]`.
 
 The wrapper has pointwise direct-JEAM/HSSM likelihood parity tests, deterministic
-predictive tests, a marked-slow Bayesian recovery test, and a predeclared four-scenario
-[repeated-recovery study](../tutorials/jeam_repeated_recovery.py). This evidence validates
-the narrow handshake; it is not a claim of production-scale sampler performance or
-long-run frequentist calibration.
+predictive tests, a marked-slow Bayesian recovery test, and an artifact-backed,
+schema-v2 four-scenario deterministic [recovery smoke](../tutorials/jeam_repeated_recovery.py).
+This evidence validates the narrow handshake; it is not a claim of production-scale
+sampler performance or simulation-based calibration.
 
 ## Promotion checklist
 
@@ -111,9 +113,9 @@ Before promoting the fixed-CDM integration to HSSM's stable released surface:
   simulator contracts.
 - [ ] HSSM replaces the source-only dependency group with a public, released optional
   extra such as `hssm[jeam]` and tests installation from built wheel metadata.
-- [ ] Gradient-free inference is benchmarked on realistic hierarchical workloads, with
-  documented runtime, convergence, and effective-sample-size expectations; otherwise a
-  production-suitable likelihood strategy is selected.
+- [ ] Every candidate inference route is benchmarked on realistic hierarchical workloads,
+  with documented runtime, convergence, and effective-sample-size expectations; the
+  promoted default is selected from that evidence.
 - [ ] A density and simulator contract is designed and tested for lapse/outlier mixtures
   over continuous and circular responses.
 - [ ] Native circular diagnostics and plotting cover prior/posterior prediction without

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -1,0 +1,125 @@
+# JEAM circular diffusion
+
+!!! warning "Experimental integration"
+
+    `circular_diffusion` is a source-checkout prototype, not part of HSSM's stable
+    released model surface. It depends on an immutable revision of the HSSM JEAM fork
+    and has the limitations recorded below.
+
+HSSM registers JEAM's two-dimensional, fixed-boundary circular diffusion model under
+the model name `circular_diffusion`. It uses the ordinary [`hssm.HSSM`][hssm.HSSM]
+class: the response domain, likelihood, and simulator are supplied by the model
+configuration rather than a circular-model subclass.
+
+## Install
+
+From an HSSM source checkout that contains the integration, run:
+
+```bash
+uv sync --group jeam-prototype
+```
+
+The group pins the HSSM fork of JEAM to
+[`a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`](https://github.com/AlexanderFengler/JEAM/commit/a9f547b3630ae8ff31ccec1b904e0c02fdba6d99).
+It is not installed with ordinary HSSM, and no public `hssm[jeam]` extra exists yet.
+See [Installation](../getting_started/installation.md#experimental-circular-diffusion-with-jeam)
+for the dependency-policy rationale.
+
+## Model contract
+
+The observed data must contain these columns in this order:
+
+| Column | Meaning | Allowed values |
+| --- | --- | --- |
+| `rt` | Response time | Finite and strictly positive |
+| `response` | Angular coordinate in radians | Finite values in the half-open interval $[-\pi, \pi)$ |
+
+`response` is circular continuous data, not a categorical choice label. The pointwise
+likelihood is a density with respect to the ordinary response-time and angular-coordinate
+differentials, $d\,rt\,d\theta$.
+
+The four HSSM parameters map to JEAM as follows:
+
+| HSSM parameter | JEAM quantity | Configured bounds |
+| --- | --- | --- |
+| `v_x` | First Cartesian component of `drift_vec` | $(-3, 3)$ |
+| `v_y` | Second Cartesian component of `drift_vec` | $(-3, 3)$ |
+| `a` | Fixed decision threshold | $(0.1, 3)$ |
+| `t` | Nondecision time (`ndt`) | $(0, 2)$ |
+
+Parameters may be intercept-only or trial-wise through ordinary HSSM formulas. The
+prototype fixes all other JEAM settings:
+
+| Setting | Fixed value |
+| --- | --- |
+| Threshold dynamics | Fixed |
+| Diffusion scale $\sigma$ | $1$ |
+| Drift variability $s_v$ | $0$ |
+| Nondecision-time variability $s_t$ | $0$ |
+| Threshold decay | $0$ |
+| Custom threshold function | None |
+
+Construct the model with the lapse mixture disabled:
+
+```python
+import hssm
+
+model = hssm.HSSM(
+    data=data,
+    model="circular_diffusion",
+    p_outlier=None,
+)
+```
+
+## Inference and prediction
+
+The JEAM likelihood crosses a NumPy/Python black-box boundary and does not expose
+gradients to PyTensor. Use the PyMC backend with an explicitly gradient-free step method,
+such as one `pm.Slice` step for each parameter. NUTS, the JAX samplers, and variational
+inference are not supported for this model.
+
+Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
+HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.
+The [complete marimo walkthrough](../tutorials/jeam_circular_diffusion.py) demonstrates
+construction, explicit Slice sampling, likelihood parity, diagnostics, and predictive
+checks.
+
+## Current boundary
+
+The prototype supports only the fixed circular diffusion model described above. It does
+not currently provide:
+
+- continuous-response lapse or outlier mixtures (`p_outlier` must be `None`);
+- native circular versions of HSSM's category-oriented plotting functions;
+- differentiable, JAX, LAN, or variational likelihood paths;
+- collapsing or custom thresholds, or nonzero $s_v$ or $s_t$;
+- spherical, hyperspherical, projected, categorical, or ordinary continuous-response
+  JEAM model registrations; or
+- higher-dimensional observed responses beyond the two columns `[rt, response]`.
+
+The wrapper has pointwise direct-JEAM/HSSM likelihood parity tests, deterministic
+predictive tests, a marked-slow Bayesian recovery test, and a predeclared four-scenario
+[repeated-recovery study](../tutorials/jeam_repeated_recovery.py). This evidence validates
+the narrow handshake; it is not a claim of production-scale sampler performance or
+long-run frequentist calibration.
+
+## Promotion checklist
+
+Before promoting the fixed-CDM integration to HSSM's stable released surface:
+
+- [ ] JEAM publishes a versioned release containing the audited likelihood and seeded
+  simulator contracts.
+- [ ] HSSM replaces the source-only dependency group with a public, released optional
+  extra such as `hssm[jeam]` and tests installation from built wheel metadata.
+- [ ] Gradient-free inference is benchmarked on realistic hierarchical workloads, with
+  documented runtime, convergence, and effective-sample-size expectations; otherwise a
+  production-suitable likelihood strategy is selected.
+- [ ] A density and simulator contract is designed and tested for lapse/outlier mixtures
+  over continuous and circular responses.
+- [ ] Native circular diagnostics and plotting cover prior/posterior prediction without
+  treating angles as categorical choices.
+
+Broader JEAM model families are a separate expansion gate. Each family must independently
+specify its response coordinates and density measure, observed shape, parameter map,
+simulation contract, numerical oracle tests, recovery evidence, and inference limitations
+before it is registered in HSSM.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,8 @@ nav:
       - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
       - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
   - Reference:
+      - Experimental integrations:
+          - JEAM circular diffusion: reference/jeam_circular_diffusion.md
       - HSSM core classes:
           - hssm.HSSM: api/hssm.md
           - hssm.Param: api/param.md


### PR DESCRIPTION
## Purpose

- document how a source checkout installs the experimental JEAM dependency without changing HSSM's released package metadata
- define the supported fixed circular-diffusion contract and its promotion boundary in one reference page

## Changes

- document the `jeam-prototype` dependency group, immutable JEAM revision, and absence of a published `hssm[jeam]` extra
- specify the response measure, parameter map, fixed settings, explicit `blackbox`/Slice inference route, predictive contract, exclusions, and promotion checklist
- describe the merged schema-v2 evidence as an artifact-backed four-scenario deterministic recovery smoke, not calibration
- add the experimental JEAM reference page to the documentation navigation

## Verification

- historical commits replayed patch-identically onto current `dev` (`range-diff` marks both `=`)
- independent replay and documentation reviews found no blocker
- strict MkDocs build passed
- documentation-weight and `git diff --check` gates passed

## Scope

- documentation only; no runtime API, dependency metadata, lockfile, or evidence changes
- fixed two-dimensional CDM and the currently registered black-box route only
- retains JEAM pin `a9f547b…`; the later analytical/x64 stack must update every pin and capability statement atomically to the accepted JEAM merge
