### PR TITLE
Register the fixed PSDM model

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -15,6 +15,7 @@ on:
       - "src/hssm/hssm.py"
       - "src/hssm/integrations/jeam.py"
       - "src/hssm/modelconfig/circular_diffusion_config.py"
+      - "src/hssm/modelconfig/projected_spherical_diffusion_config.py"
       - "src/hssm/register.py"
       - "src/hssm/utils.py"
       - "docs/tutorials/jeam_circular_diffusion.py"
@@ -27,6 +28,7 @@ on:
       - "tests/test_jeam_recovery_evidence_io.py"
       - "tests/test_jeam_modelconfig.py"
       - "tests/test_jeam_psdm_adapter.py"
+      - "tests/test_jeam_psdm_modelconfig.py"
       - "tests/integration/test_jeam_bayesian_evidence_capture.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
@@ -34,6 +36,8 @@ on:
       - "tests/integration/test_jeam_objective_parity.py"
       - "tests/integration/test_jeam_predictive.py"
       - "tests/integration/test_jeam_psdm.py"
+      - "tests/integration/test_jeam_psdm_model.py"
+      - "tests/integration/test_jeam_psdm_predictive.py"
       - "tests/integration/test_jeam_repeated_recovery.py"
       - "tests/integration/test_jeam_repeated_recovery_evidence.py"
       - "tests/integration/test_jeam_simulator.py"
@@ -100,6 +104,13 @@ jobs:
           uv run --group jeam-prototype pytest
           tests/test_jeam_psdm_adapter.py
           tests/integration/test_jeam_psdm.py
+
+      - name: Verify the fixed-PSDM model lifecycle
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/test_jeam_psdm_modelconfig.py
+          tests/integration/test_jeam_psdm_model.py
+          tests/integration/test_jeam_psdm_predictive.py
 
       - name: Verify JEAM sampler capabilities and NUTS backends
         run: >-

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -29,6 +29,7 @@ SupportedModels = Literal[
     "softmax_inv_temperature_2",
     "softmax_inv_temperature_3",
     "circular_diffusion",
+    "projected_spherical_diffusion",
 ]
 
 ResponseKind = Literal["categorical", "continuous", "circular"]

--- a/src/hssm/modelconfig/projected_spherical_diffusion_config.py
+++ b/src/hssm/modelconfig/projected_spherical_diffusion_config.py
@@ -1,0 +1,50 @@
+"""Default configuration for the experimental JEAM fixed-PSDM model."""
+
+from math import pi
+
+from .._types import DefaultConfig
+from ..integrations.jeam import (
+    logp_projected_spherical_diffusion,
+    simulate_projected_spherical_diffusion,
+)
+
+
+def get_projected_spherical_diffusion_config() -> DefaultConfig:
+    """Return the fixed-boundary JEAM projected-spherical configuration.
+
+    HSSM parameter ``v_x`` maps to JEAM's axial drift, ``v_y`` maps to its
+    nonnegative projected-radial drift, ``a`` maps to the fixed threshold, and ``t``
+    maps to nondecision time. Diffusion scale is fixed to one and drift/NDT variability
+    to zero.
+    """
+    return {
+        "response": ["rt", "response"],
+        "response_kind": "continuous",
+        "response_bounds": {"response": (0.0, pi)},
+        "list_params": ["v_x", "v_y", "a", "t"],
+        "choices": None,
+        "rv": simulate_projected_spherical_diffusion,
+        "description": (
+            "Experimental fixed-boundary JEAM projected spherical diffusion model"
+        ),
+        "default_loglik_kind": "blackbox",
+        "likelihoods": {
+            "blackbox": {
+                "loglik": logp_projected_spherical_diffusion,
+                "backend": None,
+                "default_priors": {
+                    "t": {
+                        "name": "HalfNormal",
+                        "sigma": 2.0,
+                    },
+                },
+                "bounds": {
+                    "v_x": (-3.0, 3.0),
+                    "v_y": (0.0, 3.0),
+                    "a": (0.1, 3.0),
+                    "t": (0.0, 2.0),
+                },
+                "extra_fields": None,
+            },
+        },
+    }

