### PR TITLE
Fix standard and custom Link construction

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@
 
 4. **Safe priors now zero-center matching group-specific effects** (#1224). HSSM matches each Formulae group expression to an exact common-term counterpart and assigns the generated group deviation `mu=0`. This removes disconnected group-mean variables under non-centering and the redundant common/group location under centering. Explicit priors remain authoritative, including Bambi's `common` and `group_specific` wildcards; parameterization diagnostics now warn only about the graph Bambi actually builds. The existing policy for unmatched group-only effects is unchanged and tracked in #1225.
 
+5. **`hssm.Link` now constructs Bambi built-in and custom links** (#1231). Standard links delegate correctly to Bambi, while HSSM's bounded `gen_logit` behavior remains unchanged.
+
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.

--- a/src/hssm/link.py
+++ b/src/hssm/link.py
@@ -59,7 +59,12 @@ class Link(bmb.Link):
                 self.linkinv = self._make_generalized_sigmoid_simple(*bounds)
                 self.linkinv_backend = self._make_generalized_sigmoid_simple(*bounds)
         else:
-            bmb.Link.__init__(name, link, linkinv, linkinv_backend)
+            super().__init__(
+                name=name,
+                link=link,
+                linkinv=linkinv,
+                linkinv_backend=linkinv_backend,
+            )
 
         self.bounds = bounds
 

--- a/src/hssm/link.py
+++ b/src/hssm/link.py
@@ -38,6 +38,29 @@ class Link(bmb.Link):
         ``name`` is a known name.
     bounds : optional
         Bounds of the response scale. Only needed when ``name`` is ``gen_logit``.
+
+    Examples
+    --------
+    Use any link name supported by Bambi:
+
+    >>> import hssm
+    >>> identity_link = hssm.Link("identity")
+
+    A custom link requires forward, inverse, and PyTensor-compatible inverse
+    functions:
+
+    >>> import numpy as np
+    >>> import pytensor.tensor as pt
+    >>> custom_log = hssm.Link(
+    ...     "custom_log",
+    ...     link=np.log,
+    ...     linkinv=np.exp,
+    ...     linkinv_backend=pt.exp,
+    ... )
+
+    HSSM also provides a generalized logit for bounded response scales:
+
+    >>> bounded_link = hssm.Link("gen_logit", bounds=(0.1, 0.9))
     """
 
     def __init__(

--- a/src/hssm/link.py
+++ b/src/hssm/link.py
@@ -25,17 +25,20 @@ class Link(bmb.Link):
         any other arguments because functions are already defined internally. If not
         known, all of `link``, ``linkinv`` and ``linkinv_backend`` must be specified.
     link : optional
-        A function that maps the response to the linear predictor. Known as the
-        :math:`g` function in GLM jargon. Does not need to be specified when ``name``
-        is a known name.
+        A numerical function that maps the response to the linear predictor. Known as
+        the :math:`g` function in GLM jargon. This function operates outside the PyMC
+        graph and does not need to support PyTensor tensors. It does not need to be
+        specified when ``name`` is a known name.
     linkinv : optional
-        A function that maps the linear predictor to the response. Known as the
-        :math:`g^{-1}` function in GLM jargon. Does not need to be specified when
-        ``name`` is a known name.
+        A numerical function that maps the linear predictor to the response. Known as
+        the :math:`g^{-1}` function in GLM jargon, it is used for operations such as
+        posterior prediction outside the PyMC graph. It does not need to be specified
+        when ``name`` is a known name.
     linkinv_backend : optional
-        Same than ``linkinv`` but must be something that works with PyMC backend
-        (i.e. it must work with PyTensor tensors). Does not need to be specified when
-        ``name`` is a known name.
+        The symbolic inverse link used to build the PyMC graph. It must accept PyTensor
+        tensors and return a symbolic PyTensor expression. It does not need to be
+        specified when ``name`` is a known name because Bambi supplies the backend
+        implementation for built-in links.
     bounds : optional
         Bounds of the response scale. Only needed when ``name`` is ``gen_logit``.
 
@@ -53,9 +56,9 @@ class Link(bmb.Link):
     >>> import pytensor.tensor as pt
     >>> custom_log = hssm.Link(
     ...     "custom_log",
-    ...     link=np.log,
-    ...     linkinv=np.exp,
-    ...     linkinv_backend=pt.exp,
+    ...     link=np.log,  # Numerical: response -> linear predictor
+    ...     linkinv=np.exp,  # Numerical: predictions outside the PyMC graph
+    ...     linkinv_backend=pt.exp,  # Symbolic: used inside the PyMC graph
     ... )
 
     HSSM also provides a generalized logit for bounded response scales:

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytensor.tensor as pt
 import pytest
+from pytensor.tensor.variable import TensorVariable
 
 from hssm import HSSM, Link
 
@@ -54,6 +55,10 @@ def test_custom_link_matches_bambi_semantics():
     assert link.linkinv is np.expm1
     assert link.linkinv_backend is pt.expm1
     assert link.bounds == (-1.0, np.inf)
+    response_values = np.array([0.0, 0.5, 2.0])
+    np.testing.assert_allclose(
+        link.linkinv(link.link(response_values)), response_values
+    )
 
 
 def test_incomplete_custom_link_uses_bambi_validation():
@@ -91,8 +96,8 @@ def test_generalized_logit_round_trip():
     assert str(link) == "Generalized logit link function with bounds (-2.0, 3.0)"
 
 
-def test_link_object_builds_hssm_regression():
-    """Pass an HSSM Link object through a structure-only model build."""
+def test_custom_link_builds_symbolic_hssm_regression():
+    """Use the custom backend inverse with a symbolic HSSM predictor."""
     data = pd.DataFrame(
         {
             "rt": [0.4, 0.5, 0.6, 0.7],
@@ -100,7 +105,18 @@ def test_link_object_builds_hssm_regression():
             "x": [-1.0, -0.5, 0.5, 1.0],
         }
     )
-    link = Link("identity")
+    backend_inputs = []
+
+    def inverse_backend(value):
+        backend_inputs.append(value)
+        return pt.exp(value)
+
+    link = Link(
+        "custom_log",
+        link=np.log,
+        linkinv=np.exp,
+        linkinv_backend=inverse_backend,
+    )
 
     model = HSSM(
         data=data,
@@ -115,3 +131,5 @@ def test_link_object_builds_hssm_regression():
 
     assert model.params["v"].link is link
     assert model.model.family.link["v"] is link
+    assert backend_inputs
+    assert all(isinstance(value, TensorVariable) for value in backend_inputs)

--- a/tests/unit/test_link.py
+++ b/tests/unit/test_link.py
@@ -1,0 +1,117 @@
+"""Tests for HSSM link functions."""
+
+import bambi as bmb
+import numpy as np
+import pandas as pd
+import pytensor.tensor as pt
+import pytest
+
+from hssm import HSSM, Link
+
+
+@pytest.mark.parametrize(
+    ("name", "response_values", "predictor_values"),
+    [
+        ("identity", np.array([-1.0, 0.0, 1.0]), np.array([-1.0, 0.0, 1.0])),
+        ("log", np.array([0.25, 1.0, 4.0]), np.array([-1.0, 0.0, 1.0])),
+        ("logit", np.array([0.2, 0.5, 0.8]), np.array([-1.0, 0.0, 1.0])),
+    ],
+)
+def test_builtin_link_matches_bambi(name, response_values, predictor_values):
+    """Delegate Bambi's built-in link behavior through the HSSM subclass."""
+    expected = bmb.Link(name)
+    link = Link(name)
+
+    assert link.name == expected.name
+    np.testing.assert_allclose(
+        link.link(response_values), expected.link(response_values)
+    )
+    np.testing.assert_allclose(
+        link.linkinv(predictor_values), expected.linkinv(predictor_values)
+    )
+    assert link.bounds is None
+
+
+def test_builtin_link_retains_bounds_metadata():
+    """Retain optional HSSM bounds after delegating construction to Bambi."""
+    link = Link("identity", bounds=(-2.0, 3.0))
+
+    assert link.bounds == (-2.0, 3.0)
+
+
+def test_custom_link_matches_bambi_semantics():
+    """Retain all three functions supplied for a valid custom link."""
+    link = Link(
+        "log1p",
+        link=np.log1p,
+        linkinv=np.expm1,
+        linkinv_backend=pt.expm1,
+        bounds=(-1.0, np.inf),
+    )
+
+    assert link.name == "log1p"
+    assert link.link is np.log1p
+    assert link.linkinv is np.expm1
+    assert link.linkinv_backend is pt.expm1
+    assert link.bounds == (-1.0, np.inf)
+
+
+def test_incomplete_custom_link_uses_bambi_validation():
+    """Raise Bambi's validation error when a custom function is missing."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Link name 'log1p' is not supported and at least one of 'link', "
+            "'linkinv' or 'linkinv_backend' are unspecified"
+        ),
+    ):
+        Link("log1p", link=np.log1p, linkinv=np.expm1)
+
+
+def test_generalized_logit_requires_bounds():
+    """Keep the HSSM-specific generalized-logit bounds requirement."""
+    with pytest.raises(
+        ValueError,
+        match="Bounds must be specified for generalized log link function",
+    ):
+        Link("gen_logit")
+
+
+def test_generalized_logit_round_trip():
+    """Keep generalized-logit forward and inverse transformations unchanged."""
+    bounds = (-2.0, 3.0)
+    response_values = np.array([-1.5, 0.0, 2.5])
+    link = Link("gen_logit", bounds=bounds)
+
+    transformed = link.link(response_values)
+
+    assert link.bounds == bounds
+    np.testing.assert_allclose(link.linkinv(transformed), response_values)
+    np.testing.assert_allclose(link.linkinv_backend(transformed), response_values)
+    assert str(link) == "Generalized logit link function with bounds (-2.0, 3.0)"
+
+
+def test_link_object_builds_hssm_regression():
+    """Pass an HSSM Link object through a structure-only model build."""
+    data = pd.DataFrame(
+        {
+            "rt": [0.4, 0.5, 0.6, 0.7],
+            "response": [-1, 1, -1, 1],
+            "x": [-1.0, -0.5, 0.5, 1.0],
+        }
+    )
+    link = Link("identity")
+
+    model = HSSM(
+        data=data,
+        model="ddm",
+        include=[{"name": "v", "formula": "v ~ 1 + x", "link": link}],
+        prior_settings=None,
+        z=0.5,
+        p_outlier=0.0,
+        process_initvals=False,
+        initval_jitter=0,
+    )
+
+    assert model.params["v"].link is link
+    assert model.model.family.link["v"] is link


### PR DESCRIPTION
## Summary

- delegate built-in and custom `hssm.Link` construction to Bambi with the correct bound instance
- preserve HSSM-specific `gen_logit` behavior and optional bounds metadata
- add behavioral coverage for built-ins, custom-link validation, generalized logit, and an HSSM regression build
- document working built-in, custom, and bounded-link examples

## Verification

- `pytest tests/unit/test_link.py -q` (9 passed)
- `pytest tests/unit/param/test_regression_param.py tests/unit/param/test_params.py -q` (41 passed)
- `pytest tests/ -m "not slow"` (686 passed, 371 deselected)
- configured hooks on changed files: Ruff, formatting, whitespace/EOF, Pyrefly, and mypy passed
- `mkdocs build --strict` passed
- independent review found no issues and confirmed Bambi 0.19/0.20 compatibility

## Scope

This fixes the public `hssm.Link` constructor only. It does not change safe-prior selection for explicit versus implicit identity links; that separate policy issue remains tracked in #1232.

Closes #1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for constructing built-in and custom Bambi links through `hssm.Link`.
  * Preserved bounded behavior for the generalized-logit link.

* **Documentation**
  * Expanded guidance and examples for numerical, symbolic, and PyTensor-compatible links.
  * Documented the updated link behavior in the unreleased changelog.

* **Tests**
  * Added coverage for link construction, validation, transformations, bounds, and regression model integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->