### PR TITLE
Skip BLAS setup for lint checks

### DIFF
--- a/.github/setup-env/action.yml
+++ b/.github/setup-env/action.yml
@@ -4,6 +4,10 @@ inputs:
   python-version:
     description: "The Python version to set up"
     required: true
+  install-blas:
+    description: "Whether to install the system BLAS and LAPACK development packages"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -16,6 +20,7 @@ runs:
     # packages the linker cannot resolve those flags and PyTensor's C backend
     # fails to compile any BLAS-using op.
     - name: Install BLAS and LAPACK
+      if: ${{ inputs.install-blas == 'true' }}
       run: sudo apt-get update && sudo apt-get install -y libblas-dev liblapack-dev
       shell: bash
 

--- a/.github/workflows/linting_and_type_checking.yml
+++ b/.github/workflows/linting_and_type_checking.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ./.github/setup-env
         with:
           python-version: ${{ matrix.python-version }}
+          install-blas: "false"
 
       - name: Run pyrefly
         run: uv run pyrefly check


### PR DESCRIPTION
## Summary

- let the shared setup action skip BLAS/LAPACK installation when a caller does not need it
- keep BLAS installation enabled by default for tests, docs, builds, releases, and the optional JEAM lane
- opt out only in lint/type, avoiding the Azure `apt-get update` stall that canceled HSSM #1199 twice before any static tool ran

## Validation

- parsed both changed workflow files as YAML
- verified all seven shared setup callers and confirmed only lint/type opts out
- `git diff --check`

## Scope

- CI-only; no package, dependency, lockfile, or test behavior changes
- broader retry/timeout policy for jobs that still require apt remains deferred
