### PR TITLE
docs: refresh the canonical ecosystem map

### DIFF
--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -1,160 +1,106 @@
 # The HSSM ecosystem
 
-HSSM is the user-facing package of a four-part toolchain. Most users never
-leave it: install HSSM, fit models, publish. You end up here when a question
-crosses a package boundary — where does a likelihood network come from, which
-version pairs with which, why does an ONNX file have to look a certain way.
+The HSSM ecosystem separates simulation, network training, validated artifact
+production, inference, capability support, and cross-repository coordination.
+Most users begin with HSSM; contributors use this map when a question crosses
+one of those ownership boundaries.
 
-This page is the map. It is maintained in
-[HSSMSpine](https://github.com/lnccbrown/HSSMSpine), the ecosystem's
-coordination repository, and published here so there is one description of the
-whole rather than three partial ones.
+This is the canonical public map, hosted by
+[HSSM](https://lnccbrown.github.io/HSSM/). HSSMSpine maintains the shared source
+and synchronization contract while its repository remains private, so the
+established [HSSM ecosystem URL](https://lnccbrown.github.io/HSSM/ecosystem/)
+continues to be the durable entry point.
 
-## The packages you install
+<!-- Preserve fragments from the established HSSM ecosystem URL. -->
+<span id="the-packages-you-install"></span>
+<span id="development-and-coordination"></span>
 
-| Package | Owns | Start here if you want to... |
+## The six native sites
+
+| Documentation site | Owns | Start here when you want to... |
 |---|---|---|
-| [HSSM](https://lnccbrown.github.io/HSSM/) | Bayesian inference on sequential sampling models — model specification, priors, sampling, diagnostics, model comparison | ...fit a model to behavioral data. This is the default answer. |
-| [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) (`ssms`) | The generative models: simulators for the SSM family, task environments and learning rules for RLSSMs, and the training-data generators | ...simulate from a model, add a new model to the family, or generate training data. |
-| [LANfactory](https://lnccbrown.github.io/LANfactory/) | Training likelihood approximation networks on simulated data, and exporting them to ONNX | ...train your own likelihood network, or export one trained elsewhere. |
-| [LAN_pipeline_minimal](https://github.com/lnccbrown/LAN_pipeline_minimal) | Orchestration on a cluster: data generation and network training as scheduled jobs | ...produce networks at scale rather than one at a time. |
+| [HSSM](https://lnccbrown.github.io/HSSM/) | User-facing Bayesian inference for sequential sampling models | fit and diagnose a model with the supported HSSM interfaces |
+| [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) | Simulator behavior, model configuration, and simulation-result contracts | simulate data or extend the simulator family |
+| [LANfactory](https://lnccbrown.github.io/LANfactory/) | Likelihood-network training and export | train or export a likelihood approximation |
+| [LAN_pipeline_minimal](https://lnccbrown.github.io/LAN_pipeline_minimal/) | Validated generation, training, staging, and promotion workflows | produce and validate network artifacts through the supported operator path |
+| [HSSMCortex](https://lnccbrown.github.io/HSSMCortex/) | Optional knowledge and capability support for ecosystem development | query curated knowledge or develop shared capability content |
+| [HSSMSpine](https://lnccbrown.github.io/HSSMSpine/) | Cross-repository context, contracts, launchers, and maintenance; the source workspace remains private | coordinate a change spanning repositories |
 
 ## How the pieces connect
 
-The chain runs in one direction, and the handoffs are files rather than
-imports:
-
 ```text
-ssm-simulators ──simulated training data──> LANfactory ──ONNX network──> HuggingFace
-                                                                             │
-                                                                             ▼
-                                                                           HSSM
-                                                          (downloads networks at run time)
+ssm-simulators ──> LANfactory ──> trained networks ──> artifact store
+       │                                                   │
+       │                                                   v
+       └───────────────────────────────────────────────> HSSM
+
+LAN_pipeline_minimal orchestrates generation, training, validation,
+staging, and promotion. HSSMSpine coordinates repository work.
+HSSMCortex provides optional knowledge and capability support.
 ```
 
-Two things follow from this shape.
+Python dependency edges and artifact handoffs are different. HSSM and
+LANfactory consume ssm-simulators as a package. Trained networks cross the
+boundary as artifacts plus metadata, and HSSM owns consumer-side loading.
+LAN_pipeline_minimal owns the validated promotion path; the artifact store is
+a delivery surface, not the source of training policy.
 
-**Networks are artifacts, not code.** Many SSMs have no analytical likelihood.
-For those, a neural network is trained once — offline, on simulated data — to
-approximate the likelihood, and HSSM calls that network during sampling. The
-trained networks live on
-[HuggingFace](https://huggingface.co/franklab/HSSM); HSSM downloads what a
-model needs on first use. You do not need LANfactory installed to use a
-network someone else trained.
+The ONNX consumer contract is owned by HSSM. Producers and third-party
+exporters should follow the
+[rendered HSSM contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/)
+rather than a duplicate summary here.
 
-**The boundary is a contract, not a convention.** Any ONNX file HSSM loads
-must expose one per-trial forward pass with every input dimension concrete;
-HSSM batches across trials itself. That rule is stated once, with runnable
-checks, in [The ONNX likelihood
-contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/).
-It is also what makes the ecosystem open at the edges: a network trained in
-[sbi](https://github.com/sbi-dev/sbi) or
-[BayesFlow](https://github.com/bayesflow-org/bayesflow) becomes usable in HSSM
-by exporting it to ONNX with LANfactory's exporters, after which HSSM loads it
-with the same `loglik="model.onnx"` gesture it uses for its own networks — no
-library-specific glue on the HSSM side.
+<span id="which-package-answers-your-question"></span>
+<span id="tracking-runs-with-mlflow"></span>
 
-## Which package answers your question
+## Which site answers the question?
 
-| Your question | Where it is answered |
+| Question | Owning documentation |
 |---|---|
-| How do I fit this model to my data? | [HSSM — Learn](https://lnccbrown.github.io/HSSM/) |
-| What models exist, and what are their parameters? | [ssm-simulators — Reference](https://lnccbrown.github.io/ssm-simulators/) |
-| How do I simulate data from a model? | [ssm-simulators — Learn](https://lnccbrown.github.io/ssm-simulators/) |
-| How do I add a model that does not exist yet? | [ssm-simulators — Contributing](https://lnccbrown.github.io/ssm-simulators/) |
-| How do I train a likelihood network for it? | [LANfactory — Learn](https://lnccbrown.github.io/LANfactory/) |
-| I trained a network in sbi or BayesFlow — now what? | [HSSM — Bring your own likelihood](https://lnccbrown.github.io/HSSM/how_to/external_trainers/) |
-| How do I track training and data-generation runs? | [Tracking runs with MLflow](#tracking-runs-with-mlflow), below |
-| Which versions work together? | [Version compatibility](#version-compatibility), below |
-| What is this package in my traceback or lockfile? | [Supporting components](#supporting-components), below |
-| How do I contribute across several packages? | [Development and coordination](#development-and-coordination), below |
+| How do I fit or diagnose a model? | [HSSM](https://lnccbrown.github.io/HSSM/) |
+| How do I simulate data or change simulator output? | [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) |
+| How do I train or export a likelihood network? | [LANfactory](https://lnccbrown.github.io/LANfactory/) |
+| How do I validate and promote a trained artifact? | [LAN pipeline](https://lnccbrown.github.io/LAN_pipeline_minimal/) |
+| How do I track generation and training runs? | [LAN pipeline — MLflow](https://lnccbrown.github.io/LAN_pipeline_minimal/how-to/track-with-mlflow/) |
+| How do I query or extend the capability layer? | [HSSMCortex](https://lnccbrown.github.io/HSSMCortex/) |
+| How do I coordinate a cross-repository change? | [HSSMSpine](https://lnccbrown.github.io/HSSMSpine/) |
 
-Each site is organised the same way — **Learn**, **How-to guides**,
-**Explanations**, **Reference** — so the tab you want sits in the same place
-on all three.
+All native sites use the same top-level path—**Home**, **Learn**,
+**How-to guides**, **Explanations**, and **Reference**—while keeping package
+behavior in the repository that implements and tests it.
 
-## Supporting components
+<span id="supporting-components"></span>
 
-These are not packages you choose — they arrive with HSSM, or hold artifacts
-it fetches. They are listed here because their names show up in tracebacks,
-lockfiles, and download logs.
+## Artifact and integration surfaces
 
-| Component | What it is |
-|---|---|
-| [`hddm-wfpt`](https://github.com/lnccbrown/hddm-wfpt) | The Cython implementation of the Wiener first-passage-time likelihood, inherited from HDDM. Installed with HSSM, and used for the analytical DDM likelihoods. |
-| [`franklab/HSSM`](https://huggingface.co/franklab/HSSM) | The HuggingFace repository holding trained likelihood networks. HSSM downloads from it on first use of a model without an analytical likelihood. |
-| [`franklab/ssms_gui`](https://huggingface.co/spaces/franklab/ssms_gui) | A HuggingFace Space for exploring SSM behaviour interactively, built on `ssm-simulators`. Useful for building intuition about what a parameter does. |
-| conda-forge feedstocks | `hssm` and `ssm-simulators` are also published on conda-forge; the feedstock repositories carry the recipes. |
+- [`franklab/HSSM`](https://huggingface.co/franklab/HSSM) delivers trained
+  network artifacts consumed by HSSM.
+- [`franklab/ssms_gui`](https://huggingface.co/spaces/franklab/ssms_gui)
+  provides an interactive simulator-based visualization surface.
+- conda-forge feedstocks package HSSM and ssm-simulators after their PyPI
+  releases.
 
-Third-party libraries that do real work under the hood — PyMC, Bambi, ArviZ,
-JAX, PyTensor, ONNX Runtime — are dependencies rather than ecosystem
-components, and their own documentation is the right reference for them.
+Third-party inference, array, and visualization libraries retain their own
+documentation and release policies.
 
-## Development and coordination
+<span id="version-compatibility"></span>
 
-Two repositories exist for people working *on* the ecosystem rather than with
-it. You never need them to fit models, and neither is a Python package you
-install alongside HSSM.
+## Versions and releases
 
-| Repository | Role |
-|---|---|
-| [HSSMSpine](https://github.com/lnccbrown/HSSMSpine) | The coordination repository. It holds no library code — it carries cross-repo context, shared development workflows, the release playbook, the shared documentation brand, and this page. Contributors working across two or more packages start here. |
-| [HSSMCortex](https://github.com/lnccbrown/HSSMCortex) | The capability layer: a knowledge base of papers, modeling taxonomies, and curated guides, plus tooling that makes that knowledge queryable during development. |
+The packages release independently. Exact compatibility floors belong in each
+consumer's project metadata and rendered installation reference. Coordinated
+releases follow the dependency and artifact flow: ssm-simulators first,
+LANfactory when required, validated networks when changed, and HSSM last.
 
-If you are contributing to a single package, its own contributing guide is the
-place to start; the spine matters when a change spans packages, such as adding
-a model that needs a simulator, a trained network, and an HSSM configuration.
-
-## Tracking runs with MLflow
-
-Data generation (`ssms`) and network training (LANfactory) both log to
-[MLflow](https://mlflow.org/). Point them at the same tracking store and the
-two halves of a network's history end up in one place.
-
-Two environment variables are the interface:
-
-```bash
-export MLFLOW_TRACKING_URI="sqlite:////absolute/path/to/tracking.db"
-export MLFLOW_ARTIFACT_LOCATION="/absolute/path/to/artifacts"
-```
-
-`ssms` records each generation run — the generator and model configuration,
-the `data_output_folder`, the number of files produced and their total size,
-and tags for the run phase and any SLURM job it ran under. LANfactory records
-each training run's configuration and metrics.
-
-The two are linked explicitly rather than by convention: pass the data
-generation run's experiment id to the trainer with
-`--data-generation-experiment-id`, and LANfactory records the lineage — it can
-also discover the training-data folder from MLflow instead of being told where
-it is.
-
-Per-package details — CLI flags, what exactly is logged, how to query it —
-live with the packages:
-[ssm-simulators](https://lnccbrown.github.io/ssm-simulators/core_tutorials/using_mlflow/)
-and [LANfactory](https://lnccbrown.github.io/LANfactory/using_mlflow/).
-
-## Version compatibility
-
-The packages are released independently, in dependency order:
-`ssm-simulators` → `LANfactory` → HSSM. Install floors, rather than pins, are
-what the ecosystem guarantees:
-
-| Consumer | Requires |
-|---|---|
-| HSSM | `ssm-simulators>=0.13.1` |
-| LANfactory | `ssm-simulators>=0.13.1` |
-| LAN_pipeline_minimal | `ssm-simulators>=0.13.2`, `lanfactory>=0.8` |
-
-All released packages require Python 3.12 or newer. `pip install hssm` pulls a
-compatible `ssm-simulators` automatically; you only need to think about this
-when you are pinning an environment or building networks yourself.
+Contributors should use the public
+[HSSMSpine release procedure](https://lnccbrown.github.io/HSSMSpine/release-playbook/)
+rather than copying a version table that can drift.
+LANfactory tags are bare; HSSM and ssm-simulators tags use a `v` prefix.
 
 ## Where to ask
 
-- **Usage questions and modeling advice** —
-  [HSSM Discussions](https://github.com/lnccbrown/HSSM/discussions).
-- **Bugs** — the issue tracker of the package the bug is in. If you are not
-  sure which, HSSM's tracker is the right default and we will move it.
-- **New models** — [ssm-simulators](https://github.com/lnccbrown/ssm-simulators/issues),
-  which is where the model family lives.
+- Usage and modeling questions: [HSSM Discussions](https://github.com/lnccbrown/HSSM/discussions).
+- A confirmed bug: the issue tracker of the repository that owns the behavior.
+- An uncertain cross-repository problem: begin with HSSM, then use
+  [HSSMSpine's source-ownership reference](https://lnccbrown.github.io/HSSMSpine/reference/source-ownership/)
+  to route it.


### PR DESCRIPTION
## Summary

- refresh HSSM's canonical ecosystem page with all six native documentation sites
- link the now-live public Spine and Cortex docs while keeping their source repositories private
- preserve the established HSSM route and legacy section anchors
- keep JEAM and non-native artifact/feedstock repositories outside the native package listing

## Verification

- docs-weight guard
- full strict MkDocs build with the harmonized pinned core toolchain
- rendered ecosystem page and search-index privacy/JEAM scan
- byte-for-byte comparison with the Spine-owned source
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the ecosystem guide around six native sites covering simulation, training, artifacts, inference, capabilities, and coordination.
  * Added canonical URLs and fragment-preserving navigation anchors.
  * Clarified ownership, integration flows, site routing, and artifact surfaces.
  * Updated MLflow guidance with links to LAN pipeline documentation.
  * Replaced version floors with release-order guidance and HSSMSpine release procedures.
  * Simplified support guidance for usage questions, confirmed bugs, and cross-repository issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->