### PR TITLE
Archive compact fixed-PSDM recovery evidence

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,14 +8,19 @@ on:
       - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
       - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1.json"
       - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1_addendum.json"
+      - "benchmarks/results/jeam_fixed_psdm_recovery_v1.json"
       - "benchmarks/specs/jeam_fixed_cdm_sampler_comparison_v1.json"
+      - "benchmarks/specs/jeam_fixed_psdm_recovery_v1.json"
+      - "benchmarks/specs/jeam_fixed_psdm_recovery_v1_addendum.json"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
       - "scripts/jeam_repeated_recovery_report.py"
       - "scripts/jeam_sampler_comparison_report.py"
+      - "scripts/jeam_psdm_recovery_report.py"
       - "scripts/verify_jeam_repeated_recovery_evidence.py"
       - "scripts/verify_jeam_sampler_comparison_evidence.py"
+      - "scripts/verify_jeam_psdm_recovery_evidence.py"
       - "src/hssm/**"
   push:
     branches: [main]
@@ -25,14 +30,19 @@ on:
       - "benchmarks/evidence/jeam_repeated_recovery_v2/**"
       - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1.json"
       - "benchmarks/results/jeam_fixed_cdm_sampler_comparison_v1_addendum.json"
+      - "benchmarks/results/jeam_fixed_psdm_recovery_v1.json"
       - "benchmarks/specs/jeam_fixed_cdm_sampler_comparison_v1.json"
+      - "benchmarks/specs/jeam_fixed_psdm_recovery_v1.json"
+      - "benchmarks/specs/jeam_fixed_psdm_recovery_v1_addendum.json"
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
       - "scripts/jeam_repeated_recovery_report.py"
       - "scripts/jeam_sampler_comparison_report.py"
+      - "scripts/jeam_psdm_recovery_report.py"
       - "scripts/verify_jeam_repeated_recovery_evidence.py"
       - "scripts/verify_jeam_sampler_comparison_evidence.py"
+      - "scripts/verify_jeam_psdm_recovery_evidence.py"
       - "src/hssm/**"
   release:
     types: [published]
@@ -95,6 +105,33 @@ jobs:
             echo "JEAM sampler report contains a host path or execution error"
             exit 1
           fi
+      - name: Validate archived JEAM fixed-PSDM report
+        env:
+          MPLCONFIGDIR: /tmp/hssm-jeam-psdm-report-matplotlib
+          XDG_CACHE_HOME: /tmp/hssm-jeam-psdm-report-cache
+        run: |
+          mkdir -p "$MPLCONFIGDIR" "$XDG_CACHE_HOME"
+          uv run --group docs marimo check --strict docs/tutorials/jeam_fixed_psdm_recovery.py
+          uv run --group docs marimo export html docs/tutorials/jeam_fixed_psdm_recovery.py \
+            -o /tmp/jeam-fixed-psdm-recovery.html --force --no-include-code \
+            > /tmp/jeam-fixed-psdm-recovery-export.log 2>&1
+          cat /tmp/jeam-fixed-psdm-recovery-export.log
+          grep -Fq "14/16 truths in archived HDIs" /tmp/jeam-fixed-psdm-recovery.html
+          grep -Fq "Overall gate failed" /tmp/jeam-fixed-psdm-recovery.html
+          grep -Fq "Public support remains blocked" /tmp/jeam-fixed-psdm-recovery.html
+          grep -Fq "JEAM fixed-budget endpoint" /tmp/jeam-fixed-psdm-recovery.html
+          grep -Fq "cede87d5a5a2c9789939b66962ebb025b270a13966aa2d657d5b0cbb95e9c2c4" \
+            /tmp/jeam-fixed-psdm-recovery.html
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            /tmp/jeam-fixed-psdm-recovery.html /tmp/jeam-fixed-psdm-recovery-export.log; then
+            echo "JEAM fixed-PSDM report contains a host path or execution error"
+            exit 1
+          fi
+          if grep -Eiq 'JEAM MLE|direct maximum-likelihood|Every raw dataset|same saved datasets|Sampling [0-9]+ chain' \
+            /tmp/jeam-fixed-psdm-recovery.html /tmp/jeam-fixed-psdm-recovery-export.log; then
+            echo "JEAM fixed-PSDM report contains a stale claim or sampling output"
+            exit 1
+          fi
       - name: Build docs (strict)
         env:
           MPLCONFIGDIR: /tmp/hssm-jeam-sampler-report-matplotlib
@@ -113,6 +150,27 @@ jobs:
           if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
             "$report_page"; then
             echo "Built JEAM sampler report contains contamination"
+            exit 1
+          fi
+          psdm_report_page=site/tutorials/jeam_fixed_psdm_recovery/index.html
+          grep -Fq "14/16 truths in archived HDIs" "$psdm_report_page"
+          grep -Fq "Overall gate failed" "$psdm_report_page"
+          grep -Fq "Public support remains blocked" "$psdm_report_page"
+          grep -Fq "JEAM fixed-budget endpoint" "$psdm_report_page"
+          grep -Fq "cede87d5a5a2c9789939b66962ebb025b270a13966aa2d657d5b0cbb95e9c2c4" \
+            "$psdm_report_page"
+          if [ "$(grep -o 'data:image/png' "$psdm_report_page" | wc -l)" -lt 4 ]; then
+            echo "Built JEAM fixed-PSDM report is missing figure outputs"
+            exit 1
+          fi
+          if grep -Eq '/Users/|/home/|/private/|/var/folders/|file://|Traceback|MarimoExceptionRaisedError|ModuleNotFoundError' \
+            "$psdm_report_page"; then
+            echo "Built JEAM fixed-PSDM report contains contamination"
+            exit 1
+          fi
+          if grep -Eiq 'JEAM MLE|direct maximum-likelihood|Every raw dataset|same saved datasets|Sampling [0-9]+ chain' \
+            "$psdm_report_page"; then
+            echo "Built JEAM fixed-PSDM report contains a stale claim or sampling output"
             exit 1
           fi
 

--- a/docs/tutorials/jeam_fixed_psdm_recovery.py
+++ b/docs/tutorials/jeam_fixed_psdm_recovery.py
@@ -1,11 +1,19 @@
-"""Inspect the preregistered fixed-PSDM recovery evidence without rerunning MCMC.
+"""Inspect authenticated compact evidence from fixed-PSDM recovery v1.
 
-This marimo notebook reads the committed protocol and compact v1 result. It does not
-import JEAM, construct an HSSM model, or load the raw posterior traces.
+This marimo report calls one hash-before-parse reporting API. It imports neither HSSM,
+JEAM, nor PyMC and does not access the network, simulate, optimize, predict, or sample.
+The figures present authenticated producer-recorded compact summaries; missing raw draws
+cannot be reconstructed here.
 
 Open it from the HSSM repository root::
 
     uv run --group docs marimo edit docs/tutorials/jeam_fixed_psdm_recovery.py
+
+Export a path-clean static rendering with::
+
+    uv run --group docs marimo export html \
+        docs/tutorials/jeam_fixed_psdm_recovery.py \
+        -o /tmp/jeam-fixed-psdm-recovery.html --force --no-include-code
 """
 
 # ruff: noqa: B018, D401, E501, PLR1711
@@ -17,89 +25,149 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
-    import json
-    from pathlib import Path
+    import sys as _sys
+    from pathlib import Path as _Path
 
     import marimo as mo
     import matplotlib.pyplot as plt
     import numpy as np
     import pandas as pd
 
-    return Path, json, mo, np, pd, plt
-
-
-@app.cell
-def _(mo):
-    mo.md(r"""
-    # Fixed projected-spherical diffusion recovery in HSSM
-
-    This report asks whether the fixed projected spherical diffusion model (PSDM) keeps
-    JEAM's likelihood intact when used through ordinary `hssm.HSSM`, and whether one
-    frozen gradient-free inference protocol recovers its parameters across four datasets.
-
-    The answer is deliberately mixed: **the numerical handshake passes, but the complete
-    recovery gate fails**. The failure is useful evidence. It prevents us from presenting
-    this exact ordered-Slice configuration as generally reliable while showing precisely
-    which parts of the integration already work.
-
-    Everything below is reconstructed from committed JSON. Opening this notebook never
-    reruns optimization, simulation, posterior sampling, or prediction.
-    """)
-    return
-
-
-@app.cell
-def _(Path, json):
-    repo_root = Path(__file__).resolve().parents[2]
-    artifact_path = (
-        repo_root / "benchmarks" / "results" / "jeam_fixed_psdm_recovery_v1.json"
+    _source = _Path(globals().get("__file__", _Path.cwd())).resolve()
+    _repo_root = next(
+        _candidate
+        for _candidate in (_source, *_source.parents)
+        if (_candidate / "pyproject.toml").is_file()
     )
-    spec_path = repo_root / "benchmarks" / "specs" / "jeam_fixed_psdm_recovery_v1.json"
-    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
-    spec = json.loads(spec_path.read_text(encoding="utf-8"))
-    return artifact, artifact_path, repo_root, spec, spec_path
+    if str(_repo_root) not in _sys.path:
+        _sys.path.insert(0, str(_repo_root))
+
+    from scripts.jeam_psdm_recovery_report import load_psdm_recovery_report
+
+    return load_psdm_recovery_report, mo, np, pd, plt
 
 
 @app.cell
-def _(artifact, mo):
-    _parameters = [
-        parameter
-        for scenario in artifact["scenarios"]
-        for parameter in scenario["parameters"]
-    ]
-    _covered = sum(parameter["truth_in_hdi"] for parameter in _parameters)
-    _maximum_rhat = max(parameter["rhat"] for parameter in _parameters)
-    _minimum_bulk_ess = min(parameter["ess_bulk"] for parameter in _parameters)
-    _maximum_objective_error = max(
-        scenario["maximum_objective_absolute_error"]
-        for scenario in artifact["scenarios"]
+def _(load_psdm_recovery_report):
+    report = load_psdm_recovery_report()
+    aggregate_records = report["aggregate_records"]
+    evidence_boundary = report["evidence_boundary"]
+    failure_records = report["failure_records"]
+    objective_records = report["objective_records"]
+    parameter_records = report["parameter_records"]
+    predictive_records = report["predictive_records"]
+    provenance = report["provenance"]
+    scenario_records = report["scenario_records"]
+    summary = report["summary"]
+    return (
+        aggregate_records,
+        evidence_boundary,
+        failure_records,
+        objective_records,
+        parameter_records,
+        predictive_records,
+        provenance,
+        scenario_records,
+        summary,
     )
+
+
+@app.cell
+def _(mo, summary):
+    _gate = "passed" if summary["overall_pass"] else "failed"
+    _promotion = "blocked" if summary["ecosystem_promotion_blocked"] else "not blocked"
     mo.md(f"""
-    ## Result at a glance
+    # Archived fixed-PSDM recovery evidence
 
-    | Frozen v1 gate | Scenarios | 94% HDI coverage | Maximum R-hat | Minimum bulk ESS | Maximum objective error |
-    |---|---:|---:|---:|---:|---:|
-    | **{"PASS" if artifact["gate"]["passed"] else "FAIL"}** | {len(artifact["scenarios"])} | {_covered}/{len(_parameters)} | {_maximum_rhat:.4f} | {_minimum_bulk_ess:.0f} | {_maximum_objective_error:.2e} |
+    This report audits a seeded four-scenario, scalar/intercept-only recovery smoke from
+    authenticated compact summaries. It is **not** a calibration study, a current-JEAM
+    rerun, or raw-trace reanalysis.
 
