### PR TITLE
Add fixed PSDM JEAM adapters

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -26,12 +26,14 @@ on:
       - "tests/test_jeam_recovery_evidence_bundle.py"
       - "tests/test_jeam_recovery_evidence_io.py"
       - "tests/test_jeam_modelconfig.py"
+      - "tests/test_jeam_psdm_adapter.py"
       - "tests/integration/test_jeam_bayesian_evidence_capture.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
       - "tests/integration/test_jeam_objective_parity.py"
       - "tests/integration/test_jeam_predictive.py"
+      - "tests/integration/test_jeam_psdm.py"
       - "tests/integration/test_jeam_repeated_recovery.py"
       - "tests/integration/test_jeam_repeated_recovery_evidence.py"
       - "tests/integration/test_jeam_simulator.py"
@@ -92,6 +94,12 @@ jobs:
           tests/integration/test_jeam_objective_parity.py
           tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py
+
+      - name: Verify the fixed-PSDM adapter handshake
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/test_jeam_psdm_adapter.py
+          tests/integration/test_jeam_psdm.py
 
       - name: Verify JEAM sampler capabilities and NUTS backends
         run: >-

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -1,4 +1,4 @@
-"""Adapters for the experimental JEAM circular diffusion integration."""
+"""Adapters for experimental JEAM diffusion-model integrations."""
 
 from collections.abc import Callable
 from typing import Any
@@ -22,6 +22,24 @@ def _load_circular_diffusion_model() -> Callable[..., Any]:
         raise
 
     return CircularDiffusionModel
+
+
+def _load_projected_spherical_diffusion_model() -> Callable[..., Any]:
+    """Load JEAM's projected spherical model without a core dependency."""
+    try:
+        from jeam.Models.Spherical import ProjectedSphericalDiffusionModel
+    except ModuleNotFoundError as exc:
+        if exc.name == "jeam" or (
+            exc.name is not None and exc.name.startswith("jeam.")
+        ):
+            raise ImportError(
+                "The experimental JEAM integration requires the "
+                "`jeam-prototype` dependency group. Install it with "
+                "`uv sync --group jeam-prototype`."
+            ) from exc
+        raise
+
+    return ProjectedSphericalDiffusionModel
 
 
 def _load_fixed_cdm_logpdf() -> Callable[..., Any]:
@@ -91,6 +109,32 @@ def _validate_observations(data: np.ndarray) -> np.ndarray:
     return observations
 
 
