### PR TITLE
Document archived fixed-CDM sampler evidence

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,23 +4,35 @@ on:
   pull_request:
     paths:
       - ".github/workflows/build_docs.yml"
+      - "benchmarks/evidence/jeam_fixed_cdm_sampler_comparison_v1/**"
       - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
+      - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1.json"
+      - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1_addendum.json"
+      - "benchmarks/specs/jeam_fixed_cdm_sampler_comparison_v1.json"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
       - "scripts/jeam_repeated_recovery_report.py"
+      - "scripts/jeam_sampler_comparison_report.py"
       - "scripts/verify_jeam_repeated_recovery_evidence.py"
+      - "scripts/verify_jeam_sampler_comparison_evidence.py"
       - "src/hssm/**"
   push:
     branches: [main]
     paths:
       - ".github/workflows/build_docs.yml"
+      - "benchmarks/evidence/jeam_fixed_cdm_sampler_comparison_v1/**"
       - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
+      - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1.json"
+      - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1_addendum.json"
+      - "benchmarks/specs/jeam_fixed_cdm_sampler_comparison_v1.json"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
       - "scripts/jeam_repeated_recovery_report.py"
+      - "scripts/jeam_sampler_comparison_report.py"
       - "scripts/verify_jeam_repeated_recovery_evidence.py"
+      - "scripts/verify_jeam_sampler_comparison_evidence.py"
       - "src/hssm/**"
   release:
     types: [published]
@@ -64,8 +76,45 @@ jobs:
             echo "JEAM recovery report contains a host path or execution error"
             exit 1
           fi
+      - name: Validate archived JEAM sampler report
+        env:
+          MPLCONFIGDIR: /tmp/hssm-jeam-sampler-report-matplotlib
+          XDG_CACHE_HOME: /tmp/hssm-jeam-sampler-report-cache
+        run: |
+          mkdir -p "$MPLCONFIGDIR" "$XDG_CACHE_HOME"
+          uv run --group docs marimo check --strict docs/tutorials/jeam_nuts_recovery.py
+          uv run --group docs marimo export html docs/tutorials/jeam_nuts_recovery.py \
+            -o /tmp/jeam-nuts-recovery.html --force --no-include-code \
+            > /tmp/jeam-nuts-recovery-export.log 2>&1
+          cat /tmp/jeam-nuts-recovery-export.log
+          grep -Fq "16 unique truths" /tmp/jeam-nuts-recovery.html
+          grep -Fq "48/48 route HDI checks" /tmp/jeam-nuts-recovery.html
+          grep -Fq "Promotion remains blocked" /tmp/jeam-nuts-recovery.html
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            /tmp/jeam-nuts-recovery.html /tmp/jeam-nuts-recovery-export.log; then
+            echo "JEAM sampler report contains a host path or execution error"
+            exit 1
+          fi
       - name: Build docs (strict)
-        run: uv run --group notebook --group docs mkdocs build --strict
+        env:
+          MPLCONFIGDIR: /tmp/hssm-jeam-sampler-report-matplotlib
+          XDG_CACHE_HOME: /tmp/hssm-jeam-sampler-report-cache
+        run: |
+          mkdir -p "$MPLCONFIGDIR" "$XDG_CACHE_HOME"
+          uv run --group notebook --group docs mkdocs build --strict
+          report_page=site/tutorials/jeam_nuts_recovery/index.html
+          grep -Fq "16 unique truths" "$report_page"
+          grep -Fq "48/48 route HDI checks" "$report_page"
+          grep -Fq "Promotion remains blocked" "$report_page"
+          if [ "$(grep -o 'data:image/png' "$report_page" | wc -l)" -lt 7 ]; then
+            echo "Built JEAM sampler report is missing figure outputs"
+            exit 1
+          fi
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            "$report_page"; then
+            echo "Built JEAM sampler report contains contamination"
+            exit 1
+          fi
 
   deploy:
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'

--- a/docs/reference/jeam_circular_diffusion.md
+++ b/docs/reference/jeam_circular_diffusion.md
@@ -134,6 +134,27 @@ both likelihoods against direct JEAM, compiles the analytical parameter gradient
 lets users fit the same simulated dataset with blackbox/PyMC Slice, analytical/PyMC
 NUTS, or analytical/NumPyro NUTS before running diagnostics and predictive checks.
 
