### PR TITLE
Compare JEAM likelihood routes in HSSM

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -17,7 +17,6 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "src/hssm/register.py"
       - "src/hssm/utils.py"
-      - "docs/reference/jeam_circular_diffusion.md"
       - "docs/tutorials/jeam_circular_diffusion.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
@@ -62,6 +61,28 @@ jobs:
         run: >-
           uv run --group docs --group jeam-prototype marimo check --strict
           docs/tutorials/jeam_circular_diffusion.py
+
+      - name: Export the JEAM comparison notebook without sampling
+        env:
+          MPLCONFIGDIR: /tmp/hssm-jeam-comparison-matplotlib
+          XDG_CACHE_HOME: /tmp/hssm-jeam-comparison-cache
+        run: |
+          mkdir -p "$MPLCONFIGDIR" "$XDG_CACHE_HOME"
+          uv run --group docs --group jeam-prototype marimo export html \
+            docs/tutorials/jeam_circular_diffusion.py \
+            -o /tmp/jeam-circular-default.html --force --no-include-code \
+            > /tmp/jeam-circular-default-export.log 2>&1
+          cat /tmp/jeam-circular-default-export.log
+          grep -Fq "Choose a route and sampling counts" /tmp/jeam-circular-default.html
+          if grep -Fq "completed inference with" /tmp/jeam-circular-default.html; then
+            echo "JEAM comparison notebook crossed its explicit sampling gate"
+            exit 1
+          fi
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            /tmp/jeam-circular-default.html /tmp/jeam-circular-default-export.log; then
+            echo "JEAM comparison notebook contains a host path or execution error"
+            exit 1
+          fi
 
       - name: Verify the JEAM likelihood and simulator handshake
         run: >-

--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -17,6 +17,8 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "src/hssm/register.py"
       - "src/hssm/utils.py"
+      - "docs/reference/jeam_circular_diffusion.md"
+      - "docs/tutorials/jeam_circular_diffusion.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
       - "scripts/benchmark_jeam_recovery_bundle.py"
@@ -50,11 +52,16 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Sync JEAM prototype group
-        run: uv sync --group jeam-prototype --locked
+      - name: Sync JEAM prototype and docs groups
+        run: uv sync --group docs --group jeam-prototype --locked
 
       - name: Smoke-test optional imports
         run: uv run --group jeam-prototype python -c "import hssm; import jeam"
+
+      - name: Validate the JEAM comparison notebook
+        run: >-
+          uv run --group docs --group jeam-prototype marimo check --strict
+          docs/tutorials/jeam_circular_diffusion.py
 
       - name: Verify the JEAM likelihood and simulator handshake
         run: >-

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -129,9 +129,10 @@ supported when JAX x64 execution is enabled independently.
 
 Prior and posterior predictive sampling use JEAM's simulator through HSSM and accept
 HSSM's seeded random-state interface. Draws preserve the final `[rt, response]` order.
-The [complete marimo walkthrough](../tutorials/jeam_circular_diffusion.py) demonstrates
-construction, explicit Slice sampling, likelihood parity, diagnostics, and predictive
-checks.
+The [complete marimo comparison lab](../tutorials/jeam_circular_diffusion.py) checks
+both likelihoods against direct JEAM, compiles the analytical parameter gradient, and
+lets users fit the same simulated dataset with blackbox/PyMC Slice, analytical/PyMC
+NUTS, or analytical/NumPyro NUTS before running diagnostics and predictive checks.
 
 ## Current boundary
 

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -150,7 +150,8 @@ not currently provide:
 
 The wrapper has pointwise direct-JEAM/HSSM likelihood parity tests, deterministic
 predictive tests, a marked-slow Bayesian recovery test, and an artifact-backed,
-schema-v2 four-scenario deterministic [recovery smoke](../tutorials/jeam_repeated_recovery.py).
+schema-v2 four-scenario deterministic [recovery smoke](../tutorials/jeam_repeated_recovery.py)
+for the blackbox/PyMC Slice route.
 This evidence validates the narrow handshake; it is not a claim of production-scale
 sampler performance or simulation-based calibration.
 

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -13,7 +13,7 @@ tutorial. For a longer local run, set ``FULL_RUN=1`` before starting marimo. For
 plumbing-only run that bypasses the Run button, set
 ``JEAM_NOTEBOOK_SMOKE=1``. The artifact-backed, four-scenario report in
 ``docs/tutorials/jeam_repeated_recovery.py`` provides the broader deterministic
-recovery-smoke evidence; it is not simulation-based calibration.
+blackbox/PyMC Slice recovery-smoke evidence; it is not simulation-based calibration.
 """
 
 # ruff: noqa: B018, D401, E501, PLR1711
@@ -34,6 +34,7 @@ def _():
     from time import perf_counter
 
     import arviz as az
+    import jax
     import marimo as mo
     import matplotlib.pyplot as plt
     import numpy as np
@@ -50,6 +51,7 @@ def _():
         az,
         hssm,
         importlib,
+        jax,
         json,
         logging,
         mo,
@@ -106,6 +108,11 @@ def _(mo):
     `ede7a4f4faf226e4dae52c84dfb01012939cccdc`. This is a VCS-pinned prototype,
     not a released HSSM runtime dependency.
 
+    This notebook deliberately owns its process-wide precision setup: it calls
+    `hssm.set_floatX("float64")` and asserts both PyTensor float64 and JAX x64 before
+    constructing either model. Model construction validates that state without changing
+    it.
+
     The default run below uses 120 trials and two short chains. Start marimo with
     `FULL_RUN=1` to use 300 trials and longer chains:
 
@@ -124,14 +131,14 @@ def _(mo):
     ```
 
     Both modes exercise this one illustrative two-chain analysis. Neither reproduces
-    the artifact-backed four-scenario recovery smoke nor establishes simulation-based
-    calibration.
+    the artifact-backed blackbox/PyMC Slice four-scenario recovery smoke nor establishes
+    simulation-based calibration.
     """)
     return
 
 
 @app.cell