-    The canonical run took `{artifact["total_runtime_seconds"]:.1f}` seconds with JEAM
-    `{artifact["provenance"]["jeam_revision"][:12]}`. Its thresholds were committed
-    before the run and were not relaxed afterward.
+    | Archived result | Scenarios | HDI summary | Exact failures | Support status |
+    |---|---:|---:|---:|---|
+    | **Overall gate {_gate}** | {summary["scenario_count"]} | **{summary["truth_in_hdi"]}/{summary["truth_total"]} truths in archived HDIs** | {summary["failure_count"]} | **Public support remains {_promotion}** |
+
+    A successful integrity check preserves the expected negative scientific result. It
+    does not turn that result into recovery evidence.
     """)
     return
 
 
 @app.cell
-def _(artifact, mo):
+def _(evidence_boundary, mo, pd, provenance, summary):
+    _provenance = pd.DataFrame(
+        [
+            ("result SHA-256", provenance["result_sha256"]),
+            ("result commit", provenance["result_commit"]),
+            ("historical HSSM runner", provenance["hssm_revision"]),
+            ("historical JEAM", provenance["historical_jeam_revision"]),
+            ("current safety JEAM", provenance["current_safety_jeam_revision"]),
+            ("current JEAM rerun", provenance["current_safety_revision_rerun"]),
+            ("historical Python", provenance["python_version"]),
+            ("evidence class", summary["evidence_class"]),
+        ],
+        columns=["provenance field", "authenticated value"],
+    )
+    _retention = evidence_boundary["retention"]
+    _boundary = pd.DataFrame(
+        [
+            ("raw datasets retained", _retention["raw_datasets_retained_in_git"]),
+            ("raw traces retained", _retention["raw_traces_retained_in_git"]),
+            (
+                "raw prior-predictive draws retained",
+                _retention["raw_prior_predictive_draws_retained"],
+            ),
+            (
+                "raw posterior-predictive draws retained",
+                _retention["raw_posterior_predictive_draws_retained"],
+            ),
+            (
+                "ordered Slice identity authenticated",
+                evidence_boundary["ordered_slice_identity_independently_authenticated"],
+            ),
+            (
+                "runtime HSSM checkout authenticated",
+                evidence_boundary["runtime_hssm_import_bound_to_recorded_checkout"],
+            ),
+            (
+                "independent raw re-verification",
+                evidence_boundary["independent_raw_reverification"],
+            ),
+        ],
+        columns=["evidence boundary", "status"],
+    )
+    mo.vstack(
+        [
+            mo.md("""
+            ## Provenance and evidence boundary
+
+            The verifier authenticates the frozen spec, post-hoc archive addendum, and
+            compact result before parsing the same byte snapshots. Recorded hashes are
+            identifiers for missing payloads, not substitutes for retained data or draws.
+            """),
+            mo.ui.table(_provenance, selection=None, pagination=False),
+            mo.ui.table(_boundary, selection=None, pagination=False),
+            mo.md(
+                "**Promotion blockers:** "
+                + "; ".join(evidence_boundary["promotion_blockers"])
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo, parameter_records, scenario_records):
     scenario_selector = mo.ui.dropdown(
         options={
-            scenario["scenario"].replace("_", " ").title(): scenario["scenario"]
-            for scenario in artifact["scenarios"]
+            row["scenario"].replace("_", " ").title(): row["scenario"]
+            for row in scenario_records
         },
         value="High Threshold Strong Radial",
         label="Scenario",
     )
     parameter_selector = mo.ui.dropdown(
-        options={name: name for name in artifact["parameter_order"]},
+        options={row["parameter"]: row["parameter"] for row in parameter_records},
         value="v_y",
         label="Parameter",
     )
@@ -108,100 +176,87 @@ def _(artifact, mo):
 
 
 @app.cell
-def _(artifact, pd, spec):
-    _optimizer_limits = spec["scientific_acceptance"]["optimizer_recovery"][
-        "maximum_absolute_error"
-    ]
-    _posterior_limits = spec["scientific_acceptance"]["posterior_recovery"]
-    _parameter_rows = []
-    _scenario_rows = []
-    for _scenario in artifact["scenarios"]:
-        _scenario_rows.append(
-            {
-                "scenario": _scenario["scenario"],
-                "objective_error": _scenario["maximum_objective_absolute_error"],
-                "optimizer_parameter_error": _scenario["optimizer"][
-                    "maximum_parameter_absolute_error"
-                ],
-                "sampling_seconds": _scenario["runtime_seconds"]["sampling"],
-                "total_seconds": _scenario["runtime_seconds"]["total"],
-            }
-        )
-        for _parameter in _scenario["parameters"]:
-            _name = _parameter["name"]
-            _parameter_rows.append(
-                {
-                    "scenario": _scenario["scenario"],
-                    **_parameter,
-                    "optimizer_abs_error": abs(
-                        _parameter["optimizer_estimate"] - _parameter["truth"]
-                    ),
-                    "posterior_abs_error": abs(
-                        _parameter["posterior_mean"] - _parameter["truth"]
-                    ),
-                    "optimizer_gate_pass": abs(
-                        _parameter["optimizer_estimate"] - _parameter["truth"]
-                    )
-                    <= _optimizer_limits[_name],
-                    "diagnostics_pass": (
-                        _parameter["rhat"] < _posterior_limits["maximum_rhat_exclusive"]
-                        and _parameter["ess_bulk"]
-                        > _posterior_limits["minimum_bulk_ess_exclusive"]
-                        and _parameter["ess_tail"]
-                        > _posterior_limits["minimum_tail_ess_exclusive"]
-                        and _parameter["mcse_over_posterior_sd"]
-                        < _posterior_limits["maximum_mcse_over_posterior_sd_exclusive"]
-                    ),
-                }
-            )
-    parameter_df = pd.DataFrame(_parameter_rows)
-    scenario_df = pd.DataFrame(_scenario_rows)
-    aggregate_df = pd.DataFrame(artifact["aggregate"])
-    return aggregate_df, parameter_df, scenario_df
+def _(
+    aggregate_records,
+    failure_records,
+    objective_records,
+    parameter_records,
+    pd,
+    predictive_records,
+    scenario_records,
+):
+    aggregate_df = pd.DataFrame(aggregate_records)
+    failure_df = pd.DataFrame(failure_records)
+    objective_df = pd.DataFrame(objective_records)
+    parameter_df = pd.DataFrame(parameter_records)
+    predictive_df = pd.DataFrame(predictive_records)
+    scenario_df = pd.DataFrame(scenario_records)
+    return (
+        aggregate_df,
+        failure_df,
+        objective_df,
+        parameter_df,
+        predictive_df,
+        scenario_df,
+    )
 
 
 @app.cell
-def _(artifact, mo, spec):
-    _scope = spec["scope"]
-    _execution = spec["execution"]
-    _settings = _scope["fixed_model_settings"]
-    mo.md(f"""
-    ## What was tested
+def _(failure_df, mo):
+    mo.vstack(
+        [
+            mo.md("""
+            ## The eight recomputed compact failures
 
-    - **HSSM class:** ordinary `hssm.HSSM`, not a PSDM subclass
-    - **Model:** `{_scope["model"]}` with black-box JEAM likelihood
-    - **Observation:** `[rt, response]` with density measure `{_scope["density_measure"]}`
-    - **RT support:** finite and strictly positive
-    - **Response support:** polar angle on the closed interval `[0, π]`
-    - **Parameters:** `[v_x, v_y, a, t]`; `v_y` is a nonnegative radial drift
-    - **Fixed settings:** `sigma={_settings["sigma"]}`, `s_v={_settings["s_v"]}`,
-      `s_t={_settings["s_t"]}`, fixed threshold, and `p_outlier=None`
-    - **Inference:** {_execution["chains"]} chains, {_execution["tune"]} tuning +
-      {_execution["draws"]} retained draws, with one PyMC Slice step per parameter in
-      `[v_x, v_y, a, t]`
-
-    The HSSM priors were not tuned to the generating values. The runner constructed the
-    public model defaults and asserted their exact distributions, bounds, and initial
-    values before fitting. Every raw dataset and NetCDF trace was saved before summaries;
-    the compact artifact records their hashes.
-    """)
+            These messages are derived from authenticated compact fields and the frozen
+            thresholds. They identify failed recorded subgates; without raw traces they
+            do not establish a sampler, mixing, or identifiability cause.
+            """),
+            mo.ui.table(
+                failure_df.loc[:, ["order", "message", "category"]],
+                selection=None,
+                pagination=False,
+            ),
+        ]
+    )
     return
 
 
 @app.cell
-def _(artifact, mo, pd):
-    _failures = pd.DataFrame({"predeclared failure": artifact["gate"]["failures"]})
+def _(mo, parameter_df, scenario_selector):
+    _columns = {
+        "parameter": "parameter",
+        "truth": "truth",
+        "optimizer_endpoint": "JEAM fixed-budget endpoint",
+        "optimizer_absolute_error": "endpoint |error|",
+        "optimizer_recovery_passed": "endpoint gate",
+        "posterior_mean": "recorded posterior mean",
+        "posterior_sd": "recorded posterior SD",
+        "hdi_lower": "94% HDI lower",
+        "hdi_upper": "94% HDI upper",
+        "truth_in_hdi": "covers truth",
+        "rhat": "R-hat",
+        "ess_bulk": "bulk ESS",
+        "ess_tail": "tail ESS",
+        "mcse_over_posterior_sd": "MCSE/SD",
+        "diagnostics_passed": "diagnostic subgate",
+    }
+    _selected = (
+        parameter_df.loc[parameter_df["scenario"] == scenario_selector.value]
+        .loc[:, list(_columns)]
+        .rename(columns=_columns)
+        .round(4)
+    )
     mo.vstack(
         [
             mo.md("""
-            ## The exact failed gates
+            ## Inspect one scenario
 
-            Eight messages arise from four substantive issues: convergence and efficiency
-            fail for `a` and `t` in the high-threshold scenario, while `v_y` optimizer
-            recovery fails in the low-threshold scenario and therefore also fails its
-            aggregate RMSE gate.
+            The optimizer column is a deterministic differential-evolution endpoint from
+            a fixed budget of 20 iterations and 1,260 evaluations with `polish=false`.
+            It is not a demonstrated converged optimum or maximum-likelihood estimate.
             """),
-            mo.ui.table(_failures, selection=None, pagination=False),
+            mo.ui.table(_selected, selection=None, pagination=False),
         ]
     )
     return
@@ -210,52 +265,11 @@ def _(artifact, mo, pd):
 @app.cell
 def _(mo):
     mo.md("""
-    ## Inspect one scenario
+    ## Recorded recovery summaries across four datasets
 
-    Select a scenario above. The table separates three targets: generating truth, the
-    direct-JEAM maximum-likelihood estimate, and the HSSM posterior. An MLE is not expected
-    to equal a posterior mean. The numerical handshake is instead tested by running the
-    direct JEAM and compiled HSSM optimizers with identical bounds, seeds, and budgets.
-    """)
-    return
-
-
-@app.cell
-def _(mo, parameter_df, scenario_selector):
-    _columns = {
-        "name": "parameter",
-        "truth": "truth",
-        "optimizer_estimate": "JEAM MLE",
-        "optimizer_abs_error": "MLE |error|",
-        "optimizer_gate_pass": "MLE gate",
-        "posterior_mean": "HSSM mean",
-        "posterior_abs_error": "posterior |error|",
-        "hdi_lower": "94% HDI lower",
-        "hdi_upper": "94% HDI upper",
-        "truth_in_hdi": "covers truth",
-        "rhat": "R-hat",
-        "ess_bulk": "bulk ESS",
-        "mcse_over_posterior_sd": "MCSE/SD",
-        "diagnostics_pass": "diagnostics gate",
-    }
-    _selected = (
-        parameter_df.loc[parameter_df["scenario"] == scenario_selector.value]
-        .loc[:, list(_columns)]
-        .rename(columns=_columns)
-        .round(4)
-    )
-    mo.ui.table(_selected, selection=None, pagination=False)
-    return
-
-
-@app.cell
-def _(mo):
-    mo.md("""
-    ## Recovery across all four datasets
-
-    Choose a parameter above. Crosses mark generating truth, open circles the direct-JEAM
-    MLE, squares the HSSM posterior mean, and horizontal lines the 94% HSSM HDI. This view
-    keeps a single problematic dataset visible instead of hiding it in an average.
+    Choose a parameter above. Crosses mark generating truth, open circles the JEAM
+    fixed-budget endpoint, squares the recorded posterior mean, and horizontal lines the
+    recorded 94% HDI. These are compact summaries, not posterior draws.
     """)
     return
 
@@ -263,7 +277,7 @@ def _(mo):
 @app.cell
 def _(parameter_df, parameter_selector, plt):
     _selected = parameter_df.loc[
-        parameter_df["name"] == parameter_selector.value
+        parameter_df["parameter"] == parameter_selector.value
     ].reset_index(drop=True)
     _positions = range(len(_selected))
     _figure, _axis = plt.subplots(figsize=(9.5, 4.2))
@@ -275,7 +289,7 @@ def _(parameter_df, parameter_selector, plt):
             color="#4472C4",
             linewidth=4,
             alpha=0.42,
-            label="HSSM 94% HDI" if _position == 0 else None,
+            label="recorded 94% HDI" if _position == 0 else None,
         )
     _axis.scatter(
         _selected["truth"],
@@ -288,14 +302,14 @@ def _(parameter_df, parameter_selector, plt):
         zorder=4,
     )
     _axis.scatter(
-        _selected["optimizer_estimate"],
+        _selected["optimizer_endpoint"],
         list(_positions),
         marker="o",
         s=52,
         facecolors="white",
         edgecolors="#E67E22",
         linewidth=1.8,
-        label="direct JEAM MLE",
+        label="JEAM fixed-budget endpoint",
         zorder=3,
     )
     _axis.scatter(
@@ -304,7 +318,7 @@ def _(parameter_df, parameter_selector, plt):
         marker="s",
         s=48,
         color="#4472C4",
-        label="HSSM posterior mean",
+        label="recorded posterior mean",
         zorder=3,
     )
     _axis.set_yticks(
@@ -313,64 +327,70 @@ def _(parameter_df, parameter_selector, plt):
     )
     _axis.invert_yaxis()
     _axis.set_xlabel(parameter_selector.value)
-    _axis.set_title(f"Recovery of {parameter_selector.value}")
+    _axis.set_title(f"Archived summaries for {parameter_selector.value}")
     _axis.grid(axis="x", alpha=0.2)
     _axis.legend(loc="center left", bbox_to_anchor=(1.01, 0.5))
     _figure.tight_layout()
+    plt.close(_figure)
     _figure
     return
 
 
 @app.cell
-def _(mo):
-    mo.md("""
-    ## Did HSSM change JEAM's likelihood?
-
-    No detectable mismatch appears. The plot shows the largest direct-JEAM versus
-    compiled-HSSM objective difference among three points per dataset. The red line is the
-    preregistered tolerance. Both optimizers also returned exactly the same parameter
-    vector in every scenario.
-    """)
-    return
-
-
-@app.cell
-def _(artifact, mo, pd, scenario_selector):
-    _scenario = next(
-        row
-        for row in artifact["scenarios"]
-        if row["scenario"] == scenario_selector.value
-    )
-    _rows = []
-    for _index, _candidate in enumerate(_scenario["objective_candidates"], start=1):
-        _rows.append(
-            {
-                "candidate": _index,
-                "direct JEAM NLL": _candidate["direct_jeam"],
-                "compiled HSSM NLL": _candidate["compiled_hssm"],
-                "absolute error": _candidate["absolute_error"],
+def _(mo, objective_df, scenario_selector):
+    _selected = (
+        objective_df.loc[objective_df["scenario"] == scenario_selector.value]
+        .loc[
+            :,
+            [
+                "candidate",
+                "direct_jeam",
+                "compiled_hssm",
+                "absolute_error",
+                "passed",
+            ],
+        ]
+        .rename(
+            columns={
+                "direct_jeam": "direct historical JEAM NLL",
+                "compiled_hssm": "compiled historical HSSM NLL",
+                "absolute_error": "absolute difference",
+                "passed": "compact parity gate",
             }
         )
-    _objective_table = pd.DataFrame(_rows).round(12)
-    mo.ui.table(_objective_table, selection=None, pagination=False)
+    )
+    mo.vstack(
+        [
+            mo.md("""
+            ## Same-producer adapter fidelity
+
+            The archive compares direct and compiled objectives from the same historical
+            JEAM producer. Agreement supports adapter fidelity at the recorded candidates;
+            it is not independent likelihood validation or evidence about current JEAM.
+            """),
+            mo.ui.table(_selected, selection=None, pagination=False),
+        ]
+    )
     return
 
 
 @app.cell
-def _(plt, scenario_df, spec):
-    _threshold = spec["scientific_acceptance"]["maximum_objective_absolute_error"]
-    _figure, _axis = plt.subplots(figsize=(8.5, 3.7))
-    _axis.barh(
-        [name.replace("_", " ") for name in scenario_df["scenario"]],
-        scenario_df["objective_error"],
-        color="#70AD47",
+def _(objective_df, plt, scenario_df):
+    _errors = objective_df.groupby("scenario")["absolute_error"].max()
+    _limits = scenario_df.set_index("scenario")["objective_absolute_error_limit"]
+    _labels = [name.replace("_", " ") for name in _errors.index]
+    _figure, _axis = plt.subplots(figsize=(8.7, 3.8))
+    _axis.barh(_labels, _errors.values, color="#70AD47")
+    _axis.axvline(
+        _limits.iloc[0], color="#B22222", linestyle="--", label="frozen limit"
     )
-    _axis.axvline(_threshold, color="#B22222", linestyle="--", label="frozen limit")
-    _axis.set_xscale("log")
-    _axis.set_xlabel("maximum absolute NLL difference (log scale)")
-    _axis.set_title("Direct JEAM and compiled HSSM agree to numerical precision")
+    _axis.set_xlabel("maximum recorded absolute NLL difference")
+    _axis.set_title("Historical same-producer objective comparisons")
+    _axis.ticklabel_format(axis="x", style="sci", scilimits=(0, 0))
+    _axis.grid(axis="x", alpha=0.2)
     _axis.legend()
     _figure.tight_layout()
+    plt.close(_figure)
     _figure
     return
 
@@ -378,56 +398,59 @@ def _(plt, scenario_df, spec):
 @app.cell
 def _(mo):
     mo.md("""
-    ## Where ordered Slice falls short
+    ## Recorded posterior diagnostic margins
 
-    Each bar divides a diagnostic by its frozen failure boundary; **bars above one fail**.
-    For R-hat, the plotted quantity is `(R-hat - 1) / (1.01 - 1)`. For bulk ESS it is
-    `400 / ESS`, so all three groups share the same direction. Select the high-threshold
-    scenario to see the `a` and `t` failures directly.
+    Each bar is normalized so **one or above fails** the frozen exclusive threshold.
+    These values are authenticated compact summaries. Missing traces prevent independent
+    recomputation and prevent attributing failures to an authenticated sampler identity.
     """)
     return
 
 
 @app.cell
-def _(np, parameter_df, plt, scenario_selector, spec):
+def _(np, parameter_df, plt, scenario_selector):
     _selected = parameter_df.loc[
         parameter_df["scenario"] == scenario_selector.value
     ].reset_index(drop=True)
-    _limits = spec["scientific_acceptance"]["posterior_recovery"]
-    _rhat_limit = _limits["maximum_rhat_exclusive"]
-    _ess_limit = _limits["minimum_bulk_ess_exclusive"]
-    _mcse_limit = _limits["maximum_mcse_over_posterior_sd_exclusive"]
     _x = np.arange(len(_selected))
-    _width = 0.24
-    _figure, _axis = plt.subplots(figsize=(8.5, 4.0))
+    _width = 0.19
+    _figure, _axis = plt.subplots(figsize=(9, 4.1))
     _axis.bar(
-        _x - _width,
-        (_selected["rhat"] - 1.0) / (_rhat_limit - 1.0),
+        _x - 1.5 * _width,
+        (_selected["rhat"] - 1.0) / (_selected["rhat_limit"] - 1.0),
         _width,
         label="R-hat margin",
         color="#9DC3E6",
     )
     _axis.bar(
-        _x,
-        _ess_limit / _selected["ess_bulk"],
+        _x - 0.5 * _width,
+        _selected["bulk_ess_limit"] / _selected["ess_bulk"],
         _width,
         label="bulk ESS margin",
         color="#70AD47",
     )
     _axis.bar(
-        _x + _width,
-        _selected["mcse_over_posterior_sd"] / _mcse_limit,
+        _x + 0.5 * _width,
+        _selected["tail_ess_limit"] / _selected["ess_tail"],
+        _width,
+        label="tail ESS margin",
+        color="#8064A2",
+    )
+    _axis.bar(
+        _x + 1.5 * _width,
+        _selected["mcse_over_posterior_sd"] / _selected["mcse_over_posterior_sd_limit"],
         _width,
         label="MCSE/SD margin",
         color="#F4B183",
     )
     _axis.axhline(1.0, color="#B22222", linestyle="--", label="failure boundary")
-    _axis.set_xticks(_x, _selected["name"])
-    _axis.set_ylabel("observed diagnostic / frozen boundary")
+    _axis.set_xticks(_x, _selected["parameter"])
+    _axis.set_ylabel("recorded diagnostic / frozen boundary")
     _axis.set_title(scenario_selector.value.replace("_", " ").title())
     _axis.grid(axis="y", alpha=0.2)
     _axis.legend(ncol=2, fontsize=8)
     _figure.tight_layout()
+    plt.close(_figure)
     _figure
     return
 
@@ -435,43 +458,39 @@ def _(np, parameter_df, plt, scenario_selector, spec):
 @app.cell
 def _(mo):
     mo.md("""
-    ## Posterior prediction still passes
+    ## Producer-recorded predictive summaries
 
-    The inference limitations do not produce a visible failure in the frozen predictive
-    summaries. The left panel compares observed and posterior-predictive RT quantiles. The
-    right compares mean polar unit-vector components, `[mean(sin(response)),
-    mean(cos(response))]`. Raw angular means are inappropriate for directional data.
+    The compact RT-quantile and polar-unit-vector errors meet their frozen thresholds.
+    Raw posterior-predictive draws were not retained, so the distributions cannot be
+    independently recomputed or inspected here.
     """)
     return
 
 
 @app.cell
-def _(artifact, np, plt, scenario_selector):
-    _scenario = next(
-        row
-        for row in artifact["scenarios"]
-        if row["scenario"] == scenario_selector.value
-    )
-    _predictive = _scenario["posterior_predictive"]
-    _probabilities = np.asarray(_predictive["rt_probabilities"])
+def _(np, plt, predictive_df, scenario_selector):
+    _row = predictive_df.loc[predictive_df["scenario"] == scenario_selector.value].iloc[
+        0
+    ]
+    _probabilities = np.asarray(_row["rt_probabilities"])
     _figure, (_rt_axis, _angle_axis) = plt.subplots(1, 2, figsize=(9, 3.8))
     _rt_axis.plot(
         _probabilities,
-        _predictive["observed_rt_quantiles"],
+        _row["observed_rt_quantiles"],
         marker="o",
         color="#111111",
-        label="observed",
+        label="observed compact summary",
     )
     _rt_axis.plot(
         _probabilities,
-        _predictive["predictive_rt_quantiles"],
+        _row["predictive_rt_quantiles"],
         marker="s",
         color="#4472C4",
-        label="posterior predictive",
+        label="predictive compact summary",
     )
     _rt_axis.set_xlabel("RT quantile probability")
     _rt_axis.set_ylabel("seconds")
-    _rt_axis.set_title("Response-time quantiles")
+    _rt_axis.set_title("Recorded RT quantiles")
     _rt_axis.grid(alpha=0.2)
     _rt_axis.legend(fontsize=8)
 
@@ -479,91 +498,89 @@ def _(artifact, np, plt, scenario_selector):
     _width = 0.36
     _angle_axis.bar(
         _x - _width / 2,
-        _predictive["observed_mean_polar_unit_vector"],
+        _row["observed_mean_polar_unit_vector"],
         _width,
-        label="observed",
+        label="observed compact summary",
         color="#A5A5A5",
     )
     _angle_axis.bar(
         _x + _width / 2,
-        _predictive["predictive_mean_polar_unit_vector"],
+        _row["predictive_mean_polar_unit_vector"],
         _width,
-        label="posterior predictive",
+        label="predictive compact summary",
         color="#4472C4",
     )
     _angle_axis.set_xticks(_x, ["mean sin(θ)", "mean cos(θ)"])
-    _angle_axis.set_title("Polar unit-vector mean")
+    _angle_axis.set_title("Recorded polar unit-vector means")
     _angle_axis.grid(axis="y", alpha=0.2)
     _angle_axis.legend(fontsize=8)
     _figure.suptitle(scenario_selector.value.replace("_", " ").title())
     _figure.tight_layout()
+    plt.close(_figure)
     _figure
     return
 
 
 @app.cell
-def _(aggregate_df, artifact, mo, parameter_df):
+def _(aggregate_df, evidence_boundary, mo, parameter_df, summary):
     _high = parameter_df.loc[
         parameter_df["scenario"] == "high_threshold_strong_radial"
-    ].set_index("name")
+    ].set_index("parameter")
     _low_vy = parameter_df.loc[
         (parameter_df["scenario"] == "low_threshold_balanced_drift")
-        & (parameter_df["name"] == "v_y")
+        & (parameter_df["parameter"] == "v_y")
     ].iloc[0]
-    _aggregate = aggregate_df.set_index("name")
+    _aggregate = aggregate_df.set_index("parameter")
     mo.md(f"""
-    ## Scientific interpretation
+    ## Interpretation and next experiments
 
-    1. **The HSSM handshake is numerically intact.** Direct JEAM and compiled HSSM agree
-       to `{max(s["maximum_objective_absolute_error"] for s in artifact["scenarios"]):.2e}`
-       in NLL, and their optimizer vectors are identical in every scenario.
-    2. **This ordered-Slice budget is not a general recommendation.** In the
-       high-threshold case, `a` has R-hat `{_high.loc["a", "rhat"]:.4f}` and bulk ESS
-       `{_high.loc["a", "ess_bulk"]:.0f}`; `t` has R-hat
-       `{_high.loc["t", "rhat"]:.4f}` and bulk ESS
-       `{_high.loc["t", "ess_bulk"]:.0f}`. The compact artifact establishes insufficient
-       mixing at this budget; it does not by itself identify the full posterior geometry.
-    3. **Low-threshold radial drift is weakly recovered in this dataset.** For `v_y`, truth
-       is `{_low_vy["truth"]:.2f}`, the MLE is `{_low_vy["optimizer_estimate"]:.3f}`, and
-       the posterior is `{_low_vy["posterior_mean"]:.3f} ± {_low_vy["posterior_sd"]:.3f}`
-       with 94% HDI `[{_low_vy["hdi_lower"]:.3f}, {_low_vy["hdi_upper"]:.3f}]`. The broad
-       interval covers truth, so the optimizer miss should not be misread as an HSSM/JEAM
-       mismatch.
-    4. **Aggregate posterior recovery is encouraging but limited.** Posterior RMSE passes
-       for all four parameters and {_aggregate["hdi_coverage"].mul(4).sum():.0f}/16
-       intervals cover truth. Four datasets are a regression benchmark, not a calibration
-       study of nominal 94% coverage.
+    1. **Historical adapter fidelity passed its compact checks.** The largest recorded
+       same-producer objective difference is
+       `{summary["maximum_objective_absolute_error"]:.2e}`. This does not independently
+       validate the likelihood or current JEAM.
+    2. **Six recorded diagnostic thresholds failed for `a` and `t` in one scenario.**
+       The high-threshold rows contain R-hat `{_high.loc["a", "rhat"]:.4f}` for `a`
+       and `{_high.loc["t", "rhat"]:.4f}` for `t`. Missing traces and unauthenticated
+       sampler identity mean v1 does not establish their cause.
+    3. **The low-threshold `v_y` fixed-budget endpoint missed its limit.** Truth was
+       `{_low_vy["truth"]:.2f}` and the endpoint was
+       `{_low_vy["optimizer_endpoint"]:.3f}`. The recorded posterior HDI covered truth;
+       that pattern motivates, but does not prove, an information hypothesis.
+    4. **The result remains negative and bounded.** The archived posterior rows cover
+       `{summary["truth_in_hdi"]}/{summary["truth_total"]}` truths, while
+       `{_aggregate["hdi_coverage"].mean():.3f}` is only a four-dataset smoke summary,
+       not calibration.
 
-    The appropriate next experiment is a separately preregistered v2: first increase the
-    sampling budget on the same saved datasets to isolate mixing, then vary trial count or
-    design for the low-threshold `v_y` case to isolate information. V1 remains immutable.
+    A separately preregistered **v2a** may retain datasets and traces to test the
+    budget/mixing hypothesis. A distinct **v2b** may retain new trial-design evidence to
+    test the information hypothesis. Neither hypothesis is a v1 conclusion.
+
+    The scalar `t` prior was untruncated `HalfNormal(2)`. Configured bounds `[0, 2]` were
+    separate metadata, while likelihood support required `t < min(rt)`. The frozen
+    optimizer endpoint used `nextafter(min(rt), -inf)`, which lies inside HSSM's `1e-15`
+    numerical floor; a successor must preregister a real support margin.
+
+    **Public support remains blocked.** {evidence_boundary["successor_interpretation"]}
     """)
     return
 
 
 @app.cell
-def _(artifact_path, mo, spec_path):
+def _(mo, provenance):
     mo.md(f"""
-    ## Reproduce deliberately
+    ## Audit without rerunning v1
 
-    This notebook reads:
-
-    - `{spec_path.relative_to(spec_path.parents[2])}`
-    - `{artifact_path.relative_to(artifact_path.parents[2])}`
-
-    A smoke run is the safe first check:
+    Canonical v1 execution and writes to the archived result path are disabled. Smoke
+    mode is only a noncanonical wiring check and cannot create v1 evidence. Audit the
+    immutable compact archive with:
 
     ```bash
-    python -m scripts.benchmark_jeam_psdm_recovery \
-        --smoke --scenario baseline_asymmetric \
-        --work-dir /tmp/jeam-psdm-smoke \
-        --output /tmp/jeam-psdm-smoke.json
+    python -m scripts.verify_jeam_psdm_recovery_evidence
     ```
 
-    The canonical command requires the optional JEAM dependency and several minutes. V1
-    exits nonzero because its scientific gate fails, but still writes the complete result.
-    Do not overwrite the committed v1 artifact; use a new versioned protocol for follow-up
-    work.
+    A passing verifier must report an authentic compact archive, an expected failed
+    scientific gate, and blocked promotion. The pinned result is
+    `{provenance["result_sha256"]}`.
     """)
     return
 

--- a/docs/tutorials/jeam_fixed_psdm_recovery.py
+++ b/docs/tutorials/jeam_fixed_psdm_recovery.py
@@ -1,0 +1,572 @@
+"""Inspect the preregistered fixed-PSDM recovery evidence without rerunning MCMC.
+
+This marimo notebook reads the committed protocol and compact v1 result. It does not
+import JEAM, construct an HSSM model, or load the raw posterior traces.
+
+Open it from the HSSM repository root::
+
+    uv run --group docs marimo edit docs/tutorials/jeam_fixed_psdm_recovery.py
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711
+import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import json
+    from pathlib import Path
+
+    import marimo as mo
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+
+    return Path, json, mo, np, pd, plt
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    # Fixed projected-spherical diffusion recovery in HSSM
+
+    This report asks whether the fixed projected spherical diffusion model (PSDM) keeps
+    JEAM's likelihood intact when used through ordinary `hssm.HSSM`, and whether one
+    frozen gradient-free inference protocol recovers its parameters across four datasets.
+
+    The answer is deliberately mixed: **the numerical handshake passes, but the complete
+    recovery gate fails**. The failure is useful evidence. It prevents us from presenting
+    this exact ordered-Slice configuration as generally reliable while showing precisely
+    which parts of the integration already work.
+
+    Everything below is reconstructed from committed JSON. Opening this notebook never
+    reruns optimization, simulation, posterior sampling, or prediction.
+    """)
+    return
+
+
+@app.cell
+def _(Path, json):
+    repo_root = Path(__file__).resolve().parents[2]
+    artifact_path = (
+        repo_root / "benchmarks" / "results" / "jeam_fixed_psdm_recovery_v1.json"
+    )
+    spec_path = repo_root / "benchmarks" / "specs" / "jeam_fixed_psdm_recovery_v1.json"
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    return artifact, artifact_path, repo_root, spec, spec_path
+
+
+@app.cell
+def _(artifact, mo):
+    _parameters = [
+        parameter
+        for scenario in artifact["scenarios"]
+        for parameter in scenario["parameters"]
+    ]
+    _covered = sum(parameter["truth_in_hdi"] for parameter in _parameters)
+    _maximum_rhat = max(parameter["rhat"] for parameter in _parameters)
+    _minimum_bulk_ess = min(parameter["ess_bulk"] for parameter in _parameters)
+    _maximum_objective_error = max(
+        scenario["maximum_objective_absolute_error"]
+        for scenario in artifact["scenarios"]
+    )
+    mo.md(f"""
+    ## Result at a glance
+
+    | Frozen v1 gate | Scenarios | 94% HDI coverage | Maximum R-hat | Minimum bulk ESS | Maximum objective error |
+    |---|---:|---:|---:|---:|---:|
+    | **{"PASS" if artifact["gate"]["passed"] else "FAIL"}** | {len(artifact["scenarios"])} | {_covered}/{len(_parameters)} | {_maximum_rhat:.4f} | {_minimum_bulk_ess:.0f} | {_maximum_objective_error:.2e} |
+
+    The canonical run took `{artifact["total_runtime_seconds"]:.1f}` seconds with JEAM
+    `{artifact["provenance"]["jeam_revision"][:12]}`. Its thresholds were committed
+    before the run and were not relaxed afterward.
+    """)
+    return
+
+
+@app.cell
+def _(artifact, mo):
+    scenario_selector = mo.ui.dropdown(
+        options={
+            scenario["scenario"].replace("_", " ").title(): scenario["scenario"]
+            for scenario in artifact["scenarios"]
+        },
+        value="High Threshold Strong Radial",
+        label="Scenario",
+    )
+    parameter_selector = mo.ui.dropdown(
+        options={name: name for name in artifact["parameter_order"]},
+        value="v_y",
+        label="Parameter",
+    )
+    mo.hstack([scenario_selector, parameter_selector], justify="start", gap=2)
+    return parameter_selector, scenario_selector
+
+
+@app.cell
+def _(artifact, pd, spec):
+    _optimizer_limits = spec["scientific_acceptance"]["optimizer_recovery"][
+        "maximum_absolute_error"
+    ]
+    _posterior_limits = spec["scientific_acceptance"]["posterior_recovery"]
+    _parameter_rows = []
+    _scenario_rows = []
+    for _scenario in artifact["scenarios"]:
+        _scenario_rows.append(
+            {
+                "scenario": _scenario["scenario"],
+                "objective_error": _scenario["maximum_objective_absolute_error"],
+                "optimizer_parameter_error": _scenario["optimizer"][
+                    "maximum_parameter_absolute_error"
+                ],
+                "sampling_seconds": _scenario["runtime_seconds"]["sampling"],
+                "total_seconds": _scenario["runtime_seconds"]["total"],
+            }
+        )
+        for _parameter in _scenario["parameters"]:
+            _name = _parameter["name"]
+            _parameter_rows.append(
+                {
+                    "scenario": _scenario["scenario"],
+                    **_parameter,
+                    "optimizer_abs_error": abs(
+                        _parameter["optimizer_estimate"] - _parameter["truth"]
+                    ),
+                    "posterior_abs_error": abs(
+                        _parameter["posterior_mean"] - _parameter["truth"]
+                    ),
+                    "optimizer_gate_pass": abs(
+                        _parameter["optimizer_estimate"] - _parameter["truth"]
+                    )
+                    <= _optimizer_limits[_name],
+                    "diagnostics_pass": (
+                        _parameter["rhat"] < _posterior_limits["maximum_rhat_exclusive"]
+                        and _parameter["ess_bulk"]
+                        > _posterior_limits["minimum_bulk_ess_exclusive"]
+                        and _parameter["ess_tail"]
+                        > _posterior_limits["minimum_tail_ess_exclusive"]
+                        and _parameter["mcse_over_posterior_sd"]
+                        < _posterior_limits["maximum_mcse_over_posterior_sd_exclusive"]
+                    ),
+                }
+            )
+    parameter_df = pd.DataFrame(_parameter_rows)
+    scenario_df = pd.DataFrame(_scenario_rows)
+    aggregate_df = pd.DataFrame(artifact["aggregate"])
+    return aggregate_df, parameter_df, scenario_df
+
+
+@app.cell
+def _(artifact, mo, spec):
+    _scope = spec["scope"]
+    _execution = spec["execution"]
+    _settings = _scope["fixed_model_settings"]
+    mo.md(f"""
+    ## What was tested
+
+    - **HSSM class:** ordinary `hssm.HSSM`, not a PSDM subclass
+    - **Model:** `{_scope["model"]}` with black-box JEAM likelihood
+    - **Observation:** `[rt, response]` with density measure `{_scope["density_measure"]}`
+    - **RT support:** finite and strictly positive
+    - **Response support:** polar angle on the closed interval `[0, π]`
+    - **Parameters:** `[v_x, v_y, a, t]`; `v_y` is a nonnegative radial drift
+    - **Fixed settings:** `sigma={_settings["sigma"]}`, `s_v={_settings["s_v"]}`,
+      `s_t={_settings["s_t"]}`, fixed threshold, and `p_outlier=None`
+    - **Inference:** {_execution["chains"]} chains, {_execution["tune"]} tuning +
+      {_execution["draws"]} retained draws, with one PyMC Slice step per parameter in
+      `[v_x, v_y, a, t]`
+
+    The HSSM priors were not tuned to the generating values. The runner constructed the
+    public model defaults and asserted their exact distributions, bounds, and initial
+    values before fitting. Every raw dataset and NetCDF trace was saved before summaries;
+    the compact artifact records their hashes.
+    """)
+    return
+
+
+@app.cell
+def _(artifact, mo, pd):
+    _failures = pd.DataFrame({"predeclared failure": artifact["gate"]["failures"]})
+    mo.vstack(
+        [
+            mo.md("""
+            ## The exact failed gates
+
+            Eight messages arise from four substantive issues: convergence and efficiency
+            fail for `a` and `t` in the high-threshold scenario, while `v_y` optimizer
+            recovery fails in the low-threshold scenario and therefore also fails its
+            aggregate RMSE gate.
+            """),
+            mo.ui.table(_failures, selection=None, pagination=False),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Inspect one scenario
+
+    Select a scenario above. The table separates three targets: generating truth, the
+    direct-JEAM maximum-likelihood estimate, and the HSSM posterior. An MLE is not expected
+    to equal a posterior mean. The numerical handshake is instead tested by running the
+    direct JEAM and compiled HSSM optimizers with identical bounds, seeds, and budgets.
+    """)
+    return
+
+
+@app.cell
+def _(mo, parameter_df, scenario_selector):
+    _columns = {
+        "name": "parameter",
+        "truth": "truth",
+        "optimizer_estimate": "JEAM MLE",
+        "optimizer_abs_error": "MLE |error|",
+        "optimizer_gate_pass": "MLE gate",
+        "posterior_mean": "HSSM mean",
+        "posterior_abs_error": "posterior |error|",
+        "hdi_lower": "94% HDI lower",
+        "hdi_upper": "94% HDI upper",
+        "truth_in_hdi": "covers truth",
+        "rhat": "R-hat",
+        "ess_bulk": "bulk ESS",
+        "mcse_over_posterior_sd": "MCSE/SD",
+        "diagnostics_pass": "diagnostics gate",
+    }
+    _selected = (
+        parameter_df.loc[parameter_df["scenario"] == scenario_selector.value]
+        .loc[:, list(_columns)]
+        .rename(columns=_columns)
+        .round(4)
+    )
+    mo.ui.table(_selected, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Recovery across all four datasets
+
+    Choose a parameter above. Crosses mark generating truth, open circles the direct-JEAM
+    MLE, squares the HSSM posterior mean, and horizontal lines the 94% HSSM HDI. This view
+    keeps a single problematic dataset visible instead of hiding it in an average.
+    """)
+    return
+
+
+@app.cell
+def _(parameter_df, parameter_selector, plt):
+    _selected = parameter_df.loc[
+        parameter_df["name"] == parameter_selector.value
+    ].reset_index(drop=True)
+    _positions = range(len(_selected))
+    _figure, _axis = plt.subplots(figsize=(9.5, 4.2))
+    for _position, _row in _selected.iterrows():
+        _axis.hlines(
+            _position,
+            _row["hdi_lower"],
+            _row["hdi_upper"],
+            color="#4472C4",
+            linewidth=4,
+            alpha=0.42,
+            label="HSSM 94% HDI" if _position == 0 else None,
+        )
+    _axis.scatter(
+        _selected["truth"],
+        list(_positions),
+        marker="x",
+        s=80,
+        linewidth=2.2,
+        color="#111111",
+        label="generating truth",
+        zorder=4,
+    )
+    _axis.scatter(
+        _selected["optimizer_estimate"],
+        list(_positions),
+        marker="o",
+        s=52,
+        facecolors="white",
+        edgecolors="#E67E22",
+        linewidth=1.8,
+        label="direct JEAM MLE",
+        zorder=3,
+    )
+    _axis.scatter(
+        _selected["posterior_mean"],
+        list(_positions),
+        marker="s",
+        s=48,
+        color="#4472C4",
+        label="HSSM posterior mean",
+        zorder=3,
+    )
+    _axis.set_yticks(
+        list(_positions),
+        [name.replace("_", " ") for name in _selected["scenario"]],
+    )
+    _axis.invert_yaxis()
+    _axis.set_xlabel(parameter_selector.value)
+    _axis.set_title(f"Recovery of {parameter_selector.value}")
+    _axis.grid(axis="x", alpha=0.2)
+    _axis.legend(loc="center left", bbox_to_anchor=(1.01, 0.5))
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Did HSSM change JEAM's likelihood?
+
+    No detectable mismatch appears. The plot shows the largest direct-JEAM versus
+    compiled-HSSM objective difference among three points per dataset. The red line is the
+    preregistered tolerance. Both optimizers also returned exactly the same parameter
+    vector in every scenario.
+    """)
+    return
+
+
+@app.cell
+def _(artifact, mo, pd, scenario_selector):
+    _scenario = next(
+        row
+        for row in artifact["scenarios"]
+        if row["scenario"] == scenario_selector.value
+    )
+    _rows = []
+    for _index, _candidate in enumerate(_scenario["objective_candidates"], start=1):
+        _rows.append(
+            {
+                "candidate": _index,
+                "direct JEAM NLL": _candidate["direct_jeam"],
+                "compiled HSSM NLL": _candidate["compiled_hssm"],
+                "absolute error": _candidate["absolute_error"],
+            }
+        )
+    _objective_table = pd.DataFrame(_rows).round(12)
+    mo.ui.table(_objective_table, selection=None, pagination=False)
+    return
+
+
+@app.cell
+def _(plt, scenario_df, spec):
+    _threshold = spec["scientific_acceptance"]["maximum_objective_absolute_error"]
+    _figure, _axis = plt.subplots(figsize=(8.5, 3.7))
+    _axis.barh(
+        [name.replace("_", " ") for name in scenario_df["scenario"]],
+        scenario_df["objective_error"],
+        color="#70AD47",
+    )
+    _axis.axvline(_threshold, color="#B22222", linestyle="--", label="frozen limit")
+    _axis.set_xscale("log")
+    _axis.set_xlabel("maximum absolute NLL difference (log scale)")
+    _axis.set_title("Direct JEAM and compiled HSSM agree to numerical precision")
+    _axis.legend()
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Where ordered Slice falls short
+
+    Each bar divides a diagnostic by its frozen failure boundary; **bars above one fail**.
+    For R-hat, the plotted quantity is `(R-hat - 1) / (1.01 - 1)`. For bulk ESS it is
+    `400 / ESS`, so all three groups share the same direction. Select the high-threshold
+    scenario to see the `a` and `t` failures directly.
+    """)
+    return
+
+
+@app.cell
+def _(np, parameter_df, plt, scenario_selector, spec):
+    _selected = parameter_df.loc[
+        parameter_df["scenario"] == scenario_selector.value
+    ].reset_index(drop=True)
+    _limits = spec["scientific_acceptance"]["posterior_recovery"]
+    _rhat_limit = _limits["maximum_rhat_exclusive"]
+    _ess_limit = _limits["minimum_bulk_ess_exclusive"]
+    _mcse_limit = _limits["maximum_mcse_over_posterior_sd_exclusive"]
+    _x = np.arange(len(_selected))
+    _width = 0.24
+    _figure, _axis = plt.subplots(figsize=(8.5, 4.0))
+    _axis.bar(
+        _x - _width,
+        (_selected["rhat"] - 1.0) / (_rhat_limit - 1.0),
+        _width,
+        label="R-hat margin",
+        color="#9DC3E6",
+    )
+    _axis.bar(
+        _x,
+        _ess_limit / _selected["ess_bulk"],
+        _width,
+        label="bulk ESS margin",
+        color="#70AD47",
+    )
+    _axis.bar(
+        _x + _width,
+        _selected["mcse_over_posterior_sd"] / _mcse_limit,
+        _width,
+        label="MCSE/SD margin",
+        color="#F4B183",
+    )
+    _axis.axhline(1.0, color="#B22222", linestyle="--", label="failure boundary")
+    _axis.set_xticks(_x, _selected["name"])
+    _axis.set_ylabel("observed diagnostic / frozen boundary")
+    _axis.set_title(scenario_selector.value.replace("_", " ").title())
+    _axis.grid(axis="y", alpha=0.2)
+    _axis.legend(ncol=2, fontsize=8)
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Posterior prediction still passes
+
+    The inference limitations do not produce a visible failure in the frozen predictive
+    summaries. The left panel compares observed and posterior-predictive RT quantiles. The
+    right compares mean polar unit-vector components, `[mean(sin(response)),
+    mean(cos(response))]`. Raw angular means are inappropriate for directional data.
+    """)
+    return
+
+
+@app.cell
+def _(artifact, np, plt, scenario_selector):
+    _scenario = next(
+        row
+        for row in artifact["scenarios"]
+        if row["scenario"] == scenario_selector.value
+    )
+    _predictive = _scenario["posterior_predictive"]
+    _probabilities = np.asarray(_predictive["rt_probabilities"])
+    _figure, (_rt_axis, _angle_axis) = plt.subplots(1, 2, figsize=(9, 3.8))
+    _rt_axis.plot(
+        _probabilities,
+        _predictive["observed_rt_quantiles"],
+        marker="o",
+        color="#111111",
+        label="observed",
+    )
+    _rt_axis.plot(
+        _probabilities,
+        _predictive["predictive_rt_quantiles"],
+        marker="s",
+        color="#4472C4",
+        label="posterior predictive",
+    )
+    _rt_axis.set_xlabel("RT quantile probability")
+    _rt_axis.set_ylabel("seconds")
+    _rt_axis.set_title("Response-time quantiles")
+    _rt_axis.grid(alpha=0.2)
+    _rt_axis.legend(fontsize=8)
+
+    _x = np.arange(2)
+    _width = 0.36
+    _angle_axis.bar(
+        _x - _width / 2,
+        _predictive["observed_mean_polar_unit_vector"],
+        _width,
+        label="observed",
+        color="#A5A5A5",
+    )
+    _angle_axis.bar(
+        _x + _width / 2,
+        _predictive["predictive_mean_polar_unit_vector"],
+        _width,
+        label="posterior predictive",
+        color="#4472C4",
+    )
+    _angle_axis.set_xticks(_x, ["mean sin(θ)", "mean cos(θ)"])
+    _angle_axis.set_title("Polar unit-vector mean")
+    _angle_axis.grid(axis="y", alpha=0.2)
+    _angle_axis.legend(fontsize=8)
+    _figure.suptitle(scenario_selector.value.replace("_", " ").title())
+    _figure.tight_layout()
+    _figure
+    return
+
+
+@app.cell
+def _(aggregate_df, artifact, mo, parameter_df):
+    _high = parameter_df.loc[
+        parameter_df["scenario"] == "high_threshold_strong_radial"
+    ].set_index("name")
+    _low_vy = parameter_df.loc[
+        (parameter_df["scenario"] == "low_threshold_balanced_drift")
+        & (parameter_df["name"] == "v_y")
+    ].iloc[0]
+    _aggregate = aggregate_df.set_index("name")
+    mo.md(f"""
+    ## Scientific interpretation
+
+    1. **The HSSM handshake is numerically intact.** Direct JEAM and compiled HSSM agree
+       to `{max(s["maximum_objective_absolute_error"] for s in artifact["scenarios"]):.2e}`
+       in NLL, and their optimizer vectors are identical in every scenario.
+    2. **This ordered-Slice budget is not a general recommendation.** In the
+       high-threshold case, `a` has R-hat `{_high.loc["a", "rhat"]:.4f}` and bulk ESS
+       `{_high.loc["a", "ess_bulk"]:.0f}`; `t` has R-hat
+       `{_high.loc["t", "rhat"]:.4f}` and bulk ESS
+       `{_high.loc["t", "ess_bulk"]:.0f}`. The compact artifact establishes insufficient
+       mixing at this budget; it does not by itself identify the full posterior geometry.
+    3. **Low-threshold radial drift is weakly recovered in this dataset.** For `v_y`, truth
+       is `{_low_vy["truth"]:.2f}`, the MLE is `{_low_vy["optimizer_estimate"]:.3f}`, and
+       the posterior is `{_low_vy["posterior_mean"]:.3f} ± {_low_vy["posterior_sd"]:.3f}`
+       with 94% HDI `[{_low_vy["hdi_lower"]:.3f}, {_low_vy["hdi_upper"]:.3f}]`. The broad
+       interval covers truth, so the optimizer miss should not be misread as an HSSM/JEAM
+       mismatch.
+    4. **Aggregate posterior recovery is encouraging but limited.** Posterior RMSE passes
+       for all four parameters and {_aggregate["hdi_coverage"].mul(4).sum():.0f}/16
+       intervals cover truth. Four datasets are a regression benchmark, not a calibration
+       study of nominal 94% coverage.
+
+    The appropriate next experiment is a separately preregistered v2: first increase the
+    sampling budget on the same saved datasets to isolate mixing, then vary trial count or
+    design for the low-threshold `v_y` case to isolate information. V1 remains immutable.
+    """)
+    return
+
+
+@app.cell
+def _(artifact_path, mo, spec_path):
+    mo.md(f"""
+    ## Reproduce deliberately
+
+    This notebook reads:
+
+    - `{spec_path.relative_to(spec_path.parents[2])}`
+    - `{artifact_path.relative_to(artifact_path.parents[2])}`
+
+    A smoke run is the safe first check:
+
+    ```bash
+    python -m scripts.benchmark_jeam_psdm_recovery \
+        --smoke --scenario baseline_asymmetric \
+        --work-dir /tmp/jeam-psdm-smoke \
+        --output /tmp/jeam-psdm-smoke.json
+    ```
+
+    The canonical command requires the optional JEAM dependency and several minutes. V1
+    exits nonzero because its scientific gate fails, but still writes the complete result.
+    Do not overwrite the committed v1 artifact; use a new versioned protocol for follow-up
+    work.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ nav:
           - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
           - Circular diffusion with JEAM: tutorials/jeam_circular_diffusion.py
           - Archived JEAM fixed-CDM sampler evidence: tutorials/jeam_nuts_recovery.py
-          - Fixed PSDM recovery with JEAM: tutorials/jeam_fixed_psdm_recovery.py
+          - Archived JEAM fixed-PSDM compact evidence: tutorials/jeam_fixed_psdm_recovery.py
           - Choice-only models: tutorials/choice_only_models.ipynb
           - Poisson race models: tutorials/poisson_race.ipynb
           - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
@@ -128,7 +128,6 @@ plugins:
         - tutorials/main_tutorial.ipynb
         - tutorials/attentional_ddm.py
         - tutorials/jeam_circular_diffusion.py
-        - tutorials/jeam_fixed_psdm_recovery.py
         - tutorials/jeam_repeated_recovery.py
         - tutorials/hsgp_regression.ipynb
         - tutorials/ddm_hierarchical_tutorial.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
           - Hierarchical DDM regressions: tutorials/ddm_hierarchical_tutorial.ipynb
           - Circular diffusion with JEAM: tutorials/jeam_circular_diffusion.py
           - Archived JEAM fixed-CDM sampler evidence: tutorials/jeam_nuts_recovery.py
+          - Fixed PSDM recovery with JEAM: tutorials/jeam_fixed_psdm_recovery.py
           - Choice-only models: tutorials/choice_only_models.ipynb
           - Poisson race models: tutorials/poisson_race.ipynb
           - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
@@ -127,6 +128,7 @@ plugins:
         - tutorials/main_tutorial.ipynb
         - tutorials/attentional_ddm.py
         - tutorials/jeam_circular_diffusion.py
+        - tutorials/jeam_fixed_psdm_recovery.py
         - tutorials/jeam_repeated_recovery.py
         - tutorials/hsgp_regression.ipynb
         - tutorials/ddm_hierarchical_tutorial.ipynb

--- a/scripts/jeam_psdm_recovery_report.py
+++ b/scripts/jeam_psdm_recovery_report.py
@@ -1,0 +1,40 @@
+"""Build report data from one authenticated fixed-PSDM evidence load."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from scripts.verify_jeam_psdm_recovery_evidence import (
+    REPO_ROOT,
+    load_verified_psdm_recovery_evidence,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+REPORT_KEYS = (
+    "summary",
+    "parameter_records",
+    "scenario_records",
+    "aggregate_records",
+    "objective_records",
+    "predictive_records",
+    "failure_records",
+    "evidence_boundary",
+    "provenance",
+)
+
+
+def load_psdm_recovery_report(
+    root: str | Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Return stable presentation records from one verifier-owned snapshot."""
+    verification, _spec, _addendum, _artifact = load_verified_psdm_recovery_evidence(
+        root
+    )
+    if tuple(key for key in REPORT_KEYS if key not in verification):
+        raise ValueError("Verified fixed-PSDM report records are incomplete.")
+    return {key: verification[key] for key in REPORT_KEYS}
+
+
+__all__ = ["REPORT_KEYS", "load_psdm_recovery_report"]

--- a/scripts/verify_jeam_psdm_recovery_evidence.py
+++ b/scripts/verify_jeam_psdm_recovery_evidence.py
@@ -1,0 +1,865 @@
+"""Authenticate and verify the archived fixed-PSDM compact evidence.
+
+The three JSON files contain producer summaries, not raw datasets, traces, or
+predictive draws. This network-free verifier reads each file once, authenticates
+its bytes before parsing, and recomputes every reportable compact quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Never
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SPEC_PATH = Path("benchmarks/specs/jeam_fixed_psdm_recovery_v1.json")
+ADDENDUM_PATH = Path("benchmarks/specs/jeam_fixed_psdm_recovery_v1_addendum.json")
+RESULT_PATH = Path("benchmarks/results/jeam_fixed_psdm_recovery_v1.json")
+PINS = {
+    SPEC_PATH: "2a9fabe13e612a59f7c2138e4e36ae4e01d4bde5e226c16c8572d5ebe3594198",
+    ADDENDUM_PATH: "42d4627f7e4eadd9c1ba656095cb3edf5af17d04bd03ad11ede476f78149d8f1",
+    RESULT_PATH: "cede87d5a5a2c9789939b66962ebb025b270a13966aa2d657d5b0cbb95e9c2c4",
+}
+PARAMETER_ORDER = ("v_x", "v_y", "a", "t")
+SCENARIO_ORDER = (
+    "baseline_asymmetric",
+    "reverse_axial_weak_radial",
+    "high_threshold_strong_radial",
+    "low_threshold_balanced_drift",
+)
+HISTORICAL_JEAM_REVISION = "1d7112757d8b2d27a31437255fc679194d39ab89"
+CURRENT_SAFETY_JEAM_REVISION = "ede7a4f4faf226e4dae52c84dfb01012939cccdc"
+RESULT_COMMIT = "d76f995d501603cc56f895e5fa429ce2be14e468"
+CANONICAL_START = "2026-08-17T04:15:03.738704+00:00"
+EXPECTED_DATA_HASHES = (
+    "5b39ad8f2453871a15f574437b1b62d20372476e814019caa9e028f85c0f9726",
+    "e2228ec7b121758e5a1599cdda54018caea95940caaa33cc10ae4beafebcba82",
+    "a598a0c5f76e54c4019ccefa027714c47f13525668ef3e2ef328a2cb13f21cc7",
+    "bba3bae04b0cc329586f9bce82a14aaacf51117c5009f3a5e01942c205857cc8",
+)
+EXPECTED_TRACE_HASHES = (
+    "6bda44d1412175eab0531bf36a199af79133535bc23e6fc259f3d55343ce91cf",
+    "cf2c244998de9dc284cdcdbb0c747e249d90ce77cd2f7036e5a6caad6dc05c6e",
+    "ca4070fef701cc011ce78155763da76444f2d642f1178ddf5c6b6b8274565f68",
+    "048a07fda29a3e25d9125449fc8ae8c1fe59688da8daf68a8343a2e0a66b99fc",
+)
+EXPECTED_FAILURES = (
+    "high_threshold_strong_radial/a: R-hat gate failed",
+    "high_threshold_strong_radial/a: bulk ESS gate failed",
+    "high_threshold_strong_radial/a: MCSE/SD gate failed",
+    "high_threshold_strong_radial/t: R-hat gate failed",
+    "high_threshold_strong_radial/t: bulk ESS gate failed",
+    "high_threshold_strong_radial/t: MCSE/SD gate failed",
+    "low_threshold_balanced_drift/v_y: optimizer recovery error 0.631521 exceeds 0.45",
+    "v_y: optimizer RMSE gate failed",
+)
+EXPECTED_BOUNDARY = {
+    "dataset_hashes_recorded": True,
+    "trace_hashes_recorded": True,
+    "raw_datasets_retained_in_git": 0,
+    "raw_traces_retained_in_git": 0,
+    "raw_prior_predictive_draws_retained": False,
+    "raw_posterior_predictive_draws_retained": False,
+    "independent_raw_reverification": "blocked",
+    "fixed_psdm_public_support_or_promotion": "blocked",
+}
+
+
+class EvidenceIntegrityError(ValueError):
+    """Raised when archived evidence differs from its authenticated contract."""
+
+
+def _fail(message: str) -> Never:
+    raise EvidenceIntegrityError(message)
+
+
+def _require(condition: object, message: str) -> None:
+    if not condition:
+        _fail(message)
+
+
+def _reject_constant(token: str) -> Never:
+    _fail(f"Non-finite JSON constant {token!r} is forbidden.")
+
+
+def _finite_float(token: str) -> float:
+    value = float(token)
+    _require(math.isfinite(value), f"Non-finite JSON number {token!r} is forbidden.")
+    return value
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        _require(key not in result, f"Duplicate JSON member {key!r} is forbidden.")
+        result[key] = value
+    return result
+
+
+def _load_authenticated_json(path: Path, expected_sha256: str) -> dict[str, Any]:
+    """Read once, hash before parsing, and return one strict JSON object."""
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise EvidenceIntegrityError(f"Cannot snapshot {path}.") from error
+    observed = hashlib.sha256(payload).hexdigest()
+    _require(
+        observed == expected_sha256,
+        f"SHA256 mismatch for {path.name}: expected {expected_sha256}, "
+        f"observed {observed}.",
+    )
+    try:
+        value = json.loads(
+            payload,
+            parse_constant=_reject_constant,
+            parse_float=_finite_float,
+            object_pairs_hook=_unique_object,
+        )
+    except EvidenceIntegrityError:
+        raise
+    except (TypeError, ValueError) as error:
+        raise EvidenceIntegrityError(f"Invalid JSON in {path.name}.") from error
+    _require(isinstance(value, dict), f"{path.name} must contain a JSON object.")
+    return value
+
+
+def _close(observed: float, expected: float, label: str) -> None:
+    _require(
+        math.isfinite(observed)
+        and math.isclose(observed, expected, rel_tol=1e-12, abs_tol=1e-12),
+        f"Derived value mismatch for {label}.",
+    )
+
+
+def _close_list(
+    observed: Sequence[float], expected: Sequence[float], label: str
+) -> None:
+    _require(len(observed) == len(expected), f"Derived sequence mismatch for {label}.")
+    for index, (left, right) in enumerate(zip(observed, expected, strict=True)):
+        _close(left, right, f"{label}[{index}]")
+
+
+def _mean(values: Sequence[float]) -> float:
+    return math.fsum(values) / len(values)
+
+
+def _rmse(errors: Sequence[float]) -> float:
+    return math.sqrt(_mean([error * error for error in errors]))
+
+
+def _add_failure(
+    records: list[dict[str, Any]],
+    message: str,
+    category: str,
+    scenario: str | None = None,
+    parameter: str | None = None,
+) -> None:
+    records.append(
+        {
+            "order": len(records) + 1,
+            "message": message,
+            "category": category,
+            "scenario": scenario,
+            "parameter": parameter,
+        }
+    )
+
+
+def _verify_core(
+    spec: Mapping[str, Any],
+    addendum: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+) -> None:
+    """Bind the pinned bytes to the historical scope and provenance."""
+    study = "jeam-fixed-psdm-recovery-v1"
+    _require(
+        (spec["study_id"], addendum["study_id"], artifact["study_id"])
+        == (study, study, study)
+        and (
+            spec["schema_version"],
+            addendum["schema_version"],
+            artifact["schema_version"],
+        )
+        == (1, 1, 1),
+        "Fixed-PSDM study identity or schema changed.",
+    )
+    scope = spec["scope"]
+    _require(
+        artifact["canonical"] is True
+        and artifact["model"] == scope["model"] == "projected_spherical_diffusion"
+        and tuple(artifact["parameter_order"]) == PARAMETER_ORDER
+        and tuple(scope["parameter_order"]) == PARAMETER_ORDER
+        and artifact["spec_path"] == SPEC_PATH.as_posix()
+        and artifact["spec_sha256"] == PINS[SPEC_PATH]
+        and addendum["scope"]["formula_or_regression_support_evaluated"] is False,
+        "Compact result identity or scalar model scope changed.",
+    )
+    outcome = addendum["known_v1_outcome"]
+    _require(
+        addendum["immutable_protocol"]["sha256"] == PINS[SPEC_PATH]
+        and outcome["result_commit"] == RESULT_COMMIT
+        and outcome["result_sha256"] == PINS[RESULT_PATH]
+        and outcome["canonical_started_at_utc"] == CANONICAL_START
+        and outcome["overall_pass"] is False
+        and (outcome["truth_in_hdi"], outcome["truth_total"]) == (14, 16)
+        and addendum["evidence_boundary"] == EXPECTED_BOUNDARY,
+        "Archived outcome or compact-only boundary changed.",
+    )
+    provenance = artifact["provenance"]
+    current = addendum["current_safety_revision"]
+    _require(
+        spec["provenance"]["jeam_revision"] == HISTORICAL_JEAM_REVISION
+        and addendum["historical_execution"]["jeam_revision"]
+        == HISTORICAL_JEAM_REVISION
+        and provenance["jeam_revision"] == HISTORICAL_JEAM_REVISION
+        and provenance["hssm_revision"] == "ebbd68ee6dcaad644505ae7f3739b7b1f0ba3794"
+        and provenance["spec_commit"] == "c1c68ef3c0ebdf78b4a950c4e62e61bee55b0961"
+        and current
+        == {
+            "jeam_revision": CURRENT_SAFETY_JEAM_REVISION,
+            "v1_recovery_rerun": False,
+        }
+        and artifact["started_at_utc"] == CANONICAL_START,
+        "Historical or current-safety provenance changed.",
+    )
+    runner = addendum["runner_archive"]
+    _require(
+        "fixed-budget differential-evolution endpoints"
+        in runner["optimizer_interpretation"]
+        and "not demonstrated converged optima or MLEs"
+        in runner["optimizer_interpretation"]
+        and "same historical JEAM producer" in runner["objective_parity_interpretation"]
+        and runner["ordered_slice_identity_independently_authenticated"] is False
+        and runner["runtime_hssm_import_bound_to_recorded_checkout"] is False
+        and addendum["successor_policy"]
+        == {
+            "v2a_and_v2b_require_new_preregistrations": True,
+            "mixing_and_identifiability_are_hypotheses_not_v1_conclusions": True,
+        },
+        "Archival interpretation or successor boundary changed.",
+    )
+    _require(
+        tuple(row["name"] for row in spec["scenarios"]) == SCENARIO_ORDER
+        and tuple(row["scenario"] for row in artifact["scenarios"]) == SCENARIO_ORDER,
+        "Scenario order or membership changed.",
+    )
+
+
+def _derive(
+    spec: Mapping[str, Any],
+    addendum: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive the stable report records and exact scientific-gate failures."""
+    limits = spec["scientific_acceptance"]
+    opt_limits = limits["optimizer_recovery"]
+    post_limits = limits["posterior_recovery"]
+    pred_limits = limits["posterior_predictive"]
+    prior_limits = spec["preflight_gates"]["prior_predictive"]
+    spec_scenarios = {row["name"]: row for row in spec["scenarios"]}
+    parameters: list[dict[str, Any]] = []
+    scenarios: list[dict[str, Any]] = []
+    objectives: list[dict[str, Any]] = []
+    predictives: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+
+    for scenario_index, scenario in enumerate(artifact["scenarios"]):
+        name = scenario["scenario"]
+        direct = scenario["optimizer"]["direct_jeam"]
+        compiled = scenario["optimizer"]["compiled_hssm"]
+        _require(
+            scenario["status"] == "completed"
+            and scenario["smoke"] is False
+            and scenario["trials"] == 400
+            and scenario["truth"] == spec_scenarios[name]["truth"]
+            and scenario["data"]["sha256"] == EXPECTED_DATA_HASHES[scenario_index]
+            and scenario["data"]["shape"] == [400, 2]
+            and scenario["data"]["dtype"] == "float64"
+            and scenario["trace"]["sha256"] == EXPECTED_TRACE_HASHES[scenario_index]
+            and scenario["trace"]["saved_before_summary"] is True
+            and set(scenario["sampler_diagnostics"]["sample_stats"])
+            == {"nstep_in", "nstep_out"}
+            and (direct["iterations"], direct["evaluations"]) == (20, 1260)
+            and (compiled["iterations"], compiled["evaluations"]) == (20, 1260),
+            f"Scenario execution or compact metadata changed: {name}.",
+        )
+
+        prior = scenario["prior_predictive"]
+        prior_passed = all(
+            (
+                prior["all_values_finite"],
+                prior["all_rt_strictly_positive"],
+                prior["all_angles_in_closed_domain"],
+            )
+        ) and all(
+            prior_limits["rt_quantile_ratio_to_observed_lower"]
+            <= ratio
+            <= prior_limits["rt_quantile_ratio_to_observed_upper"]
+            for ratio in prior["prior_to_observed_ratios"]
+        )
+        _require(prior_passed == prior["passed"], f"Prior gate changed: {name}.")
+        if not prior_passed:
+            _add_failure(
+                failures, f"{name}: prior predictive gate failed", "prior", name
+            )
+
+        scenario_objectives = []
+        _require(
+            len(scenario["objective_candidates"]) == 3,
+            f"Objective grid changed: {name}.",
+        )
+        for candidate_index, candidate in enumerate(
+            scenario["objective_candidates"], 1
+        ):
+            error = abs(candidate["direct_jeam"] - candidate["compiled_hssm"])
+            _close(
+                error,
+                candidate["absolute_error"],
+                f"{name} objective {candidate_index}",
+            )
+            scenario_objectives.append(error)
+            objectives.append(
+                {
+                    "scenario": name,
+                    "candidate": candidate_index,
+                    "direct_jeam": candidate["direct_jeam"],
+                    "compiled_hssm": candidate["compiled_hssm"],
+                    "absolute_error": error,
+                    "absolute_error_limit": limits["maximum_objective_absolute_error"],
+                    "passed": error <= limits["maximum_objective_absolute_error"],
+                }
+            )
+        maximum_objective_error = max(scenario_objectives)
+        _close(
+            maximum_objective_error,
+            scenario["maximum_objective_absolute_error"],
+            f"{name} maximum objective error",
+        )
+        objective_passed = (
+            maximum_objective_error <= limits["maximum_objective_absolute_error"]
+        )
+        if not objective_passed:
+            _add_failure(
+                failures, f"{name}: objective parity failed", "objective", name
+            )
+
+        parameter_parity_error = max(
+            abs(left - right)
+            for left, right in zip(
+                direct["parameters"], compiled["parameters"], strict=True
+            )
+        )
+        optimizer_objective_error = abs(direct["objective"] - compiled["objective"])
+        recovery_errors = [
+            abs(endpoint - truth)
+            for endpoint, truth in zip(
+                direct["parameters"], scenario["truth"], strict=True
+            )
+        ]
+        optimizer = scenario["optimizer"]
+        _close(
+            parameter_parity_error,
+            optimizer["maximum_parameter_absolute_error"],
+            f"{name} optimizer parameters",
+        )
+        _close(
+            optimizer_objective_error,
+            optimizer["objective_absolute_error"],
+            f"{name} optimizer objective",
+        )
+        _close_list(
+            optimizer["direct_recovery_absolute_error"],
+            recovery_errors,
+            f"{name} optimizer recovery",
+        )
+        parameter_parity_passed = (
+            parameter_parity_error
+            <= limits["maximum_optimizer_parameter_absolute_error"]
+        )
+        fit_parity_passed = (
+            optimizer_objective_error
+            <= limits["maximum_optimizer_objective_absolute_error"]
+        )
+        if not parameter_parity_passed:
+            _add_failure(
+                failures,
+                f"{name}: optimizer parameter parity failed",
+                "optimizer_parameter_parity",
+                name,
+            )
+        if not fit_parity_passed:
+            _add_failure(
+                failures,
+                f"{name}: optimizer objective parity failed",
+                "optimizer_objective_parity",
+                name,
+            )
+
+        _require(
+            tuple(row["name"] for row in scenario["parameters"]) == PARAMETER_ORDER,
+            f"Parameter order changed: {name}.",
+        )
+        scenario_hdi = 0
+        for parameter_index, row in enumerate(scenario["parameters"]):
+            parameter = row["name"]
+            _require(
+                row["truth"] == scenario["truth"][parameter_index]
+                and row["optimizer_estimate"] == direct["parameters"][parameter_index],
+                f"Parameter vectors disagree: {name}/{parameter}.",
+            )
+            truth_in_hdi = row["hdi_lower"] <= row["truth"] <= row["hdi_upper"]
+            _require(
+                truth_in_hdi == row["truth_in_hdi"],
+                f"Stored HDI inclusion changed: {name}/{parameter}.",
+            )
+            scenario_hdi += truth_in_hdi
+            optimizer_passed = (
+                recovery_errors[parameter_index]
+                <= opt_limits["maximum_absolute_error"][parameter]
+            )
+            rhat_passed = row["rhat"] < post_limits["maximum_rhat_exclusive"]
+            bulk_passed = row["ess_bulk"] > post_limits["minimum_bulk_ess_exclusive"]
+            tail_passed = row["ess_tail"] > post_limits["minimum_tail_ess_exclusive"]
+            mcse_passed = (
+                row["mcse_over_posterior_sd"]
+                < post_limits["maximum_mcse_over_posterior_sd_exclusive"]
+            )
+            if not optimizer_passed:
+                limit = opt_limits["maximum_absolute_error"][parameter]
+                _add_failure(
+                    failures,
+                    f"{name}/{parameter}: optimizer recovery error "
+                    f"{recovery_errors[parameter_index]:.6g} exceeds {limit:.6g}",
+                    "optimizer_absolute_error",
+                    name,
+                    parameter,
+                )
+            for passed, message, category in (
+                (rhat_passed, "R-hat gate failed", "rhat"),
+                (bulk_passed, "bulk ESS gate failed", "bulk_ess"),
+                (tail_passed, "tail ESS gate failed", "tail_ess"),
+                (mcse_passed, "MCSE/SD gate failed", "mcse_over_posterior_sd"),
+            ):
+                if not passed:
+                    _add_failure(
+                        failures,
+                        f"{name}/{parameter}: {message}",
+                        category,
+                        name,
+                        parameter,
+                    )
+            parameters.append(
+                {
+                    "scenario": name,
+                    "parameter": parameter,
+                    "truth": row["truth"],
+                    "optimizer_endpoint": row["optimizer_estimate"],
+                    "optimizer_absolute_error": recovery_errors[parameter_index],
+                    "optimizer_absolute_error_limit": opt_limits[
+                        "maximum_absolute_error"
+                    ][parameter],
+                    "optimizer_recovery_passed": optimizer_passed,
+                    "posterior_mean": row["posterior_mean"],
+                    "posterior_sd": row["posterior_sd"],
+                    "posterior_absolute_error": abs(
+                        row["posterior_mean"] - row["truth"]
+                    ),
+                    "hdi_lower": row["hdi_lower"],
+                    "hdi_upper": row["hdi_upper"],
+                    "truth_in_hdi": truth_in_hdi,
+                    "rhat": row["rhat"],
+                    "rhat_limit": post_limits["maximum_rhat_exclusive"],
+                    "rhat_passed": rhat_passed,
+                    "ess_bulk": row["ess_bulk"],
+                    "bulk_ess_limit": post_limits["minimum_bulk_ess_exclusive"],
+                    "bulk_ess_passed": bulk_passed,
+                    "ess_tail": row["ess_tail"],
+                    "tail_ess_limit": post_limits["minimum_tail_ess_exclusive"],
+                    "tail_ess_passed": tail_passed,
+                    "mcse_over_posterior_sd": row["mcse_over_posterior_sd"],
+                    "mcse_over_posterior_sd_limit": post_limits[
+                        "maximum_mcse_over_posterior_sd_exclusive"
+                    ],
+                    "mcse_passed": mcse_passed,
+                    "diagnostics_passed": all(
+                        (rhat_passed, bulk_passed, tail_passed, mcse_passed)
+                    ),
+                }
+            )
+
+        predictive = scenario["posterior_predictive"]
+        rt_errors = [
+            abs(left - right)
+            for left, right in zip(
+                predictive["predictive_rt_quantiles"],
+                predictive["observed_rt_quantiles"],
+                strict=True,
+            )
+        ]
+        polar_errors = [
+            abs(left - right)
+            for left, right in zip(
+                predictive["predictive_mean_polar_unit_vector"],
+                predictive["observed_mean_polar_unit_vector"],
+                strict=True,
+            )
+        ]
+        _close_list(
+            predictive["rt_quantile_absolute_errors"],
+            rt_errors,
+            f"{name} predictive RT",
+        )
+        _close_list(
+            predictive["polar_unit_vector_component_absolute_errors"],
+            polar_errors,
+            f"{name} predictive polar",
+        )
+        maximum_rt_error, maximum_polar_error = max(rt_errors), max(polar_errors)
+        predictive_passed = (
+            maximum_rt_error <= pred_limits["maximum_rt_quantile_absolute_error"]
+            and maximum_polar_error
+            <= pred_limits["maximum_polar_unit_vector_component_absolute_error"]
+        )
+        if maximum_rt_error > pred_limits["maximum_rt_quantile_absolute_error"]:
+            _add_failure(
+                failures,
+                f"{name}: predictive RT quantile gate failed",
+                "predictive_rt",
+                name,
+            )
+        if (
+            maximum_polar_error
+            > pred_limits["maximum_polar_unit_vector_component_absolute_error"]
+        ):
+            _add_failure(
+                failures,
+                f"{name}: predictive polar unit-vector gate failed",
+                "predictive_polar",
+                name,
+            )
+        predictives.append(
+            {
+                "scenario": name,
+                "rt_probabilities": list(predictive["rt_probabilities"]),
+                "observed_rt_quantiles": list(predictive["observed_rt_quantiles"]),
+                "predictive_rt_quantiles": list(predictive["predictive_rt_quantiles"]),
+                "rt_quantile_absolute_errors": rt_errors,
+                "maximum_rt_quantile_absolute_error": maximum_rt_error,
+                "maximum_rt_quantile_absolute_error_limit": pred_limits[
+                    "maximum_rt_quantile_absolute_error"
+                ],
+                "observed_mean_polar_unit_vector": list(
+                    predictive["observed_mean_polar_unit_vector"]
+                ),
+                "predictive_mean_polar_unit_vector": list(
+                    predictive["predictive_mean_polar_unit_vector"]
+                ),
+                "polar_unit_vector_component_absolute_errors": polar_errors,
+                "maximum_polar_unit_vector_component_absolute_error": (
+                    maximum_polar_error
+                ),
+                "maximum_polar_unit_vector_component_absolute_error_limit": pred_limits[
+                    "maximum_polar_unit_vector_component_absolute_error"
+                ],
+                "passed": predictive_passed,
+                "evidence_scope": "authenticated producer summaries; raw draws absent",
+            }
+        )
+        runtime, diagnostics = (
+            scenario["runtime_seconds"],
+            scenario["sampler_diagnostics"],
+        )
+        scenarios.append(
+            {
+                "scenario": name,
+                "trials": scenario["trials"],
+                "status": scenario["status"],
+                "prior_predictive_passed": prior_passed,
+                "maximum_objective_absolute_error": maximum_objective_error,
+                "objective_absolute_error_limit": limits[
+                    "maximum_objective_absolute_error"
+                ],
+                "objective_parity_passed": objective_passed,
+                "maximum_optimizer_parameter_absolute_error": parameter_parity_error,
+                "optimizer_parameter_absolute_error_limit": limits[
+                    "maximum_optimizer_parameter_absolute_error"
+                ],
+                "optimizer_parameter_parity_passed": parameter_parity_passed,
+                "optimizer_objective_absolute_error": optimizer_objective_error,
+                "optimizer_objective_absolute_error_limit": limits[
+                    "maximum_optimizer_objective_absolute_error"
+                ],
+                "optimizer_objective_parity_passed": fit_parity_passed,
+                "optimizer_iterations": direct["iterations"],
+                "optimizer_evaluations": direct["evaluations"],
+                "hdi_inclusions": scenario_hdi,
+                "hdi_total": len(PARAMETER_ORDER),
+                "data_sha256": scenario["data"]["sha256"],
+                "trace_sha256": scenario["trace"]["sha256"],
+                "trace_bytes": scenario["trace"]["bytes"],
+                "mean_nstep_in": diagnostics["mean_nstep_in"],
+                "mean_nstep_out": diagnostics["mean_nstep_out"],
+                "sampling_seconds": runtime["sampling"],
+                "total_seconds": runtime["total"],
+                "timing_scope": "descriptive recorded-machine telemetry only",
+            }
+        )
+
+    aggregates: list[dict[str, Any]] = []
+    _require(
+        tuple(row["name"] for row in artifact["aggregate"]) == PARAMETER_ORDER,
+        "Aggregate order changed.",
+    )
+    for parameter_index, (parameter, stored) in enumerate(
+        zip(PARAMETER_ORDER, artifact["aggregate"], strict=True)
+    ):
+        rows = parameters[parameter_index :: len(PARAMETER_ORDER)]
+        optimizer_errors = [row["optimizer_endpoint"] - row["truth"] for row in rows]
+        posterior_errors = [row["posterior_mean"] - row["truth"] for row in rows]
+        values = {
+            "optimizer_bias": _mean(optimizer_errors),
+            "optimizer_rmse": _rmse(optimizer_errors),
+            "posterior_bias": _mean(posterior_errors),
+            "posterior_rmse": _rmse(posterior_errors),
+            "hdi_coverage": _mean([float(row["truth_in_hdi"]) for row in rows]),
+            "maximum_rhat": max(row["rhat"] for row in rows),
+            "minimum_bulk_ess": min(row["ess_bulk"] for row in rows),
+            "minimum_tail_ess": min(row["ess_tail"] for row in rows),
+            "maximum_mcse_over_posterior_sd": max(
+                row["mcse_over_posterior_sd"] for row in rows
+            ),
+        }
+        for key, value in values.items():
+            _close(value, stored[key], f"{parameter} aggregate {key}")
+        optimizer_passed = (
+            values["optimizer_rmse"] <= opt_limits["maximum_rmse"][parameter]
+        )
+        bias_passed = (
+            abs(values["posterior_bias"])
+            <= post_limits["maximum_absolute_bias"][parameter]
+        )
+        posterior_passed = (
+            values["posterior_rmse"] <= post_limits["maximum_rmse"][parameter]
+        )
+        coverage_passed = (
+            values["hdi_coverage"]
+            >= post_limits["minimum_94_percent_hdi_coverage_per_parameter"]
+        )
+        diagnostics_passed = (
+            values["maximum_rhat"] < post_limits["maximum_rhat_exclusive"]
+            and values["minimum_bulk_ess"] > post_limits["minimum_bulk_ess_exclusive"]
+            and values["minimum_tail_ess"] > post_limits["minimum_tail_ess_exclusive"]
+            and values["maximum_mcse_over_posterior_sd"]
+            < post_limits["maximum_mcse_over_posterior_sd_exclusive"]
+        )
+        for passed, message, category in (
+            (optimizer_passed, "optimizer RMSE gate failed", "optimizer_rmse"),
+            (bias_passed, "posterior bias gate failed", "posterior_bias"),
+            (posterior_passed, "posterior RMSE gate failed", "posterior_rmse"),
+            (coverage_passed, "HDI coverage gate failed", "hdi_coverage"),
+        ):
+            if not passed:
+                _add_failure(
+                    failures, f"{parameter}: {message}", category, parameter=parameter
+                )
+        aggregates.append(
+            {
+                "parameter": parameter,
+                "scenarios": len(rows),
+                **values,
+                "optimizer_rmse_limit": opt_limits["maximum_rmse"][parameter],
+                "optimizer_rmse_passed": optimizer_passed,
+                "posterior_absolute_bias_limit": post_limits["maximum_absolute_bias"][
+                    parameter
+                ],
+                "posterior_bias_passed": bias_passed,
+                "posterior_rmse_limit": post_limits["maximum_rmse"][parameter],
+                "posterior_rmse_passed": posterior_passed,
+                "hdi_coverage_limit": post_limits[
+                    "minimum_94_percent_hdi_coverage_per_parameter"
+                ],
+                "hdi_coverage_passed": coverage_passed,
+                "diagnostics_passed": diagnostics_passed,
+            }
+        )
+
+    truth_in_hdi, truth_total = (
+        sum(row["truth_in_hdi"] for row in parameters),
+        len(parameters),
+    )
+    coverage = truth_in_hdi / truth_total
+    _close(coverage, artifact["overall_hdi_coverage"], "overall HDI coverage")
+    if coverage < post_limits["minimum_overall_94_percent_hdi_coverage"]:
+        _add_failure(
+            failures, "overall HDI coverage gate failed", "overall_hdi_coverage"
+        )
+    messages = tuple(row["message"] for row in failures)
+    _require(messages == EXPECTED_FAILURES, "Recomputed scientific failures changed.")
+    _require(
+        artifact["gate"]
+        == {"evaluated": True, "passed": False, "failures": list(messages)},
+        "Stored gate disagrees with recomputation.",
+    )
+
+    runner = addendum["runner_archive"]
+    summary = {
+        "study_id": artifact["study_id"],
+        "model": artifact["model"],
+        "canonical": artifact["canonical"],
+        "scenario_count": len(scenarios),
+        "parameter_count": len(PARAMETER_ORDER),
+        "unique_truth_count": len(
+            {(row["scenario"], row["parameter"]) for row in parameters}
+        ),
+        "truth_in_hdi": truth_in_hdi,
+        "truth_total": truth_total,
+        "hdi_coverage": coverage,
+        "failure_count": len(failures),
+        "overall_pass": not failures,
+        "ecosystem_promotion_blocked": True,
+        "maximum_rhat": max(row["rhat"] for row in parameters),
+        "minimum_bulk_ess": min(row["ess_bulk"] for row in parameters),
+        "minimum_tail_ess": min(row["ess_tail"] for row in parameters),
+        "maximum_mcse_over_posterior_sd": max(
+            row["mcse_over_posterior_sd"] for row in parameters
+        ),
+        "maximum_objective_absolute_error": max(
+            row["absolute_error"] for row in objectives
+        ),
+        "total_runtime_seconds": artifact["total_runtime_seconds"],
+        "optimizer_endpoint_label": "fixed-budget DE endpoint (not MLE)",
+        "evidence_class": "authenticated compact producer summaries only",
+    }
+    boundary = {
+        "evidence_class": summary["evidence_class"],
+        "retention": {
+            **EXPECTED_BOUNDARY,
+            "sampler_backend_trace_attributes_retained": False,
+            "historical_uv_lock_bytes_retained": False,
+        },
+        "independent_raw_reverification": "blocked",
+        "ecosystem_promotion_blocked": True,
+        "public_support_or_promotion": "blocked",
+        "promotion_blockers": [
+            "the overall frozen v1 recovery gate failed",
+            "raw datasets and traces are absent",
+            "raw prior- and posterior-predictive draws are absent",
+            "ordered-Slice identity and backend trace attributes are not authenticated",
+            "runtime HSSM source is not bound to the recorded checkout",
+            "historical uv.lock bytes are absent",
+            "the current JEAM safety revision was not rerun",
+        ],
+        "optimizer_interpretation": runner["optimizer_interpretation"],
+        "objective_parity_interpretation": runner["objective_parity_interpretation"],
+        "ordered_slice_identity_independently_authenticated": False,
+        "runtime_hssm_import_bound_to_recorded_checkout": False,
+        "telemetry_interpretation": (
+            "descriptive recorded-machine observations; never a pass/fail criterion"
+        ),
+        "successor_interpretation": (
+            "mixing and identifiability are v2a/v2b hypotheses, not v1 conclusions"
+        ),
+    }
+    provenance = {
+        "spec_sha256": PINS[SPEC_PATH],
+        "addendum_sha256": PINS[ADDENDUM_PATH],
+        "result_sha256": PINS[RESULT_PATH],
+        "result_commit": RESULT_COMMIT,
+        "hssm_revision": artifact["provenance"]["hssm_revision"],
+        "spec_commit": artifact["provenance"]["spec_commit"],
+        "historical_jeam_revision": HISTORICAL_JEAM_REVISION,
+        "current_safety_jeam_revision": CURRENT_SAFETY_JEAM_REVISION,
+        "current_safety_revision_rerun": False,
+        "python_version": artifact["provenance"]["python_version"],
+        "package_versions": dict(artifact["provenance"]["package_versions"]),
+        "canonical_started_at_utc": artifact["started_at_utc"],
+        "generated_at_utc": artifact["generated_at_utc"],
+    }
+    return {
+        "study_id": artifact["study_id"],
+        "summary": summary,
+        "parameter_records": parameters,
+        "scenario_records": scenarios,
+        "aggregate_records": aggregates,
+        "objective_records": objectives,
+        "predictive_records": predictives,
+        "failure_records": failures,
+        "evidence_boundary": boundary,
+        "provenance": provenance,
+    }
+
+
+def verify_psdm_recovery_documents(
+    spec: Mapping[str, Any],
+    addendum: Mapping[str, Any],
+    artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Verify authenticated documents and derive their compact report records."""
+    try:
+        _verify_core(spec, addendum, artifact)
+        return _derive(spec, addendum, artifact)
+    except EvidenceIntegrityError:
+        raise
+    except (KeyError, TypeError, ValueError, ZeroDivisionError) as error:
+        raise EvidenceIntegrityError(
+            "Malformed fixed-PSDM compact evidence."
+        ) from error
+
+
+def load_verified_psdm_recovery_evidence(
+    root: str | Path = REPO_ROOT,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load one authenticated snapshot per frozen file and verify its science."""
+    repository = Path(root)
+    spec = _load_authenticated_json(repository / SPEC_PATH, PINS[SPEC_PATH])
+    addendum = _load_authenticated_json(repository / ADDENDUM_PATH, PINS[ADDENDUM_PATH])
+    artifact = _load_authenticated_json(repository / RESULT_PATH, PINS[RESULT_PATH])
+    return (
+        verify_psdm_recovery_documents(spec, addendum, artifact),
+        spec,
+        addendum,
+        artifact,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify the archive and emit a compact summary without tracebacks."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+    try:
+        verification, *_ = load_verified_psdm_recovery_evidence(args.root)
+    except EvidenceIntegrityError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(verification["summary"], sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "ADDENDUM_PATH",
+    "CURRENT_SAFETY_JEAM_REVISION",
+    "EXPECTED_FAILURES",
+    "EvidenceIntegrityError",
+    "HISTORICAL_JEAM_REVISION",
+    "PARAMETER_ORDER",
+    "PINS",
+    "REPO_ROOT",
+    "RESULT_PATH",
+    "SCENARIO_ORDER",
+    "SPEC_PATH",
+    "load_verified_psdm_recovery_evidence",
+    "main",
+    "verify_psdm_recovery_documents",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_jeam_psdm_recovery_report.py
+++ b/tests/test_jeam_psdm_recovery_report.py
@@ -1,0 +1,304 @@
+"""Tests for verifier-backed fixed-PSDM compact report data."""
+
+import ast
+import copy
+import inspect
+from pathlib import Path
+
+import pytest
+
+import scripts.jeam_psdm_recovery_report as report_module
+import scripts.verify_jeam_psdm_recovery_evidence as verifier_module
+from scripts.jeam_psdm_recovery_report import (
+    REPORT_KEYS,
+    load_psdm_recovery_report,
+)
+from scripts.verify_jeam_psdm_recovery_evidence import (
+    CURRENT_SAFETY_JEAM_REVISION,
+    EXPECTED_FAILURES,
+    HISTORICAL_JEAM_REVISION,
+    PARAMETER_ORDER,
+    REPO_ROOT,
+    SCENARIO_ORDER,
+    EvidenceIntegrityError,
+    load_verified_psdm_recovery_evidence,
+    verify_psdm_recovery_documents,
+)
+
+
+@pytest.fixture(scope="module")
+def verified_documents():
+    """Load the authenticated documents and recomputed records once."""
+    return load_verified_psdm_recovery_evidence()
+
+
+@pytest.fixture(scope="module")
+def report():
+    """Build the canonical compact report through its public boundary."""
+    return load_psdm_recovery_report()
+
+
+def test_authentication_precedes_json_parsing(tmp_path, monkeypatch):
+    """Malformed corrupt bytes must fail their pin without reaching JSON."""
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_bytes(b"{")
+
+    def forbidden_parse(*_args, **_kwargs):
+        raise AssertionError("corrupt unauthenticated bytes reached json.loads")
+
+    monkeypatch.setattr(verifier_module.json, "loads", forbidden_parse)
+    with pytest.raises(EvidenceIntegrityError, match="SHA256 mismatch"):
+        verifier_module._load_authenticated_json(corrupt, "0" * 64)
+
+
+def test_verifier_snapshots_each_frozen_file_once(monkeypatch):
+    """Hashing and parsing must share one byte snapshot per source file."""
+    original = Path.read_bytes
+    counts = {
+        verifier_module.SPEC_PATH.as_posix(): 0,
+        verifier_module.ADDENDUM_PATH.as_posix(): 0,
+        verifier_module.RESULT_PATH.as_posix(): 0,
+    }
+
+    def counted_read(path):
+        relative = path.relative_to(REPO_ROOT).as_posix()
+        if relative in counts:
+            counts[relative] += 1
+        return original(path)
+
+    monkeypatch.setattr(Path, "read_bytes", counted_read)
+    load_verified_psdm_recovery_evidence(REPO_ROOT)
+
+    assert counts == {name: 1 for name in counts}
+
+
+def test_report_has_stable_keys_and_exact_record_cardinalities(report):
+    """The notebook receives one unambiguous row for every compact quantity."""
+    assert tuple(report) == REPORT_KEYS
+    assert len(report["parameter_records"]) == 16
+    assert len(report["scenario_records"]) == 4
+    assert len(report["aggregate_records"]) == 4
+    assert len(report["objective_records"]) == 12
+    assert len(report["predictive_records"]) == 4
+    assert len(report["failure_records"]) == 8
+
+    assert [row["scenario"] for row in report["scenario_records"]] == list(
+        SCENARIO_ORDER
+    )
+    assert [row["parameter"] for row in report["aggregate_records"]] == list(
+        PARAMETER_ORDER
+    )
+    assert [
+        (row["scenario"], row["parameter"]) for row in report["parameter_records"]
+    ] == [
+        (scenario, parameter)
+        for scenario in SCENARIO_ORDER
+        for parameter in PARAMETER_ORDER
+    ]
+
+
+def test_summary_counts_unique_truths_and_failed_gate(report):
+    """Four scenarios by four parameters means 16 unique truth checks."""
+    summary = report["summary"]
+    unique_truths = {
+        (row["scenario"], row["parameter"]) for row in report["parameter_records"]
+    }
+
+    assert summary["unique_truth_count"] == len(unique_truths) == 16
+    assert (summary["truth_in_hdi"], summary["truth_total"]) == (14, 16)
+    assert summary["hdi_coverage"] == pytest.approx(14 / 16)
+    assert summary["failure_count"] == 8
+    assert summary["overall_pass"] is False
+    assert summary["ecosystem_promotion_blocked"] is True
+
+
+def test_failure_rows_are_recomputed_in_exact_historical_order(report):
+    """The report must preserve the eight derivable gate failures exactly."""
+    failures = report["failure_records"]
+
+    assert tuple(row["message"] for row in failures) == EXPECTED_FAILURES
+    assert [row["order"] for row in failures] == list(range(1, 9))
+    assert [row["category"] for row in failures] == [
+        "rhat",
+        "bulk_ess",
+        "mcse_over_posterior_sd",
+        "rhat",
+        "bulk_ess",
+        "mcse_over_posterior_sd",
+        "optimizer_absolute_error",
+        "optimizer_rmse",
+    ]
+
+
+def test_parameter_and_aggregate_limits_explain_the_failures(report):
+    """Individual and aggregate flags are derived from frozen thresholds."""
+    parameters = {
+        (row["scenario"], row["parameter"]): row for row in report["parameter_records"]
+    }
+    high_a = parameters[("high_threshold_strong_radial", "a")]
+    high_t = parameters[("high_threshold_strong_radial", "t")]
+    low_vy = parameters[("low_threshold_balanced_drift", "v_y")]
+
+    for row in (high_a, high_t):
+        assert row["rhat_passed"] is False
+        assert row["bulk_ess_passed"] is False
+        assert row["mcse_passed"] is False
+        assert row["tail_ess_passed"] is True
+        assert row["diagnostics_passed"] is False
+    assert low_vy["optimizer_absolute_error"] == pytest.approx(0.631520764620942)
+    assert low_vy["optimizer_absolute_error_limit"] == 0.45
+    assert low_vy["optimizer_recovery_passed"] is False
+
+    aggregate = {row["parameter"]: row for row in report["aggregate_records"]}
+    assert aggregate["v_y"]["optimizer_rmse"] > aggregate["v_y"]["optimizer_rmse_limit"]
+    assert aggregate["v_y"]["optimizer_rmse_passed"] is False
+    assert all(row["posterior_bias_passed"] for row in aggregate.values())
+    assert all(row["posterior_rmse_passed"] for row in aggregate.values())
+    assert all(row["hdi_coverage_passed"] for row in aggregate.values())
+
+
+def test_objective_and_predictive_records_are_bounded_compact_summaries(report):
+    """Passing subgates stay distinct from the failed overall recovery gate."""
+    objective = report["objective_records"]
+    predictive = report["predictive_records"]
+
+    assert {row["candidate"] for row in objective} == {1, 2, 3}
+    assert all(row["passed"] for row in objective)
+    assert max(row["absolute_error"] for row in objective) == pytest.approx(
+        report["summary"]["maximum_objective_absolute_error"]
+    )
+    assert all(row["passed"] for row in predictive)
+    assert all(
+        row["evidence_scope"] == "authenticated producer summaries; raw draws absent"
+        for row in predictive
+    )
+
+
+def test_evidence_boundary_keeps_every_missing_source_visible(report):
+    """Compact summaries cannot masquerade as retained raw evidence."""
+    boundary = report["evidence_boundary"]
+    retention = boundary["retention"]
+
+    assert retention["raw_datasets_retained_in_git"] == 0
+    assert retention["raw_traces_retained_in_git"] == 0
+    assert retention["raw_prior_predictive_draws_retained"] is False
+    assert retention["raw_posterior_predictive_draws_retained"] is False
+    assert retention["sampler_backend_trace_attributes_retained"] is False
+    assert retention["historical_uv_lock_bytes_retained"] is False
+    assert boundary["independent_raw_reverification"] == "blocked"
+    assert boundary["ecosystem_promotion_blocked"] is True
+    assert boundary["public_support_or_promotion"] == "blocked"
+    assert boundary["ordered_slice_identity_independently_authenticated"] is False
+    assert boundary["runtime_hssm_import_bound_to_recorded_checkout"] is False
+    assert (
+        "same historical JEAM producer" in boundary["objective_parity_interpretation"]
+    )
+    assert "v2a/v2b hypotheses" in boundary["successor_interpretation"]
+
+
+def test_revision_and_optimizer_labels_prevent_historical_overclaim(report):
+    """Historical evidence is not relabeled as a current rerun or an MLE."""
+    provenance = report["provenance"]
+    boundary = report["evidence_boundary"]
+
+    assert provenance["historical_jeam_revision"] == HISTORICAL_JEAM_REVISION
+    assert provenance["current_safety_jeam_revision"] == CURRENT_SAFETY_JEAM_REVISION
+    assert provenance["current_safety_revision_rerun"] is False
+    assert report["summary"]["optimizer_endpoint_label"] == (
+        "fixed-budget DE endpoint (not MLE)"
+    )
+    assert (
+        "fixed-budget differential-evolution endpoints"
+        in boundary["optimizer_interpretation"]
+    )
+    assert (
+        "not demonstrated converged optima or MLEs"
+        in boundary["optimizer_interpretation"]
+    )
+
+
+def test_runtime_telemetry_is_descriptive_not_a_gate(report):
+    """Recorded wall time remains descriptive and machine-scoped."""
+    boundary = report["evidence_boundary"]
+    scenarios = report["scenario_records"]
+
+    assert boundary["telemetry_interpretation"] == (
+        "descriptive recorded-machine observations; never a pass/fail criterion"
+    )
+    assert all(row["timing_scope"].startswith("descriptive") for row in scenarios)
+    assert all(row["sampling_seconds"] > 0 for row in scenarios)
+    assert all(row["total_seconds"] > row["sampling_seconds"] for row in scenarios)
+    assert not any("seconds" in row["message"] for row in report["failure_records"])
+
+
+def test_report_loader_calls_verifier_once_and_never_reads_files(
+    monkeypatch, verified_documents
+):
+    """Only the verifier may own frozen-file reads and authentication."""
+    calls = []
+
+    def fake_load(root):
+        calls.append(root)
+        return copy.deepcopy(verified_documents)
+
+    monkeypatch.setattr(
+        report_module, "load_verified_psdm_recovery_evidence", fake_load
+    )
+    loaded = report_module.load_psdm_recovery_report("sentinel-root")
+
+    assert calls == ["sentinel-root"]
+    assert loaded["summary"]["unique_truth_count"] == 16
+
+    tree = ast.parse(inspect.getsource(report_module))
+    verifier_calls = 0
+    forbidden_calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "load_verified_psdm_recovery_evidence":
+                verifier_calls += 1
+            if node.func.id == "open":
+                forbidden_calls.append(node.func.id)
+        elif isinstance(node.func, ast.Attribute) and node.func.attr in {
+            "open",
+            "read_bytes",
+            "read_text",
+        }:
+            forbidden_calls.append(node.func.attr)
+    assert verifier_calls == 1
+    assert forbidden_calls == []
+
+
+def test_verifier_and_report_import_no_modeling_or_sampling_stack():
+    """Compact verification must stay network-free and model-stack-free."""
+    forbidden_imports = {"hssm", "jeam", "pymc", "bambi", "arviz"}
+    for module in (verifier_module, report_module):
+        tree = ast.parse(inspect.getsource(module))
+        imports = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+        assert imports.isdisjoint(forbidden_imports)
+
+
+def test_semantic_mutation_is_rejected_after_authentication(verified_documents):
+    """Derived truth inclusion and stored gates cannot drift independently."""
+    _verification, spec, addendum, artifact = verified_documents
+    mutated = copy.deepcopy(artifact)
+    mutated["scenarios"][0]["parameters"][0]["truth_in_hdi"] = False
+
+    with pytest.raises(EvidenceIntegrityError, match="Stored HDI inclusion changed"):
+        verify_psdm_recovery_documents(spec, addendum, mutated)
+
+
+def test_verifier_cli_normalizes_integrity_errors(tmp_path, capsys):
+    """CLI failures are concise and never expose an internal traceback."""
+    assert verifier_module.main(["--root", str(tmp_path)]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("error: Cannot snapshot")
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Purpose

- archive the fixed-PSDM v1 recovery result as authenticated compact evidence
- replace the stale report with a network-free marimo view that verifies the frozen spec, addendum, and result before rendering

## Changes

- hash and cross-check the three immutable JSON snapshots, then recompute every derivable compact quantity and the exact eight recorded failures
- report the expected failed gate, 14/16 truth-in-HDI checks, fixed-budget differential-evolution endpoints, objective-adapter parity, diagnostics, and producer-recorded predictive summaries
- execute the report in MkDocs and validate both its standalone export and deployed page for required content, rendered figures, stale claims, errors, and host-path leakage

## Evidence boundary

- this is a seeded four-scenario scalar/intercept-only recovery smoke, not calibration or current-stack recovery evidence
- the optimizer rows are fixed-budget endpoints, not demonstrated MLEs or converged optima
- objective agreement establishes same-historical-producer adapter fidelity, not independent likelihood validation
- zero raw datasets, posterior traces, prior/PPC draws, or backend attributes survive; raw reverification and fixed-PSDM public support remain blocked
- historical JEAM was `1d711275...`; current safety JEAM `ede7a4f4...` was not rerun
- no frozen artifact was changed and no simulation, optimization, prediction, or MCMC was run

## Verification

- 30 focused protocol, compact-artifact, and report tests passed
- standalone verifier reproduced `overall_pass=false`, 14/16 inclusions, and eight failures
- Ruff check/format, mypy, Pyrefly, YAML parsing, docs-weight, and diff checks passed
- strict marimo check/export and strict MkDocs build passed; the report rendered four scientific figures and two selectors without contamination

## Follow-up

Any v2a mixing-budget or v2b information-design study needs a new preregistration and durable raw evidence. This PR does not authorize a v1 rerun or alter its negative result.