--- a/src/hssm/modelconfig/projected_spherical_diffusion_config.py
+++ b/src/hssm/modelconfig/projected_spherical_diffusion_config.py
@@ -45,6 +45,7 @@ def get_projected_spherical_diffusion_config() -> DefaultConfig:
                     "t": (0.0, 2.0),
                 },
                 "extra_fields": None,
+                "supported_samplers": ("pymc",),
             },
         },
     }

--- a/tests/integration/test_jeam_psdm_model.py
+++ b/tests/integration/test_jeam_psdm_model.py
@@ -99,7 +99,7 @@ def test_compiled_distribution_matches_adapter_and_direct_jeam():
 
 
 def test_compiled_distribution_accepts_trialwise_radial_drift():
-    """Regression-shaped radial drift should reach JEAM row by row."""
+    """Positive trial-wise radial-drift vectors should reach JEAM row by row."""
     model = _build_projected_spherical_model()
     data = np.array([[0.28, 0.2], [0.53, 1.4], [0.91, 2.7]])
     radial_drift = np.array([0.70, 0.55, 0.40])

--- a/tests/integration/test_jeam_psdm_model.py
+++ b/tests/integration/test_jeam_psdm_model.py
@@ -1,0 +1,135 @@
+"""Construction and compiled-likelihood tests for the registered fixed PSDM."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("jeam")
+
+from jeam.Models.Spherical import ProjectedSphericalDiffusionModel
+
+import hssm
+from hssm.integrations.jeam import (
+    logp_projected_spherical_diffusion,
+    simulate_projected_spherical_diffusion,
+)
+
+COMPILED_RTOL = 5e-7
+COMPILED_ATOL = 5e-7
+
+
+def _build_projected_spherical_model() -> hssm.HSSM:
+    """Build an ordinary HSSM model from deterministic JEAM observations."""
+    observations = simulate_projected_spherical_diffusion(
+        theta=np.array([0.70, 0.35, 0.40, 0.08]),
+        random_state=1947,
+        n_replicas=12,
+    )
+    return hssm.HSSM(
+        data=pd.DataFrame(observations, columns=["rt", "response"]),
+        model="projected_spherical_diffusion",
+        p_outlier=None,
+    )
+
+
+def test_simulated_projected_data_builds_an_ordinary_hssm_model():
+    """The fixed PSDM should use HSSM's standard config-driven lifecycle."""
+    model = _build_projected_spherical_model()
+
+    assert type(model) is hssm.HSSM
+    assert model.model_name == "projected_spherical_diffusion"
+    assert model.response_kind == "continuous"
+    assert model.response_bounds == {"response": (0.0, np.pi)}
+    assert model.choices is None
+    assert model.n_choices is None
+    assert model.list_params == ["v_x", "v_y", "a", "t"]
+    assert model.model_config.loglik is logp_projected_spherical_diffusion
+    assert model.model_config.rv is simulate_projected_spherical_diffusion
+    assert model.params["v_y"].bounds == (0.0, 3.0)
+
+
+def test_compiled_distribution_matches_adapter_and_direct_jeam():
+    """The registered black-box path should preserve pointwise JEAM values."""
+    model = _build_projected_spherical_model()
+    data = np.array([[0.28, 0.2], [0.53, 1.4], [0.91, 2.7]])
+    v_x = 0.45
+    v_y = 0.70
+    threshold = 1.10
+    ndt = 0.08
+    producer = ProjectedSphericalDiffusionModel(threshold_dynamic="fixed")
+    direct = producer.joint_lpdf(
+        rt=data[:, 0],
+        theta=data[:, 1],
+        drift_vec=np.column_stack(
+            (np.full(data.shape[0], v_x), np.full(data.shape[0], v_y))
+        ),
+        ndt=np.full(data.shape[0], ndt),
+        threshold=threshold,
+        decay=0.0,
+        threshold_function=None,
+        dt_threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+    )
+    adapted = logp_projected_spherical_diffusion(
+        data,
+        v_x,
+        v_y,
+        threshold,
+        ndt,
+    )
+    compiled = np.asarray(
+        model.model_distribution.logp(
+            data,
+            v_x,
+            v_y,
+            threshold,
+            ndt,
+        ).eval()
+    )
+
+    np.testing.assert_allclose(adapted, direct, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        compiled,
+        direct,
+        rtol=COMPILED_RTOL,
+        atol=COMPILED_ATOL,
+    )
+
+
+def test_compiled_distribution_accepts_trialwise_radial_drift():
+    """Regression-shaped radial drift should reach JEAM row by row."""
+    model = _build_projected_spherical_model()
+    data = np.array([[0.28, 0.2], [0.53, 1.4], [0.91, 2.7]])
+    radial_drift = np.array([0.70, 0.55, 0.40])
+    direct = ProjectedSphericalDiffusionModel(threshold_dynamic="fixed").joint_lpdf(
+        rt=data[:, 0],
+        theta=data[:, 1],
+        drift_vec=np.column_stack((np.full(data.shape[0], 0.45), radial_drift)),
+        ndt=np.full(data.shape[0], 0.08),
+        threshold=1.10,
+        decay=0.0,
+        threshold_function=None,
+        dt_threshold_function=None,
+        s_v=0.0,
+        s_t=0.0,
+        sigma=1.0,
+    )
+
+    compiled = np.asarray(
+        model.model_distribution.logp(
+            data,
+            0.45,
+            radial_drift,
+            1.10,
+            0.08,
+        ).eval()
+    )
+
+    np.testing.assert_allclose(
+        compiled,
+        direct,
+        rtol=COMPILED_RTOL,
+        atol=COMPILED_ATOL,
+    )

