### PR TITLE
Stabilize the HSSM documentation baseline

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/linting_and_type_checking.yml
 
   publish:
-    name: Build wheel and publish to test-PyPI, then PyPI, and publish docs
+    name: Build wheel and publish to TestPyPI, then PyPI
     needs: [lint_and_typecheck]
     runs-on: ubuntu-latest
 
@@ -40,6 +40,3 @@ jobs:
       - name: Publish to PyPI
         run: |
           uv publish --token ${{ secrets.PYPI_TOKEN }}
-
-      - name: Build and publish docs
-        run: uv run --group notebook --group docs mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,12 +6,13 @@ edit_uri: edit/main/docs
 
 validation:
   omitted_files: warn
-  # phase-2 consolidation targets, deliberately unlisted until then
-not_in_nav: |
-  tutorials/attentional_ddm.py
   absolute_links: warn
   unrecognized_links: warn
   anchors: warn
+
+# phase-2 consolidation targets, deliberately unlisted until then
+not_in_nav: |
+  tutorials/attentional_ddm.py
 
 nav:
   - Home:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ docs = [
     "mkdocs>=1.6.0",
     "mkdocs-jupyter>=0.25.1",
     "mkdocstrings-python>=1.10.0",
-    "mkdocs-redirects>=1.2.0",
+    "mkdocs-redirects==1.2.2",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Purpose

Restore HSSM's strict documentation baseline before the ecosystem-wide Pages
artifact migration.

## Changes

- restore `absolute_links`, `unrecognized_links`, and `anchors` as real MkDocs
  validation keys alongside `omitted_files`;
- pin `mkdocs-redirects==1.2.2`, avoiding the 1.2.3 ProperDocs release; and
- remove the duplicate release-time docs deployment from package publishing,
  leaving the existing Docs workflow as the temporary sole deploy owner.

## Verification

- `python3 scripts/check_docs_weight.py`
- parsed `mkdocs.yml` with all four validation keys
- resolved `mkdocs-redirects 1.2.2` and confirmed ProperDocs is absent
- `uv run --group notebook --group docs mkdocs build --strict`
- confirmed only `.github/workflows/build_docs.yml` retains `gh-deploy`

## Scope

This PR does not yet migrate Pages publication or standardize the full docs
toolchain; those changes follow after the shared HSSMSpine workflow is live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation validation settings for more consistent link and anchor checking.
  * Clarified navigation handling for the attentional DDM tutorial.
* **Chores**
  * Automated package publishing to TestPyPI and PyPI remains available.
  * Automated documentation deployment has been removed from the publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->