### PR TITLE
ci: drop duplicate graphviz install from notebook env setup

### DIFF
--- a/.github/setup-env-notebooks/action.yml
+++ b/.github/setup-env-notebooks/action.yml
@@ -28,14 +28,6 @@ runs:
 
     # (a stale `if: steps.cache.outputs.cache-hit` guard used to sit here —
     # no step with id `cache` exists, so it always evaluated true)
-    # Several tutorials call `model.graph()`, which shells out to Graphviz's
-    # `dot`. The Python wrapper comes from the notebook group; the binary does
-    # not, and without it those notebooks fail with
-    # `FileNotFoundError: PosixPath('dot')`.
-    - name: Install Graphviz
-      run: sudo apt-get update && sudo apt-get install -y graphviz
-      shell: bash
-
     - name: Install hssm
       run: uv sync --group notebook
       shell: bash


### PR DESCRIPTION
Mechanical drift healing (weekly `audit-drift` session, 2026-08-17).

- `.github/setup-env-notebooks/action.yml` installed graphviz **twice**: PRs #1184 and #1188 landed within two hours of each other on 2026-08-13 and each added an `apt-get update && apt-get install -y graphviz` step.
- Keeps the first step (and its comment); drops the second. Net −8 lines.
- Saves a redundant `apt-get update` on each of the 4 notebook shards per drift run.

No behavior change — `dot` is still on PATH for every notebook job. Verified the action still parses and retains exactly one graphviz step.

Context: the `hssm-notebooks` freshness budget went red because run 31734899653 (2026-08-13 19:15 UTC) failed all 4 shards on `ExecutableNotFound: 'dot'` — that run started *before* either graphviz fix merged. A fresh notebook run is in flight to clear the budget: https://github.com/lnccbrown/HSSM/actions/runs/32063688775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined notebook environment setup by removing a redundant Graphviz installation step.
  * Notebook dependency installation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->