### PR TITLE
ddm_sdv: declare the sv bound the network was actually trained on

### DIFF
--- a/src/hssm/modelconfig/ddm_sdv_config.py
+++ b/src/hssm/modelconfig/ddm_sdv_config.py
@@ -45,12 +45,20 @@ def get_ddm_sdv_config() -> DefaultConfig:
                         "sigma": 2.0,
                     },
                 },
+                # The network's training box (ssms `ddm_sdv` param_bounds), which
+                # is what these bounds are supposed to describe: outside it the
+                # LAN extrapolates and returns a finite but wrong density.
+                # `sv` was (0.0, 1.0) here while training covered (0.001, 2.5) —
+                # written before any ddm_sdv.onnx existed, so it described no
+                # actual network. The published network's density gate samples
+                # `sv` up to 2.25 and passes there (total mass within 0.15% of 1,
+                # Hellinger at or below the KDE sampling floor).
                 "bounds": {
                     "v": (-3.0, 3.0),
                     "a": (0.3, 2.5),
                     "z": (0.1, 0.9),
                     "t": (0.0, 2.0),
-                    "sv": (0.0, 1.0),
+                    "sv": (0.0, 2.5),
                 },
                 "extra_fields": None,
             },

--- a/tests/unit/modelconfig/test_lan_bounds_match_training.py
+++ b/tests/unit/modelconfig/test_lan_bounds_match_training.py
@@ -1,0 +1,73 @@
+"""The `approx_differentiable` bounds must describe the network's training box.
+
+These bounds are not a modelling preference — they are the region the LAN was
+fit on. Outside it the network does not fail; it extrapolates and returns a
+finite, plausible, wrong density, which the sampler will happily explore. So a
+bound wider than the training box is a correctness bug, and one narrower than
+it silently withholds range the network was validated on.
+
+The source of truth is ssms' `param_bounds` for the same model.
+"""
+
+import pytest
+import ssms
+
+from hssm.modelconfig import get_default_model_config
+from hssm.defaults import SupportedModels
+from typing import get_args
+
+# Bounds HSSM declares that do NOT match the training box, with the reason.
+# Pinned exactly: a new mismatch fails this test, and so does *fixing* one
+# without removing it here — which is the point. A silently-growing waiver
+# list is how this kind of drift becomes permanent.
+KNOWN_MISMATCHES = {
+    # HSSM allows z in (0, 1) while ddm.onnx was trained on [0.1, 0.9], so the
+    # sampler can explore 20% of the interval where the network extrapolates.
+    # Widening the training box or narrowing this bound is a user-facing
+    # change to the most-used model in the ecosystem; tracked separately.
+    ("ddm", "z"),
+}
+
+
+def _models_with_lan_bounds():
+    for name in get_args(SupportedModels):
+        try:
+            cfg = get_default_model_config(name)
+        except Exception:
+            continue
+        lik = (cfg.get("likelihoods") or {}).get("approx_differentiable")
+        if lik and lik.get("bounds") and name in ssms.config.model_config:
+            yield name, lik["bounds"]
+
+
+def test_declared_bounds_match_the_training_box():
+    found = set()
+    for name, bounds in _models_with_lan_bounds():
+        mc = ssms.config.model_config[name]
+        lo, hi = mc["param_bounds"]
+        train = dict(zip(mc["params"], zip(map(float, lo), map(float, hi))))
+        for param, (declared_lo, declared_hi) in bounds.items():
+            if param not in train:
+                continue
+            train_lo, train_hi = train[param]
+            # The lower edge is conventionally rounded (0.001 -> 0.0); the
+            # upper edge and any real difference are not.
+            mismatch = (
+                abs(declared_hi - train_hi) > 1e-6 or abs(declared_lo - train_lo) > 0.01
+            )
+            if mismatch:
+                found.add((name, param))
+    assert found == KNOWN_MISMATCHES, (
+        f"bounds drifted from the training box.\n"
+        f"  newly mismatched: {sorted(found - KNOWN_MISMATCHES)}\n"
+        f"  fixed (remove from KNOWN_MISMATCHES): {sorted(KNOWN_MISMATCHES - found)}"
+    )
+
+
+def test_ddm_sdv_sv_covers_the_full_trained_range():
+    # Regression: this was (0.0, 1.0) — written before any ddm_sdv.onnx
+    # existed — while training and the density gate both cover sv up to 2.5.
+    bounds = get_default_model_config("ddm_sdv")["likelihoods"][
+        "approx_differentiable"
+    ]["bounds"]
+    assert bounds["sv"] == (0.0, 2.5)


