### PR TITLE
Add x64-safe analytical JEAM circular likelihood

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -85,7 +85,7 @@ uv sync --group jeam-prototype
 ```
 
 The group resolves the HSSM fork of JEAM at the immutable commit
-[`0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`](https://github.com/AlexanderFengler/JEAM/commit/0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce).
+[`ede7a4f4faf226e4dae52c84dfb01012939cccdc`](https://github.com/AlexanderFengler/JEAM/commit/ede7a4f4faf226e4dae52c84dfb01012939cccdc).
 To run the [circular-diffusion tutorial](../tutorials/jeam_circular_diffusion.py),
 also install the documentation dependencies:
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -85,7 +85,7 @@ uv sync --group jeam-prototype
 ```
 
 The group resolves the HSSM fork of JEAM at the immutable commit
-[`a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`](https://github.com/AlexanderFengler/JEAM/commit/a9f547b3630ae8ff31ccec1b904e0c02fdba6d99).
+[`0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`](https://github.com/AlexanderFengler/JEAM/commit/0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce).
 To run the [circular-diffusion tutorial](../tutorials/jeam_circular_diffusion.py),
 also install the documentation dependencies:
 

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -20,7 +20,7 @@ uv sync --group jeam-prototype
 ```
 
 The group pins the HSSM fork of JEAM to
-[`a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`](https://github.com/AlexanderFengler/JEAM/commit/a9f547b3630ae8ff31ccec1b904e0c02fdba6d99).
+[`0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`](https://github.com/AlexanderFengler/JEAM/commit/0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce).
 It is not installed with ordinary HSSM, and no public `hssm[jeam]` extra exists yet.
 See [Installation](../getting_started/installation.md#experimental-circular-diffusion-with-jeam)
 for the dependency-policy rationale.
@@ -80,6 +80,23 @@ gradient-free step method. The linked intercept-only tutorial assigns one `pm.Sl
 step to each free PyMC variable. NUTS, the JAX samplers, and variational inference are
 not available for this black-box route.
 
+An opt-in, strict JAX likelihood is also registered through HSSM's ordinary
+configuration surface:
+
+```python
+model = hssm.HSSM(
+    data=data,
+    model="circular_diffusion",
+    loglik_kind="approx_differentiable",
+    p_outlier=None,
+)
+```
+
+This path preserves JEAM's pointwise values and exposes reverse-mode parameter gradients
+through HSSM's existing JAX/PyTensor bridge. It is still under sampler recovery and
+efficiency evaluation; NUTS, JAX samplers, and variational inference are not promoted as
+supported workflows for this model yet.
+
 Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
 HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.
 The [complete marimo walkthrough](../tutorials/jeam_circular_diffusion.py) demonstrates
@@ -93,7 +110,8 @@ not currently provide:
 
 - continuous-response lapse or outlier mixtures (`p_outlier` must be `None`);
 - native circular versions of HSSM's category-oriented plotting functions;
-- differentiable, JAX, LAN, or variational likelihood paths;
+- a promoted differentiable sampler default, LAN likelihood, or validated variational
+  workflow;
 - collapsing or custom thresholds, or nonzero $s_v$ or $s_t$;
 - spherical, hyperspherical, projected, categorical, or ordinary continuous-response
   JEAM model registrations; or

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -98,6 +98,13 @@ reverse-mode parameter gradients through HSSM's existing JAX/PyTensor bridge. It
 under sampler recovery and efficiency evaluation; NUTS, JAX samplers, and variational
 inference are not promoted as supported workflows for this model yet.
 
+The analytical route requires JAX x64 execution. HSSM checks
+`jax.config.jax_enable_x64` during model construction and does not change the global JAX
+setting. Call `hssm.set_floatX("float64")` before constructing this route. When x64 is
+disabled, the `blackbox` likelihood and its PyMC Slice workflow remain available.
+The gate checks JAX execution precision, not input dtype: float32 model inputs remain
+supported when JAX x64 execution is enabled independently.
+
 Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
 HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.
 The [complete marimo walkthrough](../tutorials/jeam_circular_diffusion.py) demonstrates

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -20,7 +20,7 @@ uv sync --group jeam-prototype
 ```
 
 The group pins the HSSM fork of JEAM to
-[`0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`](https://github.com/AlexanderFengler/JEAM/commit/0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce).
+[`ede7a4f4faf226e4dae52c84dfb01012939cccdc`](https://github.com/AlexanderFengler/JEAM/commit/ede7a4f4faf226e4dae52c84dfb01012939cccdc).
 It is not installed with ordinary HSSM, and no public `hssm[jeam]` extra exists yet.
 See [Installation](../getting_started/installation.md#experimental-circular-diffusion-with-jeam)
 for the dependency-policy rationale.

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -87,15 +87,16 @@ configuration surface:
 model = hssm.HSSM(
     data=data,
     model="circular_diffusion",
-    loglik_kind="approx_differentiable",
+    loglik_kind="analytical",
     p_outlier=None,
 )
 ```
 
-This path preserves JEAM's pointwise values and exposes reverse-mode parameter gradients
-through HSSM's existing JAX/PyTensor bridge. It is still under sampler recovery and
-efficiency evaluation; NUTS, JAX samplers, and variational inference are not promoted as
-supported workflows for this model yet.
+This semi-analytical path evaluates JEAM's truncated first-passage series directly; it is
+not a learned likelihood approximation. It preserves JEAM's pointwise values and exposes
+reverse-mode parameter gradients through HSSM's existing JAX/PyTensor bridge. It is still
+under sampler recovery and efficiency evaluation; NUTS, JAX samplers, and variational
+inference are not promoted as supported workflows for this model yet.
 
 Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
 HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -97,7 +97,7 @@ def _(mo):
     ```
 
     The dependency group resolves the HSSM fork of JEAM at commit
-    `0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`. This is a VCS-pinned prototype,
+    `ede7a4f4faf226e4dae52c84dfb01012939cccdc`. This is a VCS-pinned prototype,
     not a released HSSM runtime dependency.
 
     The default run below uses 120 trials and two short chains. Start marimo with
@@ -153,7 +153,7 @@ def _(hssm, os, pytensor, warnings):
 
 @app.cell
 def _(importlib, json, mo):
-    expected_jeam_revision = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
+    expected_jeam_revision = "ede7a4f4faf226e4dae52c84dfb01012939cccdc"
     _distribution = importlib.metadata.distribution("jeam")
     _direct_url_text = _distribution.read_text("direct_url.json")
     if _direct_url_text is None:

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -97,7 +97,7 @@ def _(mo):
     ```
 
     The dependency group resolves the HSSM fork of JEAM at commit
-    `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`. This is a VCS-pinned prototype,
+    `0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`. This is a VCS-pinned prototype,
     not a released HSSM runtime dependency.
 
     The default run below uses 120 trials and two short chains. Start marimo with
@@ -153,7 +153,7 @@ def _(hssm, os, pytensor, warnings):
 
 @app.cell
 def _(importlib, json, mo):
-    expected_jeam_revision = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+    expected_jeam_revision = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
     _distribution = importlib.metadata.distribution("jeam")
     _direct_url_text = _distribution.read_text("direct_url.json")
     if _direct_url_text is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ publish-url = "https://test.pypi.org/legacy/"
 
 [tool.uv.sources]
 hssm = { workspace = true }
-jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99" }
+jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce" }
 
 [tool.pyrefly]
 preset = "legacy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ publish-url = "https://test.pypi.org/legacy/"
 
 [tool.uv.sources]
 hssm = { workspace = true }
-jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce" }
+jeam = { git = "https://github.com/AlexanderFengler/JEAM.git", rev = "ede7a4f4faf226e4dae52c84dfb01012939cccdc" }
 
 [tool.pyrefly]
 preset = "legacy"

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -42,6 +42,7 @@ class LoglikConfig(TypedDict):
 
     loglik: LogLik
     backend: Optional[Literal["jax", "pytensor"]]
+    requires_jax_x64: NotRequired[bool]
     default_priors: dict[str, ParamSpec]
     bounds: dict[str, tuple[float, float]]
     extra_fields: Optional[list[str]]

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -61,6 +61,7 @@ class DefaultConfig(TypedDict):
     rv: NotRequired[Any]
     description: Optional[str]
     likelihoods: LoglikConfigs
+    default_loglik_kind: NotRequired[LoglikKind]
 
 
 DefaultConfigs = dict[SupportedModels, DefaultConfig]

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -181,11 +181,17 @@ class Config(BaseModelConfig):
                 raise ValueError(
                     "When using a custom model, please provide a `loglik_kind.`"
                 )
+            model_name = cast("SupportedModels", model_name)
+            default_config = deepcopy(default_model_config[model_name])
+            default_loglik_kind = default_config.get("default_loglik_kind")
+            if default_loglik_kind is not None:
+                return cls._from_registered_default(
+                    model_name, default_loglik_kind, default_config
+                )
+
             # Setting loglik_kind to be the first of analytical or
             # approx_differentiable
             for kind in ["analytical", "approx_differentiable", "blackbox"]:
-                model_name = cast("SupportedModels", model_name)
-                default_config = deepcopy(default_model_config[model_name])
                 if kind in default_config["likelihoods"]:
                     kind = cast("LoglikKind", kind)
                     return cls._from_registered_default(

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from math import isfinite
 from typing import Any, Literal, Union, cast, get_args
 
+import jax
 from bambi import Prior
 from ssms.config import model_config as ssms_model_config
 
@@ -144,6 +145,7 @@ class Config(BaseModelConfig):
     """Config class that stores the configurations for models."""
 
     rv: Any | None = None
+    requires_jax_x64: bool = False
     # Fields with dictionaries are automatically deepcopied
     default_priors: dict[str, ParamSpec] = field(default_factory=dict)
 
@@ -321,6 +323,13 @@ class Config(BaseModelConfig):
             raise ValueError("Please provide a log-likelihood function via `loglik`.")
         if self.loglik_kind == "approx_differentiable" and self.backend is None:
             raise ValueError("Please provide `backend` via `model_config`.")
+        if self.requires_jax_x64 and not jax.config.jax_enable_x64:
+            raise ValueError(
+                f"The {self.model_name!r} {self.loglik_kind!r} likelihood requires "
+                "JAX x64 execution, but `jax_enable_x64` is disabled. Enable JAX "
+                "x64 before constructing the model; HSSM does not mutate global "
+                "JAX configuration."
+            )
 
     def get_defaults(
         self, param: str

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -24,6 +24,30 @@ def _load_circular_diffusion_model() -> Callable[..., Any]:
     return CircularDiffusionModel
 
 
+def _load_fixed_cdm_logpdf_single() -> Callable[..., Any]:
+    """Load JEAM's JAX kernel without importing JEAM from base HSSM paths."""
+    try:
+        from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf_single
+    except ModuleNotFoundError as exc:
+        if exc.name == "jeam" or (
+            exc.name is not None and exc.name.startswith("jeam.")
+        ):
+            raise ImportError(
+                "The experimental JEAM integration requires the "
+                "`jeam-prototype` dependency group. Install it with "
+                "`uv sync --group jeam-prototype`."
+            ) from exc
+        raise
+    except ImportError as exc:
+        raise ImportError(
+            "The installed JEAM revision does not provide the differentiable "
+            "fixed-CDM likelihood. Refresh it with "
+            "`uv sync --group jeam-prototype --locked`."
+        ) from exc
+
+    return fixed_cdm_logpdf_single
+
+
 def _broadcast_parameter(
     value: float | np.ndarray, name: str, n_observations: int
 ) -> np.ndarray:
@@ -124,6 +148,33 @@ def logp_circular_diffusion(
     return logp
 
 
+def logp_circular_diffusion_jax(
+    data: Any,
+    v_x: Any,
+    v_y: Any,
+    a: Any,
+    t: Any,
+) -> Any:
+    """Evaluate one strict fixed-CDM log density through JEAM's JAX kernel.
+
+    ``data`` is one HSSM observation in ``[rt, response]`` order. HSSM's standard
+    differentiable-likelihood builder vmaps this single-trial callable according to
+    the model's scalar and regression-generated parameter shapes. The diffusion scale
+    is fixed to one, matching :func:`logp_circular_diffusion`; no finite density floor
+    is applied on this strict inference path.
+    """
+    fixed_cdm_logpdf_single = _load_fixed_cdm_logpdf_single()
+    return fixed_cdm_logpdf_single(
+        data[0],
+        data[1],
+        v_x,
+        v_y,
+        a,
+        t,
+        sigma=1.0,
+    )
+
+
 def _normalize_simulator_theta(theta: np.ndarray) -> np.ndarray:
     """Normalize HSSM simulator parameters to one ``[v_x, v_y, a, t]`` row."""
     try:
@@ -222,4 +273,8 @@ setattr(simulate_circular_diffusion, "choices", [])
 setattr(simulate_circular_diffusion, "obs_dim", 2)
 
 
-__all__ = ["logp_circular_diffusion", "simulate_circular_diffusion"]
+__all__ = [
+    "logp_circular_diffusion",
+    "logp_circular_diffusion_jax",
+    "simulate_circular_diffusion",
+]

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -24,10 +24,10 @@ def _load_circular_diffusion_model() -> Callable[..., Any]:
     return CircularDiffusionModel
 
 
-def _load_fixed_cdm_logpdf_single() -> Callable[..., Any]:
-    """Load JEAM's JAX kernel without importing JEAM from base HSSM paths."""
+def _load_fixed_cdm_logpdf() -> Callable[..., Any]:
+    """Load JEAM's batched JAX kernel without importing it from base HSSM paths."""
     try:
-        from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf_single
+        from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf
     except ModuleNotFoundError as exc:
         if exc.name == "jeam" or (
             exc.name is not None and exc.name.startswith("jeam.")
@@ -45,7 +45,7 @@ def _load_fixed_cdm_logpdf_single() -> Callable[..., Any]:
             "`uv sync --group jeam-prototype --locked`."
         ) from exc
 
-    return fixed_cdm_logpdf_single
+    return fixed_cdm_logpdf
 
 
 def _broadcast_parameter(
@@ -155,18 +155,19 @@ def logp_circular_diffusion_jax(
     a: Any,
     t: Any,
 ) -> Any:
-    """Evaluate one strict fixed-CDM log density through JEAM's JAX kernel.
+    """Evaluate strict fixed-CDM log densities through JEAM's JAX kernel.
 
-    ``data`` is one HSSM observation in ``[rt, response]`` order. HSSM's standard
-    differentiable-likelihood builder vmaps this single-trial callable according to
-    the model's scalar and regression-generated parameter shapes. The diffusion scale
-    is fixed to one, matching :func:`logp_circular_diffusion`; no finite density floor
-    is applied on this strict inference path.
+    ``data`` contains HSSM observations in ``[rt, response]`` order. JEAM's public
+    batched evaluator broadcasts scalar and regression-generated parameters across the
+    observations. This lets HSSM classify the semi-analytical likelihood as
+    ``analytical`` instead of routing it through the LAN-oriented single-trial vmap
+    path. The diffusion scale is fixed to one, matching
+    :func:`logp_circular_diffusion`; no finite density floor is applied.
     """
-    fixed_cdm_logpdf_single = _load_fixed_cdm_logpdf_single()
-    return fixed_cdm_logpdf_single(
-        data[0],
-        data[1],
+    fixed_cdm_logpdf = _load_fixed_cdm_logpdf()
+    return fixed_cdm_logpdf(
+        data[:, 0],
+        data[:, 1],
         v_x,
         v_y,
         a,

--- a/src/hssm/modelconfig/circular_diffusion_config.py
+++ b/src/hssm/modelconfig/circular_diffusion_config.py
@@ -3,7 +3,11 @@
 from math import pi
 
 from .._types import DefaultConfig
-from ..integrations.jeam import logp_circular_diffusion, simulate_circular_diffusion
+from ..integrations.jeam import (
+    logp_circular_diffusion,
+    logp_circular_diffusion_jax,
+    simulate_circular_diffusion,
+)
 
 
 def get_circular_diffusion_config() -> DefaultConfig:
@@ -24,7 +28,25 @@ def get_circular_diffusion_config() -> DefaultConfig:
             "Experimental fixed-boundary JEAM circular diffusion model with "
             "Cartesian drift"
         ),
+        "default_loglik_kind": "blackbox",
         "likelihoods": {
+            "approx_differentiable": {
+                "loglik": logp_circular_diffusion_jax,
+                "backend": "jax",
+                "default_priors": {
+                    "t": {
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
+                    },
+                },
+                "bounds": {
+                    "v_x": (-3.0, 3.0),
+                    "v_y": (-3.0, 3.0),
+                    "a": (0.1, 3.0),
+                    "t": (0.0, 2.0),
+                },
+                "extra_fields": None,
+            },
             "blackbox": {
                 "loglik": logp_circular_diffusion,
                 "backend": None,
@@ -41,6 +63,6 @@ def get_circular_diffusion_config() -> DefaultConfig:
                     "t": (0.0, 2.0),
                 },
                 "extra_fields": None,
-            }
+            },
         },
     }

--- a/src/hssm/modelconfig/circular_diffusion_config.py
+++ b/src/hssm/modelconfig/circular_diffusion_config.py
@@ -33,6 +33,7 @@ def get_circular_diffusion_config() -> DefaultConfig:
             "analytical": {
                 "loglik": logp_circular_diffusion_jax,
                 "backend": "jax",
+                "requires_jax_x64": True,
                 "default_priors": {
                     "t": {
                         "name": "HalfNormal",

--- a/src/hssm/modelconfig/circular_diffusion_config.py
+++ b/src/hssm/modelconfig/circular_diffusion_config.py
@@ -30,7 +30,7 @@ def get_circular_diffusion_config() -> DefaultConfig:
         ),
         "default_loglik_kind": "blackbox",
         "likelihoods": {
-            "approx_differentiable": {
+            "analytical": {
                 "loglik": logp_circular_diffusion_jax,
                 "backend": "jax",
                 "default_priors": {

--- a/src/hssm/register.py
+++ b/src/hssm/register.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from ._types import (
     DefaultConfig,
     LoglikConfigs,
+    LoglikKind,
     ResponseKind,
     SupportedModels,
 )
@@ -24,6 +25,7 @@ def register_model(
     response_kind: ResponseKind = "categorical",
     response_bounds: dict[str, tuple[float, float]] | None = None,
     rv: Any | None = None,
+    default_loglik_kind: LoglikKind | None = None,
 ) -> None:
     """Register a new model in HSSM.
 
@@ -47,6 +49,8 @@ def register_model(
         Optional bounds keyed by non-RT response column.
     rv : optional
         RandomVariable or simulator callable used for predictive sampling.
+    default_loglik_kind : optional
+        Explicit likelihood kind selected when callers do not provide one.
 
     Returns
     -------
@@ -60,6 +64,11 @@ def register_model(
     # Ensure no collisions with existing models
     if name in registered_models:
         raise ValueError(f"Model '{name}' already exists")
+    if default_loglik_kind is not None and default_loglik_kind not in likelihoods:
+        raise ValueError(
+            f"Default likelihood kind {default_loglik_kind!r} is not registered "
+            f"for model {name!r}."
+        )
 
     _config: dict[str, Any] = {
         "response": response,
@@ -74,6 +83,8 @@ def register_model(
         _config["response_bounds"] = response_bounds
     if rv is not None:
         _config["rv"] = rv
+    if default_loglik_kind is not None:
+        _config["default_loglik_kind"] = default_loglik_kind
     config = cast("DefaultConfig", _config)
 
     # TODO: validate provided configs?

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -7,8 +7,8 @@ pytest.importorskip("jeam")
 
 import jax
 import jax.numpy as jnp
+from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf, fixed_cdm_logpdf_single
 from jeam.Models.Circular import CircularDiffusionModel
-from jeam.likelihoods import fixed_cdm_logpdf, fixed_cdm_logpdf_single
 
 from hssm.distribution_utils.dist import (
     LOGP_LB,
@@ -74,13 +74,11 @@ def test_jax_adapter_parameter_gradient_matches_the_direct_jeam_kernel():
     data = jnp.asarray([0.53, 0.7])
     parameters = jnp.asarray([0.45, -0.30, 1.20, 0.08])
 
-    observed = jax.grad(
-        lambda values: logp_circular_diffusion_jax(data, *values)
-    )(parameters)
+    observed = jax.grad(lambda values: logp_circular_diffusion_jax(data, *values))(
+        parameters
+    )
     expected = jax.grad(
-        lambda values: fixed_cdm_logpdf_single(
-            data[0], data[1], *values
-        )
+        lambda values: fixed_cdm_logpdf_single(data[0], data[1], *values)
     )(parameters)
 
     np.testing.assert_allclose(observed, expected, rtol=5e-7, atol=5e-7)
@@ -190,7 +188,7 @@ def test_adapter_preserves_jeam_impossible_rt_support_value():
     observed = logp_circular_diffusion(data, v_x=v_x, v_y=v_y, a=threshold, t=ndt)
 
     np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
-    np.testing.assert_allclose(observed, np.log(1e-14), rtol=0.0, atol=1e-12)
+    np.testing.assert_array_equal(observed, -np.inf)
 
 
 def test_compiled_hssm_distribution_matches_adapter_and_direct_jeam(
@@ -234,7 +232,7 @@ def test_compiled_hssm_distribution_accepts_a_trialwise_drift(
 
 
 def test_hssm_distribution_applies_standard_ndt_support_mask(circular_distribution):
-    """HSSM should replace JEAM's finite floor when nondecision time reaches RT."""
+    """HSSM should replace JEAM's strict support value with its standard mask."""
     data = np.array([[0.18, -0.4], [0.37, 0.6], [0.82, 1.2]])
     ndt = np.array([0.08, 0.37, 0.90])
 
@@ -248,7 +246,7 @@ def test_hssm_distribution_applies_standard_ndt_support_mask(circular_distributi
         adapted[0], rel=COMPILED_RTOL, abs=COMPILED_ATOL
     )
     np.testing.assert_array_equal(compiled[1:], lower_bound)
-    np.testing.assert_allclose(adapted[1:], np.log(1e-14), atol=1e-12)
+    np.testing.assert_array_equal(adapted[1:], -np.inf)
 
 
 def test_hssm_distribution_applies_parameter_bounds_pointwise(

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -7,8 +7,11 @@ pytest.importorskip("jeam")
 
 import jax
 import jax.numpy as jnp
+import pytensor
+import pytensor.tensor as pt
 from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf, fixed_cdm_logpdf_single
 from jeam.Models.Circular import CircularDiffusionModel
+from pytensor.compile.mode import Mode
 
 from hssm.distribution_utils.dist import (
     LOGP_LB,
@@ -31,6 +34,30 @@ BOUNDS = {
 # float32 ULPs while keeping the direct adapter comparisons at float64 precision.
 COMPILED_RTOL = 5e-7
 COMPILED_ATOL = 5e-7
+JAX_RTOL = 2e-5
+JAX_ATOL = 2e-6
+GRADIENT_RTOL = 2e-4
+GRADIENT_ATOL = 1e-5
+PYTHON_MODE = Mode(linker="py", optimizer="fast_compile")
+
+
+def _make_differentiable_distribution(
+    params_is_trialwise: list[bool],
+):
+    """Build the ordinary HSSM distribution around the single-trial JAX bridge."""
+    likelihood = make_likelihood_callable(
+        loglik=logp_circular_diffusion_jax,
+        loglik_kind="approx_differentiable",
+        backend="jax",
+        params_is_reg=params_is_trialwise,
+    )
+    return make_distribution(
+        rv="circular_diffusion",
+        loglik=likelihood,
+        list_params=PARAMETERS.copy(),
+        bounds=BOUNDS,
+        params_is_trialwise=params_is_trialwise,
+    )
 
 
 def test_jax_adapter_preserves_the_single_trial_data_contract():
@@ -269,3 +296,196 @@ def test_hssm_distribution_applies_parameter_bounds_pointwise(
         atol=COMPILED_ATOL,
     )
     assert compiled[1] == lower_bound
+
+
+def test_differentiable_distribution_matches_jeam_through_both_linkers():
+    """PyTensor and JAX lowering should preserve direct JAX and NumPy values."""
+    distribution = _make_differentiable_distribution([False] * 4)
+    dtype = pytensor.config.floatX
+    data = np.asarray(
+        [[0.081, -2.1], [0.090, 0.35], [0.370, 2.4]],
+        dtype=dtype,
+    )
+    parameters = np.asarray([0.45, -0.30, 1.20, 0.08], dtype=dtype)
+
+    data_symbol = pt.matrix("data", dtype=dtype)
+    parameter_symbols = [pt.scalar(name, dtype=dtype) for name in PARAMETERS]
+    pointwise = distribution.logp(data_symbol, *parameter_symbols)
+    inputs = [data_symbol, *parameter_symbols]
+    values = [data, *parameters]
+
+    compiled = np.asarray(
+        pytensor.function(inputs, pointwise, mode=PYTHON_MODE)(*values)
+    )
+    lowered = np.asarray(pytensor.function(inputs, pointwise, mode="JAX")(*values))
+    direct_jax = np.asarray(
+        fixed_cdm_logpdf(
+            data[:, 0],
+            data[:, 1],
+            *parameters,
+        )
+    )
+    direct_numpy = logp_circular_diffusion(data, *parameters)
+
+    np.testing.assert_allclose(compiled, direct_jax, rtol=JAX_RTOL, atol=JAX_ATOL)
+    np.testing.assert_allclose(lowered, direct_jax, rtol=JAX_RTOL, atol=JAX_ATOL)
+    np.testing.assert_allclose(direct_jax, direct_numpy, rtol=JAX_RTOL, atol=JAX_ATOL)
+    assert compiled.shape == lowered.shape == direct_jax.shape == (3,)
+
+
+def test_differentiable_distribution_symbolic_gradients_match_direct_jax():
+    """HSSM's VJP Op and JAX lowering should retain all four scalar gradients."""
+    distribution = _make_differentiable_distribution([False] * 4)
+    dtype = pytensor.config.floatX
+    data = np.asarray(
+        [[0.23, -1.4], [0.51, 0.25], [0.94, 2.1]],
+        dtype=dtype,
+    )
+    parameters = np.asarray([0.45, -0.30, 1.20, 0.08], dtype=dtype)
+
+    data_symbol = pt.matrix("data", dtype=dtype)
+    parameter_symbols = [pt.scalar(name, dtype=dtype) for name in PARAMETERS]
+    objective = distribution.logp(data_symbol, *parameter_symbols).sum()
+    gradients = pt.stack(pytensor.grad(objective, wrt=parameter_symbols))
+    inputs = [data_symbol, *parameter_symbols]
+    values = [data, *parameters]
+
+    compiled = np.asarray(
+        pytensor.function(inputs, gradients, mode=PYTHON_MODE)(*values)
+    )
+    lowered = np.asarray(pytensor.function(inputs, gradients, mode="JAX")(*values))
+    expected = np.asarray(
+        jax.grad(
+            lambda current: fixed_cdm_logpdf(
+                data[:, 0],
+                data[:, 1],
+                *current,
+            ).sum()
+        )(jnp.asarray(parameters))
+    )
+
+    np.testing.assert_allclose(
+        compiled,
+        expected,
+        rtol=GRADIENT_RTOL,
+        atol=GRADIENT_ATOL,
+    )
+    np.testing.assert_allclose(
+        lowered,
+        expected,
+        rtol=GRADIENT_RTOL,
+        atol=GRADIENT_ATOL,
+    )
+    assert np.all(np.isfinite(compiled))
+    assert np.all(np.isfinite(lowered))
+
+
+def test_differentiable_distribution_preserves_trialwise_values_and_gradients():
+    """Regression-generated ``v_x`` and ``t`` vectors should remain row-aligned."""
+    distribution = _make_differentiable_distribution([True, False, False, True])
+    dtype = pytensor.config.floatX
+    data = np.asarray(
+        [[0.24, -1.7], [0.49, 0.2], [0.91, 2.2]],
+        dtype=dtype,
+    )
+    v_x = np.asarray([0.55, -0.20, 0.35], dtype=dtype)
+    v_y = np.asarray(-0.25, dtype=dtype)
+    threshold = np.asarray(1.15, dtype=dtype)
+    ndt = np.asarray([0.04, 0.11, 0.17], dtype=dtype)
+
+    data_symbol = pt.matrix("data", dtype=dtype)
+    v_x_symbol = pt.vector("v_x", dtype=dtype)
+    v_y_symbol = pt.scalar("v_y", dtype=dtype)
+    threshold_symbol = pt.scalar("a", dtype=dtype)
+    ndt_symbol = pt.vector("t", dtype=dtype)
+    pointwise = distribution.logp(
+        data_symbol,
+        v_x_symbol,
+        v_y_symbol,
+        threshold_symbol,
+        ndt_symbol,
+    )
+    trialwise_gradients = pytensor.grad(
+        pointwise.sum(),
+        wrt=[v_x_symbol, ndt_symbol],
+    )
+    inputs = [
+        data_symbol,
+        v_x_symbol,
+        v_y_symbol,
+        threshold_symbol,
+        ndt_symbol,
+    ]
+    values = [data, v_x, v_y, threshold, ndt]
+
+    compiled = np.asarray(
+        pytensor.function(inputs, pointwise, mode=PYTHON_MODE)(*values)
+    )
+    compiled_gradients = tuple(
+        np.asarray(value)
+        for value in pytensor.function(
+            inputs,
+            trialwise_gradients,
+            mode=PYTHON_MODE,
+        )(*values)
+    )
+    lowered_gradients = tuple(
+        np.asarray(value)
+        for value in pytensor.function(inputs, trialwise_gradients, mode="JAX")(*values)
+    )
+    direct_jax = np.asarray(
+        fixed_cdm_logpdf(
+            data[:, 0],
+            data[:, 1],
+            v_x,
+            v_y,
+            threshold,
+            ndt,
+        )
+    )
+    direct_numpy = logp_circular_diffusion(
+        data,
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+    )
+    expected_gradients = tuple(
+        np.asarray(value)
+        for value in jax.grad(
+            lambda current_v_x, current_t: fixed_cdm_logpdf(
+                data[:, 0],
+                data[:, 1],
+                current_v_x,
+                v_y,
+                threshold,
+                current_t,
+            ).sum(),
+            argnums=(0, 1),
+        )(jnp.asarray(v_x), jnp.asarray(ndt))
+    )
+
+    np.testing.assert_allclose(compiled, direct_jax, rtol=JAX_RTOL, atol=JAX_ATOL)
+    np.testing.assert_allclose(direct_jax, direct_numpy, rtol=JAX_RTOL, atol=JAX_ATOL)
+    for observed, expected in zip(
+        compiled_gradients,
+        expected_gradients,
+        strict=True,
+    ):
+        np.testing.assert_allclose(
+            observed,
+            expected,
+            rtol=GRADIENT_RTOL,
+            atol=GRADIENT_ATOL,
+        )
+    for observed, expected in zip(
+        lowered_gradients,
+        expected_gradients,
+        strict=True,
+    ):
+        np.testing.assert_allclose(
+            observed,
+            expected,
+            rtol=GRADIENT_RTOL,
+            atol=GRADIENT_ATOL,
+        )

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -30,8 +30,8 @@ BOUNDS = {
     "a": (0.1, 3.0),
     "t": (0.0, 2.0),
 }
-# HSSM test modules may select float32 globally during collection. Allow several
-# float32 ULPs while keeping the direct adapter comparisons at float64 precision.
+# Allow small linker round-trip differences while keeping direct adapter comparisons
+# at exact float64 precision.
 COMPILED_RTOL = 5e-7
 COMPILED_ATOL = 5e-7
 JAX_RTOL = 2e-5
@@ -39,6 +39,18 @@ JAX_ATOL = 2e-6
 GRADIENT_RTOL = 2e-4
 GRADIENT_ATOL = 1e-5
 PYTHON_MODE = Mode(linker="py", optimizer="fast_compile")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pin_fixed_cdm_x64():
+    """Run fixed-CDM JAX checks in their supported precision mode."""
+    original_floatx = pytensor.config.floatX
+    original_jax_x64 = jax.config.jax_enable_x64
+    pytensor.config.floatX = "float64"
+    jax.config.update("jax_enable_x64", True)
+    yield
+    pytensor.config.floatX = original_floatx
+    jax.config.update("jax_enable_x64", original_jax_x64)
 
 
 def _make_analytical_distribution():
@@ -66,6 +78,26 @@ def test_jax_adapter_preserves_the_batched_data_contract():
 
     np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
     assert observed.shape == (2,)
+
+
+def test_jax_adapter_preserves_jeam_x64_guard():
+    """The HSSM wrapper must not bypass or mutate JEAM's precision contract."""
+    jax.config.update("jax_enable_x64", False)
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match=r"requires JAX x64 execution.*jax_enable_x64.*disabled",
+        ):
+            logp_circular_diffusion_jax(
+                jnp.asarray([[0.37, -0.65]]),
+                0.45,
+                -0.30,
+                1.20,
+                0.08,
+            )
+        assert jax.config.jax_enable_x64 is False
+    finally:
+        jax.config.update("jax_enable_x64", True)
 
 
 def test_jax_adapter_broadcasts_scalar_and_trialwise_parameters_in_row_order():

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 import pytensor
 import pytensor.tensor as pt
-from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf, fixed_cdm_logpdf_single
+from jeam.likelihoods.jax_fixed import fixed_cdm_logpdf
 from jeam.Models.Circular import CircularDiffusionModel
 from pytensor.compile.mode import Mode
 
@@ -41,49 +41,42 @@ GRADIENT_ATOL = 1e-5
 PYTHON_MODE = Mode(linker="py", optimizer="fast_compile")
 
 
-def _make_differentiable_distribution(
-    params_is_trialwise: list[bool],
-):
-    """Build the ordinary HSSM distribution around the single-trial JAX bridge."""
+def _make_analytical_distribution():
+    """Build the ordinary HSSM distribution around JEAM's batched JAX bridge."""
     likelihood = make_likelihood_callable(
         loglik=logp_circular_diffusion_jax,
-        loglik_kind="approx_differentiable",
+        loglik_kind="analytical",
         backend="jax",
-        params_is_reg=params_is_trialwise,
     )
     return make_distribution(
         rv="circular_diffusion",
         loglik=likelihood,
         list_params=PARAMETERS.copy(),
         bounds=BOUNDS,
-        params_is_trialwise=params_is_trialwise,
     )
 
 
-def test_jax_adapter_preserves_the_single_trial_data_contract():
-    """The JAX bridge should map ``[rt, response]`` onto JEAM without reordering."""
-    data = jnp.asarray([0.37, -0.65])
+def test_jax_adapter_preserves_the_batched_data_contract():
+    """The JAX bridge should map batched ``[rt, response]`` data without reordering."""
+    data = jnp.asarray([[0.37, -0.65], [0.82, 1.20]])
     parameters = (0.45, -0.30, 1.20, 0.08)
 
     observed = logp_circular_diffusion_jax(data, *parameters)
-    expected = fixed_cdm_logpdf_single(data[0], data[1], *parameters)
+    expected = fixed_cdm_logpdf(data[:, 0], data[:, 1], *parameters)
 
     np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
-    assert observed.shape == ()
+    assert observed.shape == (2,)
 
 
-def test_jax_adapter_vmaps_scalar_and_trialwise_parameters_in_row_order():
-    """HSSM's vmap patterns should retain scalar sharing and trial association."""
+def test_jax_adapter_broadcasts_scalar_and_trialwise_parameters_in_row_order():
+    """The batched bridge should retain scalar sharing and trial association."""
     data = jnp.asarray([[0.21, -1.7], [0.46, 0.2], [0.91, 2.2]])
     v_x = jnp.asarray([0.55, -0.20, 0.35])
     v_y = -0.25
     threshold = jnp.asarray([1.00, 1.25, 1.10])
     ndt = jnp.asarray([0.04, 0.11, 0.17])
 
-    observed = jax.vmap(
-        logp_circular_diffusion_jax,
-        in_axes=(0, 0, None, 0, 0),
-    )(data, v_x, v_y, threshold, ndt)
+    observed = logp_circular_diffusion_jax(data, v_x, v_y, threshold, ndt)
     expected = fixed_cdm_logpdf(
         data[:, 0],
         data[:, 1],
@@ -98,14 +91,14 @@ def test_jax_adapter_vmaps_scalar_and_trialwise_parameters_in_row_order():
 
 def test_jax_adapter_parameter_gradient_matches_the_direct_jeam_kernel():
     """The HSSM argument bridge must leave JEAM's four-parameter gradient intact."""
-    data = jnp.asarray([0.53, 0.7])
+    data = jnp.asarray([[0.53, 0.7], [0.84, -1.1]])
     parameters = jnp.asarray([0.45, -0.30, 1.20, 0.08])
 
-    observed = jax.grad(lambda values: logp_circular_diffusion_jax(data, *values))(
-        parameters
-    )
+    observed = jax.grad(
+        lambda values: logp_circular_diffusion_jax(data, *values).sum()
+    )(parameters)
     expected = jax.grad(
-        lambda values: fixed_cdm_logpdf_single(data[0], data[1], *values)
+        lambda values: fixed_cdm_logpdf(data[:, 0], data[:, 1], *values).sum()
     )(parameters)
 
     np.testing.assert_allclose(observed, expected, rtol=5e-7, atol=5e-7)
@@ -300,7 +293,7 @@ def test_hssm_distribution_applies_parameter_bounds_pointwise(
 
 def test_differentiable_distribution_matches_jeam_through_both_linkers():
     """PyTensor and JAX lowering should preserve direct JAX and NumPy values."""
-    distribution = _make_differentiable_distribution([False] * 4)
+    distribution = _make_analytical_distribution()
     dtype = pytensor.config.floatX
     data = np.asarray(
         [[0.081, -2.1], [0.090, 0.35], [0.370, 2.4]],
@@ -335,7 +328,7 @@ def test_differentiable_distribution_matches_jeam_through_both_linkers():
 
 def test_differentiable_distribution_symbolic_gradients_match_direct_jax():
     """HSSM's VJP Op and JAX lowering should retain all four scalar gradients."""
-    distribution = _make_differentiable_distribution([False] * 4)
+    distribution = _make_analytical_distribution()
     dtype = pytensor.config.floatX
     data = np.asarray(
         [[0.23, -1.4], [0.51, 0.25], [0.94, 2.1]],
@@ -382,7 +375,7 @@ def test_differentiable_distribution_symbolic_gradients_match_direct_jax():
 
 def test_differentiable_distribution_preserves_trialwise_values_and_gradients():
     """Regression-generated ``v_x`` and ``t`` vectors should remain row-aligned."""
-    distribution = _make_differentiable_distribution([True, False, False, True])
+    distribution = _make_analytical_distribution()
     dtype = pytensor.config.floatX
     data = np.asarray(
         [[0.24, -1.7], [0.49, 0.2], [0.91, 2.2]],

--- a/tests/integration/test_jeam.py
+++ b/tests/integration/test_jeam.py
@@ -5,14 +5,20 @@ import pytest
 
 pytest.importorskip("jeam")
 
+import jax
+import jax.numpy as jnp
 from jeam.Models.Circular import CircularDiffusionModel
+from jeam.likelihoods import fixed_cdm_logpdf, fixed_cdm_logpdf_single
 
 from hssm.distribution_utils.dist import (
     LOGP_LB,
     make_distribution,
     make_likelihood_callable,
 )
-from hssm.integrations.jeam import logp_circular_diffusion
+from hssm.integrations.jeam import (
+    logp_circular_diffusion,
+    logp_circular_diffusion_jax,
+)
 
 PARAMETERS = ["v_x", "v_y", "a", "t"]
 BOUNDS = {
@@ -25,6 +31,60 @@ BOUNDS = {
 # float32 ULPs while keeping the direct adapter comparisons at float64 precision.
 COMPILED_RTOL = 5e-7
 COMPILED_ATOL = 5e-7
+
+
+def test_jax_adapter_preserves_the_single_trial_data_contract():
+    """The JAX bridge should map ``[rt, response]`` onto JEAM without reordering."""
+    data = jnp.asarray([0.37, -0.65])
+    parameters = (0.45, -0.30, 1.20, 0.08)
+
+    observed = logp_circular_diffusion_jax(data, *parameters)
+    expected = fixed_cdm_logpdf_single(data[0], data[1], *parameters)
+
+    np.testing.assert_allclose(observed, expected, rtol=0.0, atol=0.0)
+    assert observed.shape == ()
+
+
+def test_jax_adapter_vmaps_scalar_and_trialwise_parameters_in_row_order():
+    """HSSM's vmap patterns should retain scalar sharing and trial association."""
+    data = jnp.asarray([[0.21, -1.7], [0.46, 0.2], [0.91, 2.2]])
+    v_x = jnp.asarray([0.55, -0.20, 0.35])
+    v_y = -0.25
+    threshold = jnp.asarray([1.00, 1.25, 1.10])
+    ndt = jnp.asarray([0.04, 0.11, 0.17])
+
+    observed = jax.vmap(
+        logp_circular_diffusion_jax,
+        in_axes=(0, 0, None, 0, 0),
+    )(data, v_x, v_y, threshold, ndt)
+    expected = fixed_cdm_logpdf(
+        data[:, 0],
+        data[:, 1],
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+    )
+
+    np.testing.assert_allclose(observed, expected, rtol=5e-7, atol=5e-7)
+
+
+def test_jax_adapter_parameter_gradient_matches_the_direct_jeam_kernel():
+    """The HSSM argument bridge must leave JEAM's four-parameter gradient intact."""
+    data = jnp.asarray([0.53, 0.7])
+    parameters = jnp.asarray([0.45, -0.30, 1.20, 0.08])
+
+    observed = jax.grad(
+        lambda values: logp_circular_diffusion_jax(data, *values)
+    )(parameters)
+    expected = jax.grad(
+        lambda values: fixed_cdm_logpdf_single(
+            data[0], data[1], *values
+        )
+    )(parameters)
+
+    np.testing.assert_allclose(observed, expected, rtol=5e-7, atol=5e-7)
+    assert np.all(np.isfinite(observed))
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -22,7 +22,7 @@ from scripts.benchmark_jeam_bayesian_recovery import (
 )
 from scripts.benchmark_jeam_objective_parity import HSSM_BOUNDS, PARAMETER_ORDER
 
-PINNED_JEAM_REVISION = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
+PINNED_JEAM_REVISION = "ede7a4f4faf226e4dae52c84dfb01012939cccdc"
 MEAN_ERROR_LIMITS = {"a": 0.10, "t": 0.04, "v_x": 0.15, "v_y": 0.15}
 MAX_RHAT = 1.01
 MIN_ESS = 1_000.0

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -22,7 +22,7 @@ from scripts.benchmark_jeam_bayesian_recovery import (
 )
 from scripts.benchmark_jeam_objective_parity import HSSM_BOUNDS, PARAMETER_ORDER
 
-PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+PINNED_JEAM_REVISION = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
 MEAN_ERROR_LIMITS = {"a": 0.10, "t": 0.04, "v_x": 0.15, "v_y": 0.15}
 MAX_RHAT = 1.01
 MIN_ESS = 1_000.0

--- a/tests/integration/test_jeam_model.py
+++ b/tests/integration/test_jeam_model.py
@@ -47,12 +47,12 @@ def test_differentiable_circular_data_builds_an_ordinary_hssm_model():
     model = hssm.HSSM(
         data=data,
         model="circular_diffusion",
-        loglik_kind="approx_differentiable",
+        loglik_kind="analytical",
         p_outlier=None,
     )
 
     assert type(model) is hssm.HSSM
-    assert model.loglik_kind == "approx_differentiable"
+    assert model.loglik_kind == "analytical"
     assert model.model_config.backend == "jax"
     assert model.response_kind == "circular"
     assert model.list_params == ["v_x", "v_y", "a", "t"]

--- a/tests/integration/test_jeam_model.py
+++ b/tests/integration/test_jeam_model.py
@@ -33,3 +33,27 @@ def test_simulated_circular_data_builds_an_ordinary_hssm_model():
     assert model.n_choices is None
     assert model.list_params == ["v_x", "v_y", "a", "t"]
     assert model.model_config.rv is simulate_circular_diffusion
+
+
+def test_differentiable_circular_data_builds_an_ordinary_hssm_model():
+    """The opt-in JAX path should use the same class and config lifecycle."""
+    observations = simulate_circular_diffusion(
+        theta=np.array([0.70, -0.35, 0.40, 0.08]),
+        random_state=1947,
+        n_replicas=12,
+    )
+    data = pd.DataFrame(observations, columns=["rt", "response"])
+
+    model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        loglik_kind="approx_differentiable",
+        p_outlier=None,
+    )
+
+    assert type(model) is hssm.HSSM
+    assert model.loglik_kind == "approx_differentiable"
+    assert model.model_config.backend == "jax"
+    assert model.response_kind == "circular"
+    assert model.list_params == ["v_x", "v_y", "a", "t"]
+    assert model.model_config.rv is simulate_circular_diffusion

--- a/tests/integration/test_jeam_model.py
+++ b/tests/integration/test_jeam_model.py
@@ -6,8 +6,22 @@ import pytest
 
 pytest.importorskip("jeam")
 
+import jax
+import pytensor
+
 import hssm
 from hssm.integrations.jeam import simulate_circular_diffusion
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pin_fixed_cdm_x64():
+    """Construct analytical models in JEAM's supported precision mode."""
+    original_floatx = pytensor.config.floatX
+    original_jax_x64 = jax.config.jax_enable_x64
+    hssm.set_floatX("float64")
+    yield
+    pytensor.config.floatX = original_floatx
+    jax.config.update("jax_enable_x64", original_jax_x64)
 
 
 def test_simulated_circular_data_builds_an_ordinary_hssm_model():

--- a/tests/integration/test_jeam_objective_parity.py
+++ b/tests/integration/test_jeam_objective_parity.py
@@ -18,7 +18,7 @@ from scripts.benchmark_jeam_objective_parity import (
     simulate_dataset,
 )
 
-PINNED_JEAM_REVISION = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
+PINNED_JEAM_REVISION = "ede7a4f4faf226e4dae52c84dfb01012939cccdc"
 OBJECTIVE_RTOL = 1e-6
 OBJECTIVE_ATOL = 5e-5
 

--- a/tests/integration/test_jeam_objective_parity.py
+++ b/tests/integration/test_jeam_objective_parity.py
@@ -18,7 +18,7 @@ from scripts.benchmark_jeam_objective_parity import (
     simulate_dataset,
 )
 
-PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+PINNED_JEAM_REVISION = "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce"
 OBJECTIVE_RTOL = 1e-6
 OBJECTIVE_ATOL = 5e-5
 

--- a/tests/test_jeam_adapter.py
+++ b/tests/test_jeam_adapter.py
@@ -150,7 +150,14 @@ def test_adapter_rejects_an_unexpected_jeam_output_shape(monkeypatch):
         )
 
 
-def test_loader_explains_how_to_install_the_optional_dependency(monkeypatch):
+@pytest.mark.parametrize(
+    "loader",
+    [
+        jeam_integration._load_circular_diffusion_model,
+        jeam_integration._load_fixed_cdm_logpdf_single,
+    ],
+)
+def test_loaders_explain_how_to_install_the_optional_dependency(monkeypatch, loader):
     """A missing JEAM install should report the prototype-group command."""
     real_import = builtins.__import__
 
@@ -162,4 +169,22 @@ def test_loader_explains_how_to_install_the_optional_dependency(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", import_without_jeam)
 
     with pytest.raises(ImportError, match="uv sync --group jeam-prototype"):
-        jeam_integration._load_circular_diffusion_model()
+        loader()
+
+
+def test_jax_loader_explains_how_to_refresh_a_stale_jeam_revision(monkeypatch):
+    """An older JEAM install should fail with the exact locked refresh command."""
+    real_import = builtins.__import__
+
+    def import_without_jax_kernel(name, *args, **kwargs):
+        if name == "jeam.likelihoods.jax_fixed":
+            raise ImportError("missing fixed_cdm_logpdf_single")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_jax_kernel)
+
+    with pytest.raises(
+        ImportError,
+        match=r"uv sync --group jeam-prototype --locked",
+    ):
+        jeam_integration._load_fixed_cdm_logpdf_single()

--- a/tests/test_jeam_adapter.py
+++ b/tests/test_jeam_adapter.py
@@ -154,7 +154,7 @@ def test_adapter_rejects_an_unexpected_jeam_output_shape(monkeypatch):
     "loader",
     [
         jeam_integration._load_circular_diffusion_model,
-        jeam_integration._load_fixed_cdm_logpdf_single,
+        jeam_integration._load_fixed_cdm_logpdf,
     ],
 )
 def test_loaders_explain_how_to_install_the_optional_dependency(monkeypatch, loader):
@@ -178,7 +178,7 @@ def test_jax_loader_explains_how_to_refresh_a_stale_jeam_revision(monkeypatch):
 
     def import_without_jax_kernel(name, *args, **kwargs):
         if name == "jeam.likelihoods.jax_fixed":
-            raise ImportError("missing fixed_cdm_logpdf_single")
+            raise ImportError("missing fixed_cdm_logpdf")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", import_without_jax_kernel)
@@ -187,4 +187,4 @@ def test_jax_loader_explains_how_to_refresh_a_stale_jeam_revision(monkeypatch):
         ImportError,
         match=r"uv sync --group jeam-prototype --locked",
     ):
-        jeam_integration._load_fixed_cdm_logpdf_single()
+        jeam_integration._load_fixed_cdm_logpdf()

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -1,7 +1,9 @@
 """Tests for the experimental built-in JEAM model configuration."""
 
+import jax
 import numpy as np
 import pandas as pd
+import pytensor
 import pytest
 
 import hssm
@@ -13,6 +15,16 @@ from hssm.integrations.jeam import (
 )
 from hssm.modelconfig import get_default_model_config
 from hssm.plotting.model_cartoon import _require_categorical_choices
+
+
+@pytest.fixture
+def restore_precision_settings():
+    """Restore the independent PyTensor and JAX precision settings after a test."""
+    original_floatx = pytensor.config.floatX
+    original_jax_x64 = jax.config.jax_enable_x64
+    yield
+    pytensor.config.floatX = original_floatx
+    jax.config.update("jax_enable_x64", original_jax_x64)
 
 
 def test_circular_diffusion_is_a_supported_model():
@@ -47,9 +59,11 @@ def test_get_circular_diffusion_config():
     analytical = config["likelihoods"]["analytical"]
     assert analytical["loglik"] is logp_circular_diffusion_jax
     assert analytical["backend"] == "jax"
+    assert analytical["requires_jax_x64"] is True
     assert analytical["bounds"] == blackbox["bounds"]
     assert analytical["default_priors"] == blackbox["default_priors"]
     assert analytical["extra_fields"] is None
+    assert "requires_jax_x64" not in blackbox
 
 
 def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
@@ -68,15 +82,77 @@ def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
     config.validate()
 
 
-def test_circular_diffusion_analytical_likelihood_is_explicitly_selectable():
+def test_circular_diffusion_analytical_likelihood_is_explicitly_selectable(
+    restore_precision_settings,
+):
     """The semi-analytical JAX path remains opt-in until its promotion gate passes."""
+    hssm.set_floatX("float64")
     config = Config.from_defaults("circular_diffusion", "analytical")
 
     assert config.loglik_kind == "analytical"
     assert config.backend == "jax"
+    assert config.requires_jax_x64 is True
     assert config.loglik is logp_circular_diffusion_jax
     assert config.rv is simulate_circular_diffusion
     config.validate()
+
+
+def test_x64_off_rejects_only_the_analytical_model(restore_precision_settings):
+    """Float32 users should retain the black-box route and fail early on JAX."""
+    data = pd.DataFrame({"rt": [0.4, 0.8], "response": [-0.2, 0.3]})
+    hssm.set_floatX("float32")
+
+    blackbox = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        p_outlier=None,
+        process_initvals=False,
+        initval_jitter=0.0,
+    )
+    assert blackbox.model_config.loglik_kind == "blackbox"
+    assert blackbox.model_config.requires_jax_x64 is False
+    assert jax.config.jax_enable_x64 is False
+
+    with pytest.raises(
+        ValueError,
+        match=r"requires JAX x64 execution.*jax_enable_x64.*disabled",
+    ):
+        hssm.HSSM(
+            data=data,
+            model="circular_diffusion",
+            loglik_kind="analytical",
+            p_outlier=None,
+            process_initvals=False,
+            initval_jitter=0.0,
+        )
+
+    assert jax.config.jax_enable_x64 is False
+
+
+def test_x64_gate_reads_jax_execution_state(restore_precision_settings):
+    """The capability gate must not infer JAX precision from PyTensor floatX."""
+    hssm.set_floatX("float64")
+    jax.config.update("jax_enable_x64", False)
+    with pytest.raises(ValueError, match="requires JAX x64 execution"):
+        Config._build_model_config(
+            model="circular_diffusion",
+            loglik_kind="analytical",
+            model_config=None,
+            choices=None,
+        )
+
+    hssm.set_floatX("float32")
+    jax.config.update("jax_enable_x64", True)
+    config = Config._build_model_config(
+        model="circular_diffusion",
+        loglik_kind="analytical",
+        model_config=None,
+        choices=None,
+    )
+
+    assert pytensor.config.floatX == "float32"
+    assert config.requires_jax_x64 is True
+    assert jax.config.jax_enable_x64 is True
 
 
 @pytest.mark.parametrize("p_outlier", [0.0, 0.05])

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -44,12 +44,12 @@ def test_get_circular_diffusion_config():
     assert blackbox["default_priors"] == {"t": {"name": "HalfNormal", "sigma": 2.0}}
     assert blackbox["extra_fields"] is None
 
-    differentiable = config["likelihoods"]["approx_differentiable"]
-    assert differentiable["loglik"] is logp_circular_diffusion_jax
-    assert differentiable["backend"] == "jax"
-    assert differentiable["bounds"] == blackbox["bounds"]
-    assert differentiable["default_priors"] == blackbox["default_priors"]
-    assert differentiable["extra_fields"] is None
+    analytical = config["likelihoods"]["analytical"]
+    assert analytical["loglik"] is logp_circular_diffusion_jax
+    assert analytical["backend"] == "jax"
+    assert analytical["bounds"] == blackbox["bounds"]
+    assert analytical["default_priors"] == blackbox["default_priors"]
+    assert analytical["extra_fields"] is None
 
 
 def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
@@ -68,11 +68,11 @@ def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
     config.validate()
 
 
-def test_circular_diffusion_differentiable_likelihood_is_explicitly_selectable():
-    """The JAX path should be opt-in until its recovery promotion gate passes."""
-    config = Config.from_defaults("circular_diffusion", "approx_differentiable")
+def test_circular_diffusion_analytical_likelihood_is_explicitly_selectable():
+    """The semi-analytical JAX path remains opt-in until its promotion gate passes."""
+    config = Config.from_defaults("circular_diffusion", "analytical")
 
-    assert config.loglik_kind == "approx_differentiable"
+    assert config.loglik_kind == "analytical"
     assert config.backend == "jax"
     assert config.loglik is logp_circular_diffusion_jax
     assert config.rv is simulate_circular_diffusion

--- a/tests/test_jeam_modelconfig.py
+++ b/tests/test_jeam_modelconfig.py
@@ -8,6 +8,7 @@ import hssm
 from hssm.config import Config
 from hssm.integrations.jeam import (
     logp_circular_diffusion,
+    logp_circular_diffusion_jax,
     simulate_circular_diffusion,
 )
 from hssm.modelconfig import get_default_model_config
@@ -29,18 +30,26 @@ def test_get_circular_diffusion_config():
     assert config["choices"] is None
     assert config["list_params"] == ["v_x", "v_y", "a", "t"]
     assert config["rv"] is simulate_circular_diffusion
+    assert config["default_loglik_kind"] == "blackbox"
 
-    likelihood = config["likelihoods"]["blackbox"]
-    assert likelihood["loglik"] is logp_circular_diffusion
-    assert likelihood["backend"] is None
-    assert likelihood["bounds"] == {
+    blackbox = config["likelihoods"]["blackbox"]
+    assert blackbox["loglik"] is logp_circular_diffusion
+    assert blackbox["backend"] is None
+    assert blackbox["bounds"] == {
         "v_x": (-3.0, 3.0),
         "v_y": (-3.0, 3.0),
         "a": (0.1, 3.0),
         "t": (0.0, 2.0),
     }
-    assert likelihood["default_priors"] == {"t": {"name": "HalfNormal", "sigma": 2.0}}
-    assert likelihood["extra_fields"] is None
+    assert blackbox["default_priors"] == {"t": {"name": "HalfNormal", "sigma": 2.0}}
+    assert blackbox["extra_fields"] is None
+
+    differentiable = config["likelihoods"]["approx_differentiable"]
+    assert differentiable["loglik"] is logp_circular_diffusion_jax
+    assert differentiable["backend"] == "jax"
+    assert differentiable["bounds"] == blackbox["bounds"]
+    assert differentiable["default_priors"] == blackbox["default_priors"]
+    assert differentiable["extra_fields"] is None
 
 
 def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
@@ -55,6 +64,17 @@ def test_circular_diffusion_from_defaults_preserves_domain_and_rv():
     assert config.choices is None
     assert config.list_params == ["v_x", "v_y", "a", "t"]
     assert config.loglik is logp_circular_diffusion
+    assert config.rv is simulate_circular_diffusion
+    config.validate()
+
+
+def test_circular_diffusion_differentiable_likelihood_is_explicitly_selectable():
+    """The JAX path should be opt-in until its recovery promotion gate passes."""
+    config = Config.from_defaults("circular_diffusion", "approx_differentiable")
+
+    assert config.loglik_kind == "approx_differentiable"
+    assert config.backend == "jax"
+    assert config.loglik is logp_circular_diffusion_jax
     assert config.rv is simulate_circular_diffusion
     config.validate()
 

--- a/tests/test_jeam_recovery_evidence_bundle.py
+++ b/tests/test_jeam_recovery_evidence_bundle.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+JEAM_REVISION = "ede7a4f4faf226e4dae52c84dfb01012939cccdc"
 
 
 def _repository(tmp_path: Path) -> tuple[Path, Path, Path]:

--- a/tests/unit/test_register.py
+++ b/tests/unit/test_register.py
@@ -30,6 +30,7 @@ def test_register_model_preserves_non_categorical_metadata():
             response_kind="circular",
             response_bounds={"response": (-3.14, 3.14)},
             rv=simulator,
+            default_loglik_kind="blackbox",
             description="A registration-contract test model",
             likelihoods={
                 "blackbox": {
@@ -42,7 +43,7 @@ def test_register_model_preserves_non_categorical_metadata():
             },
         )
 
-        config = Config.from_defaults(name, "blackbox")
+        config = Config.from_defaults(name, None)
 
         assert config.choices is None
         assert config.response_kind == "circular"
@@ -51,6 +52,28 @@ def test_register_model_preserves_non_categorical_metadata():
         config.validate()
     finally:
         registered_models.pop(name, None)
+
+
+def test_register_model_rejects_an_unregistered_default_likelihood():
+    """An explicit default must identify one of the supplied likelihood configs."""
+    with pytest.raises(ValueError, match="is not registered"):
+        register_model(
+            name="invalid_default_likelihood_test_model",
+            response=["rt", "response"],
+            list_params=["v"],
+            choices=[-1, 1],
+            description=None,
+            default_loglik_kind="approx_differentiable",
+            likelihoods={
+                "blackbox": {
+                    "loglik": lambda data, v: data[:, 0] * 0.0 + v * 0.0,
+                    "backend": None,
+                    "bounds": {"v": (-1.0, 1.0)},
+                    "default_priors": {},
+                    "extra_fields": None,
+                }
+            },
+        )
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Purpose

- replay the bounded analytical fixed-CDM unit on the accepted `dev` history
- pin the live prototype surfaces to merged JEAM #13
- prevent the current cancellation-sensitive kernel from running silently with JAX x64 disabled

## Changes

- expose JEAM's batched fixed-CDM JAX evaluator as the opt-in `analytical` likelihood while preserving `blackbox` as the default
- preserve values, parameter gradients, JAX lowering, and mixed scalar/trial-wise parameters through HSSM's existing analytical bridge
- add producer-owned `requires_jax_x64` metadata only to the analytical route and validate the actual `jax_enable_x64` flag before PyMC model construction
- keep HSSM validation and direct JEAM evaluation non-mutating; the black-box/Slice route remains available with x64 disabled
- distinguish JAX execution precision from input dtype: float32 PyTensor/model inputs remain valid when JAX x64 is enabled independently
- update live dependency, documentation, tutorial, and integration-test pins to JEAM `ede7a4f4faf226e4dae52c84dfb01012939cccdc`

## Provenance boundary

The committed schema-v2 recovery bundle remains unchanged and authenticated against historical producer `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`. Only live/current-pin surfaces and the synthetic bundle-construction fixture advance to JEAM #13.

## Replay

- historical commits 1, 3, and 4 are patch-identical
- the registration commit has the expected semantic documentation resolution preserving #1206's explicit black-box example, route-local sampler limits, schema-v2 evidence language, and route-neutral promotion criteria
- the obsolete historical JEAM pin commit was replaced rather than replayed

## Verification

- 808 non-slow HSSM tests passed
- 91 focused recovery/evidence tests passed, including one real four-chain Slice recovery; the canonical four-scenario capture was not rerun
- 68 generic config/registration/analytical tests passed
- 35 JEAM handshake, value, gradient, lowering, construction, objective, predictive, and simulator tests passed
- independent evidence verifier: 14 artifacts, 4 scenarios, 16/16 HDI inclusions, gate passed
- strict marimo check and headless black-box tutorial export passed with no host-path or error leakage
- strict MkDocs build and documentation-weight check passed
- affected Ruff lint/format, mypy, Pyrefly, `git diff --check`, sdist build, and wheel build passed

## Scope

This PR does not promote a differentiable sampler default, rerun or rewrite the frozen recovery evidence, add a public JEAM extra, or claim true x64-off/float32 execution support. Sampler capability, comparison, and evidence remain in the later bounded #1208--#1211 units.
