### PR TITLE
Define JEAM sampler capabilities

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -5,12 +5,18 @@ on:
     paths:
       - "pyproject.toml"
       - ".github/workflows/jeam_prototype.yml"
+      - "src/hssm/_types.py"
       - "src/hssm/base.py"
+      - "src/hssm/config.py"
       - "src/hssm/distribution_utils/blackbox.py"
       - "src/hssm/distribution_utils/dist.py"
+      - "src/hssm/distribution_utils/func_utils.py"
+      - "src/hssm/distribution_utils/jax.py"
       - "src/hssm/hssm.py"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
+      - "src/hssm/register.py"
+      - "src/hssm/utils.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
       - "scripts/benchmark_jeam_recovery_bundle.py"
@@ -18,6 +24,7 @@ on:
       - "scripts/benchmark_jeam_repeated_recovery.py"
       - "tests/test_jeam_recovery_evidence_bundle.py"
       - "tests/test_jeam_recovery_evidence_io.py"
+      - "tests/test_jeam_modelconfig.py"
       - "tests/integration/test_jeam_bayesian_evidence_capture.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
@@ -27,6 +34,7 @@ on:
       - "tests/integration/test_jeam_repeated_recovery.py"
       - "tests/integration/test_jeam_repeated_recovery_evidence.py"
       - "tests/integration/test_jeam_simulator.py"
+      - "tests/integration/test_jeam_sampler_capabilities.py"
   workflow_dispatch:
 
 jobs:
@@ -56,6 +64,11 @@ jobs:
           tests/integration/test_jeam_objective_parity.py
           tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py