-def _(hssm, logging, os, pytensor, warnings):
+def _(hssm, jax, logging, os, pytensor, warnings):
     warnings.filterwarnings(
         "ignore",
         message=r"Numba will use object mode to run .*",
@@ -173,6 +180,7 @@ def _(hssm, logging, os, pytensor, warnings):
     PARAMETER_ORDER = ("a", "t", "v_x", "v_y")
     HSSM_PARAMETER_ORDER = ("v_x", "v_y", "a", "t")
     assert pytensor.config.floatX == "float64"
+    assert jax.config.jax_enable_x64
     return (
         FULL_RUN,
         HSSM_PARAMETER_ORDER,
@@ -354,7 +362,7 @@ def _(mo):
 
 
 @app.cell
-def _(data, hssm, inference_route):
+def _(data, hssm):
     blackbox_model = hssm.HSSM(
         data=data,
         model="circular_diffusion",
@@ -371,15 +379,14 @@ def _(data, hssm, inference_route):
         "blackbox": blackbox_model,
         "analytical": analytical_model,
     }
+    return analytical_model, blackbox_model, models_by_likelihood
+
+
+@app.cell
+def _(inference_route, models_by_likelihood):
     selected_likelihood, selected_sampler = inference_route.value.split("_", 1)
     circular_model = models_by_likelihood[selected_likelihood]
-    return (
-        analytical_model,
-        blackbox_model,
-        circular_model,
-        selected_likelihood,
-        selected_sampler,
-    )
+    return circular_model, selected_likelihood, selected_sampler
 
 
 @app.cell
@@ -680,8 +687,8 @@ def _(inference_route, mo):
 
     `cores=1` keeps the notebook portable and reproducible. Runtime here is descriptive,
     not a benchmark: JAX compilation and short-run warmup costs are a large fraction of
-    an interactive run. The artifact-backed, schema-v2 recovery smoke and any efficiency
-    gate remain separate from this workflow demonstration.
+    an interactive run. The artifact-backed, schema-v2 blackbox/PyMC Slice recovery
+    smoke and any efficiency gate remain separate from this workflow demonstration.
     """)
     return
 
@@ -778,6 +785,8 @@ def _(
     sample_stat_names = tuple(
         sorted(str(name) for name in traces["sample_stats"].data_vars)
     )
+    inference_library = str(traces["posterior"].attrs.get("inference_library", ""))
+    backend_provenance_ok = inference_library == selected_sampler
     nuts_statistics = {
         "acceptance_rate",
         "diverging",
@@ -806,6 +815,7 @@ def _(
         [
             {"diagnostic": "likelihood", "observed": selected_likelihood},
             {"diagnostic": "sampler", "observed": selected_sampler},
+            {"diagnostic": "trace backend", "observed": inference_library},
             {"diagnostic": "tune per chain", "observed": tune_count.value},
             {"diagnostic": "draws per chain", "observed": draw_count.value},
             {"diagnostic": "sampler statistics", "observed": str(sample_stat_names)},
@@ -822,8 +832,10 @@ def _(
             },
         ]
     )
+    assert backend_provenance_ok
     assert sampler_statistics_ok
     return (
+        backend_provenance_ok,
         diagnostic_limits,
         diagnostics_ok,
         lower_column,
@@ -870,7 +882,8 @@ def _(
 
 
 @app.cell
-def _(mo):
+def _(mo, sampling_report):
+    assert not sampling_report.empty
     mo.md("""
     ### Diagnose before interpreting
     """)
@@ -884,7 +897,8 @@ def _(mo, sampling_report):
 
 
 @app.cell
-def _(mo):
+def _(mo, recovery_table):
+    assert not recovery_table.empty
     mo.md("""
     ### Parameter recovery in this one illustrative dataset
     """)
@@ -978,7 +992,8 @@ def _(RUN_CONFIG, circular_model, perf_counter, traces):
 
 
 @app.cell
-def _(mo):
+def _(mo, posterior_predictive_values):
+    assert posterior_predictive_values.shape[-1] == 2
     predictive_view = mo.ui.dropdown(
         options={
             "Response time and angle": "both",
@@ -1115,7 +1130,8 @@ def _(data, np, pd, posterior_predictive_values, predictive_seconds):
 
 
 @app.cell
-def _(mo):
+def _(mo, predictive_summary):
+    assert not predictive_summary.empty
     mo.md("""
     ## 5. Check posterior predictions
 
@@ -1136,6 +1152,7 @@ def _(mo, predictive_summary):
 def _(
     HSSM_PARAMETER_ORDER,
     analytical_gradient,
+    backend_provenance_ok,
     circular_model,
     hssm,
     logp_absolute_errors,
@@ -1177,6 +1194,10 @@ def _(
                 "result": analytical_gradient_ok,
             },
             {
+                "workflow gate": "selected sampler backend",
+                "result": backend_provenance_ok,
+            },
+            {
                 "workflow gate": "selected sampler statistics",
                 "result": sampler_statistics_ok,
             },
@@ -1191,7 +1212,8 @@ def _(
 
 
 @app.cell
-def _(mo):
+def _(mo, validation_table):
+    assert validation_table["result"].all()
     mo.md("""
     ## What this run established
     """)
@@ -1205,7 +1227,8 @@ def _(mo, validation_table):
 
 
 @app.cell
-def _(inference_route, mo):
+def _(inference_route, mo, validation_table):
+    assert validation_table["result"].all()
     mo.md(rf"""
     The notebook has now checked both registered HSSM likelihoods against direct JEAM,
     verified that the analytical route exposes a finite nonzero parameter gradient,
@@ -1219,7 +1242,8 @@ def _(inference_route, mo):
     2. choose and justify domain-specific priors;
     3. compare posterior predictions to all scientifically important summaries;
     4. consult `docs/tutorials/jeam_repeated_recovery.py` for the artifact-backed,
-       four-scenario deterministic recovery smoke (not calibration); and
+       blackbox/PyMC Slice four-scenario deterministic recovery smoke (not calibration);
+       and
     5. retain the exact JEAM revision in the analysis environment.
 
     The integration remains deliberately narrow: fixed CDM, two-dimensional angular

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -529,6 +529,7 @@ def _(
     np,
     observations,
     pd,
+    perf_counter,
     pm,
 ):
     direct_jeam = CircularDiffusionModel(threshold_dynamic="fixed")
@@ -553,6 +554,7 @@ def _(
         ),
         dtype=np.float64,
     )
+    _blackbox_objective_started = perf_counter()
     blackbox_logp = np.asarray(
         blackbox_model.model_distribution.logp(
             observations,
@@ -563,6 +565,8 @@ def _(
         ).eval(),
         dtype=np.float64,
     )
+    blackbox_objective_seconds = perf_counter() - _blackbox_objective_started
+    _analytical_objective_started = perf_counter()
     analytical_logp = np.asarray(
         analytical_model.model_distribution.logp(
             observations,
@@ -573,6 +577,7 @@ def _(
         ).eval(),
         dtype=np.float64,
     )
+    analytical_objective_seconds = perf_counter() - _analytical_objective_started
     logp_by_likelihood = {
         "blackbox": blackbox_logp,
         "analytical": analytical_logp,
@@ -581,6 +586,7 @@ def _(
         likelihood: np.abs(values - direct_logp)
         for likelihood, values in logp_by_likelihood.items()
     }
+    _gradient_compile_started = perf_counter()
     _transformed_initial_point = pm.initial_point.make_initial_point_fn(
         model=analytical_model.pymc_model,
         overrides=analytical_model.initvals,
@@ -590,6 +596,7 @@ def _(
         analytical_model.pymc_model.compile_dlogp()(_transformed_initial_point),
         dtype=np.float64,
     )
+    analytical_gradient_compile_seconds = perf_counter() - _gradient_compile_started
     assert analytical_gradient.shape == (4,)
     assert np.all(np.isfinite(analytical_gradient))
     assert np.any(analytical_gradient != 0.0)
@@ -600,10 +607,20 @@ def _(
                 "HSSM likelihood": likelihood,
                 "summed log likelihood": values.sum(),
                 "maximum error vs direct JEAM": logp_absolute_errors[likelihood].max(),
+                "objective evaluation seconds": (
+                    analytical_objective_seconds
+                    if likelihood == "analytical"
+                    else blackbox_objective_seconds
+                ),
                 "parameter gradient": (
                     "finite, nonzero (4 components)"
                     if likelihood == "analytical"
                     else "not exposed"
+                ),
+                "gradient compile + first eval seconds": (
+                    analytical_gradient_compile_seconds
+                    if likelihood == "analytical"
+                    else np.nan
                 ),
             }
             for likelihood, values in logp_by_likelihood.items()

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -1,4 +1,4 @@
-"""Fit JEAM's circular diffusion model through ordinary HSSM.
+"""Compare JEAM's blackbox and analytical circular likelihoods through HSSM.
 
 From the HSSM repository root, install the pinned prototype and open this marimo
 notebook with::
@@ -7,13 +7,16 @@ notebook with::
     uv run --group docs --group jeam-prototype \
         marimo edit docs/tutorials/jeam_circular_diffusion.py
 
-The default two-chain fit is intentionally small enough for an interactive tutorial.
-For a longer local run, set ``FULL_RUN=1`` before starting marimo. The artifact-backed,
-four-scenario report in ``docs/tutorials/jeam_repeated_recovery.py`` provides the broader
-recovery smoke evidence; it is not simulation-based calibration.
+Choose the likelihood and sampler in the notebook. The default two-chain fit is
+intentionally small enough for an interactive tutorial. For a longer local run, set
+``FULL_RUN=1`` before starting marimo. For a plumbing-only run, set
+``JEAM_NOTEBOOK_SMOKE=1``. The artifact-backed, four-scenario report in
+``docs/tutorials/jeam_repeated_recovery.py`` provides the broader deterministic
+recovery-smoke evidence; it is not simulation-based calibration.
 """
 
 # ruff: noqa: B018, D401, E501, PLR1711
+
 import marimo
 
 __generated_with = "0.23.14"
@@ -24,6 +27,7 @@ app = marimo.App(width="medium")
 def _():
     import importlib.metadata
     import json
+    import logging
     import os
     import warnings
     from time import perf_counter
@@ -46,6 +50,7 @@ def _():
         hssm,
         importlib,
         json,
+        logging,
         mo,
         np,
         os,
@@ -62,12 +67,12 @@ def _():
 @app.cell
 def _(mo):
     mo.md(r"""
-    # Fit a circular diffusion model with HSSM and JEAM
+    # Compare JEAM likelihood routes through HSSM
 
-    This tutorial exercises the complete black-box prototype handshake: simulate angular
-    responses with JEAM, construct an **ordinary `hssm.HSSM` object**, verify its
-    likelihood numerically against JEAM, fit it with a gradient-free sampler, and
-    perform posterior predictive checks.
+    This tutorial exercises the complete prototype handshake: simulate angular
+    responses with JEAM, construct **ordinary `hssm.HSSM` objects**, compare both
+    registered likelihoods against direct JEAM, compile the analytical gradient,
+    fit a selected likelihood/sampler route, and perform posterior predictive checks.
     """)
     return
 
@@ -108,31 +113,56 @@ def _(mo):
       marimo edit docs/tutorials/jeam_circular_diffusion.py
     ```
 
-    `FULL_RUN=1` only lengthens this one illustrative two-chain analysis. It does
-    not reproduce the artifact-backed four-scenario recovery smoke or establish
-    simulation-based calibration.
+    Automated or plumbing-only checks can use 24 trials and 10 tune plus 10
+    posterior draws per chain:
+
+    ```bash
+    JEAM_NOTEBOOK_SMOKE=1 uv run --group docs --group jeam-prototype \
+      marimo export html docs/tutorials/jeam_circular_diffusion.py \
+      -o /tmp/jeam-circular-smoke.html
+    ```
+
+    Both modes exercise this one illustrative two-chain analysis. Neither reproduces
+    the artifact-backed four-scenario recovery smoke nor establishes simulation-based
+    calibration.
     """)
     return
 
 
 @app.cell
-def _(hssm, os, pytensor, warnings):
+def _(hssm, logging, os, pytensor, warnings):
     warnings.filterwarnings(
         "ignore",
         message=r"Numba will use object mode to run .*",
         category=UserWarning,
         module=r"pytensor\.link\.numba\.dispatch\.basic",
     )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"`init='adapt_diag'` is ignored by `nuts_sampler='numpyro'`.*",
+        category=UserWarning,
+        module=r"bambi\.backend\.pymc",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"There are not enough devices to run parallel chains:.*",
+        category=UserWarning,
+        module=r"pymc\.sampling\.jax",
+    )
+    logging.getLogger("jax._src.xla_bridge").setLevel(logging.ERROR)
     hssm.set_floatX("float64")
     FULL_RUN = os.getenv("FULL_RUN", "0") == "1"
+    SMOKE_RUN = os.getenv("JEAM_NOTEBOOK_SMOKE", "0") == "1"
+    if FULL_RUN and SMOKE_RUN:
+        raise RuntimeError("FULL_RUN and JEAM_NOTEBOOK_SMOKE cannot both be enabled.")
     RUN_CONFIG = {
-        "mode": "full" if FULL_RUN else "tutorial",
-        "trials": 300 if FULL_RUN else 120,
+        "mode": "full" if FULL_RUN else "smoke" if SMOKE_RUN else "tutorial",
+        "trials": 300 if FULL_RUN else 24 if SMOKE_RUN else 120,
         "chains": 2,
-        "tune": 1_500 if FULL_RUN else 500,
-        "draws": 1_500 if FULL_RUN else 500,
-        "prior_draws": 20 if FULL_RUN else 8,
-        "predictive_draws": 100 if FULL_RUN else 30,
+        "tune": 1_500 if FULL_RUN else 10 if SMOKE_RUN else 500,
+        "draws": 1_500 if FULL_RUN else 10 if SMOKE_RUN else 500,
+        "prior_draws": 20 if FULL_RUN else 2 if SMOKE_RUN else 8,
+        "predictive_draws": 100 if FULL_RUN else 2 if SMOKE_RUN else 30,
         "data_seed": 1_492,
         "chain_seeds": (3_101, 3_102),
         "prior_seed": 6_101,
@@ -147,6 +177,7 @@ def _(hssm, os, pytensor, warnings):
         HSSM_PARAMETER_ORDER,
         PARAMETER_ORDER,
         RUN_CONFIG,
+        SMOKE_RUN,
         TRUTH,
     )
 
@@ -171,7 +202,7 @@ def _(importlib, json, mo):
         f"Verified installed JEAM revision `{installed_jeam_revision}`.",
         kind="success",
     )
-    return expected_jeam_revision, installed_jeam_revision
+    return
 
 
 @app.cell
@@ -211,7 +242,7 @@ def _(RUN_CONFIG, TRUTH, np, pd, simulate_circular_diffusion):
     data = pd.DataFrame(observations, columns=["rt", "response"])
     assert np.all(data["rt"] > 0.0)
     assert np.all((-np.pi <= data["response"]) & (data["response"] < np.pi))
-    return data, observations, simulator_theta
+    return data, observations
 
 
 @app.cell
@@ -276,37 +307,102 @@ def _(mo):
 
 
 @app.cell
-def _(data, hssm):
-    circular_model = hssm.HSSM(
-        data=data,
-        model="circular_diffusion",
-        loglik_kind="blackbox",
-        p_outlier=None,
+def _(mo, os):
+    inference_routes = {
+        "Blackbox + PyMC Slice": "blackbox_pymc",
+        "Analytical + PyMC NUTS": "analytical_pymc",
+        "Analytical + NumPyro NUTS": "analytical_numpyro",
+    }
+    default_route = os.getenv("JEAM_INFERENCE_ROUTE", "blackbox_pymc")
+    if default_route not in inference_routes.values():
+        raise RuntimeError(
+            "JEAM_INFERENCE_ROUTE must be one of "
+            f"{tuple(inference_routes.values())}, not {default_route!r}."
+        )
+    default_route_label = next(
+        label for label, value in inference_routes.items() if value == default_route
     )
-    return (circular_model,)
+    inference_route = mo.ui.dropdown(
+        options=inference_routes,
+        value=default_route_label,
+        label="Likelihood and sampler",
+    )
+    inference_route
+    return (inference_route,)
 
 
 @app.cell
 def _(mo):
-    mo.md("""
-    ## 2. Build an ordinary HSSM model
+    mo.md(r"""
+    ## 2. Build both ordinary HSSM models
 
-    No `HSSMCircular` subclass is involved. HSSM discovers the likelihood,
+    Use the dropdown above to choose the route that will be sampled later. The
+    notebook always constructs and numerically checks **both** likelihoods on the
+    same observations:
+
+    - `blackbox` calls JEAM's NumPy implementation and requires gradient-free Slice;
+    - `analytical` evaluates JEAM's truncated first-passage series with JAX and
+      exposes parameter gradients for NUTS.
+
+    There is no `HSSMCircular` subclass. HSSM discovers each likelihood, the shared
     simulator, bounds, and response semantics from the registered
-    `circular_diffusion` model configuration. This walkthrough selects the
-    `blackbox` likelihood explicitly so its sampler guidance remains local to
-    that route.
+    `circular_diffusion` model configuration. Sampler guidance below remains local
+    to the likelihood route selected above.
     """)
     return
 
 
 @app.cell
-def _(circular_model, hssm, mo, np, pd):
+def _(data, hssm, inference_route):
+    blackbox_model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        loglik_kind="blackbox",
+        p_outlier=None,
+    )
+    analytical_model = hssm.HSSM(
+        data=data,
+        model="circular_diffusion",
+        loglik_kind="analytical",
+        p_outlier=None,
+    )
+    models_by_likelihood = {
+        "blackbox": blackbox_model,
+        "analytical": analytical_model,
+    }
+    selected_likelihood, selected_sampler = inference_route.value.split("_", 1)
+    circular_model = models_by_likelihood[selected_likelihood]
+    return (
+        analytical_model,
+        blackbox_model,
+        circular_model,
+        selected_likelihood,
+        selected_sampler,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ### Selected HSSM contract
+    """)
+    return
+
+
+@app.cell
+def _(circular_model, hssm, inference_route, mo, np, pd, selected_sampler):
+    supported_samplers = circular_model.model_config.supported_samplers
     model_contract = pd.DataFrame(
         [
+            {"property": "selected route", "value": inference_route.selected_key},
             {"property": "Python class", "value": type(circular_model).__name__},
             {"property": "model name", "value": circular_model.model_name},
             {"property": "likelihood", "value": circular_model.loglik_kind},
+            {"property": "sampler", "value": selected_sampler},
+            {
+                "property": "supported samplers",
+                "value": ", ".join(supported_samplers or ()),
+            },
             {"property": "response kind", "value": circular_model.response_kind},
             {
                 "property": "angle bounds",
@@ -319,17 +415,18 @@ def _(circular_model, hssm, mo, np, pd):
     )
     assert type(circular_model) is hssm.HSSM
     assert circular_model.response_bounds == {"response": (-np.pi, np.pi)}
+    assert selected_sampler in (supported_samplers or ())
     mo.ui.table(model_contract, selection=None, pagination=False)
-    return (model_contract,)
+    return
 
 
 @app.cell
-def _(RUN_CONFIG, data, hssm):
+def _(RUN_CONFIG, data, hssm, selected_likelihood):
     # Keep prior draws separate from the HSSM object that will hold posterior traces.
     _prior_check_model = hssm.HSSM(
         data=data,
         model="circular_diffusion",
-        loglik_kind="blackbox",
+        loglik_kind=selected_likelihood,
         p_outlier=None,
     )
     prior_predictive = _prior_check_model.sample_prior_predictive(
@@ -337,7 +434,7 @@ def _(RUN_CONFIG, data, hssm):
         random_seed=RUN_CONFIG["prior_seed"],
     )
     prior_values = prior_predictive["prior_predictive"]["rt,response"].values
-    return prior_predictive, prior_values
+    return (prior_values,)
 
 
 @app.cell
@@ -407,15 +504,17 @@ def _(mo):
     observed likelihood is used. For an applied analysis, replace default priors with
     domain-informed priors rather than treating this picture as a one-time ritual.
 
-    ## 3. Verify the numerical handshake
+    ## 3. Verify both numerical handshakes
 
-    The next cell evaluates every observation twice at the known parameters:
+    The next cell evaluates every observation three ways at the known parameters:
 
-    1. directly through JEAM's `CircularDiffusionModel.joint_lpdf`, and
-    2. through the distribution constructed by this exact HSSM object.
+    1. directly through JEAM's `CircularDiffusionModel.joint_lpdf`;
+    2. through HSSM's registered `blackbox` distribution; and
+    3. through HSSM's registered `analytical` distribution.
 
-    Agreement checks the objective itself, not merely whether both APIs return finite
-    numbers.
+    It also compiles the analytical model's four-parameter gradient at HSSM's initial
+    point and requires every component to be finite. Agreement checks the objectives
+    themselves, rather than merely whether all three APIs return finite numbers.
     """)
     return
 
@@ -424,10 +523,12 @@ def _(mo):
 def _(
     CircularDiffusionModel,
     TRUTH,
-    circular_model,
+    analytical_model,
+    blackbox_model,
     np,
     observations,
     pd,
+    pm,
 ):
     direct_jeam = CircularDiffusionModel(threshold_dynamic="fixed")
     direct_logp = np.asarray(
@@ -451,8 +552,8 @@ def _(
         ),
         dtype=np.float64,
     )
-    hssm_logp = np.asarray(
-        circular_model.model_distribution.logp(
+    blackbox_logp = np.asarray(
+        blackbox_model.model_distribution.logp(
             observations,
             TRUTH["v_x"],
             TRUTH["v_y"],
@@ -461,88 +562,134 @@ def _(
         ).eval(),
         dtype=np.float64,
     )
-    logp_absolute_error = np.abs(hssm_logp - direct_logp)
-    logp_comparison = pd.DataFrame(
+    analytical_logp = np.asarray(
+        analytical_model.model_distribution.logp(
+            observations,
+            TRUTH["v_x"],
+            TRUTH["v_y"],
+            TRUTH["a"],
+            TRUTH["t"],
+        ).eval(),
+        dtype=np.float64,
+    )
+    logp_by_likelihood = {
+        "blackbox": blackbox_logp,
+        "analytical": analytical_logp,
+    }
+    logp_absolute_errors = {
+        likelihood: np.abs(values - direct_logp)
+        for likelihood, values in logp_by_likelihood.items()
+    }
+    _transformed_initial_point = pm.initial_point.make_initial_point_fn(
+        model=analytical_model.pymc_model,
+        overrides=analytical_model.initvals,
+        return_transformed=True,
+    )(None)
+    analytical_gradient = np.asarray(
+        analytical_model.pymc_model.compile_dlogp()(_transformed_initial_point),
+        dtype=np.float64,
+    )
+    assert analytical_gradient.shape == (4,)
+    assert np.all(np.isfinite(analytical_gradient))
+    assert np.any(analytical_gradient != 0.0)
+
+    likelihood_comparison = pd.DataFrame(
         [
             {
-                "quantity": "summed log likelihood",
-                "direct JEAM": direct_logp.sum(),
-                "HSSM distribution": hssm_logp.sum(),
-                "absolute error": abs(hssm_logp.sum() - direct_logp.sum()),
-            },
-            {
-                "quantity": "largest pointwise absolute error",
-                "direct JEAM": np.nan,
-                "HSSM distribution": np.nan,
-                "absolute error": logp_absolute_error.max(),
-            },
+                "HSSM likelihood": likelihood,
+                "summed log likelihood": values.sum(),
+                "maximum error vs direct JEAM": logp_absolute_errors[likelihood].max(),
+                "parameter gradient": (
+                    "finite, nonzero (4 components)"
+                    if likelihood == "analytical"
+                    else "not exposed"
+                ),
+            }
+            for likelihood, values in logp_by_likelihood.items()
         ]
     )
-    np.testing.assert_allclose(hssm_logp, direct_logp, rtol=1e-6, atol=5e-5)
-    return (
-        direct_jeam,
-        direct_logp,
-        hssm_logp,
-        logp_absolute_error,
-        logp_comparison,
-    )
+    for _values in logp_by_likelihood.values():
+        np.testing.assert_allclose(_values, direct_logp, rtol=1e-6, atol=5e-5)
+    return analytical_gradient, likelihood_comparison, logp_absolute_errors
 
 
 @app.cell
-def _(logp_comparison, mo):
-    mo.ui.table(logp_comparison.round(8), selection=None, pagination=False)
+def _(likelihood_comparison, mo):
+    mo.ui.table(likelihood_comparison.round(10), selection=None, pagination=False)
     return
 
 
 @app.cell
-def _(mo):
-    mo.md(r"""
-    ## 4. Fit with explicit PyMC Slice steps
+def _(inference_route, mo):
+    mo.md(f"""
+    ## 4. Fit the selected route through HSSM
 
-    This explicitly selected `blackbox` likelihood crosses a Python/NumPy boundary and
-    does **not** provide gradients to PyTensor. Consequently, for this route:
+    **Selected:** `{inference_route.selected_key}`.
 
-    - this tutorial uses one explicit PyMC `Slice` step per parameter;
-    - NUTS, JAX NUTS (`numpyro`, `blackjax`, or `nutpie`), and variational inference
-      are not available;
-    - `cores=1` keeps the notebook portable and reproducible; and
-    - `p_outlier=None` is required because HSSM's categorical lapse mixture is not a
-      density over continuous angles.
+    The blackbox likelihood crosses a Python/NumPy boundary and does not expose
+    gradients to PyTensor, so this tutorial uses one explicit PyMC `Slice` step per
+    free variable for that route. The analytical routes use NUTS through either PyMC
+    or NumPyro and require JAX x64 execution. Every route uses the same model formulas,
+    priors, observed dataset, chain seeds, tune count, and draw count; only the
+    likelihood implementation and sampler change. `p_outlier=None` is required because
+    HSSM's categorical lapse mixture is not a density over continuous angles.
 
-    The short default run demonstrates the workflow. It is not a replacement for the
-    artifact-backed, schema-v2 four-scenario deterministic recovery smoke in
-    `docs/tutorials/jeam_repeated_recovery.py`.
+    `cores=1` keeps the notebook portable and reproducible. Runtime here is
+    descriptive, not a benchmark: JAX compilation and short-run warmup costs are a
+    large fraction of an interactive run. The artifact-backed, schema-v2 recovery
+    smoke and any efficiency gate remain separate from this workflow demonstration.
     """)
     return
 
 
 @app.cell
-def _(PARAMETER_ORDER, RUN_CONFIG, circular_model, perf_counter, pm):
-    slice_steps = [
-        pm.Slice(
-            vars=[circular_model.pymc_model[name]],
-            model=circular_model.pymc_model,
-        )
-        for name in PARAMETER_ORDER
-    ]
+def _(
+    PARAMETER_ORDER,
+    RUN_CONFIG,
+    circular_model,
+    perf_counter,
+    pm,
+    selected_likelihood,
+    selected_sampler,
+):
+    _sample_kwargs = {
+        "sampler": selected_sampler,
+        "chains": RUN_CONFIG["chains"],
+        "cores": 1,
+        "tune": RUN_CONFIG["tune"],
+        "draws": RUN_CONFIG["draws"],
+        "random_seed": list(RUN_CONFIG["chain_seeds"]),
+        "progressbar": False,
+        "idata_kwargs": {"log_likelihood": False},
+    }
+    if selected_likelihood == "blackbox":
+        _sample_kwargs["step"] = [
+            pm.Slice(
+                vars=[circular_model.pymc_model[name]],
+                model=circular_model.pymc_model,
+            )
+            for name in PARAMETER_ORDER
+        ]
     sampling_started = perf_counter()
-    traces = circular_model.sample(
-        sampler="pymc",
-        step=slice_steps,
-        chains=RUN_CONFIG["chains"],
-        cores=1,
-        tune=RUN_CONFIG["tune"],
-        draws=RUN_CONFIG["draws"],
-        random_seed=list(RUN_CONFIG["chain_seeds"]),
-        progressbar=False,
-        idata_kwargs={"log_likelihood": False},
-    )
+    traces = circular_model.sample(**_sample_kwargs)
     sampling_seconds = perf_counter() - sampling_started
-    return sampling_seconds, slice_steps, traces
+    return sampling_seconds, traces
 
 
 @app.cell
-def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
+def _(
+    FULL_RUN,
+    PARAMETER_ORDER,
+    SMOKE_RUN,
+    TRUTH,
+    az,
+    np,
+    pd,
+    sampling_seconds,
+    selected_likelihood,
+    selected_sampler,
+    traces,
+):
     posterior_summary = az.summary(
         traces,
         var_names=list(PARAMETER_ORDER),
@@ -573,6 +720,18 @@ def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
     sample_stat_names = tuple(
         sorted(str(name) for name in traces["sample_stats"].data_vars)
     )
+    nuts_statistics = {
+        "acceptance_rate",
+        "diverging",
+        "n_steps",
+        "step_size",
+        "tree_depth",
+    }
+    sampler_statistics_ok = (
+        sample_stat_names == ("nstep_in", "nstep_out")
+        if selected_likelihood == "blackbox"
+        else nuts_statistics <= set(sample_stat_names)
+    )
     maximum_rhat = float(posterior_summary["r_hat"].max())
     minimum_bulk_ess = float(posterior_summary["ess_bulk"].min())
     diagnostic_limits = {
@@ -580,13 +739,20 @@ def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
         "minimum bulk ESS": 400.0 if FULL_RUN else 100.0,
     }
     diagnostics_ok = (
-        np.isfinite(maximum_rhat)
+        not SMOKE_RUN
+        and np.isfinite(maximum_rhat)
         and maximum_rhat <= diagnostic_limits["maximum R-hat"]
         and minimum_bulk_ess >= diagnostic_limits["minimum bulk ESS"]
     )
     sampling_report = pd.DataFrame(
         [
+            {"diagnostic": "likelihood", "observed": selected_likelihood},
+            {"diagnostic": "sampler", "observed": selected_sampler},
             {"diagnostic": "sampler statistics", "observed": str(sample_stat_names)},
+            {
+                "diagnostic": "sampler statistics match route",
+                "observed": sampler_statistics_ok,
+            },
             {"diagnostic": "sampling seconds", "observed": sampling_seconds},
             {"diagnostic": "maximum R-hat", "observed": maximum_rhat},
             {"diagnostic": "minimum bulk ESS", "observed": minimum_bulk_ess},
@@ -596,7 +762,7 @@ def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
             },
         ]
     )
-    assert sample_stat_names == ("nstep_in", "nstep_out")
+    assert sampler_statistics_ok
     return (
         diagnostic_limits,
         diagnostics_ok,
@@ -605,26 +771,41 @@ def _(FULL_RUN, PARAMETER_ORDER, TRUTH, az, np, pd, sampling_seconds, traces):
         minimum_bulk_ess,
         posterior_summary,
         recovery_table,
-        sample_stat_names,
+        sampler_statistics_ok,
         sampling_report,
         upper_column,
     )
 
 
 @app.cell
-def _(diagnostic_limits, diagnostics_ok, maximum_rhat, minimum_bulk_ess, mo):
+def _(
+    SMOKE_RUN,
+    diagnostic_limits,
+    diagnostics_ok,
+    maximum_rhat,
+    minimum_bulk_ess,
+    mo,
+):
     _message = (
-        f"The diagnostic screen passed: maximum R-hat is {maximum_rhat:.3f} "
-        f"(limit {diagnostic_limits['maximum R-hat']:.2f}) and minimum bulk ESS "
-        f"is {minimum_bulk_ess:.0f} "
-        f"(limit {diagnostic_limits['minimum bulk ESS']:.0f})."
-        if diagnostics_ok
-        else f"Treat the posterior as provisional: maximum R-hat is "
-        f"{maximum_rhat:.3f} and minimum bulk ESS is {minimum_bulk_ess:.0f}. "
-        "Run FULL_RUN=1, inspect the chains, and revise the model before "
-        "substantive interpretation."
+        "Smoke mode only checks execution and sampler identity; 10 draws per chain "
+        "cannot support convergence or recovery claims."
+        if SMOKE_RUN
+        else (
+            f"The diagnostic screen passed: maximum R-hat is {maximum_rhat:.3f} "
+            f"(limit {diagnostic_limits['maximum R-hat']:.2f}) and minimum bulk ESS "
+            f"is {minimum_bulk_ess:.0f} "
+            f"(limit {diagnostic_limits['minimum bulk ESS']:.0f})."
+            if diagnostics_ok
+            else f"Treat the posterior as provisional: maximum R-hat is "
+            f"{maximum_rhat:.3f} and minimum bulk ESS is {minimum_bulk_ess:.0f}. "
+            "Run FULL_RUN=1, inspect the chains, and revise the model before "
+            "substantive interpretation."
+        )
     )
-    mo.callout(_message, kind="success" if diagnostics_ok else "warn")
+    mo.callout(
+        _message,
+        kind="info" if SMOKE_RUN else "success" if diagnostics_ok else "warn",
+    )
     return
 
 
@@ -673,7 +854,14 @@ def _(lower_column, mo, recovery_table, upper_column):
 
 
 @app.cell
-def _(PARAMETER_ORDER, TRUTH, lower_column, posterior_summary, plt, upper_column):
+def _(
+    PARAMETER_ORDER,
+    TRUTH,
+    lower_column,
+    plt,
+    posterior_summary,
+    upper_column,
+):
     _positions = list(range(len(PARAMETER_ORDER)))
     _means = posterior_summary.loc[list(PARAMETER_ORDER), "mean"].to_numpy()
     _lower = posterior_summary.loc[list(PARAMETER_ORDER), lower_column].to_numpy()
@@ -726,7 +914,7 @@ def _(RUN_CONFIG, circular_model, perf_counter, traces):
     posterior_predictive_values = posterior_predictive["posterior_predictive"][
         "rt,response"
     ].values
-    return posterior_predictive, posterior_predictive_values, predictive_seconds
+    return posterior_predictive_values, predictive_seconds
 
 
 @app.cell
@@ -887,19 +1075,28 @@ def _(mo, predictive_summary):
 @app.cell
 def _(
     HSSM_PARAMETER_ORDER,
+    analytical_gradient,
     circular_model,
     hssm,
-    logp_absolute_error,
+    logp_absolute_errors,
     np,
     pd,
     posterior_predictive_values,
-    sample_stat_names,
+    sampler_statistics_ok,
 ):
     predictive_support_ok = bool(
         np.all(np.isfinite(posterior_predictive_values))
         and np.all(posterior_predictive_values[..., 0] > 0.0)
         and np.all(posterior_predictive_values[..., 1] >= -np.pi)
         and np.all(posterior_predictive_values[..., 1] < np.pi)
+    )
+    both_likelihoods_match = all(
+        float(errors.max()) <= 5e-5 for errors in logp_absolute_errors.values()
+    )
+    analytical_gradient_ok = bool(
+        analytical_gradient.shape == (4,)
+        and np.all(np.isfinite(analytical_gradient))
+        and np.any(analytical_gradient != 0.0)
     )
     validation_table = pd.DataFrame(
         [
@@ -912,12 +1109,16 @@ def _(
                 "result": tuple(circular_model.list_params) == HSSM_PARAMETER_ORDER,
             },
             {
-                "workflow gate": "direct JEAM vs HSSM logp",
-                "result": float(logp_absolute_error.max()) <= 5e-5,
+                "workflow gate": "both HSSM likelihoods vs direct JEAM",
+                "result": both_likelihoods_match,
             },
             {
-                "workflow gate": "explicit Slice statistics",
-                "result": sample_stat_names == ("nstep_in", "nstep_out"),
+                "workflow gate": "finite nonzero analytical gradient",
+                "result": analytical_gradient_ok,
+            },
+            {
+                "workflow gate": "selected sampler statistics",
+                "result": sampler_statistics_ok,
             },
             {
                 "workflow gate": "posterior predictive support",
@@ -926,7 +1127,7 @@ def _(
         ]
     )
     assert validation_table["result"].all()
-    return predictive_support_ok, validation_table
+    return (validation_table,)
 
 
 @app.cell
@@ -944,15 +1145,17 @@ def _(mo, validation_table):
 
 
 @app.cell
-def _(mo):
-    mo.md(r"""
-    The notebook has now exercised the same registered likelihood and random variable
-    in both directions: inference consumed JEAM log densities, and predictive sampling
-    called JEAM's simulator through HSSM.
+def _(inference_route, mo):
+    mo.md(rf"""
+    The notebook has now checked both registered HSSM likelihoods against direct JEAM,
+    verified that the analytical route exposes a finite nonzero parameter gradient,
+    and completed inference with **{inference_route.selected_key}**. Predictive sampling
+    called JEAM's simulator through the selected ordinary HSSM object.
 
     Before using this prototype for substantive work:
 
-    1. run `FULL_RUN=1` and require satisfactory diagnostics for your data;
+    1. run `FULL_RUN=1` for each route you intend to evaluate and require satisfactory
+       diagnostics for your data;
     2. choose and justify domain-specific priors;
     3. compare posterior predictions to all scientifically important summaries;
     4. consult `docs/tutorials/jeam_repeated_recovery.py` for the artifact-backed,
@@ -960,8 +1163,9 @@ def _(mo):
     5. retain the exact JEAM revision in the analysis environment.
 
     The integration remains deliberately narrow: fixed CDM, two-dimensional angular
-    responses, no lapse mixture, and a black-box likelihood with gradient-free PyMC
-    Slice sampling.
+    responses, and no lapse mixture. Successful NUTS execution here is a capability
+    check, not a scientific recovery or efficiency recommendation; the blackbox route
+    remains the gradient-free PyMC Slice baseline.
     """)
     return
 

--- a/docs/tutorials/jeam_circular_diffusion.py
+++ b/docs/tutorials/jeam_circular_diffusion.py
@@ -7,9 +7,10 @@ notebook with::
     uv run --group docs --group jeam-prototype \
         marimo edit docs/tutorials/jeam_circular_diffusion.py
 
-Choose the likelihood and sampler in the notebook. The default two-chain fit is
-intentionally small enough for an interactive tutorial. For a longer local run, set
-``FULL_RUN=1`` before starting marimo. For a plumbing-only run, set
+Choose the likelihood and sampler, adjust tune/draw counts, and click Run in the
+notebook. The default two-chain fit is intentionally small enough for an interactive
+tutorial. For a longer local run, set ``FULL_RUN=1`` before starting marimo. For a
+plumbing-only run that bypasses the Run button, set
 ``JEAM_NOTEBOOK_SMOKE=1``. The artifact-backed, four-scenario report in
 ``docs/tutorials/jeam_repeated_recovery.py`` provides the broader deterministic
 recovery-smoke evidence; it is not simulation-based calibration.
@@ -620,6 +621,27 @@ def _(likelihood_comparison, mo):
 
 
 @app.cell
+def _(RUN_CONFIG, mo):
+    tune_count = mo.ui.number(
+        start=10,
+        stop=5_000,
+        step=10,
+        value=RUN_CONFIG["tune"],
+        label="Tune per chain",
+    )
+    draw_count = mo.ui.number(
+        start=10,
+        stop=5_000,
+        step=10,
+        value=RUN_CONFIG["draws"],
+        label="Draws per chain",
+    )
+    run_inference = mo.ui.run_button(label="Run selected fit")
+    mo.hstack([tune_count, draw_count, run_inference], justify="start")
+    return draw_count, run_inference, tune_count
+
+
+@app.cell
 def _(inference_route, mo):
     mo.md(f"""
     ## 4. Fit the selected route through HSSM
@@ -634,10 +656,15 @@ def _(inference_route, mo):
     likelihood implementation and sampler change. `p_outlier=None` is required because
     HSSM's categorical lapse mixture is not a density over continuous angles.
 
-    `cores=1` keeps the notebook portable and reproducible. Runtime here is
-    descriptive, not a benchmark: JAX compilation and short-run warmup costs are a
-    large fraction of an interactive run. The artifact-backed, schema-v2 recovery
-    smoke and any efficiency gate remain separate from this workflow demonstration.
+    Adjust the tune and draw counts, then click **Run selected fit**. Ordinary notebook
+    loading stops at this gate, so changing explanatory controls does not accidentally
+    launch MCMC. `JEAM_NOTEBOOK_SMOKE=1` deliberately bypasses the button for automated
+    end-to-end checks.
+
+    `cores=1` keeps the notebook portable and reproducible. Runtime here is descriptive,
+    not a benchmark: JAX compilation and short-run warmup costs are a large fraction of
+    an interactive run. The artifact-backed, schema-v2 recovery smoke and any efficiency
+    gate remain separate from this workflow demonstration.
     """)
     return
 
@@ -646,18 +673,30 @@ def _(inference_route, mo):
 def _(
     PARAMETER_ORDER,
     RUN_CONFIG,
+    SMOKE_RUN,
     circular_model,
+    draw_count,
+    mo,
     perf_counter,
     pm,
+    run_inference,
     selected_likelihood,
     selected_sampler,
+    tune_count,
 ):
+    mo.stop(
+        not (SMOKE_RUN or run_inference.value),
+        mo.callout(
+            "Choose a route and sampling counts, then click Run selected fit.",
+            kind="info",
+        ),
+    )
     _sample_kwargs = {
         "sampler": selected_sampler,
         "chains": RUN_CONFIG["chains"],
         "cores": 1,
-        "tune": RUN_CONFIG["tune"],
-        "draws": RUN_CONFIG["draws"],
+        "tune": tune_count.value,
+        "draws": draw_count.value,
         "random_seed": list(RUN_CONFIG["chain_seeds"]),
         "progressbar": False,
         "idata_kwargs": {"log_likelihood": False},
@@ -688,7 +727,9 @@ def _(
     sampling_seconds,
     selected_likelihood,
     selected_sampler,
+    draw_count,
     traces,
+    tune_count,
 ):
     posterior_summary = az.summary(
         traces,
@@ -748,6 +789,8 @@ def _(
         [
             {"diagnostic": "likelihood", "observed": selected_likelihood},
             {"diagnostic": "sampler", "observed": selected_sampler},
+            {"diagnostic": "tune per chain", "observed": tune_count.value},
+            {"diagnostic": "draws per chain", "observed": draw_count.value},
             {"diagnostic": "sampler statistics", "observed": str(sample_stat_names)},
             {
                 "diagnostic": "sampler statistics match route",


### PR DESCRIPTION
Built on the sampler-capability contract merged in #1208 and JEAM #13
(`ede7a4f4faf226e4dae52c84dfb01012939cccdc`).

## Purpose

Turn the JEAM circular-diffusion walkthrough into an executable comparison lab for
HSSM's blackbox and analytical likelihood routes.

## Changes

- construct ordinary `hssm.HSSM` models for both registered likelihoods on one seeded
  dataset and keep expensive model/parity work independent of the route selector
- compare both pointwise objectives against direct JEAM and compile a finite, nonzero
  analytical parameter gradient
- let users explicitly choose blackbox/PyMC Slice, analytical/PyMC NUTS, or
  analytical/NumPyro NUTS while keeping priors, data, seeds, tune counts, and draws fixed
- verify the returned DataTree's `inference_library`, route-specific sampler statistics,
  diagnostics, predictive support, and descriptive timings
- make the notebook own and assert PyTensor float64 plus actual JAX x64 execution before
  analytical model construction
- keep MCMC behind an explicit Run button; every post-fit section now depends on
  validated fit output, so an ordinary export cannot claim inference completed
- scope the retained schema-v2 recovery evidence to its historical blackbox/PyMC Slice
  route and retain the explicit non-calibration/non-efficiency language
- add an optional-lane no-sampling HTML export that checks the Run gate, rejects a false
  completion claim, and scans HTML/log output for host paths and execution errors

## Validation

- strict marimo check passed
- ordinary no-code export reached the Run gate after both likelihood/gradient checks,
  launched no MCMC, and rendered no post-fit completion claim
- deliberate smoke exports passed for all three routes; each recorded the selected
  backend and all seven workflow gates as true
- full sampler-capability module: 9 passed, including real PyMC and NumPyro NUTS smokes
- Ruff check and format check passed for the notebook
- docs-weight check passed (`169` files checked)
- strict MkDocs build passed
- workflow YAML parse and `git diff --check` passed

## Scope

This is an interactive mechanics and capability comparison, not recovery calibration,
an efficiency benchmark, or a sampler-default recommendation. The committed recovery
bundle remains immutable historical evidence for blackbox/PyMC Slice only; analytical
recovery and efficiency evidence remains a separate follow-up.