+### Archived sampler-comparison evidence
+
+The artifact-backed [fixed-CDM sampler report](../tutorials/jeam_nuts_recovery.py)
+renders a historical compact result without importing HSSM or JEAM and without running
+sampling. On the recorded macOS ARM machine, all 15 fits completed, all 16 unique
+scenario-parameter truths fell inside every route's interval (48/48 route HDI checks),
+both analytical NUTS routes reported zero divergences, and both passed the predeclared
+machine-local efficiency thresholds. Those observations are a bounded recovery smoke
+benchmark, not simulation-based calibration or portable performance evidence.
+
+The comparison's analytical fits were produced with JEAM
+[`0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce`](https://github.com/AlexanderFengler/JEAM/commit/0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce),
+not the currently pinned safety revision `ede7a4f4`. The blackbox reference is separately
+anchored by the durable repeated-recovery bundle produced with JEAM
+[`a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`](https://github.com/AlexanderFengler/JEAM/commit/a9f547b3630ae8ff31ccec1b904e0c02fdba6d99).
+Ecosystem promotion remains blocked because the current JEAM revision has not been rerun
+and the historical raw posterior traces, raw prior- and posterior-predictive draws,
+sampler-backend trace attributes, and `uv.lock` bytes were not retained. Consequently,
+this report does not change HSSM's default, the blackbox/Slice fallback, or the
+“not yet recommended” status of either analytical NUTS route above.
+
 ## Current boundary
 
 The prototype supports only the fixed circular diffusion model described above. It does

--- a/docs/tutorials/jeam_nuts_recovery.py
+++ b/docs/tutorials/jeam_nuts_recovery.py
@@ -1,0 +1,895 @@
+"""Inspect authenticated compact evidence from the fixed-CDM sampler study.
+
+This marimo report calls the evidence verifier through one reporting API. It imports
+neither HSSM, JEAM, nor PyMC and does not access the network, optimize, or sample. Its
+tables and empirical figures present authenticated compact summaries; missing raw draws
+cannot be reconstructed here.
+
+Open it from the HSSM repository root::
+
+    uv run --group docs marimo edit docs/tutorials/jeam_nuts_recovery.py
+
+Export a path-clean static rendering with::
+
+    uv run --group docs marimo export html docs/tutorials/jeam_nuts_recovery.py \
+        -o /tmp/jeam-nuts-recovery.html --force --no-include-code
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711
+import marimo
+
+__generated_with = "0.23.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+
+    _source = _Path(globals().get("__file__", _Path.cwd())).resolve()
+    _repo_root = next(
+        _candidate
+        for _candidate in (_source, *_source.parents)
+        if (_candidate / "pyproject.toml").is_file()
+    )
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+
+    from scripts.jeam_sampler_comparison_report import (
+        SAMPLER_COLORS,
+        SAMPLER_LABELS,
+        SAMPLER_ORDER,
+        load_sampler_comparison_report,
+    )
+
+    return (
+        SAMPLER_COLORS,
+        SAMPLER_LABELS,
+        SAMPLER_ORDER,
+        load_sampler_comparison_report,
+        mo,
+        np,
+        pd,
+        plt,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Fixed-CDM sampler evidence: an authenticated historical snapshot
+
+    This report asks a bounded historical question: what did the preregistered,
+    fixed two-dimensional circular-diffusion study record for a blackbox Slice route
+    and two analytical NUTS routes?
+
+    It is an **authenticated compact-only smoke benchmark**, not a rerun and not a
+    durable posterior archive. The routes below are historical candidates that
+    demonstrate capabilities under one protocol. They are not current defaults or
+    recommendations.
+    """)
+    return
+
+
+@app.cell
+def _(load_sampler_comparison_report):
+    _report = load_sampler_comparison_report()
+    verification = _report["verification"]
+    specification = _report["specification"]
+    compact_result = _report["compact_result"]
+    summary = _report["summary"]
+    parameter_records = _report["parameter_records"]
+    fit_records = _report["fit_records"]
+    objective_records = _report["objective_records"]
+    predictive_records = _report["predictive_records"]
+    efficiency_records = _report["efficiency_records"]
+    evidence_boundary = _report["evidence_boundary"]
+    return (
+        compact_result,
+        efficiency_records,
+        evidence_boundary,
+        fit_records,
+        objective_records,
+        parameter_records,
+        predictive_records,
+        specification,
+        summary,
+        verification,
+    )
+
+
+@app.cell
+def _(
+    efficiency_records,
+    fit_records,
+    objective_records,
+    parameter_records,
+    pd,
+    predictive_records,
+    specification,
+):
+    parameter_df = pd.DataFrame(parameter_records)
+    fit_df = pd.DataFrame(fit_records)
+    objective_df = pd.DataFrame(objective_records)
+    predictive_df = pd.DataFrame(predictive_records)
+    efficiency_df = pd.DataFrame(efficiency_records)
+    canonical_scenarios = [
+        row["name"] for row in specification["scenarios"] if row["role"] == "canonical"
+    ]
+    return (
+        canonical_scenarios,
+        efficiency_df,
+        fit_df,
+        objective_df,
+        parameter_df,
+        predictive_df,
+    )
+
+
+@app.cell
+def _(evidence_boundary, mo, summary, verification):
+    _science = "PASS" if verification["scientific_gate"]["passed"] else "FAIL"
+    _machine = (
+        "PASS" if verification["recorded_machine_efficiency"]["passed"] else "FAIL"
+    )
+    _promotion = (
+        "BLOCKED" if evidence_boundary["ecosystem_promotion_blocked"] else "OPEN"
+    )
+    mo.md(f"""
+    ## Result at a glance
+
+    | Authenticated compact gate | Fits | Unique generating truths | Route-specific 94% HDI checks | Reported NUTS divergences | Historical recorded-machine thresholds | Ecosystem promotion |
+    |---|---:|---:|---:|---:|---|---|
+    | **{_science}** | {summary["fit_count"]} | {summary["unique_truth_count"]} | {summary["route_hdi_inclusions"]}/{summary["route_hdi_checks"]} | {summary["nuts_divergences"]} | **{_machine}** | **{_promotion}** |
+
+    Authenticated headline: 15 fits; 16 unique truths; 48/48 route HDI checks
+    (48 route-specific checks); 0 reported NUTS divergences; and a historical
+    recorded-machine threshold pass. Promotion remains blocked.
+
+    “PASS” here means that the retained compact rows satisfy the frozen smoke-test
+    arithmetic. It does not turn those rows into raw posterior evidence, establish
+    portable performance, or validate the current JEAM revision.
+    """)
+    return
+
+
+@app.cell
+def _(compact_result, evidence_boundary, mo, pd):
+    _revisions = evidence_boundary["jeam_revisions"]
+    _retention = evidence_boundary["retention"]
+    _retention_rows = [
+        {
+            "evidence": "posterior traces",
+            "retained": f"{_retention['raw_trace_files_retained']} of 15",
+            "consequence": "posterior diagnostics and sampler backend identity cannot be independently recomputed",
+        },
+        {
+            "evidence": "raw prior-predictive draws",
+            "retained": "no",
+            "consequence": "prior-predictive compact summaries cannot be independently recomputed",
+        },
+        {
+            "evidence": "raw posterior-predictive draws",
+            "retained": "no",
+            "consequence": "posterior-predictive compact summaries cannot be independently recomputed",
+        },
+        {
+            "evidence": "sampler backend trace attributes",
+            "retained": "no",
+            "consequence": "the recorded backend labels cannot be checked against trace metadata",
+        },
+        {
+            "evidence": "historical uv.lock bytes",
+            "retained": "no",
+            "consequence": "the recorded environment hash cannot recreate the historical lockfile",
+        },
+        {
+            "evidence": "1,500-trial scale input",
+            "retained": "post-hoc reconstruction only",
+            "consequence": "the historical scale dataset bytes themselves are absent",
+        },
+    ]
+    mo.vstack(
+        [
+            mo.md(f"""
+            ## Provenance and evidence boundary
+
+            The three JEAM revisions have different roles and must not be collapsed:
+
+            - historical analytical result: `{_revisions["historical_analytical_result"]}`;
+            - durable blackbox reference: `{_revisions["durable_blackbox_reference"]}`;
+            - current safety revision: `{_revisions["current_safety_revision"]}` — **not rerun** by this study.
+
+            The recorded scope was PyTensor `float64` with JAX x64 enabled on
+            `{compact_result["provenance"]["platform"]}` using the JAX CPU backend. In
+            plain terms: this is one macOS ARM recorded-machine result, not a portable
+            timing claim. Trace hashes and sizes were recorded, but zero posterior trace
+            files remain.
+            """),
+            mo.ui.table(
+                pd.DataFrame(_retention_rows), selection=None, pagination=False
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(SAMPLER_LABELS, compact_result, mo, pd, specification):
+    _sampler_specs = {row["id"]: row for row in specification["samplers"]}
+    _rows = []
+    for _sampler in specification["execution"]["sampler_order"]:
+        _sampler_spec = _sampler_specs[_sampler]
+        _rows.append(
+            {
+                "historical route": SAMPLER_LABELS[_sampler],
+                "likelihood": _sampler_spec["likelihood"],
+                "backend": _sampler_spec["backend"],
+                "step": _sampler_spec["step"],
+                "chains": compact_result["execution"]["chains"],
+                "tune": compact_result["execution"]["tune"],
+                "draws": compact_result["execution"]["draws"],
+            }
+        )
+    mo.vstack(
+        [
+            mo.md("""
+            ## Frozen study design
+
+            Four deterministic 300-trial scenarios were designated for recovery, and
+            one nested 1,500-trial scenario was designated for scaling. Crossing five
+            scenarios with three routes produced the 15 recorded fits. The compact
+            result says each historical route used the same scenario input, priors,
+            initial values, four chains, and fresh subprocess policy.
+
+            The protocol intended to save each trace before summarization, but those
+            trace files are not retained. Consequently, the report can authenticate the
+            compact rows while neither recreating nor independently deriving them.
+            """),
+            mo.ui.table(pd.DataFrame(_rows), selection=None, pagination=False),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(canonical_scenarios, mo, specification):
+    scenario_selector = mo.ui.dropdown(
+        options={name.replace("_", " ").title(): name for name in canonical_scenarios},
+        value=canonical_scenarios[0].replace("_", " ").title(),
+        label="Scenario",
+    )
+    parameter_selector = mo.ui.dropdown(
+        options={
+            name: name for name in specification["scope"]["scientific_parameter_order"]
+        },
+        value=specification["scope"]["scientific_parameter_order"][0],
+        label="Parameter",
+    )
+    mo.hstack([scenario_selector, parameter_selector], justify="start", gap=2)
+    return parameter_selector, scenario_selector
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## Why the analytical likelihood is differentiable *almost everywhere*
+
+    This conceptual figure explains the historical analytical route; it is not a
+    benchmark recomputation. For fixed diffusion scale $\sigma=1$, define scaled
+    decision time
+
+    $$s = \frac{rt-t}{a^2}.$$
+
+    The implementation uses a stable short-time representation for $s\leq0.002$, a
+    long-time Bessel-series representation for $s\geq0.02$, and a linear density-space
+    blend between them:
+
+    $$w(s)=\operatorname{clip}\!\left(\frac{s-0.002}{0.02-0.002},0,1\right).$$
+
+    Inside the overlap, the long series is faded in according to its signal above a
+    conservative summation-error bound $E$:
+
+    $$r=\operatorname{clip}\!\left(\frac{\log(S/E)}{\log 100},0,1\right).$$
+
+    The likelihood is smooth within each open region and intentionally non-smooth on
+    support surfaces, blend knots, and reliability clipping surfaces. The historical
+    capability claim is finite, accurate gradients at ordinary interior points—not a
+    derivative at every exact boundary.
+    """)
+    return
+
+
+@app.cell
+def _(np, plt):
+    _scaled_time = np.linspace(0.0, 0.026, 400)
+    _blend = np.clip((_scaled_time - 0.002) / (0.02 - 0.002), 0.0, 1.0)
+    _signal_ratio = np.logspace(-1, 3, 400)
+    _reliability = np.clip(np.log(_signal_ratio) / np.log(100.0), 0.0, 1.0)
+
+    _figure, (_blend_axis, _reliability_axis) = plt.subplots(1, 2, figsize=(9, 3.7))
+    _blend_axis.plot(_scaled_time, _blend, color="#4472C4", linewidth=2.5)
+    _blend_axis.axvline(0.002, color="#B22222", linestyle="--", linewidth=1)
+    _blend_axis.axvline(0.02, color="#B22222", linestyle="--", linewidth=1)
+    _blend_axis.set_xlabel(r"scaled decision time $s$")
+    _blend_axis.set_ylabel("long-time blend weight")
+    _blend_axis.set_title("Conceptual representation blend")
+    _blend_axis.grid(alpha=0.2)
+
+    _reliability_axis.semilogx(
+        _signal_ratio, _reliability, color="#E67E22", linewidth=2.5
+    )
+    _reliability_axis.axvline(1.0, color="#B22222", linestyle="--", linewidth=1)
+    _reliability_axis.axvline(100.0, color="#B22222", linestyle="--", linewidth=1)
+    _reliability_axis.set_xlabel("long-series signal / error bound")
+    _reliability_axis.set_ylabel("reliability fade weight")
+    _reliability_axis.set_title("Conceptual reliability fade")
+    _reliability_axis.grid(alpha=0.2)
+    _figure.tight_layout()
+    plt.close(_figure)
+    _figure
+    return
+
+
+@app.cell
+def _(compact_result, mo, objective_df, plt, specification):
+    _scenario_error = objective_df.groupby("scenario", sort=False)[
+        "maximum_absolute_error"
+    ].max()
+    _threshold = specification["objective_parity"]["maximum_absolute_error"]
+    _figure, _axis = plt.subplots(figsize=(8.5, 3.8))
+    _axis.barh(
+        [name.replace("_", " ") for name in _scenario_error.index],
+        _scenario_error.values,
+        color="#70AD47",
+    )
+    _axis.axvline(_threshold, color="#B22222", linestyle="--", label="frozen limit")
+    _axis.set_xscale("log")
+    _axis.set_xlabel("recorded maximum absolute objective difference")
+    _axis.set_title("Authenticated compact objective summaries")
+    _axis.legend()
+    _figure.tight_layout()
+    mo.vstack(
+        [
+            mo.md(f"""
+            ## Objective and gradient summaries
+
+            The figure presents authenticated compact summaries for 15 preregistered
+            parameter points; it does not reevaluate JEAM, HSSM, or any objective. The
+            largest recorded discrepancy is
+            `{objective_df["maximum_absolute_error"].max():.2e}`, against the frozen
+            `{_threshold:.0e}` limit.
+
+            The compact fit rows also report finite, nonzero four-coordinate gradients
+            for each analytical fit before sampling. Those gradients and compile times
+            are historical summaries, not recomputed derivatives. Their producer is the
+            historical JEAM revision
+            `{compact_result["provenance"]["jeam_revision"]}`.
+            """),
+            _figure,
+        ]
+    )
+    return
+
+
+@app.cell
+def _(SAMPLER_LABELS, compact_result, mo, np, pd, scenario_selector):
+    _rows = []
+    for _fit in compact_result["fits"]:
+        if (
+            _fit["scenario"] == scenario_selector.value
+            and _fit["initial_gradient"] is not None
+        ):
+            _gradient = np.asarray(_fit["initial_gradient"])
+            _rows.append(
+                {
+                    "historical route": SAMPLER_LABELS[_fit["sampler"]],
+                    "reported finite coordinates": int(np.isfinite(_gradient).sum()),
+                    "reported nonzero coordinates": int(np.count_nonzero(_gradient)),
+                    "reported gradient L2 norm": float(np.linalg.norm(_gradient)),
+                    "reported compile + first evaluation (s)": _fit["runtime_seconds"][
+                        "gradient_compile_and_first_eval"
+                    ],
+                }
+            )
+    mo.ui.table(pd.DataFrame(_rows).round(4), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Recorded posterior recovery summaries
+
+    Select a parameter above. The plot subtracts each scenario's generating truth, so
+    zero denotes the truth even though the four datasets use different values. Points
+    and 94% HDIs come from authenticated compact posterior summaries. Because all 15
+    posterior traces are missing, the notebook cannot recompute any mean, interval, or
+    route-specific coverage decision from raw draws.
+
+    There are 16 unique scenario–parameter truths. Repeating each across three routes
+    produces 48 route-specific HDI checks; it does not create 48 independent truths.
+    """)
+    return
+
+
+@app.cell
+def _(
+    SAMPLER_COLORS,
+    SAMPLER_LABELS,
+    SAMPLER_ORDER,
+    canonical_scenarios,
+    np,
+    parameter_df,
+    parameter_selector,
+    plt,
+):
+    _selected = parameter_df.loc[parameter_df["parameter"] == parameter_selector.value]
+    _positions = np.arange(len(canonical_scenarios), dtype=float)
+    _offsets = {"slice": -0.22, "pymc_nuts": 0.0, "numpyro_nuts": 0.22}
+    _figure, _axis = plt.subplots(figsize=(8.5, 4.5))
+    for _sampler in SAMPLER_ORDER:
+        _rows = (
+            _selected.loc[_selected["sampler"] == _sampler]
+            .set_index("scenario")
+            .loc[canonical_scenarios]
+        )
+        _means = _rows["posterior_error"].to_numpy()
+        _lower = _rows["relative_hdi_lower"].to_numpy()
+        _upper = _rows["relative_hdi_upper"].to_numpy()
+        _axis.errorbar(
+            _means,
+            _positions + _offsets[_sampler],
+            xerr=np.vstack((_means - _lower, _upper - _means)),
+            fmt="o",
+            capsize=3,
+            linewidth=1.8,
+            color=SAMPLER_COLORS[_sampler],
+            label=SAMPLER_LABELS[_sampler],
+        )
+    _axis.axvline(0.0, color="#111111", linestyle="--", linewidth=1.2)
+    _axis.set_yticks(
+        _positions, [name.replace("_", " ") for name in canonical_scenarios]
+    )
+    _axis.invert_yaxis()
+    _axis.set_xlabel("recorded posterior summary minus generating truth")
+    _axis.set_title(
+        f"Authenticated compact recovery summary: {parameter_selector.value}"
+    )
+    _axis.grid(axis="x", alpha=0.2)
+    _axis.legend(fontsize=8)
+    _figure.tight_layout()
+    plt.close(_figure)
+    _figure
+    return
+
+
+@app.cell
+def _(mo, parameter_df, scenario_selector):
+    _columns = {
+        "route": "historical route",
+        "parameter": "parameter",
+        "truth": "truth",
+        "posterior_mean": "recorded posterior mean",
+        "hdi_lower": "recorded 94% HDI lower",
+        "hdi_upper": "recorded 94% HDI upper",
+        "truth_in_hdi": "recorded coverage",
+        "rhat": "recorded R-hat",
+        "ess_bulk": "recorded bulk ESS",
+        "ess_tail": "recorded tail ESS",
+        "mcse_over_posterior_sd": "recorded MCSE/SD",
+    }
+    _selected = (
+        parameter_df.loc[parameter_df["scenario"] == scenario_selector.value]
+        .loc[:, list(_columns)]
+        .rename(columns=_columns)
+        .round(4)
+    )
+    mo.ui.table(_selected, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Recorded diagnostic summaries
+
+    Each bar is the worst parameter-level value stored in a selected compact fit. Red
+    lines show frozen protocol boundaries. These are authenticated reported diagnostics,
+    not diagnostics recomputed from chains. In particular, “0 reported divergences” is
+    what the compact NUTS rows say; missing raw traces and backend trace attributes
+    prevent independent chain- and backend-level verification.
+    """)
+    return
+
+
+@app.cell
+def _(SAMPLER_COLORS, SAMPLER_ORDER, fit_df, np, plt, scenario_selector, specification):
+    _selected = (
+        fit_df.loc[
+            (fit_df["scenario"] == scenario_selector.value)
+            & (fit_df["role"] == "canonical")
+        ]
+        .set_index("sampler")
+        .loc[list(SAMPLER_ORDER)]
+    )
+    _labels = ["Slice", "PyMC\nNUTS", "NumPyro\nNUTS"]
+    _colors = [SAMPLER_COLORS[name] for name in SAMPLER_ORDER]
+    _thresholds = specification["scientific_acceptance"]
+    _figure, (_rhat_axis, _ess_axis, _mcse_axis) = plt.subplots(1, 3, figsize=(10, 3.8))
+    _rhat_axis.bar(_labels, _selected["maximum_rhat"], color=_colors)
+    _rhat_axis.axhline(
+        _thresholds["maximum_rhat_exclusive"], color="#B22222", linestyle="--"
+    )
+    _rhat_axis.set_ylim(0.99, 1.011)
+    _rhat_axis.set_title("Recorded maximum R-hat")
+
+    _x = np.arange(len(_labels))
+    _width = 0.34
+    _ess_axis.bar(
+        _x - _width / 2,
+        _selected["minimum_bulk_ess"],
+        _width,
+        label="bulk",
+        color="#5B9BD5",
+    )
+    _ess_axis.bar(
+        _x + _width / 2,
+        _selected["minimum_tail_ess"],
+        _width,
+        label="tail",
+        color="#A5A5A5",
+    )
+    _ess_axis.axhline(
+        _thresholds["minimum_bulk_ess_exclusive"],
+        color="#B22222",
+        linestyle="--",
+    )
+    _ess_axis.set_xticks(_x, _labels)
+    _ess_axis.set_title("Recorded minimum ESS")
+    _ess_axis.legend(fontsize=8)
+
+    _mcse_axis.bar(_labels, _selected["maximum_mcse_over_sd"], color=_colors)
+    _mcse_axis.axhline(
+        _thresholds["maximum_mcse_over_posterior_sd_exclusive"],
+        color="#B22222",
+        linestyle="--",
+    )
+    _mcse_axis.set_title("Recorded maximum MCSE / SD")
+    for _axis in (_rhat_axis, _ess_axis, _mcse_axis):
+        _axis.grid(axis="y", alpha=0.2)
+        _axis.tick_params(axis="x", labelsize=8)
+    _figure.suptitle("Authenticated compact diagnostic summaries", y=1.03)
+    _figure.tight_layout()
+    plt.close(_figure)
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Recorded posterior-predictive summaries
+
+    The compact rows store RT-quantile errors, circular mean-angle distance, and
+    mean-resultant-length error. The figure divides those stored errors by their frozen
+    limits. It does not regenerate posterior prediction: no raw posterior-predictive
+    draws were retained, so these summaries cannot be independently recomputed.
+    """)
+    return
+
+
+@app.cell
+def _(
+    SAMPLER_COLORS,
+    SAMPLER_LABELS,
+    SAMPLER_ORDER,
+    mo,
+    np,
+    plt,
+    predictive_df,
+    scenario_selector,
+):
+    _selected = (
+        predictive_df.loc[predictive_df["scenario"] == scenario_selector.value]
+        .set_index("sampler")
+        .loc[list(SAMPLER_ORDER)]
+    )
+    _metrics = [
+        "rt_fraction_of_limit",
+        "angle_fraction_of_limit",
+        "resultant_fraction_of_limit",
+    ]
+    _labels = ["RT quantiles", "mean angle", "resultant length"]
+    _x = np.arange(len(_metrics))
+    _width = 0.24
+    _figure, _axis = plt.subplots(figsize=(8.5, 3.9))
+    for _index, _sampler in enumerate(SAMPLER_ORDER):
+        _axis.bar(
+            _x + (_index - 1) * _width,
+            _selected.loc[_sampler, _metrics],
+            _width,
+            color=SAMPLER_COLORS[_sampler],
+            label=SAMPLER_LABELS[_sampler],
+        )
+    _axis.axhline(1.0, color="#B22222", linestyle="--", label="frozen limit")
+    _axis.set_xticks(_x, _labels)
+    _axis.set_ylabel("recorded compact error / frozen limit")
+    _axis.set_title("Authenticated compact predictive summaries")
+    _axis.grid(axis="y", alpha=0.2)
+    _axis.legend(fontsize=8, ncol=2)
+    _figure.tight_layout()
+    mo.vstack(
+        [
+            _figure,
+            mo.ui.table(
+                _selected.reset_index()[
+                    [
+                        "route",
+                        "maximum_rt_quantile_error",
+                        "mean_angle_error",
+                        "resultant_length_error",
+                    ]
+                ].round(4),
+                selection=None,
+                pagination=False,
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Historical recorded-machine efficiency
+
+    The frozen protocol compared each NUTS route with Slice using minimum bulk ESS per
+    sampling second, total time, and a 1,500-trial normalized-efficiency check. The
+    authenticated compact summaries pass those historical thresholds on the recorded
+    macOS ARM machine. They are neither portable benchmarks nor grounds for ecosystem
+    promotion.
+    """)
+    return
+
+
+@app.cell
+def _(efficiency_df, mo):
+    _table = efficiency_df[
+        [
+            "route",
+            "efficiency_ratio_vs_slice",
+            "maximum_total_time_ratio_vs_slice",
+            "scale_normalized_efficiency_ratio",
+            "recorded_machine_gate_passed",
+        ]
+    ].rename(
+        columns={
+            "route": "historical route",
+            "efficiency_ratio_vs_slice": "recorded median min bulk ESS/s vs Slice",
+            "maximum_total_time_ratio_vs_slice": "recorded worst total-time ratio vs Slice",
+            "scale_normalized_efficiency_ratio": "recorded 1,500-trial normalized efficiency",
+            "recorded_machine_gate_passed": "historical threshold pass",
+        }
+    )
+    mo.ui.table(_table.round(3), selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(SAMPLER_COLORS, efficiency_df, np, plt, specification):
+    _samplers = efficiency_df["sampler"].tolist()
+    _labels = ["PyMC NUTS", "NumPyro NUTS"]
+    _colors = [SAMPLER_COLORS[name] for name in _samplers]
+    _limits = specification["promotion_decision"]
+    _x = np.arange(len(_samplers))
+    _width = 0.34
+    _figure, (_gain_axis, _time_axis) = plt.subplots(1, 2, figsize=(9, 3.8))
+    _gain_axis.bar(
+        _x - _width / 2,
+        efficiency_df["efficiency_ratio_vs_slice"],
+        _width,
+        color=_colors,
+        label="recorded canonical ratio",
+    )
+    _gain_axis.bar(
+        _x + _width / 2,
+        efficiency_df["scale_normalized_efficiency_ratio"],
+        _width,
+        color=_colors,
+        alpha=0.5,
+        hatch="//",
+        label="recorded scaling ratio",
+    )
+    _gain_axis.axhline(
+        _limits["canonical_minimum_median_bulk_ess_per_sampling_second_ratio_vs_slice"],
+        color="#B22222",
+        linestyle="--",
+        label="frozen ESS/s limit",
+    )
+    _gain_axis.axhline(
+        _limits["scale_minimum_normalized_efficiency_ratio_vs_reference"],
+        color="#7030A0",
+        linestyle=":",
+        label="frozen scaling limit",
+    )
+    _gain_axis.set_xticks(_x, _labels)
+    _gain_axis.set_ylabel("recorded ratio")
+    _gain_axis.set_title("Historical recorded-machine efficiency")
+    _gain_axis.legend(fontsize=7)
+
+    _time_axis.bar(
+        _labels,
+        efficiency_df["maximum_total_time_ratio_vs_slice"],
+        color=_colors,
+    )
+    _time_axis.axhline(
+        _limits["canonical_maximum_total_seconds_ratio_vs_slice_per_scenario"],
+        color="#B22222",
+        linestyle="--",
+        label="frozen maximum",
+    )
+    _time_axis.axhline(1.0, color="#111111", linestyle=":", label="equal to Slice")
+    _time_axis.set_ylabel("recorded worst total-time ratio")
+    _time_axis.set_title("Historical recorded-machine wall time")
+    _time_axis.legend(fontsize=7)
+    for _axis in (_gain_axis, _time_axis):
+        _axis.grid(axis="y", alpha=0.2)
+        _axis.tick_params(axis="x", labelsize=8)
+    _figure.tight_layout()
+    plt.close(_figure)
+    _figure
+    return
+
+
+@app.cell
+def _(SAMPLER_ORDER, fit_df, mo, np, plt, scenario_selector):
+    _selected = (
+        fit_df.loc[fit_df["scenario"] == scenario_selector.value]
+        .set_index("sampler")
+        .loc[list(SAMPLER_ORDER)]
+    )
+    _labels = ["Slice", "PyMC NUTS", "NumPyro NUTS"]
+    _segments = [
+        ("model_build_seconds", "model build", "#A5A5A5"),
+        ("objective_compile_seconds", "objective compile + first eval", "#70AD47"),
+        ("gradient_compile_seconds", "gradient compile + first eval", "#FFC000"),
+        ("sampling_seconds", "sampling call", "#4472C4"),
+        ("predictive_seconds", "posterior prediction", "#ED7D31"),
+    ]
+    _bottom = np.zeros(len(_selected))
+    _figure, _axis = plt.subplots(figsize=(8.5, 4.2))
+    for _field, _label, _color in _segments:
+        _values = _selected[_field].to_numpy()
+        _axis.bar(_labels, _values, bottom=_bottom, label=_label, color=_color)
+        _bottom += _values
+    _axis.set_ylabel("recorded seconds on one historical machine")
+    _axis.set_title(
+        f"Authenticated compact timing summary: {scenario_selector.value.replace('_', ' ')}"
+    )
+    _axis.grid(axis="y", alpha=0.2)
+    _axis.legend(fontsize=8)
+    _figure.tight_layout()
+    mo.vstack(
+        [
+            mo.md("""
+            ### Timing interpretation
+
+            These stacked durations are values stored in the compact result. They were
+            not remeasured by this report and should not be extrapolated to another OS,
+            architecture, dependency stack, or JEAM revision.
+            """),
+            _figure,
+        ]
+    )
+    return
+
+
+@app.cell
+def _(fit_df, mo, verification):
+    _scale = fit_df.loc[fit_df["role"] == "scale"][
+        [
+            "route",
+            "trials",
+            "route_hdi_inclusions",
+            "route_hdi_checks",
+            "minimum_bulk_ess",
+            "minimum_tail_ess",
+            "maximum_rhat",
+            "sampling_seconds",
+        ]
+    ].copy()
+    _scale["recorded HDI coverage"] = (
+        _scale["route_hdi_inclusions"].astype(str)
+        + "/"
+        + _scale["route_hdi_checks"].astype(str)
+    )
+    mo.vstack(
+        [
+            mo.md(f"""
+            ### The scaling input is reconstructed evidence
+
+            The 1,500-trial compact rows are shown because scaling was part of the frozen
+            protocol. However, the historical scale dataset bytes were not retained.
+            Only a post-hoc reconstruction is now available; its authenticated SHA256 is
+            `{verification["reconstructed_scale_dataset_sha256"]}`. Treat the scaling
+            table as a compact historical summary with a reconstructed input binding,
+            not as a fully retained rerunnable benchmark.
+
+            The scale scenario's frozen gate covered diagnostics and normalized
+            efficiency, not recovery. Its recorded 3/4 HDI results must not be added to
+            the 48 canonical route checks.
+            """),
+            mo.ui.table(
+                _scale[
+                    [
+                        "route",
+                        "trials",
+                        "recorded HDI coverage",
+                        "minimum_bulk_ess",
+                        "minimum_tail_ess",
+                        "maximum_rhat",
+                        "sampling_seconds",
+                    ]
+                ].round(3),
+                selection=None,
+                pagination=False,
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(evidence_boundary, mo):
+    _blockers = "\n".join(
+        f"- {blocker}" for blocker in evidence_boundary["ecosystem_promotion_blockers"]
+    )
+    mo.md(f"""
+    ## Interpretation
+
+    - The compact result records that both analytical NUTS routes met the study's
+      historical smoke thresholds. That establishes bounded historical candidates and
+      capabilities only.
+    - Blackbox + Slice remains the durable reference and gradient-free route.
+    - This report does **not** recommend NUTS, change HSSM's current sampler or
+      likelihood defaults, or claim portable timing dominance.
+    - This deterministic recovery smoke is not simulation-based calibration. It does
+      not establish nominal long-run coverage, hierarchical-model performance, GPU
+      scaling, or support beyond the fixed CDM scope.
+
+    Ecosystem promotion is blocked for all verifier-reported reasons:
+
+    {_blockers}
+    """)
+    return
+
+
+@app.cell
+def _(mo, specification):
+    mo.md(f"""
+    ## Audit without rerunning the benchmark
+
+    From the repository root, run the standalone verifier-only audit:
+
+    ```bash
+    uv run --python 3.12 --group jeam-prototype python -m scripts.verify_jeam_sampler_comparison_evidence
+    ```
+
+    That command authenticates the frozen inputs and compact result, recomputes the
+    bounded verification summary, and performs no sampling. The v1 protocol was frozen
+    at `{specification["frozen_at_utc"]}`. A scientifically necessary new run requires
+    a **new versioned protocol and result**; it must not overwrite or silently
+    regenerate v1.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - Model walkthroughs:
           - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
           - Circular diffusion with JEAM: tutorials/jeam_circular_diffusion.py
+          - Archived JEAM fixed-CDM sampler evidence: tutorials/jeam_nuts_recovery.py
           - Choice-only models: tutorials/choice_only_models.ipynb
           - Poisson race models: tutorials/poisson_race.ipynb
           - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb

--- a/scripts/jeam_sampler_comparison_report.py
+++ b/scripts/jeam_sampler_comparison_report.py
@@ -1,0 +1,371 @@
+"""Verifier-backed reporting data for the fixed-CDM sampler study."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from scripts.verify_jeam_sampler_comparison_evidence import (
+    REPO_ROOT,
+    load_verified_sampler_report_evidence,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+SAMPLER_ORDER = ("slice", "pymc_nuts", "numpyro_nuts")
+SAMPLER_LABELS = {
+    "slice": "Blackbox + PyMC Slice",
+    "pymc_nuts": "Analytical + PyMC NUTS",
+    "numpyro_nuts": "Analytical + NumPyro NUTS",
+}
+SAMPLER_COLORS = {
+    "slice": "#7F8C8D",
+    "pymc_nuts": "#4472C4",
+    "numpyro_nuts": "#E67E22",
+}
+REVISION_ROLES = {
+    "historical_analytical_result",
+    "durable_blackbox_reference",
+    "current_safety_revision",
+}
+
+
+def validate_report_contract(
+    verification: Mapping[str, Any],
+    spec: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+) -> None:
+    """Reject evidence that cannot support the bounded compact-only report."""
+    if spec.get("study_id") != "jeam-fixed-cdm-sampler-comparison-v1":
+        raise ValueError("Unexpected fixed-CDM sampler specification.")
+    if (
+        artifact.get("study_id") != spec["study_id"]
+        or verification.get("study_id") != spec["study_id"]
+    ):
+        raise ValueError("The result does not belong to the verified specification.")
+    if artifact.get("status") != "canonical-complete":
+        raise ValueError("The compact fixed-CDM result is not canonically complete.")
+
+    scenario_names = [row["name"] for row in spec["scenarios"]]
+    sampler_names = [row["id"] for row in spec["samplers"]]
+    if artifact.get("selected_scenarios") != scenario_names:
+        raise ValueError("The result does not contain the preregistered scenarios.")
+    if artifact.get("selected_samplers") != sampler_names:
+        raise ValueError("The result does not contain the preregistered samplers.")
+
+    expected_fits = {
+        (scenario_name, sampler_name)
+        for scenario_name in scenario_names
+        for sampler_name in sampler_names
+    }
+    observed_fits = {
+        (fit["scenario"], fit["sampler"]) for fit in artifact.get("fits", [])
+    }
+    if observed_fits != expected_fits or len(artifact.get("fits", [])) != len(
+        expected_fits
+    ):
+        raise ValueError(
+            "The result does not contain one fit per scenario and sampler."
+        )
+
+    canonical_scenarios = {
+        row["name"] for row in spec["scenarios"] if row["role"] == "canonical"
+    }
+    parameter_names = spec["scope"]["scientific_parameter_order"]
+    unique_truth_count = len(canonical_scenarios) * len(parameter_names)
+    route_rows = [
+        parameter
+        for fit in artifact["fits"]
+        if fit["scenario"] in canonical_scenarios
+        for parameter in fit["parameters"]
+    ]
+    counts = verification["counts"]
+    if (
+        counts["canonical_scenario_parameter_truths"] != unique_truth_count
+        or counts["canonical_route_hdi_checks"] != len(route_rows)
+        or counts["canonical_route_hdi_inclusions"]
+        != sum(row["truth_in_hdi"] for row in route_rows)
+    ):
+        raise ValueError("The verified truth and route-HDI cardinalities disagree.")
+
+    retention = verification["retention"]
+    missing_evidence = (
+        retention["raw_trace_files_retained"] == 0
+        and retention["raw_prior_predictive_draws_retained"] is False
+        and retention["raw_posterior_predictive_draws_retained"] is False
+        and retention["sampler_backend_trace_attributes_retained"] is False
+        and retention["historical_uv_lock_bytes_retained"] is False
+    )
+    if not missing_evidence:
+        raise ValueError("The report's compact-only evidence boundary has changed.")
+    if verification["ecosystem_promotion"]["blocked"] is not True:
+        raise ValueError("The report must retain the ecosystem promotion block.")
+    if set(verification["jeam_revisions"]) != REVISION_ROLES:
+        raise ValueError("The report must distinguish all three JEAM revisions.")
+
+
+def build_parameter_records(artifact: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return one route-specific HDI row per canonical fit and parameter."""
+    records = []
+    for fit in artifact["fits"]:
+        if fit["role"] != "canonical":
+            continue
+        for parameter in fit["parameters"]:
+            records.append(
+                {
+                    "scenario": fit["scenario"],
+                    "sampler": fit["sampler"],
+                    "route": SAMPLER_LABELS[fit["sampler"]],
+                    "parameter": parameter["name"],
+                    "truth": parameter["truth"],
+                    "posterior_mean": parameter["posterior_mean"],
+                    "posterior_error": parameter["posterior_mean"] - parameter["truth"],
+                    "hdi_lower": parameter["hdi_lower"],
+                    "hdi_upper": parameter["hdi_upper"],
+                    "relative_hdi_lower": parameter["hdi_lower"] - parameter["truth"],
+                    "relative_hdi_upper": parameter["hdi_upper"] - parameter["truth"],
+                    "truth_in_hdi": parameter["truth_in_hdi"],
+                    "rhat": parameter["rhat"],
+                    "ess_bulk": parameter["ess_bulk"],
+                    "ess_tail": parameter["ess_tail"],
+                    "mcse_over_posterior_sd": parameter["mcse_over_posterior_sd"],
+                    "ess_bulk_per_second": parameter["ess_bulk_per_sampling_second"],
+                }
+            )
+    return records
+
+
+def build_fit_records(artifact: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Aggregate diagnostics and recorded-machine timing by fit."""
+    records = []
+    for fit in artifact["fits"]:
+        parameters = fit["parameters"]
+        runtime = fit["runtime_seconds"]
+        records.append(
+            {
+                "scenario": fit["scenario"],
+                "role": fit["role"],
+                "trials": fit["trials"],
+                "sampler": fit["sampler"],
+                "route": SAMPLER_LABELS[fit["sampler"]],
+                "likelihood": fit["likelihood"],
+                "backend": fit["backend"],
+                "route_hdi_inclusions": sum(
+                    parameter["truth_in_hdi"] for parameter in parameters
+                ),
+                "route_hdi_checks": len(parameters),
+                "maximum_rhat": max(parameter["rhat"] for parameter in parameters),
+                "minimum_bulk_ess": min(
+                    parameter["ess_bulk"] for parameter in parameters
+                ),
+                "minimum_tail_ess": min(
+                    parameter["ess_tail"] for parameter in parameters
+                ),
+                "maximum_mcse_over_sd": max(
+                    parameter["mcse_over_posterior_sd"] for parameter in parameters
+                ),
+                "minimum_bulk_ess_per_second": min(
+                    parameter["ess_bulk_per_sampling_second"]
+                    for parameter in parameters
+                ),
+                "divergences": fit["sampler_diagnostics"]["divergences"],
+                "model_build_seconds": runtime["model_build"],
+                "objective_compile_seconds": runtime[
+                    "objective_compile_and_first_eval"
+                ],
+                "gradient_compile_seconds": runtime["gradient_compile_and_first_eval"],
+                "sampling_seconds": runtime[
+                    "sampling_call_including_backend_kernel_compilation"
+                ],
+                "predictive_seconds": runtime["posterior_predictive"],
+                "total_seconds": runtime["total"],
+                "timing_scope": "recorded-machine only",
+            }
+        )
+    return records
+
+
+def build_objective_records(artifact: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Flatten every preregistered pointwise objective comparison."""
+    records = []
+    for scenario in artifact["shared_preflight"]:
+        for candidate_index, candidate in enumerate(
+            scenario["objective_candidates"], start=1
+        ):
+            records.append(
+                {
+                    "scenario": scenario["scenario"],
+                    "candidate": candidate_index,
+                    "direct_numpy": candidate["direct_numpy"],
+                    "direct_jax": candidate["direct_jax"],
+                    "compiled_hssm": candidate["compiled_hssm"],
+                    "maximum_absolute_error": candidate["maximum_absolute_error"],
+                }
+            )
+    return records
+
+
+def build_predictive_records(
+    spec: Mapping[str, Any], artifact: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    """Return canonical predictive errors normalized by preregistered limits."""
+    thresholds = spec["scientific_acceptance"]
+    records = []
+    for fit in artifact["fits"]:
+        if fit["role"] != "canonical":
+            continue
+        predictive = fit["predictive"]
+        maximum_rt_error = max(predictive["rt_quantile_absolute_errors"])
+        mean_angle_error = predictive["mean_angle_distance"]
+        resultant_error = predictive["mean_resultant_length_absolute_error"]
+        records.append(
+            {
+                "scenario": fit["scenario"],
+                "sampler": fit["sampler"],
+                "route": SAMPLER_LABELS[fit["sampler"]],
+                "maximum_rt_quantile_error": maximum_rt_error,
+                "mean_angle_error": mean_angle_error,
+                "resultant_length_error": resultant_error,
+                "rt_fraction_of_limit": maximum_rt_error
+                / thresholds["maximum_rt_quantile_absolute_error"],
+                "angle_fraction_of_limit": mean_angle_error
+                / thresholds["maximum_circular_mean_angle_distance"],
+                "resultant_fraction_of_limit": resultant_error
+                / thresholds["maximum_mean_resultant_length_absolute_error"],
+            }
+        )
+    return records
+
+
+def build_efficiency_records(
+    verification: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return efficiency ratios explicitly scoped to the recorded machine."""
+    efficiency = verification["recorded_machine_efficiency"]
+    records = []
+    for sampler in SAMPLER_ORDER[1:]:
+        row = efficiency["by_sampler"][sampler]
+        records.append(
+            {
+                "sampler": sampler,
+                "route": SAMPLER_LABELS[sampler],
+                "canonical_median_minimum_bulk_ess_per_second": row[
+                    "canonical_median_minimum_bulk_ess_per_second"
+                ],
+                "slice_canonical_median_minimum_bulk_ess_per_second": efficiency[
+                    "slice_canonical_median_minimum_bulk_ess_per_second"
+                ],
+                "efficiency_ratio_vs_slice": row["canonical_efficiency_ratio_vs_slice"],
+                "maximum_total_time_ratio_vs_slice": max(
+                    row["canonical_total_seconds_ratios_vs_slice"].values()
+                ),
+                "total_time_ratios_vs_slice": row[
+                    "canonical_total_seconds_ratios_vs_slice"
+                ],
+                "scale_normalized_efficiency_ratio": row[
+                    "scale_normalized_efficiency_ratio_vs_reference"
+                ],
+                "recorded_machine_gate_passed": row["passed"],
+                "evidence_scope": "recorded-machine only",
+                "portable_performance_claim": False,
+            }
+        )
+    return records
+
+
+def summarize_artifact(
+    artifact: Mapping[str, Any], verification: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Recompute headline science without conflating truths and route checks."""
+    canonical_fits = [fit for fit in artifact["fits"] if fit["role"] == "canonical"]
+    canonical_parameters = [
+        parameter for fit in canonical_fits for parameter in fit["parameters"]
+    ]
+    unique_truths = {
+        (fit["scenario"], parameter["name"])
+        for fit in canonical_fits
+        for parameter in fit["parameters"]
+    }
+    nuts_fits = [fit for fit in artifact["fits"] if fit["sampler"] != "slice"]
+    return {
+        "fit_count": len(artifact["fits"]),
+        "canonical_fit_count": len(canonical_fits),
+        "unique_truth_count": len(unique_truths),
+        "route_hdi_inclusions": sum(
+            parameter["truth_in_hdi"] for parameter in canonical_parameters
+        ),
+        "route_hdi_checks": len(canonical_parameters),
+        "nuts_divergences": sum(
+            fit["sampler_diagnostics"]["divergences"] for fit in nuts_fits
+        ),
+        "maximum_rhat": max(parameter["rhat"] for parameter in canonical_parameters),
+        "minimum_bulk_ess": min(
+            parameter["ess_bulk"] for parameter in canonical_parameters
+        ),
+        "minimum_tail_ess": min(
+            parameter["ess_tail"] for parameter in canonical_parameters
+        ),
+        "maximum_mcse_over_sd": max(
+            parameter["mcse_over_posterior_sd"] for parameter in canonical_parameters
+        ),
+        "maximum_objective_absolute_error": max(
+            row["maximum_absolute_error"]
+            for scenario in artifact["shared_preflight"]
+            for row in scenario["objective_candidates"]
+        ),
+        "ecosystem_promotion_blocked": verification["ecosystem_promotion"]["blocked"],
+    }
+
+
+def build_evidence_boundary(
+    verification: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Expose the authenticated limitations alongside reportable claims."""
+    return {
+        "evidence_class": verification["evidence_class"],
+        "efficiency_scope": "recorded-machine only",
+        "portable_performance_claim": False,
+        "jeam_revisions": dict(verification["jeam_revisions"]),
+        "retention": dict(verification["retention"]),
+        "ecosystem_promotion_blocked": verification["ecosystem_promotion"]["blocked"],
+        "ecosystem_promotion_blockers": list(
+            verification["ecosystem_promotion"]["blockers"]
+        ),
+    }
+
+
+def load_sampler_comparison_report(
+    root: str | Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Build every report table from one authenticated verifier load."""
+    verification, spec, artifact = load_verified_sampler_report_evidence(root)
+    validate_report_contract(verification, spec, artifact)
+    return {
+        "verification": verification,
+        "specification": spec,
+        "compact_result": artifact,
+        "summary": summarize_artifact(artifact, verification),
+        "parameter_records": build_parameter_records(artifact),
+        "fit_records": build_fit_records(artifact),
+        "objective_records": build_objective_records(artifact),
+        "predictive_records": build_predictive_records(spec, artifact),
+        "efficiency_records": build_efficiency_records(verification),
+        "evidence_boundary": build_evidence_boundary(verification),
+    }
+
+
+__all__ = [
+    "SAMPLER_COLORS",
+    "SAMPLER_LABELS",
+    "SAMPLER_ORDER",
+    "build_efficiency_records",
+    "build_evidence_boundary",
+    "build_fit_records",
+    "build_objective_records",
+    "build_parameter_records",
+    "build_predictive_records",
+    "load_sampler_comparison_report",
+    "summarize_artifact",
+    "validate_report_contract",
+]

--- a/scripts/verify_jeam_sampler_comparison_evidence.py
+++ b/scripts/verify_jeam_sampler_comparison_evidence.py
@@ -418,7 +418,9 @@ def _ratios(
     }
 
 
-def _load(root: Path) -> dict[str, Any]:
+def _load(
+    root: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     snapshots, documents = _authenticate(root)
     addendum, spec, result = documents[ADDENDUM], documents[SPEC], documents[RESULT]
     _check_provenance(addendum, result)
@@ -454,7 +456,7 @@ def _load(root: Path) -> dict[str, Any]:
     expected = (5, 4, 3, 15, 16, 48, 48, 8, 10, 0, 15, 0)
     if tuple(counts.values()) != expected:
         _fail("Recomputed evidence counts mismatch.")
-    return {
+    verification = {
         "study_id": spec["study_id"],
         "evidence_class": "authenticated compact-only smoke benchmark",
         "counts": counts,
@@ -471,18 +473,39 @@ def _load(root: Path) -> dict[str, Any]:
             "blockers": addendum["promotion"]["blockers"],
         },
     }
+    return verification, spec, result
 
 
-def load_verified_sampler_comparison(
-    root: str | Path = REPO_ROOT,
-) -> dict[str, Any]:
-    """Authenticate compact evidence and return independently derived boundaries."""
+def _load_verified(
+    root: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load one authenticated snapshot behind both public verifier APIs."""
     try:
         return _load(Path(root))
     except SamplerEvidenceMismatch:
         raise
     except (ImportError, KeyError, OSError, TypeError, ValueError) as error:
         raise SamplerEvidenceMismatch(f"Invalid sampler evidence: {error}") from error
+
+
+def load_verified_sampler_comparison(
+    root: str | Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Authenticate compact evidence and return independently derived boundaries."""
+    verification, _, _ = _load_verified(root)
+    return verification
+
+
+def load_verified_sampler_report_evidence(
+    root: str | Path = REPO_ROOT,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Return verification, spec, and result from one authenticated snapshot.
+
+    This is the reporting API. The specification and compact result are parsed only
+    after their pinned bytes authenticate, and the returned documents are the same
+    objects used to derive the verification summary.
+    """
+    return _load_verified(root)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/test_jeam_sampler_comparison_report.py
+++ b/tests/test_jeam_sampler_comparison_report.py
@@ -1,0 +1,202 @@
+"""Tests for the verifier-backed fixed-CDM sampler report data."""
+
+import ast
+import copy
+import inspect
+
+import pytest
+
+import scripts.jeam_sampler_comparison_report as report_module
+from scripts.jeam_sampler_comparison_report import (
+    SAMPLER_LABELS,
+    load_sampler_comparison_report,
+    validate_report_contract,
+)
+from scripts.verify_jeam_sampler_comparison_evidence import (
+    load_verified_sampler_report_evidence,
+)
+
+EXPECTED_REVISIONS = {
+    "historical_analytical_result": "0c0ef8b834dd062ad8aea5ff8e7a09dfb55492ce",
+    "durable_blackbox_reference": "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99",
+    "current_safety_revision": "ede7a4f4faf226e4dae52c84dfb01012939cccdc",
+}
+
+
+@pytest.fixture(scope="module")
+def verified_documents():
+    """Load the summary and its authenticated source documents together."""
+    return load_verified_sampler_report_evidence()
+
+
+@pytest.fixture(scope="module")
+def report():
+    """Build the canonical report through its only public loading path."""
+    return load_sampler_comparison_report()
+
+
+def test_canonical_report_loads_only_verified_documents(verified_documents, report):
+    """The canonical API exposes the same authenticated study to every table."""
+    verification, spec, artifact = verified_documents
+
+    assert verification["study_id"] == spec["study_id"] == artifact["study_id"]
+    assert report["verification"]["study_id"] == verification["study_id"]
+    assert report["specification"] == spec
+    assert report["compact_result"] == artifact
+    assert len(report["fit_records"]) == verification["counts"]["fits"] == 15
+
+
+def test_report_contract_rejects_incomplete_or_mismatched_evidence(
+    verified_documents,
+):
+    """A partial or unrelated compact result cannot reach presentation code."""
+    verification, spec, artifact = verified_documents
+    validate_report_contract(verification, spec, artifact)
+
+    incomplete = copy.deepcopy(artifact)
+    incomplete["fits"].pop()
+    with pytest.raises(ValueError, match="one fit per scenario and sampler"):
+        validate_report_contract(verification, spec, incomplete)
+
+    mismatched = copy.deepcopy(artifact)
+    mismatched["study_id"] = "another-study"
+    with pytest.raises(ValueError, match="does not belong"):
+        validate_report_contract(verification, spec, mismatched)
+
+
+def test_report_distinguishes_unique_truths_from_route_hdi_checks(report):
+    """Four scenarios by four parameters are not 48 independent truths."""
+    summary = report["summary"]
+    parameters = report["parameter_records"]
+
+    assert summary["unique_truth_count"] == 4 * 4 == 16
+    assert summary["route_hdi_inclusions"] == 4 * 3 * 4 == 48
+    assert summary["route_hdi_checks"] == 4 * 3 * 4 == 48
+    assert len(parameters) == 48
+    assert len({(row["scenario"], row["parameter"]) for row in parameters}) == 16
+    assert all(row["truth_in_hdi"] for row in parameters)
+    assert {
+        "canonical_truth_count",
+        "canonical_truths_covered",
+    }.isdisjoint(summary)
+
+
+def test_headline_diagnostics_are_recomputed_from_compact_rows(report):
+    """Headline diagnostics retain the compact study's bounded smoke result."""
+    summary = report["summary"]
+
+    assert summary["fit_count"] == 15
+    assert summary["canonical_fit_count"] == 12
+    assert summary["nuts_divergences"] == 0
+    assert summary["maximum_rhat"] < 1.01
+    assert summary["minimum_bulk_ess"] > 400
+    assert summary["minimum_tail_ess"] > 400
+    assert summary["maximum_mcse_over_sd"] < 0.05
+    assert summary["maximum_objective_absolute_error"] == pytest.approx(
+        4.547473508864641e-13
+    )
+
+
+def test_report_retains_all_three_jeam_revisions_and_promotion_block(report):
+    """Historical evidence is not relabeled as a current-revision rerun."""
+    boundary = report["evidence_boundary"]
+
+    assert boundary["jeam_revisions"] == EXPECTED_REVISIONS
+    assert boundary["ecosystem_promotion_blocked"] is True
+    assert report["summary"]["ecosystem_promotion_blocked"] is True
+    assert boundary["efficiency_scope"] == "recorded-machine only"
+    assert boundary["portable_performance_claim"] is False
+    assert any(
+        "current JEAM safety revision was not rerun" in blocker
+        for blocker in boundary["ecosystem_promotion_blockers"]
+    )
+
+
+def test_report_keeps_missing_raw_evidence_visible(report):
+    """Compact summaries cannot stand in for traces, draws, or lock bytes."""
+    retention = report["evidence_boundary"]["retention"]
+    blockers = report["evidence_boundary"]["ecosystem_promotion_blockers"]
+
+    assert retention["raw_trace_files_retained"] == 0
+    assert retention["raw_prior_predictive_draws_retained"] is False
+    assert retention["raw_posterior_predictive_draws_retained"] is False
+    assert retention["sampler_backend_trace_attributes_retained"] is False
+    assert retention["historical_uv_lock_bytes_retained"] is False
+    assert any("backend identity" in blocker for blocker in blockers)
+    assert any("prior- and posterior-predictive" in blocker for blocker in blockers)
+    assert any("uv.lock bytes" in blocker for blocker in blockers)
+
+
+def test_efficiency_rows_are_recorded_machine_observations(report):
+    """Passing timing thresholds does not imply portable ecosystem promotion."""
+    rows = report["efficiency_records"]
+
+    assert [row["sampler"] for row in rows] == ["pymc_nuts", "numpyro_nuts"]
+    assert {row["route"] for row in rows} <= set(SAMPLER_LABELS.values())
+    assert all(row["recorded_machine_gate_passed"] for row in rows)
+    assert all(row["evidence_scope"] == "recorded-machine only" for row in rows)
+    assert not any(row["portable_performance_claim"] for row in rows)
+    assert all(row["efficiency_ratio_vs_slice"] >= 1.5 for row in rows)
+    assert all(row["maximum_total_time_ratio_vs_slice"] <= 1.25 for row in rows)
+    assert all(row["scale_normalized_efficiency_ratio"] >= 0.8 for row in rows)
+    assert report["summary"]["ecosystem_promotion_blocked"] is True
+
+
+def test_objective_and_predictive_tables_preserve_every_compact_comparison(report):
+    """The report retains all preflight points and canonical predictive routes."""
+    objective = report["objective_records"]
+    predictive = report["predictive_records"]
+
+    assert len(objective) == 5 * 3 == 15
+    assert {row["candidate"] for row in objective} == {1, 2, 3}
+    assert max(row["maximum_absolute_error"] for row in objective) < 1e-8
+    assert len(predictive) == 4 * 3 == 12
+    assert {row["route"] for row in predictive} == set(SAMPLER_LABELS.values())
+    assert max(row["rt_fraction_of_limit"] for row in predictive) <= 1.0
+    assert max(row["angle_fraction_of_limit"] for row in predictive) <= 1.0
+    assert max(row["resultant_fraction_of_limit"] for row in predictive) <= 1.0
+
+
+def test_report_loader_calls_the_verifier_once(monkeypatch, verified_documents):
+    """Spec and result reuse the verifier's single authenticated snapshot."""
+    calls = []
+
+    def fake_verified_load(root):
+        calls.append(root)
+        return copy.deepcopy(verified_documents)
+
+    monkeypatch.setattr(
+        report_module, "load_verified_sampler_report_evidence", fake_verified_load
+    )
+    loaded = report_module.load_sampler_comparison_report("sentinel-root")
+
+    assert calls == ["sentinel-root"]
+    assert loaded["summary"]["unique_truth_count"] == 16
+    assert loaded["summary"]["route_hdi_checks"] == 48
+
+
+def test_report_module_has_no_direct_evidence_reads():
+    """Only the hash-before-parse verifier may touch frozen evidence bytes."""
+    tree = ast.parse(inspect.getsource(report_module))
+    forbidden_calls = []
+    verifier_calls = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = [alias.name for alias in node.names]
+            assert "json" not in names
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "open":
+                forbidden_calls.append(node.func.id)
+            if node.func.id == "load_verified_sampler_report_evidence":
+                verifier_calls += 1
+        elif isinstance(node.func, ast.Attribute) and node.func.attr in {
+            "open",
+            "read_bytes",
+            "read_text",
+        }:
+            forbidden_calls.append(node.func.attr)
+
+    assert forbidden_calls == []
+    assert verifier_calls == 1


### PR DESCRIPTION
## Purpose

- replace the stale fixed-CDM NUTS notebook with an authenticated report over the merged compact v1 evidence
- keep the historical sampler comparison inspectable without importing HSSM or JEAM, accessing the network, optimizing, or rerunning MCMC

## Changes

- load the pinned specification, compact result, and provenance addendum from one hash-before-parse verifier snapshot
- distinguish 16 unique scenario-parameter truths from 48 route-specific HDI checks and keep ecosystem promotion explicitly blocked
- render the historical recorded-machine summaries through a seven-figure marimo report while preserving all three JEAM revision roles and every missing-evidence limitation
- retain the current documentation boundary: blackbox/Slice remains the durable reference, analytical NUTS is CI-supported but not yet recommended, and no HSSM default changes
- execute the report during the strict MkDocs build and verify the deployed page's claims, figure outputs, and host-path/error cleanliness in CI

## Verification

- focused sampler/spec/runner/artifact/report plus durable-verifier suite: `67 passed`
- Ruff check and format check on all changed Python files
- mypy and Pyrefly on the verifier/report helpers
- strict marimo check and sampling-free headless HTML export
- strict MkDocs build with seven unique scientific figures rendered in the deployed page
- standalone verifier: 15 fits, 48/48 route HDIs, zero reported NUTS divergences, promotion blocked

## Scope

- this is an authenticated compact-only historical recovery smoke, not simulation-based calibration, durable analytical posterior evidence, or a portable performance benchmark
- the 15 historical posterior traces, raw prior/posterior-predictive draws, sampler-backend trace attributes, and historical lock bytes were not retained
- the analytical result used JEAM `0c0ef8b`; the durable blackbox reference used `a9f547b`; the current safety revision `ede7a4f4` has not been rerun
- no evidence bytes were changed and no inference was rerun