+
+      - name: Verify JEAM sampler capabilities and NUTS backends
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/integration/test_jeam_sampler_capabilities.py
 
       - name: Run the Bayesian recovery preflight and gate
         run: >-

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -95,13 +95,35 @@ model = hssm.HSSM(
 This semi-analytical path evaluates JEAM's truncated first-passage series directly; it is
 not a learned likelihood approximation. It preserves JEAM's pointwise values and exposes
 reverse-mode parameter gradients through HSSM's existing JAX/PyTensor bridge. It is still
-under sampler recovery and efficiency evaluation; NUTS, JAX samplers, and variational
-inference are not promoted as supported workflows for this model yet.
+under sampler recovery and efficiency evaluation; NUTS is not yet recommended for
+substantive inference, and variational inference has not been validated.
+
+### Sampler capability matrix
+
+“CI-supported” means that HSSM runs a real one-chain compilation smoke test and verifies
+finite gradients, posterior variables, and sampler-specific statistics. It is weaker than
+a recovery or efficiency recommendation.
+
+| Likelihood | Sampler | Works | CI-supported | Recommended |
+|---|---|---:|---:|---:|
+| `blackbox` | PyMC Slice | yes | yes | yes, current baseline |
+| `analytical` | PyMC NUTS | yes | yes | not yet |
+| `analytical` | NumPyro NUTS | yes | yes | not yet |
+| `analytical` | BlackJAX | not enabled | no | no |
+| `analytical` | nutpie | not enabled | no | no |
+| `analytical` | Laplace | not enabled | no | no |
+
+The likelihood choice does not silently change HSSM's global sampler policy. With the
+analytical likelihood, select either `sampler="pymc"` or `sampler="numpyro"` explicitly
+when the backend distinction matters. Unverified `sampler=` backend combinations fail
+before dispatch with the currently enabled choices in the error message. This capability
+metadata governs backend selection, not arbitrary `step=` objects supplied within the
+PyMC backend; the black-box tutorial's explicit Slice steps are the validated baseline.
 
 The analytical route requires JAX x64 execution. HSSM checks
-`jax.config.jax_enable_x64` during model construction and does not change the global JAX
-setting. Call `hssm.set_floatX("float64")` before constructing this route. When x64 is
-disabled, the `blackbox` likelihood and its PyMC Slice workflow remain available.
+`jax.config.jax_enable_x64` during model construction, which does not change the global
+JAX setting. Call `hssm.set_floatX("float64")` before constructing this route. When x64
+is disabled, the `blackbox` likelihood and its PyMC Slice workflow remain available.
 The gate checks JAX execution precision, not input dtype: float32 model inputs remain
 supported when JAX x64 execution is enabled independently.
 

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -36,6 +36,8 @@ ResponseKind = Literal["categorical", "continuous", "circular"]
 
 LoglikKind = Literal["analytical", "approx_differentiable", "blackbox"]
 
+SamplerName = Literal["pymc", "numpyro", "blackjax", "nutpie", "laplace"]
+
 
 class LoglikConfig(TypedDict):
     """Type for the value of LoglikConfig."""
@@ -46,6 +48,7 @@ class LoglikConfig(TypedDict):
     default_priors: dict[str, ParamSpec]
     bounds: dict[str, tuple[float, float]]
     extra_fields: Optional[list[str]]
+    supported_samplers: NotRequired[tuple[SamplerName, ...]]
 
 
 LoglikConfigs = dict[LoglikKind, LoglikConfig]

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from pytensor.tensor.variable import TensorVariable
 
 from hssm import _vi_compat
-from hssm._types import SupportedModels
+from hssm._types import SamplerName, SupportedModels
 from hssm.data_validator import DataValidatorMixin
 from hssm.defaults import (
     INITVAL_JITTER_SETTINGS,
@@ -568,8 +568,7 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
 
     def sample(
         self,
-        sampler: Literal["pymc", "numpyro", "blackjax", "nutpie", "laplace"]
-        | None = None,
+        sampler: SamplerName | None = None,
         init: str | None = None,
         initvals: str | dict | None = None,
         include_response_params: bool = False,
@@ -634,6 +633,24 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
                 "Please use the vi() method instead."
             )
 
+        if sampler is None:
+            if (
+                self.loglik_kind == "approx_differentiable"
+                and self.model_config.backend == "jax"
+            ):
+                sampler = "numpyro"
+            else:
+                sampler = "pymc"
+
+        supported_samplers = self.model_config.supported_samplers
+        if supported_samplers is not None and sampler not in supported_samplers:
+            supported = ", ".join(repr(name) for name in supported_samplers)
+            raise ValueError(
+                f"Sampler {sampler!r} is not supported for model "
+                f"{self.model_name!r} with loglik_kind={self.loglik_kind!r}. "
+                f"Supported samplers: {supported}."
+            )
+
         if initvals is not None:
             if isinstance(initvals, dict):
                 kwargs["initvals"] = initvals
@@ -658,15 +675,6 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         else:
             kwargs["initvals"] = self._initvals
             _logger.info("Using default initvals. \n")
-
-        if sampler is None:
-            if (
-                self.loglik_kind == "approx_differentiable"
-                and self.model_config.backend == "jax"
-            ):
-                sampler = "numpyro"
-            else:
-                sampler = "pymc"
 
         if self.loglik_kind == "blackbox":
             if sampler in ["blackjax", "numpyro", "nutpie"]:

--- a/src/hssm/config.py
+++ b/src/hssm/config.py
@@ -14,7 +14,14 @@ import jax
 from bambi import Prior
 from ssms.config import model_config as ssms_model_config
 
-from ._types import DefaultConfig, LogLik, LoglikKind, ResponseKind, SupportedModels
+from ._types import (
+    DefaultConfig,
+    LogLik,
+    LoglikKind,
+    ResponseKind,
+    SamplerName,
+    SupportedModels,
+)
 from .defaults import (
     default_model_config,
 )
@@ -53,6 +60,7 @@ class BaseModelConfig(ABC):
     loglik: LogLik | None = None
     loglik_kind: LoglikKind | None = None
     backend: Literal["jax", "pytensor"] | None = None
+    supported_samplers: tuple[SamplerName, ...] | None = None
 
     # Additional data requirements
     extra_fields: list[str] | None = None
@@ -323,12 +331,22 @@ class Config(BaseModelConfig):
             raise ValueError("Please provide a log-likelihood function via `loglik`.")
         if self.loglik_kind == "approx_differentiable" and self.backend is None:
             raise ValueError("Please provide `backend` via `model_config`.")
-        if self.requires_jax_x64 and not jax.config.jax_enable_x64:
+        if self.supported_samplers is not None:
+            if not self.supported_samplers:
+                raise ValueError("`supported_samplers` cannot be empty when provided.")
+            allowed_samplers = set(get_args(SamplerName))
+            invalid_samplers = set(self.supported_samplers) - allowed_samplers
+            if invalid_samplers:
+                invalid = ", ".join(sorted(invalid_samplers))
+                raise ValueError(f"Unrecognized supported sampler(s): {invalid}.")
+            if len(self.supported_samplers) != len(set(self.supported_samplers)):
+                raise ValueError("`supported_samplers` cannot contain duplicates.")
+        if self.requires_jax_x64 and not jax.config.read("jax_enable_x64"):
             raise ValueError(
                 f"The {self.model_name!r} {self.loglik_kind!r} likelihood requires "
                 "JAX x64 execution, but `jax_enable_x64` is disabled. Enable JAX "
-                "x64 before constructing the model; HSSM does not mutate global "
-                "JAX configuration."
+                "x64 before constructing the model; model construction does not "
+                "mutate global JAX configuration."
             )
 
     def get_defaults(

--- a/src/hssm/modelconfig/circular_diffusion_config.py
+++ b/src/hssm/modelconfig/circular_diffusion_config.py
@@ -47,6 +47,7 @@ def get_circular_diffusion_config() -> DefaultConfig:
                     "t": (0.0, 2.0),
                 },
                 "extra_fields": None,
+                "supported_samplers": ("pymc", "numpyro"),
             },
             "blackbox": {
                 "loglik": logp_circular_diffusion,
@@ -64,6 +65,7 @@ def get_circular_diffusion_config() -> DefaultConfig:
                     "t": (0.0, 2.0),
                 },
                 "extra_fields": None,
+                "supported_samplers": ("pymc",),
             },
         },
     }