### PR DESCRIPTION
## What

`ddm_sdv`'s `approx_differentiable` bound for `sv` goes from `(0.0, 1.0)` to `(0.0, 2.5)`, matching the box ssms trains the network on. Adds a test asserting that every model's declared LAN bounds match its training box.

## Why

These bounds are not a modelling preference — they describe the region the LAN was fit on. Outside it the network does not fail; it extrapolates and returns a finite, plausible, wrong density that the sampler explores freely.

`ddm_sdv` declared `sv ∈ (0.0, 1.0)` while ssms trains it on `(0.001, 2.5)`. That bound was written **before any `ddm_sdv.onnx` existed** — it described no actual network, and withheld 60% of the trained range from users for no reason.

A network now exists ([`franklab/HSSM` commit `79a62f3b`](https://huggingface.co/franklab/HSSM), published today), and its density gate samples `sv` up to 2.25 and passes there. From its `validation_report.json`, all five draws had `sv > 1.0`:

| `sv` | total mass | Hellinger ratio |
|---|---|---|
| 1.877 | 0.9978 | 0.795 |
| 2.120 | 1.0005 | 0.919 |
| 1.710 | 1.0013 | 1.025 |
| 1.096 | 0.9985 | 0.772 |
| 1.481 | 0.9985 | 0.997 |

Mass within 0.15% of 1.0 throughout, and Hellinger at or below the KDE sampling noise floor on four of five. The lower edge is rounded `0.001 → 0.0`, matching how `t` is already declared here.

## The test

An audit of all eight models carrying `approx_differentiable` bounds found six matching their training box exactly and two not. This class of drift is invisible — nothing fails, the fit just quietly uses an extrapolated density — so the invariant is now pinned in `tests/unit/modelconfig/test_lan_bounds_match_training.py`.

It asserts the mismatch set **equals** `{("ddm", "z")}` rather than merely containing it. A new mismatch fails, and so does *fixing* one without removing its waiver. A waiver list that can only grow is how `ddm_sdv`'s wrong bound survived describing a nonexistent network.

## Not fixed here

`ddm` declares `z: (0.0, 1.0)` against a trained `[0.1, 0.9]` — **wider** than the training box, i.e. the dangerous direction, in the most-used model in the ecosystem. Measured error against the analytical density is ~0.1 log units per trial inside the box and **1.68 at `z = 0.99`**.

That is filed as #1229 rather than fixed here: narrowing a bound changes user-facing sampling behaviour and could alter published fits, which deserves its own decision.

## Verification

`49 passed` across `tests/unit/modelconfig/` and `tests/unit/likelihoods/`; ruff clean. The new test passes precisely because `ddm_sdv` is now clean and `ddm` is still the sole outlier — the equality assertion checks both directions at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental JEAM circular-diffusion support, including simulation, analytical and black-box likelihoods, circular responses, and selectable sampler support.
  * Added reproducible predictive sampling with integer seeds.
  * Added benchmark reports for recovery, objective parity, and sampler comparisons.
* **Documentation**
  * Added installation guidance, reference documentation, and interactive tutorials for JEAM modeling, recovery, and sampler efficiency.
* **Bug Fixes**
  * Improved validation for continuous and circular responses, parameter bounds, choices, and sampler configuration.
  * Corrected plotting behavior for models without categorical choices.
* **Tests**
  * Expanded coverage for JEAM integration, simulation, prediction, recovery, validation, and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->