--- a/tests/integration/test_jeam_psdm_predictive.py
+++ b/tests/integration/test_jeam_psdm_predictive.py
@@ -1,0 +1,173 @@
+"""Predictive and persistence tests for the registered fixed PSDM."""
+
+import numpy as np
+import pandas as pd
+import pytensor
+import pytest
+import xarray as xr
+
+pytest.importorskip("jeam")
+
+import hssm
+from hssm.integrations.jeam import simulate_projected_spherical_diffusion
+
+OBSERVED_NAME = "rt,response"
+OBSERVATION_DIM = "__obs__"
+RESPONSE_DIM = "rt,response_dim"
+
+
+def _build_projected_spherical_model() -> hssm.HSSM:
+    """Build an ordinary HSSM model from deterministic JEAM observations."""
+    observations = simulate_projected_spherical_diffusion(
+        theta=np.array([0.70, 0.35, 0.40, 0.08]),
+        random_state=1947,
+        n_replicas=6,
+    )
+    return hssm.HSSM(
+        data=pd.DataFrame(observations, columns=["rt", "response"]),
+        model="projected_spherical_diffusion",
+        p_outlier=None,
+    )
+
+
+@pytest.fixture(scope="module")
+def projected_spherical_model() -> hssm.HSSM:
+    """Share one projected-spherical model across predictive-path tests."""
+    return _build_projected_spherical_model()
+
+
+def _assert_predictive_contract(values: np.ndarray) -> None:
+    """Check the common final-axis, support, and numeric predictive contract."""
+    assert values.shape[-1] == 2
+    assert values.dtype == np.dtype(pytensor.config.floatX)
+    assert np.all(np.isfinite(values))
+    assert np.all(values[..., 0] > 0.0)
+    assert np.all(values[..., 1] >= 0.0)
+    assert np.all(values[..., 1] <= np.pi)
+
+
+def _fixed_posterior(n_draws: int = 12) -> xr.DataTree:
+    """Return identical parameter draws to isolate simulator RNG behavior."""
+    coords = {"chain": [0], "draw": np.arange(n_draws)}
+    posterior = xr.Dataset(
+        {
+            name: (("chain", "draw"), np.full((1, n_draws), value))
+            for name, value in {
+                "v_x": 0.70,
+                "v_y": 0.35,
+                "a": 0.40,
+                "t": 0.08,
+            }.items()
+        },
+        coords=coords,
+    )
+    return xr.DataTree.from_dict({"posterior": posterior})
+
+
+def test_prior_predictive_preserves_shape_support_and_seed(
+    projected_spherical_model,
+):
+    """Prior draws should retain `[rt, response]` and repeat exactly by seed."""
+    first = projected_spherical_model.sample_prior_predictive(draws=3, random_seed=519)
+    second = projected_spherical_model.sample_prior_predictive(draws=3, random_seed=519)
+    different = projected_spherical_model.sample_prior_predictive(
+        draws=3,
+        random_seed=520,
+    )
+
+    first_values = first["prior_predictive"][OBSERVED_NAME].values
+    second_values = second["prior_predictive"][OBSERVED_NAME].values
+    different_values = different["prior_predictive"][OBSERVED_NAME].values
+
+    np.testing.assert_array_equal(first_values, second_values)
+    assert not np.array_equal(first_values, different_values)
+    assert first["prior_predictive"][OBSERVED_NAME].dims == (
+        "chain",
+        "draw",
+        OBSERVATION_DIM,
+        RESPONSE_DIM,
+    )
+    assert first_values.shape == (1, 3, 6, 2)
+    np.testing.assert_array_equal(
+        first["prior_predictive"].coords[RESPONSE_DIM].values,
+        np.array([0, 1]),
+    )
+    _assert_predictive_contract(first_values)
+
+
+def test_posterior_predictive_advances_one_seeded_safe_mode_stream(
+    projected_spherical_model,
+):
+    """Chunked posterior draws should repeat by seed without repeating chunks."""
+    first = projected_spherical_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=997,
+    )
+    second = projected_spherical_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=997,
+    )
+    different = projected_spherical_model.sample_posterior_predictive(
+        dt=_fixed_posterior(),
+        inplace=False,
+        safe_mode=True,
+        random_seed=998,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert different is not None
+    first_values = first["posterior_predictive"][OBSERVED_NAME].values
+    second_values = second["posterior_predictive"][OBSERVED_NAME].values
+    different_values = different["posterior_predictive"][OBSERVED_NAME].values
+
+    np.testing.assert_array_equal(first_values, second_values)
+    assert not np.array_equal(first_values, different_values)
+    assert not np.array_equal(first_values[:, 0], first_values[:, 10])
+    assert first["posterior_predictive"][OBSERVED_NAME].dims == (
+        "chain",
+        "draw",
+        OBSERVATION_DIM,
+        RESPONSE_DIM,
+    )
+    assert first_values.shape == (1, 12, 6, 2)
+    np.testing.assert_array_equal(
+        first["posterior_predictive"].coords["draw"].values,
+        np.arange(12),
+    )
+    _assert_predictive_contract(first_values)
+
+
+def test_projected_spherical_round_trip_reconstructs_predictive_state(tmp_path):
+    """Existing persistence should reconstruct the config and custom RV."""
+    model = _build_projected_spherical_model()
+    model.save_model(
+        model_name="projected_spherical_round_trip",
+        base_path=tmp_path,
+        allow_absolute_base_path=True,
+    )
+
+    model_path = tmp_path / "projected_spherical_round_trip"
+    restored = hssm.HSSM.load_model(model_path)
+
+    assert isinstance(restored, hssm.HSSM)
+    assert restored.model_name == "projected_spherical_diffusion"
+    assert restored._init_args["model"] == "projected_spherical_diffusion"
+    assert restored._init_args["p_outlier"] is None
+    assert restored.model_config.rv is simulate_projected_spherical_diffusion
+    assert restored.data.equals(model.data)
+    assert (model_path / "model.pkl").is_file()
+    assert not (model_path / "traces.nc").exists()
+
+    original_draws = model.sample_prior_predictive(draws=2, random_seed=1623)[
+        "prior_predictive"
+    ][OBSERVED_NAME].values
+    restored_draws = restored.sample_prior_predictive(draws=2, random_seed=1623)[
+        "prior_predictive"
+    ][OBSERVED_NAME].values
+    np.testing.assert_array_equal(original_draws, restored_draws)
+    _assert_predictive_contract(restored_draws)

--- a/tests/test_jeam_psdm_modelconfig.py
+++ b/tests/test_jeam_psdm_modelconfig.py
@@ -1,0 +1,97 @@
+"""Contracts for the experimental built-in fixed-PSDM model configuration."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import hssm
+from hssm.config import Config
+from hssm.integrations.jeam import (
+    logp_projected_spherical_diffusion,
+    simulate_projected_spherical_diffusion,
+)
+from hssm.modelconfig import get_default_model_config
+
+MODEL_NAME = "projected_spherical_diffusion"
+
+pytestmark = pytest.mark.xfail(
+    MODEL_NAME not in hssm.list_models(),
+    reason="the fixed-PSDM built-in model is not registered yet",
+    strict=True,
+)
+
+
+def test_projected_spherical_diffusion_is_a_supported_model():
+    """The prototype should be discoverable through the public model list."""
+    assert MODEL_NAME in hssm.list_models()
+
+
+def test_get_projected_spherical_diffusion_config():
+    """The raw built-in config should expose the complete fixed-model contract."""
+    config = get_default_model_config(MODEL_NAME)
+
+    assert config["response"] == ["rt", "response"]
+    assert config["response_kind"] == "continuous"
+    assert config["response_bounds"] == {"response": (0.0, np.pi)}
+    assert config["choices"] is None
+    assert config["list_params"] == ["v_x", "v_y", "a", "t"]
+    assert config["rv"] is simulate_projected_spherical_diffusion
+    assert config["default_loglik_kind"] == "blackbox"
+    assert set(config["likelihoods"]) == {"blackbox"}
+
+    blackbox = config["likelihoods"]["blackbox"]
+    assert blackbox["loglik"] is logp_projected_spherical_diffusion
+    assert blackbox["backend"] is None
+    assert blackbox["bounds"] == {
+        "v_x": (-3.0, 3.0),
+        "v_y": (0.0, 3.0),
+        "a": (0.1, 3.0),
+        "t": (0.0, 2.0),
+    }
+    assert blackbox["default_priors"] == {"t": {"name": "HalfNormal", "sigma": 2.0}}
+    assert blackbox["extra_fields"] is None
+
+
+def test_projected_spherical_defaults_preserve_domain_and_rv():
+    """Lazy registration should produce a validated continuous-response Config."""
+    config = Config.from_defaults(MODEL_NAME, None)
+
+    assert config.model_name == MODEL_NAME
+    assert config.loglik_kind == "blackbox"
+    assert config.backend is None
+    assert config.response == ["rt", "response"]
+    assert config.response_kind == "continuous"
+    assert config.response_bounds == {"response": (0.0, np.pi)}
+    assert config.choices is None
+    assert config.list_params == ["v_x", "v_y", "a", "t"]
+    assert config.loglik is logp_projected_spherical_diffusion
+    assert config.rv is simulate_projected_spherical_diffusion
+    config.validate()
+
+
+@pytest.mark.parametrize("p_outlier", [0.0, 0.05])
+def test_projected_spherical_model_requires_disabled_lapse(p_outlier):
+    """A continuous coordinate density cannot use the categorical lapse model."""
+    data = pd.DataFrame({"rt": [0.4, 0.8], "response": [0.2, 1.4]})
+
+    with pytest.raises(
+        ValueError,
+        match=r"`p_outlier` is not supported.*Set `p_outlier=None`",
+    ):
+        hssm.HSSM(
+            data=data,
+            model=MODEL_NAME,
+            p_outlier=p_outlier,
+        )
+
+
+@pytest.mark.parametrize("response", [0.0, np.pi])
+def test_projected_spherical_config_accepts_both_polar_endpoints(response):
+    """Continuous bounds should retain the model's closed polar support."""
+    model = hssm.HSSM(
+        data=pd.DataFrame({"rt": [0.4, 0.8], "response": [response, 1.4]}),
+        model=MODEL_NAME,
+        p_outlier=None,
+    )
+
+    assert model.response_bounds == {"response": (0.0, np.pi)}

--- a/tests/test_jeam_psdm_modelconfig.py
+++ b/tests/test_jeam_psdm_modelconfig.py
@@ -42,6 +42,7 @@ def test_get_projected_spherical_diffusion_config():
     blackbox = config["likelihoods"]["blackbox"]
     assert blackbox["loglik"] is logp_projected_spherical_diffusion
     assert blackbox["backend"] is None
+    assert blackbox["supported_samplers"] == ("pymc",)
     assert blackbox["bounds"] == {
         "v_x": (-3.0, 3.0),
         "v_y": (0.0, 3.0),
@@ -66,7 +67,45 @@ def test_projected_spherical_defaults_preserve_domain_and_rv():
     assert config.list_params == ["v_x", "v_y", "a", "t"]
     assert config.loglik is logp_projected_spherical_diffusion
     assert config.rv is simulate_projected_spherical_diffusion
+    assert config.supported_samplers == ("pymc",)
     config.validate()
+
+
+def test_projected_spherical_rejects_unverified_sampler_before_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The fixed black-box route should reject unverified backends immediately."""
+    model = hssm.HSSM(
+        data=pd.DataFrame({"rt": [0.4, 0.8], "response": [0.2, 1.4]}),
+        model=MODEL_NAME,
+        p_outlier=None,
+    )
+
+    def unexpected_fit(**kwargs):
+        pytest.fail("Bambi.fit was called for an unsupported PSDM sampler.")
+
+    def unexpected_map():
+        pytest.fail("MAP ran for an unsupported PSDM sampler.")
+
+    monkeypatch.setattr(model.model, "fit", unexpected_fit)
+    monkeypatch.setattr(model, "find_MAP", unexpected_map)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Sampler 'laplace' is not supported.*"
+            r"projected_spherical_diffusion.*blackbox"
+        ),
+    ):
+        model.sample(
+            sampler="laplace",
+            initvals="map",
+            chains=1,
+            cores=1,
+            tune=1,
+            draws=1,
+            progressbar=False,
+        )
 
 
 @pytest.mark.parametrize("p_outlier", [0.0, 0.05])


### PR DESCRIPTION
## Purpose

- register the experimental fixed-boundary projected spherical diffusion model through HSSM's ordinary config-driven lifecycle
- expose JEAM's continuous polar response on `[0, pi]` with parameters `v_x`, nonnegative radial drift `v_y`, threshold `a`, and nondecision time `t`

## Changes

- add the built-in `projected_spherical_diffusion` configuration and public model-name registration
- constrain the black-box likelihood to the verified PyMC sampler backend before dispatch
- verify direct JEAM, adapter, and compiled pointwise parity; positive trial-wise vector inputs; predictive DataTree dimensions/support/RNG behavior; and save/load reconstruction
- make the optional JEAM workflow watch and execute the complete fixed-PSDM model lifecycle against JEAM #13

## Verification

- focused fixed-PSDM lifecycle: 14 passed
- widened current JEAM/fixed-CDM/fixed-PSDM matrix: 120 passed, 2 slow NUTS smokes deselected
- complete non-slow HSSM suite: 901 passed, 378 deselected
- Ruff check/format, focused mypy and Pyrefly, workflow YAML validation, `git diff --check`
- strict MkDocs build and wheel/sdist build

## Scope

- validated against JEAM `ede7a4f4faf226e4dae52c84dfb01012939cccdc`; no dependency, pin, docs, or evidence artifact changes
- this slice covers the simple experimental fixed model and positive trial-wise likelihood vectors; it does not claim default identity-link formula/regression support
- fixed-PSDM v1 evidence remains experimental (`overall_pass=false`, 14/16 truth-in-HDI checks); there is no recovery, public-support, or promotion claim
- no PSDM recovery, canonical MCMC, or evidence generation was run