--- a/tests/integration/test_jeam_sampler_capabilities.py
+++ b/tests/integration/test_jeam_sampler_capabilities.py
@@ -1,0 +1,188 @@
+"""Sampler capability contract for the analytical JEAM likelihood."""
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytest
+import xarray as xr
+
+pytest.importorskip("jeam")
+
+import jax
+import pytensor
+
+import hssm
+from hssm.integrations.jeam import simulate_circular_diffusion
+from hssm.modelconfig import get_default_model_config
+
+PARAMETERS = ("v_x", "v_y", "a", "t")
+NUTS_STATISTICS = {"acceptance_rate", "diverging", "n_steps", "step_size", "tree_depth"}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pin_fixed_cdm_x64():
+    """Exercise analytical samplers in JEAM's supported precision mode."""
+    original_floatx = pytensor.config.floatX
+    original_jax_x64 = jax.config.jax_enable_x64
+    hssm.set_floatX("float64")
+    yield
+    pytensor.config.floatX = original_floatx
+    jax.config.update("jax_enable_x64", original_jax_x64)
+
+
+@pytest.fixture(scope="module")
+def circular_data() -> pd.DataFrame:
+    """Return one deterministic dataset shared by all sampler probes."""
+    observations = simulate_circular_diffusion(
+        theta=np.array([0.70, -0.35, 0.80, 0.08]),
+        random_state=1947,
+        n_replicas=24,
+    )
+    return pd.DataFrame(observations, columns=["rt", "response"])
+
+
+def _make_circular_model(data: pd.DataFrame, loglik_kind: str) -> hssm.HSSM:
+    """Construct an ordinary HSSM with the requested JEAM likelihood route."""
+    return hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        loglik_kind=loglik_kind,
+        p_outlier=None,
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Sampler capability metadata is introduced by the next commit.",
+)
+def test_circular_config_declares_verified_sampler_combinations():
+    """Each likelihood route should advertise only its verified samplers."""
+    config = get_default_model_config("circular_diffusion")
+
+    assert config["likelihoods"]["blackbox"]["supported_samplers"] == ("pymc",)
+    assert config["likelihoods"]["analytical"]["supported_samplers"] == (
+        "pymc",
+        "numpyro",
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Early per-likelihood sampler validation is introduced by the next commit.",
+)
+@pytest.mark.parametrize(
+    ("loglik_kind", "sampler"),
+    [
+        ("analytical", "blackjax"),
+        ("analytical", "nutpie"),
+        ("analytical", "laplace"),
+        ("blackbox", "laplace"),
+    ],
+)
+def test_unverified_sampler_backends_fail_before_backend_dispatch(
+    circular_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+    loglik_kind: str,
+    sampler: str,
+):
+    """Unverified JEAM backends must fail before Bambi starts inference."""
+    model = _make_circular_model(circular_data, loglik_kind)
+
+    def unexpected_fit(**kwargs):
+        pytest.fail(f"Bambi.fit was called for unsupported sampler {sampler!r}.")
+
+    def unexpected_map():
+        pytest.fail(f"MAP ran for unsupported sampler {sampler!r}.")
+
+    monkeypatch.setattr(model.model, "fit", unexpected_fit)
+    monkeypatch.setattr(model, "find_MAP", unexpected_map)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"Sampler {sampler!r} is not supported.*"
+            rf"circular_diffusion.*{loglik_kind}"
+        ),
+    ):
+        model.sample(
+            sampler=sampler,
+            initvals="map",
+            chains=1,
+            cores=1,
+            tune=1,
+            draws=1,
+            progressbar=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("requested_sampler", "resolved_sampler"),
+    [(None, "pymc"), ("nuts_numpyro", "numpyro")],
+)
+def test_supported_sampler_resolution_precedes_capability_gate(
+    circular_data: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+    requested_sampler: str | None,
+    resolved_sampler: str,
+):
+    """Defaults and legacy aliases should resolve before capability validation."""
+    model = _make_circular_model(circular_data, "analytical")
+
+    def expected_fit(**kwargs):
+        assert kwargs["inference_method"] == resolved_sampler
+        raise RuntimeError("backend dispatch reached")
+
+    monkeypatch.setattr(model.model, "fit", expected_fit)
+
+    with pytest.raises(RuntimeError, match="backend dispatch reached"):
+        model.sample(
+            sampler=requested_sampler,
+            chains=1,
+            cores=1,
+            tune=1,
+            draws=1,
+            progressbar=False,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("sampler", ["pymc", "numpyro"])
+def test_verified_nuts_backends_compile_and_return_nuts_statistics(
+    circular_data: pd.DataFrame,
+    sampler: str,
+):
+    """The two supported NUTS backends must use finite gradients and NUTS steps."""
+    model = _make_circular_model(circular_data, "analytical")
+    transformed_init = pm.initial_point.make_initial_point_fn(
+        model=model.pymc_model,
+        overrides=model.initvals,
+        return_transformed=True,
+    )(None)
+    gradient = np.asarray(model.pymc_model.compile_dlogp()(transformed_init))
+
+    assert gradient.shape == (len(PARAMETERS),)
+    assert np.all(np.isfinite(gradient))
+    assert np.any(gradient != 0.0)
+
+    traces = model.sample(
+        sampler=sampler,
+        chains=1,
+        cores=1,
+        tune=10,
+        draws=10,
+        random_seed=3101,
+        progressbar=False,
+        idata_kwargs={"log_likelihood": False},
+    )
+
+    assert isinstance(traces, xr.DataTree)
+    assert set(PARAMETERS) <= set(traces["posterior"].data_vars)
+    for parameter in PARAMETERS:
+        values = np.asarray(traces["posterior"][parameter])
+        assert values.shape == (1, 10)
+        assert np.all(np.isfinite(values))
+
+    sample_statistics = set(traces["sample_stats"].data_vars)
+    assert NUTS_STATISTICS <= sample_statistics
+    assert {"nstep_in", "nstep_out"}.isdisjoint(sample_statistics)
+    assert traces["posterior"].attrs["inference_library"] == sampler

--- a/tests/integration/test_jeam_sampler_capabilities.py
+++ b/tests/integration/test_jeam_sampler_capabilities.py
@@ -51,10 +51,6 @@ def _make_circular_model(data: pd.DataFrame, loglik_kind: str) -> hssm.HSSM:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Sampler capability metadata is introduced by the next commit.",
-)
 def test_circular_config_declares_verified_sampler_combinations():
     """Each likelihood route should advertise only its verified samplers."""
     config = get_default_model_config("circular_diffusion")