+def _validate_projected_spherical_observations(data: np.ndarray) -> np.ndarray:
+    """Validate and normalize fixed-PSDM ``[rt, response]`` observations."""
+    try:
+        observations = np.asarray(data, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "JEAM projected spherical observations must be a numeric two-column array."
+        ) from exc
+
+    if observations.ndim != 2 or observations.shape[1] != 2:
+        raise ValueError(
+            "JEAM projected spherical observations must have shape "
+            "(n_observations, 2) with columns [rt, response]."
+        )
+    if not np.all(np.isfinite(observations)):
+        raise ValueError(
+            "JEAM projected spherical observations must contain only finite values."
+        )
+
+    angles = observations[:, 1]
+    if np.any((angles < 0.0) | (angles > np.pi)):
+        raise ValueError("JEAM projected spherical responses must lie in [0, pi].")
+
+    return observations
+
+
 def logp_circular_diffusion(
     data: np.ndarray,
     v_x: float | np.ndarray,
@@ -116,6 +160,64 @@ def logp_circular_diffusion(
     ndt_values = _broadcast_parameter(t, "t", n_observations)
 
     model_type = _load_circular_diffusion_model()
+    model = model_type(threshold_dynamic="fixed")
+    logp = np.empty(n_observations, dtype=np.float64)
+    thresholds, threshold_groups = np.unique(threshold_values, return_inverse=True)
+
+    for group, threshold in enumerate(thresholds):
+        selection = threshold_groups == group
+        drift = np.column_stack((v_x_values[selection], v_y_values[selection]))
+        group_logp = model.joint_lpdf(
+            rt=observations[selection, 0],
+            theta=observations[selection, 1],
+            drift_vec=drift,
+            ndt=ndt_values[selection],
+            threshold=float(threshold),
+            decay=0.0,
+            threshold_function=None,
+            dt_threshold_function=None,
+            s_v=0.0,
+            s_t=0.0,
+            sigma=1.0,
+        )
+        group_logp = np.asarray(group_logp, dtype=np.float64)
+        expected_shape = (int(np.count_nonzero(selection)),)
+        if group_logp.shape != expected_shape:
+            raise RuntimeError(
+                "JEAM returned an unexpected pointwise log-density shape: "
+                f"expected {expected_shape}, got {group_logp.shape}."
+            )
+        logp[selection] = group_logp
+
+    return logp
+
+
+def logp_projected_spherical_diffusion(
+    data: np.ndarray,
+    v_x: float | np.ndarray,
+    v_y: float | np.ndarray,
+    a: float | np.ndarray,
+    t: float | np.ndarray,
+) -> np.ndarray:
+    """Evaluate the fixed-boundary JEAM PSDM log density.
+
+    The two data columns are response time and polar response angle. The angle uses the
+    closed interval ``[0, pi]``. ``v_x`` is the axial drift and ``v_y`` is JEAM's
+    nonnegative projected-radial drift. The adapter fixes diffusion scale to one and
+    drift/NDT variability to zero.
+
+    Parameters may be scalars or arrays broadcastable to the observation count. Because
+    JEAM evaluates one threshold per call, trial-wise thresholds are partitioned without
+    changing pointwise order.
+    """
+    observations = _validate_projected_spherical_observations(data)
+    n_observations = observations.shape[0]
+    v_x_values = _broadcast_parameter(v_x, "v_x", n_observations)
+    v_y_values = _broadcast_parameter(v_y, "v_y", n_observations)
+    threshold_values = _broadcast_parameter(a, "a", n_observations)
+    ndt_values = _broadcast_parameter(t, "t", n_observations)
+
+    model_type = _load_projected_spherical_diffusion_model()
     model = model_type(threshold_dynamic="fixed")
     logp = np.empty(n_observations, dtype=np.float64)
     thresholds, threshold_groups = np.unique(threshold_values, return_inverse=True)
@@ -267,15 +369,103 @@ def simulate_circular_diffusion(
     return observations
 
 
+def simulate_projected_spherical_diffusion(
+    theta: np.ndarray,
+    random_state: int | np.random.Generator | None,
+    n_replicas: int,
+) -> np.ndarray:
+    """Simulate fixed-boundary JEAM PSDM observations for HSSM.
+
+    ``theta`` follows HSSM's ``[v_x, v_y, a, t]`` parameter order, where ``v_y`` is
+    the nonnegative projected-radial drift. Replicas remain contiguous within trials.
+    The returned columns are ``[rt, response]`` with response in closed ``[0, pi]``.
+    JEAM's decision-time horizon is fixed to 20 seconds; an omitted trial raises a
+    targeted error because the current HSSM random-variable contract has no omission
+    mask.
+    """
+    parameters = _normalize_simulator_theta(theta)
+    if (
+        isinstance(n_replicas, (bool, np.bool_))
+        or not isinstance(n_replicas, (int, np.integer))
+        or n_replicas < 1
+    ):
+        raise ValueError("n_replicas must be a positive integer.")
+
+    replicated = np.repeat(parameters, int(n_replicas), axis=0)
+    model_type = _load_projected_spherical_diffusion_model()
+    model = model_type(threshold_dynamic="fixed")
+    simulated = model.simulate(
+        drift_vec=replicated[:, :2],
+        ndt=replicated[:, 3],
+        threshold=replicated[:, 2],
+        decay=0.0,
+        threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+        n_sample=replicated.shape[0],
+        max_time=20.0,
+        random_state=random_state,
+    )
+
+    try:
+        observations = np.asarray(
+            simulated.loc[:, ["rt", "response"]], dtype=np.float64
+        )
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "JEAM projected spherical simulator output must expose numeric columns "
+            "[rt, response]."
+        ) from exc
+
+    expected_shape = (replicated.shape[0], 2)
+    if observations.shape != expected_shape:
+        raise RuntimeError(
+            "JEAM returned an unexpected simulator output shape: "
+            f"expected {expected_shape}, got {observations.shape}."
+        )
+
+    omitted = np.all(np.isnan(observations), axis=1)
+    if np.any(omitted):
+        raise RuntimeError(
+            "JEAM projected spherical simulator omitted "
+            f"{int(np.count_nonzero(omitted))} trial(s) before max_time=20.0; "
+            "HSSM predictive simulation currently requires complete output."
+        )
+    if not np.all(np.isfinite(observations)):
+        raise RuntimeError(
+            "JEAM projected spherical simulator output must contain only finite values."
+        )
+    if np.any(observations[:, 0] <= 0.0):
+        raise RuntimeError("JEAM simulator response times must be positive.")
+    angles = observations[:, 1]
+    if np.any((angles < 0.0) | (angles > np.pi)):
+        raise RuntimeError(
+            "JEAM projected spherical simulator responses must lie in [0, pi]."
+        )
+
+    return observations
+
+
 setattr(simulate_circular_diffusion, "model_name", "circular_diffusion")
 # Required by ssms.hssm_support for compatibility. Circular responses are continuous,
 # so there are deliberately no categorical choices to enumerate.
 setattr(simulate_circular_diffusion, "choices", [])
 setattr(simulate_circular_diffusion, "obs_dim", 2)
 
+setattr(
+    simulate_projected_spherical_diffusion,
+    "model_name",
+    "projected_spherical_diffusion",
+)
+setattr(simulate_projected_spherical_diffusion, "choices", [])
+setattr(simulate_projected_spherical_diffusion, "obs_dim", 2)
+
 
 __all__ = [
     "logp_circular_diffusion",
     "logp_circular_diffusion_jax",
+    "logp_projected_spherical_diffusion",
     "simulate_circular_diffusion",
+    "simulate_projected_spherical_diffusion",
 ]

--- a/src/hssm/integrations/jeam.py
+++ b/src/hssm/integrations/jeam.py
@@ -384,6 +384,18 @@ def simulate_projected_spherical_diffusion(
     mask.
     """
     parameters = _normalize_simulator_theta(theta)
+    if np.any(parameters[:, 1] < 0.0):
+        raise ValueError(
+            "JEAM projected spherical simulator parameter 'v_y' must be non-negative."
+        )
+    if np.any(parameters[:, 2] <= 0.0):
+        raise ValueError(
+            "JEAM projected spherical simulator parameter 'a' must be positive."
+        )
+    if np.any(parameters[:, 3] < 0.0):
+        raise ValueError(
+            "JEAM projected spherical simulator parameter 't' must be non-negative."
+        )
     if (
         isinstance(n_replicas, (bool, np.bool_))
         or not isinstance(n_replicas, (int, np.integer))

--- a/tests/integration/test_jeam_psdm.py
+++ b/tests/integration/test_jeam_psdm.py
@@ -1,0 +1,159 @@
+"""Real-producer tests for the JEAM fixed-PSDM adapter handshake."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+from jeam.Models.Spherical import ProjectedSphericalDiffusionModel
+
+from hssm.distribution_utils.dist import make_hssm_rv
+from hssm.integrations.jeam import (
+    logp_projected_spherical_diffusion,
+    simulate_projected_spherical_diffusion,
+)
+
+PARAMETERS = ["v_x", "v_y", "a", "t"]
+
+
+def _assert_projected_observations(observations: np.ndarray) -> None:
+    """Check the fixed two-column predictive-data contract."""
+    assert observations.shape[-1] == 2
+    assert observations.dtype == np.float64
+    assert np.all(np.isfinite(observations))
+    assert np.all(observations[..., 0] > 0.0)
+    assert np.all(observations[..., 1] >= 0.0)
+    assert np.all(observations[..., 1] <= np.pi)
+
+
+def test_likelihood_adapter_matches_direct_trialwise_jeam():
+    """Every mapped row should equal direct fixed-PSDM evaluation."""
+    data = np.array([[0.28, 0.2], [0.53, 1.4], [0.91, 2.7]])
+    v_x = np.array([0.55, -0.20, 0.35])
+    v_y = np.array([0.25, 0.45, 0.15])
+    threshold = np.array([1.00, 1.25, 1.00])
+    ndt = np.array([0.04, 0.11, 0.17])
+    model = ProjectedSphericalDiffusionModel(threshold_dynamic="fixed")
+    expected = np.array(
+        [
+            model.joint_lpdf(
+                rt=data[index : index + 1, 0],
+                theta=data[index : index + 1, 1],
+                drift_vec=np.array([[v_x[index], v_y[index]]]),
+                ndt=np.array([ndt[index]]),
+                threshold=float(threshold[index]),
+                decay=0.0,
+                threshold_function=None,
+                dt_threshold_function=None,
+                s_v=0.0,
+                s_t=0.0,
+                sigma=1.0,
+            )[0]
+            for index in range(data.shape[0])
+        ],
+        dtype=np.float64,
+    )
+
+    observed = logp_projected_spherical_diffusion(
+        data,
+        v_x=v_x,
+        v_y=v_y,
+        a=threshold,
+        t=ndt,
+    )
+
+    np.testing.assert_allclose(observed, expected, rtol=1e-12, atol=1e-12)
+    assert observed.shape == (3,)
+    assert observed.dtype == np.float64
+
+
+def test_likelihood_adapter_preserves_projected_drift_error():
+    """A negative projected-radial drift should retain JEAM's exact policy."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^drift_vec second component must be non-negative for the projected "
+            r"spherical model\.$"
+        ),
+    ):
+        logp_projected_spherical_diffusion(
+            np.array([[0.3, 0.5]]),
+            v_x=0.4,
+            v_y=-0.2,
+            a=1.0,
+            t=0.05,
+        )
+
+
+def test_simulator_adapter_matches_direct_seeded_jeam():
+    """The adapter should only map parameters, replicas, and output columns."""
+    theta = np.array(
+        [[0.70, 0.35, 0.40, 0.08], [-0.20, 0.55, 0.32, 0.12]],
+        dtype=np.float64,
+    )
+    replicated = np.repeat(theta, 3, axis=0)
+    model = ProjectedSphericalDiffusionModel(threshold_dynamic="fixed")
+    expected = model.simulate(
+        drift_vec=replicated[:, :2],
+        ndt=replicated[:, 3],
+        threshold=replicated[:, 2],
+        decay=0.0,
+        threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+        n_sample=replicated.shape[0],
+        max_time=20.0,
+        random_state=1947,
+    )[["rt", "response"]].to_numpy(dtype=np.float64)
+
+    observed = simulate_projected_spherical_diffusion(
+        theta,
+        random_state=1947,
+        n_replicas=3,
+    )
+
+    np.testing.assert_array_equal(observed, expected)
+    _assert_projected_observations(observed)
+
+
+def test_hssm_random_variable_reproduces_trialwise_replicas():
+    """HSSM seed and reshape behavior should preserve trial identity."""
+    random_variable = make_hssm_rv(
+        simulate_projected_spherical_diffusion,
+        PARAMETERS.copy(),
+    )
+    v_x = np.array([0.70, -0.20, 0.35])
+    v_y = np.array([0.35, 0.55, 0.10])
+    threshold = np.array([0.40, 0.32, 0.36])
+    ndt = np.array([0.08, 0.12, 0.05])
+
+    first = random_variable.rng_fn(
+        np.random.default_rng(997),
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+        size=6,
+    )
+    matching = random_variable.rng_fn(
+        np.random.default_rng(997),
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+        size=6,
+    )
+    different = random_variable.rng_fn(
+        np.random.default_rng(998),
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+        size=6,
+    )
+
+    np.testing.assert_array_equal(first, matching)
+    assert not np.array_equal(first, different)
+    assert first.shape == (3, 2, 2)
+    _assert_projected_observations(first)

--- a/tests/test_jeam_psdm_adapter.py
+++ b/tests/test_jeam_psdm_adapter.py
@@ -10,13 +10,6 @@ from ssms.hssm_support import validate_simulator_fun
 
 from hssm.integrations import jeam as jeam_integration
 
-pytestmark = pytest.mark.xfail(
-    not hasattr(jeam_integration, "logp_projected_spherical_diffusion"),
-    reason="projected-spherical JEAM adapters are not implemented yet",
-    raises=AttributeError,
-    strict=True,
-)
-
 
 class _RecordingProjectedSphericalModel:
     likelihood_calls: list[dict] = []
@@ -274,6 +267,32 @@ def test_simulator_preserves_trial_major_replica_order(_fake_jeam):
     )
     np.testing.assert_array_equal(call["threshold"], [1.20, 1.20, 0.90, 0.90])
     np.testing.assert_array_equal(call["ndt"], [0.08, 0.08, 0.12, 0.12])
+
+
+@pytest.mark.parametrize(
+    ("theta", "message"),
+    [
+        ([0.45, -0.01, 1.20, 0.08], "v_y.*non-negative"),
+        ([0.45, 0.70, 0.00, 0.08], "a.*positive"),
+        ([0.45, 0.70, 1.20, -0.01], "t.*non-negative"),
+        (
+            [[0.45, 0.70, 1.20, 0.08], [0.20, -0.01, 0.90, 0.12]],
+            "v_y.*non-negative",
+        ),
+    ],
+)
+def test_simulator_rejects_parameters_outside_the_psdm_domain(
+    _fake_jeam, theta, message
+):
+    """Invalid fixed-PSDM parameters should fail before loading the producer."""
+    with pytest.raises(ValueError, match=message):
+        jeam_integration.simulate_projected_spherical_diffusion(
+            np.asarray(theta),
+            random_state=1947,
+            n_replicas=2,
+        )
+
+    assert _RecordingProjectedSphericalModel.simulator_calls == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_jeam_psdm_adapter.py
+++ b/tests/test_jeam_psdm_adapter.py
@@ -1,0 +1,319 @@
+"""Dependency-free contracts for the projected-spherical JEAM adapters."""
+
+import builtins
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+from ssms.hssm_support import validate_simulator_fun
+
+from hssm.integrations import jeam as jeam_integration
+
+pytestmark = pytest.mark.xfail(
+    not hasattr(jeam_integration, "logp_projected_spherical_diffusion"),
+    reason="projected-spherical JEAM adapters are not implemented yet",
+    raises=AttributeError,
+    strict=True,
+)
+
+
+class _RecordingProjectedSphericalModel:
+    likelihood_calls: list[dict] = []
+    simulator_calls: list[dict] = []
+    likelihood_error: Exception | None = None
+
+    def __init__(self, threshold_dynamic):
+        assert threshold_dynamic == "fixed"
+
+    def joint_lpdf(self, **kwargs):
+        self.likelihood_calls.append(kwargs)
+        if self.likelihood_error is not None:
+            raise self.likelihood_error
+        return (
+            kwargs["rt"]
+            + kwargs["theta"]
+            + kwargs["drift_vec"][:, 0]
+            + kwargs["drift_vec"][:, 1]
+            + kwargs["ndt"]
+            + kwargs["threshold"]
+        )
+
+    def simulate(self, **kwargs):
+        self.simulator_calls.append(kwargs)
+        n_sample = kwargs["n_sample"]
+        return pd.DataFrame(
+            {
+                "rt": np.arange(n_sample, dtype=np.float64) + 0.25,
+                "response": np.linspace(0.0, np.pi, n_sample),
+                "ignored": np.full(n_sample, 99.0),
+            }
+        )
+
+
+@pytest.fixture
+def _fake_jeam(monkeypatch):
+    _RecordingProjectedSphericalModel.likelihood_calls = []
+    _RecordingProjectedSphericalModel.simulator_calls = []
+    _RecordingProjectedSphericalModel.likelihood_error = None
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_projected_spherical_diffusion_model",
+        lambda: _RecordingProjectedSphericalModel,
+    )
+
+
+def test_likelihood_maps_scalars_and_fixed_settings(_fake_jeam):
+    """Scalar parameters should reach PSDM as fixed trial-wise settings."""
+    data = np.array([[0.2, 0.0], [0.5, 0.25], [0.9, np.pi]])
+
+    observed = jeam_integration.logp_projected_spherical_diffusion(
+        data,
+        v_x=0.4,
+        v_y=0.7,
+        a=1.1,
+        t=0.05,
+    )
+
+    expected = data.sum(axis=1) + 0.4 + 0.7 + 1.1 + 0.05
+    np.testing.assert_allclose(observed, expected)
+    assert observed.dtype == np.float64
+    call = _RecordingProjectedSphericalModel.likelihood_calls[0]
+    np.testing.assert_array_equal(call["drift_vec"], [[0.4, 0.7]] * 3)
+    np.testing.assert_array_equal(call["ndt"], [0.05] * 3)
+    assert call["threshold"] == 1.1
+    assert call["decay"] == 0.0
+    assert call["threshold_function"] is None
+    assert call["dt_threshold_function"] is None
+    assert call["s_v"] == 0.0
+    assert call["s_t"] == 0.0
+    assert call["sigma"] == 1.0
+
+
+def test_likelihood_preserves_pointwise_order_with_trialwise_thresholds(_fake_jeam):
+    """Threshold grouping should preserve the original observation order."""
+    data = np.array([[0.2, 0.1], [0.4, 1.2], [0.6, 2.5]])
+    v_x = np.array([0.1, 0.2, 0.3])
+    v_y = np.array([0.4, 0.5, 0.6])
+    threshold = np.array([1.2, 0.8, 1.2])
+    ndt = np.array([0.01, 0.02, 0.03])
+
+    observed = jeam_integration.logp_projected_spherical_diffusion(
+        data,
+        v_x=v_x,
+        v_y=v_y,
+        a=threshold,
+        t=ndt,
+    )
+
+    np.testing.assert_allclose(
+        observed,
+        data.sum(axis=1) + v_x + v_y + threshold + ndt,
+    )
+    assert [
+        call["threshold"] for call in _RecordingProjectedSphericalModel.likelihood_calls
+    ] == [0.8, 1.2]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [np.array([0.2, 0.1]), np.ones((2, 1)), np.ones((2, 3))],
+)
+def test_likelihood_rejects_invalid_data_shapes(data):
+    """Only the two-column HSSM observation contract should be accepted."""
+    with pytest.raises(ValueError, match=r"shape \(n_observations, 2\)"):
+        jeam_integration.logp_projected_spherical_diffusion(
+            data,
+            0.1,
+            0.2,
+            1.0,
+            0.05,
+        )
+
+
+@pytest.mark.parametrize(
+    "angle",
+    [np.nextafter(0.0, -np.inf), np.nextafter(np.pi, np.inf)],
+)
+def test_likelihood_rejects_angles_outside_closed_polar_interval(angle):
+    """Polar observations should use the declared closed interval."""
+    with pytest.raises(ValueError, match=r"\[0, pi\]"):
+        jeam_integration.logp_projected_spherical_diffusion(
+            np.array([[0.2, angle]]),
+            0.1,
+            0.2,
+            1.0,
+            0.05,
+        )
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("v_x", np.ones(3)),
+        ("v_y", np.array([np.inf, 0.2])),
+        ("a", np.array([1.0, np.nan])),
+        ("t", "not-a-number"),
+    ],
+)
+def test_likelihood_rejects_invalid_parameter_arrays(parameter, value):
+    """Parameters must provide one finite value for every observation."""
+    parameters = {"v_x": 0.1, "v_y": 0.2, "a": 1.0, "t": 0.05}
+    parameters[parameter] = value
+
+    with pytest.raises(ValueError, match=parameter):
+        jeam_integration.logp_projected_spherical_diffusion(
+            np.array([[0.2, 0.1], [0.3, 0.2]]),
+            **parameters,
+        )
+
+
+def test_likelihood_preserves_exact_producer_errors(_fake_jeam):
+    """Scientific producer failures should cross the adapter unchanged."""
+    expected = FloatingPointError("PSDM first-passage calculation failed")
+    _RecordingProjectedSphericalModel.likelihood_error = expected
+
+    with pytest.raises(FloatingPointError, match="first-passage") as caught:
+        jeam_integration.logp_projected_spherical_diffusion(
+            np.array([[0.2, 0.1]]),
+            0.1,
+            0.2,
+            1.0,
+            0.05,
+        )
+
+    assert caught.value is expected
+
+
+def test_likelihood_rejects_an_unexpected_producer_shape(monkeypatch):
+    """A pointwise-shape regression should fail at the integration boundary."""
+    bad_model = SimpleNamespace(joint_lpdf=lambda **kwargs: np.ones((1, 1)))
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_projected_spherical_diffusion_model",
+        lambda: lambda **kwargs: bad_model,
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected pointwise log-density shape"):
+        jeam_integration.logp_projected_spherical_diffusion(
+            np.array([[0.2, 0.1]]),
+            0.1,
+            0.2,
+            1.0,
+            0.05,
+        )
+
+
+def test_loader_explains_how_to_install_the_optional_dependency(monkeypatch):
+    """A missing JEAM install should report the prototype-group command."""
+    real_import = builtins.__import__
+
+    def import_without_jeam(name, *args, **kwargs):
+        if name.startswith("jeam"):
+            raise ModuleNotFoundError("No module named 'jeam'", name="jeam")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_jeam)
+
+    with pytest.raises(ImportError, match="uv sync --group jeam-prototype"):
+        jeam_integration._load_projected_spherical_diffusion_model()
+
+
+def test_simulator_advertises_the_hssm_callable_contract():
+    """HSSM should recognize two continuous observation columns."""
+    model_name, choices, obs_dim = validate_simulator_fun(
+        jeam_integration.simulate_projected_spherical_diffusion
+    )
+
+    assert model_name == "projected_spherical_diffusion"
+    assert choices == []
+    assert obs_dim == 2
+
+
+def test_simulator_maps_parameters_replicas_and_fixed_settings(_fake_jeam):
+    """One parameter row should produce contiguous fixed-model replicas."""
+    observed = jeam_integration.simulate_projected_spherical_diffusion(
+        theta=np.array([0.45, 0.70, 1.20, 0.08]),
+        random_state=1947,
+        n_replicas=3,
+    )
+
+    np.testing.assert_array_equal(
+        observed,
+        [[0.25, 0.0], [1.25, np.pi / 2], [2.25, np.pi]],
+    )
+    call = _RecordingProjectedSphericalModel.simulator_calls[0]
+    np.testing.assert_array_equal(call["drift_vec"], [[0.45, 0.70]] * 3)
+    np.testing.assert_array_equal(call["threshold"], [1.20] * 3)
+    np.testing.assert_array_equal(call["ndt"], [0.08] * 3)
+    assert call["decay"] == 0.0
+    assert call["threshold_function"] is None
+    assert call["s_v"] == 0.0
+    assert call["s_t"] == 0.0
+    assert call["sigma"] == 1.0
+    assert call["n_sample"] == 3
+    assert call["max_time"] == 20.0
+    assert call["random_state"] == 1947
+
+
+def test_simulator_preserves_trial_major_replica_order(_fake_jeam):
+    """Each trial's replicas should remain adjacent for HSSM's reshape."""
+    theta = np.array([[0.45, 0.70, 1.20, 0.08], [-0.15, 0.55, 0.90, 0.12]])
+
+    observed = jeam_integration.simulate_projected_spherical_diffusion(
+        theta=theta,
+        random_state=519,
+        n_replicas=2,
+    )
+
+    assert observed.shape == (4, 2)
+    call = _RecordingProjectedSphericalModel.simulator_calls[0]
+    np.testing.assert_array_equal(
+        call["drift_vec"],
+        [[0.45, 0.70], [0.45, 0.70], [-0.15, 0.55], [-0.15, 0.55]],
+    )
+    np.testing.assert_array_equal(call["threshold"], [1.20, 1.20, 0.90, 0.90])
+    np.testing.assert_array_equal(call["ndt"], [0.08, 0.08, 0.12, 0.12])
+
+
+@pytest.mark.parametrize(
+    ("frame", "message"),
+    [
+        (pd.DataFrame({"rt": [0.2], "choice": [0.1]}), "columns"),
+        (pd.DataFrame({"rt": [0.2, 0.3], "response": [0.1, 0.2]}), "shape"),
+        (pd.DataFrame({"rt": [np.nan], "response": [0.1]}), "finite"),
+        (pd.DataFrame({"rt": [0.0], "response": [0.1]}), "positive"),
+        (pd.DataFrame({"rt": [0.2], "response": [-1e-8]}), r"\[0, pi\]"),
+    ],
+)
+def test_simulator_rejects_producer_contract_drift(monkeypatch, frame, message):
+    """Malformed producer output should fail at the integration boundary."""
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_projected_spherical_diffusion_model",
+        lambda: lambda **kwargs: SimpleNamespace(simulate=lambda **kwargs: frame),
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        jeam_integration.simulate_projected_spherical_diffusion(
+            np.array([0.1, 0.2, 1.0, 0.05]),
+            11,
+            1,
+        )
+
+
+def test_simulator_reports_producer_omissions_explicitly(monkeypatch):
+    """A finite-horizon omission should not silently become predictive data."""
+    omitted = pd.DataFrame({"rt": [np.nan], "response": [np.nan]})
+    monkeypatch.setattr(
+        jeam_integration,
+        "_load_projected_spherical_diffusion_model",
+        lambda: lambda **kwargs: SimpleNamespace(simulate=lambda **kwargs: omitted),
+    )
+
+    with pytest.raises(RuntimeError, match=r"omitted 1 trial.*max_time=20\.0"):
+        jeam_integration.simulate_projected_spherical_diffusion(
+            np.array([0.1, 0.2, 1.0, 0.05]),
+            11,
+            1,
+        )


### PR DESCRIPTION
## Purpose

Add the experimental fixed projected-spherical diffusion model (PSDM) likelihood and
simulator adapters at HSSM's existing two-column JEAM boundary.

This refresh is based directly on `dev@ff8b275e` after #1211. It preserves the current
JEAM #13 pin, `ede7a4f4faf226e4dae52c84dfb01012939cccdc`; it does not replay the stale
#11 pin or the superseded #1207–#1211 ancestry.

## Scope

- lazily load JEAM's `ProjectedSphericalDiffusionModel` without making JEAM a core HSSM
  dependency
- map `[rt, response]` observations and `[v_x, v_y, a, t]` parameters while preserving
  pointwise row order
- expose deterministic predictive simulation with contiguous HSSM replica ordering
- reject `v_y < 0`, `a <= 0`, and `t < 0` before producer execution
- reject finite-horizon `(NaN, NaN)` omissions explicitly because the current HSSM random
  variable has no omission mask
- execute both dependency-free and real-producer PSDM suites in the optional JEAM job

The adapter fixes threshold dynamics, `sigma=1`, `s_v=0`, and `s_t=0`. Polar responses
use the closed interval `[0, pi]`.

## Commits

1. `test: define fixed PSDM adapter contracts`
2. `feat: add fixed PSDM likelihood and simulator adapters`
3. `test: verify fixed PSDM against current JEAM`
4. `test: require fixed PSDM simulator domains`
5. `fix: reject invalid fixed PSDM simulation parameters`
6. `ci: exercise fixed PSDM adapters`

The first two commits are patch-identical replays of the historical adapter unit. The
real-producer integration test is byte-identical to its historical version; obsolete pin
and documentation edits were excluded.

## Validation

- focused PSDM contract and live-producer suite: 31 passed
- widened current-JEAM/HSSM regression lane: 62 passed
- complete non-slow HSSM suite: 886 passed, 378 deselected
- Ruff check and format check on all changed Python files
- mypy and Pyrefly on the adapter module
- JEAM provenance resolves exactly to #13 `ede7a4f4`
- workflow YAML parse, range-diff, blob identity, and `git diff --check`

No recovery, MCMC, benchmark, or evidence regeneration was run.

## Scientific boundary

This is experimental `dev` infrastructure only. Fixed-PSDM v1 remains
`overall_pass=false`: 14 of 16 truth-in-HDI checks passed, with unresolved high-threshold
diagnostics and low-threshold radial-drift recovery. This PR makes no public-support,
recovery, or promotion claim and does not alter HSSM defaults.

Model registration, priors/bounds, full HSSM construction, predictive lifecycle, and
serialization remain #1213. Recovery protocol/artifact/report work remains #1214–#1217
and must be refreshed separately.
