### PR TITLE
Register `dev_rlddm` in HSSM (from fontanesi-2019-rlddm)

### DIFF
--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -12,6 +12,7 @@ LogLik = Union[str, PathLike, Callable, Op, type[Distribution]]
 ParamSpec = Union[float, dict[str, Any], bmb.Prior, None]
 
 SupportedModels = Literal[
+    "dev_rlddm",
     "ddm",
     "ddm_sdv",
     "full_ddm",

--- a/src/hssm/modelconfig/dev_rlddm_config.py
+++ b/src/hssm/modelconfig/dev_rlddm_config.py
@@ -1,0 +1,47 @@
+"""Registration for `dev_rlddm`, contributed by HSSMCortex.
+
+Blocked on the `ssm-simulators` release carrying the simulator; opened as a draft.
+Spec: papers/ssm-theory/fontanesi-2019-rlddm.spec.md
+"""
+
+from .._types import DefaultConfig
+
+
+def get_dev_rlddm_config() -> DefaultConfig:
+    """Get the default configuration for the `dev_rlddm` model.
+
+    Returns
+    -------
+    DefaultConfig
+        Response variables, parameters, choices and likelihood specification.
+    """
+    return {
+        "response": ["rt", "response"],
+        "list_params": ['eta_pos', 'eta_neg', 'v_mod', 'v_max', 'a_fix', 'a_mod', 't_er', 'q_cor', 'q_inc', 'q_pres'],
+        "choices": [-1, 1],
+        "description": 'fontanesi-2019-rlddm',
+        "likelihoods": {
+            "approx_differentiable": {
+                # NOT TRAINED. This registration is a draft: the likelihood approximator this
+                # model needs does not exist yet, and training one is a modelling decision with a
+                # cost, made by a person. Naming the file it would be is how the reviewer sees
+                # what is outstanding; setting it to something that exists would be worse.
+                "loglik": None,
+                "backend": "jax",
+                "default_priors": {},
+                "bounds": {
+                    'eta_pos': (0.01, 0.3),
+                    'eta_neg': (0.01, 0.3),
+                    'v_mod': (0.1, 2.0),
+                    'v_max': (1.5, 6.0),
+                    'a_fix': (0.3, 1.8),
+                    'a_mod': (-0.05, 0.01),
+                    't_er': (0.4, 1.1),
+                    'q_cor': (27.5, 55.0),
+                    'q_inc': (27.5, 55.0),
+                    'q_pres': (27.5, 55.0),
+                },
+                "extra_fields": None,
+            },
+        },
+    }


### PR DESCRIPTION
Rungs 2 (reduction), 3 (benchmark) ran. Not run: rung 1 (reference) — the model has no ssms entry, which is the normal case for a new model: rung 1 is unavailable BY DEFINITION for anything genuinely novel, since the registry cannot already carry it; rung 4 (recovery) — timed one fit cycle: 0.114 min at 1000 trials.

**Opened as a draft.** The verification report reached only the rungs listed below. `verified` is reserved for a spec reaching rung 1 or rung 3 — see the contribution contract §2 for why this is the expected shape of a novel-model contribution rather than a failure.

**This opens as a draft because every failure is explained, not because none failed.**

*Accounted for by a diagnosis*: `benchmark:results_behavioral_learning_effect:accuracy_first_20_trials`, `benchmark:results_behavioral_learning_effect:accuracy_last_20_trials`, `benchmark:results_behavioral_difficulty_effect:accuracy_easy_AC_BD`, `benchmark:results_behavioral_difficulty_effect:accuracy_difficult_AB_CD`, `benchmark:results_behavioral_magnitude_effect:accuracy_high_value_pairs`, `benchmark:results_behavioral_magnitude_effect:accuracy_low_value_pairs` — no prediction covered these; the harness identified their cause afterwards, from the sign pattern across statistic classes. See **Review this first** above. The reviewer, not the pipeline, decides whether the account holds.


Opened as a draft **blocked on** the `ssm-simulators` release that must carry the model (lnccbrown/ssm-simulators#334). The proposed prior is a modelling claim and is **not** derived from `sim_range` or from `param_bounds` — which makes it the part of this change least supported by anything the harness checks, and the part most in need of a maintainer's judgement.


## Review this first

> **The specification behind this contribution has not been read by a person.** Its `provenance.review_status` is `proposal`: a model extracted this paper's model from the paper, and everything below follows from that reading. Treat the whole contribution as a proposal about what the paper says, not as a transcription of it.

This contribution was generated by reading a paper, and a paper does not state every quantity a simulator needs. Below is everything the pipeline decided that the paper did not, and everything it could not verify but can explain. Each row says what would show it wrong.

### Assumed — the paper is silent, the pipeline filled it in

| Field | Value | Kind | Taken from | Wrong if |
| --- | --- | --- | --- | --- |
| `model_name` | `dev_rlddm` | notational | the spec's own `family` | a maintainer preferring a different token, or an existing entry that already models this -- in which case this paper contributes a citation and a benchmark to it rather than `dev_rlddm` |

### Diagnosed — checks that failed, and why

**These are still failures.** A diagnosis is the pipeline's account of the cause, measured rather than asserted; it does not turn a `fail` into a `pass`, and no parameter was adjusted to close any gap. It is what to look at first.

**drift too large** — high confidence, covering 12 check(s).

- *measured*: 12 benchmark values across 2 statistic class(es) miss in one direction: central_rt below published in 6 of 6, proportion above published in 6 of 6. Of the 6 single causes this family admits, that pattern is produced by exactly one
- *look at*: the scale of the drift's input. A drift built from a quantity the paper reports on one scale (a learning signal, a value difference) and consumed on another is off by a factor in exactly this direction. The reading this runs through is one the extractor was not sure of -- `process.dynamics.drift.expression`, `process.dynamics.drift.time_dependence`, `process.dynamics.noise.scale`, `conventions.paper.noise_scale` graded low/medium in `provenance.field_confidence`
- *refuted by*: a condition where the published accuracy is HIGHER than the simulated one. One such condition refutes a uniform drift excess


| Provenance | |
| --- | --- |
| Spec | `papers/ssm-theory/fontanesi-2019-rlddm.spec.md` |
| Report | `papers/ssm-theory/fontanesi-2019-rlddm.report.json` |
| `ssms` version | `0.13.2` |
| Verdict | `draft (amber)` (gate arm: amber) |
| Consultation | `pending` |

This change was opened by a machine and is **awaiting human approval**. It is a draft: nothing here has been approved by a person, and the checks above are the machine's own account of its work. Merging is the approval.

**Verification**

| Check | Result | Predicted | Accounted |
| --- | --- | --- | --- |
| `conventions` | pass | — | — |
| `property:candidate__dev_rlddm` | pass | — | — |
| `structural:candidate__dev_rlddm` | pass | — | — |
| `analytic` | not_run | — | — |
| `reference` | not_run | — | — |
| `reduction:ddm` | pass | — | — |
| `reduction:ddm` | pass | — | — |
| `benchmark:results_behavioral_learning_effect:accuracy_first_20_trials` | fail | — | yes |
| `benchmark:results_behavioral_learning_effect:accuracy_last_20_trials` | fail | — | yes |
| `benchmark:results_behavioral_learning_effect:mean_rt_first_20_trials_s` | advisory | — | — |
| `benchmark:results_behavioral_learning_effect:mean_rt_last_20_trials_s` | advisory | — | — |
| `benchmark:results_behavioral_difficulty_effect:accuracy_easy_AC_BD` | fail | — | yes |
| `benchmark:results_behavioral_difficulty_effect:accuracy_difficult_AB_CD` | fail | — | yes |
| `benchmark:results_behavioral_difficulty_effect_rt:mean_rt_easy_s` | advisory | — | — |
| `benchmark:results_behavioral_difficulty_effect_rt:mean_rt_difficult_s` | advisory | — | — |
| `benchmark:results_behavioral_magnitude_effect:accuracy_high_value_pairs` | fail | — | yes |
| `benchmark:results_behavioral_magnitude_effect:accuracy_low_value_pairs` | fail | — | yes |
| `benchmark:results_behavioral_magnitude_effect:mean_rt_high_value_pairs_s` | advisory | — | — |
| `benchmark:results_behavioral_magnitude_effect:mean_rt_low_value_pairs_s` | advisory | — | — |
| `recovery` | not_run | — | — |