@@ -66,10 +62,6 @@ def test_circular_config_declares_verified_sampler_combinations():
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Early per-likelihood sampler validation is introduced by the next commit.",
-)
 @pytest.mark.parametrize(
     ("loglik_kind", "sampler"),
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -175,6 +175,29 @@ def test_circular_responses_require_valid_bounds():
         config.validate()
 
 
+@pytest.mark.parametrize(
+    ("supported_samplers", "message"),
+    [
+        ((), "cannot be empty"),
+        (("stan",), "Unrecognized supported sampler.*stan"),
+        (("pymc", "pymc"), "cannot contain duplicates"),
+    ],
+)
+def test_supported_sampler_metadata_is_validated(supported_samplers, message):
+    """Sampler restrictions should be nonempty, recognized, and unique."""
+    config = Config(
+        model_name="custom",
+        choices=(0, 1),
+        list_params=["v"],
+        loglik_kind="analytical",
+        loglik=lambda *args: None,
+        supported_samplers=supported_samplers,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
 class TestConfigBuildModelConfigExtraLogic:
     def test_build_model_config_dict_with_choices_conflict(self, caplog):
         # model 'ddm' has defaults in hssm.defaults; use a minimal dict override


### PR DESCRIPTION
## Purpose

- add producer-owned sampler-backend capabilities for each JEAM likelihood route
- CI-verify analytical PyMC and NumPyro NUTS mechanics without changing HSSM defaults or making a scientific sampler recommendation

## Changes

- declare `pymc` for the black-box route and `pymc`/`numpyro` for the analytical route
- resolve defaults and legacy aliases before rejecting unsupported combinations, and reject before MAP initialization or backend dispatch
- isolate JAX x64 state in the tests and run real one-chain PyMC and NumPyro NUTS compilation smokes
- document the distinction between working, CI-supported, and recommended routes, including the boundary between HSSM's `sampler=` selector and user-supplied PyMC `step=` objects
- broaden the optional JEAM workflow triggers and run the complete capability contract before the longer recovery jobs

## Verification

- sampler capability suite: 9 passed, including both real NUTS smokes
- complete fast suite: 818 passed, 378 slow tests deselected
- existing JEAM black-box/recovery regression: 24 passed
- Ruff lint/format, mypy, documentation weight, strict marimo validation, strict MkDocs, diff hygiene, and sdist/wheel build passed

## Scope

- no global or per-model default sampler change
- analytical NUTS is technically supported and CI-checked, but not promoted as the recommended route
- no canonical recovery-evidence rerun; the authenticated schema-v2 black-box/Slice evidence remains bound to historical JEAM `a9f547b`
- the live analytical route uses immutable JEAM #13 at `ede7a4f4faf226e4dae52c84dfb01012939cccdc`
