### PR TITLE
Fix safe common-intercept priors for explicit identity links

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@
 
 5. **`hssm.Link` now constructs Bambi built-in and custom links** (#1231). Standard links delegate correctly to Bambi, while HSSM's bounded `gen_logit` behavior remains unchanged.
 
+6. **Safe common-intercept priors now recognize every identity-link spelling consistently** (#1232). An omitted link, `"identity"`, `bambi.Link("identity")`, and `hssm.Link("identity")` all retain response-scale priors, including HDDM-derived priors; transformed links use a coefficient-scale `Normal(mu=0, sigma=0.25)`. Explicit priors still win, and unmatched group-only terms remain unchanged pending [#1225](https://github.com/lnccbrown/HSSM/issues/1225).
+
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@
 
 5. **`hssm.Link` now constructs Bambi built-in and custom links** (#1231). Standard links delegate correctly to Bambi, while HSSM's bounded `gen_logit` behavior remains unchanged.
 
-6. **Safe common-intercept priors now recognize every identity-link spelling consistently** (#1232). An omitted link, `"identity"`, `bambi.Link("identity")`, and `hssm.Link("identity")` all retain response-scale priors, including HDDM-derived priors; transformed links use a coefficient-scale `Normal(mu=0, sigma=0.25)`. Explicit priors still win, and unmatched group-only terms remain unchanged pending [#1225](https://github.com/lnccbrown/HSSM/issues/1225).
+6. **Safe common-intercept priors now recognize every identity-link spelling consistently** (#1232). An omitted link, `"identity"`, `bambi.Link("identity")`, and `hssm.Link("identity")` all retain response-scale priors, including HDDM-derived priors; transformed links use a coefficient-scale `Normal(mu=0, sigma=0.25)`. Explicit priors still win, and unmatched group-only terms remain unchanged pending [#1225](https://github.com/lnccbrown/HSSM/issues/1225). See [Link functions and safe priors](tutorials/link_functions.ipynb) for the underlying model-design logic.
 
 ### 0.4.0
 

--- a/docs/explanations/coming_from_hddm.md
+++ b/docs/explanations/coming_from_hddm.md
@@ -103,8 +103,14 @@ explains the tradeoff and when each is the better choice.
 - **Priors.** For `ddm`, `ddm_sdv`, and `full_ddm`, HSSM's default priors on
   regression terms are derived from HDDM's — the settings are carried in
   `hssm.prior` under names like `HDDM_MU` and `HDDM_SIGMA` — so a regression
-  model on these families starts from familiar ground. The rule is the
-  likelihood: those defaults apply unless you are using the neural
+  model on these families starts from familiar ground. For safe common-intercept
+  priors, an omitted link, `"identity"`, `bambi.Link("identity")`, and
+  `hssm.Link("identity")` are equivalent: each keeps the intercept on the
+  response scale and uses the HDDM-derived prior. A transformed link instead
+  uses a coefficient-scale `Normal(mu=0, sigma=0.25)`. An explicit prior always
+  wins. Unmatched group-only terms retain their existing behavior, tracked in
+  [#1225](https://github.com/lnccbrown/HSSM/issues/1225). The broader rule is
+  the likelihood: these defaults apply unless you use the neural
   (`approx_differentiable`) likelihood, which has its own priors derived from
   the network's training bounds. Specifying your own is a different interface
   — see [Specify priors and fix parameters](../how_to/specify_priors.ipynb).

--- a/docs/explanations/coming_from_hddm.md
+++ b/docs/explanations/coming_from_hddm.md
@@ -107,8 +107,10 @@ explains the tradeoff and when each is the better choice.
   priors, an omitted link, `"identity"`, `bambi.Link("identity")`, and
   `hssm.Link("identity")` are equivalent: each keeps the intercept on the
   response scale and uses the HDDM-derived prior. A transformed link instead
-  uses a coefficient-scale `Normal(mu=0, sigma=0.25)`. An explicit prior always
-  wins. Unmatched group-only terms retain their existing behavior, tracked in
+  uses a coefficient-scale `Normal(mu=0, sigma=0.25)`. [Link functions and safe
+  priors](../tutorials/link_functions.ipynb) explains that scale change from
+  first principles. An explicit prior always wins. Unmatched group-only terms
+  retain their existing behavior, tracked in
   [#1225](https://github.com/lnccbrown/HSSM/issues/1225). The broader rule is
   the likelihood: these defaults apply unless you use the neural
   (`approx_differentiable`) likelihood, which has its own priors derived from

--- a/docs/tutorials/link_functions.ipynb
+++ b/docs/tutorials/link_functions.ipynb
@@ -1,0 +1,957 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Hbol",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import os\n",
+    "import warnings\n",
+    "from contextlib import redirect_stderr, redirect_stdout\n",
+    "from io import BytesIO, StringIO\n",
+    "from tempfile import gettempdir\n",
+    "\n",
+    "# This notebook does not use GPU computation. Molab can expose an unusable\n",
+    "# CUDA plugin, so keep JAX on CPU before importing the HSSM stack.\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_SKIP_CUDA_CONSTRAINTS_CHECK\"] = \"1\"\n",
+    "os.environ.setdefault(\"MPLCONFIGDIR\", f\"{gettempdir()}/hssm-link-matplotlib\")\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "logging.getLogger(\"jax._src.xla_bridge\").setLevel(logging.CRITICAL)\n",
+    "logging.getLogger(\"matplotlib\").setLevel(logging.ERROR)\n",
+    "\n",
+    "import bambi as bmb\n",
+    "import marimo as mo\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import pytensor.tensor as pt\n",
+    "\n",
+    "with redirect_stderr(StringIO()):\n",
+    "    import matplotlib.pyplot as plt\n",
+    "\n",
+    "import hssm\n",
+    "\n",
+    "logging.getLogger(\"hssm\").setLevel(logging.ERROR)\n",
+    "hssm.set_floatX(\"float64\")\n",
+    "pd.set_option(\"display.max_colwidth\", 80)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "MJUe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "# Understanding link functions in HSSM\n",
+       "\n",
+       "A link function is the bridge between an ordinary regression and a model\n",
+       "parameter that may be positive, bounded, or otherwise constrained. This\n",
+       "tutorial starts from that idea and then shows how links determine the scale\n",
+       "on which HSSM interprets regression coefficients and chooses safe priors.\n",
+       "\n",
+       "The examples use **HSSM 0.4.0** and **Bambi 0.20.0**.\n",
+       "They only construct models and inspect their structure; no MCMC is needed.\n",
+       "\n",
+       "By the end, you should be able to answer three questions:\n",
+       "\n",
+       "1. What does a link do to a linear predictor?\n",
+       "2. When should an HSSM parameter use identity, log, or generalized logit?\n",
+       "3. Why do HSSM's safe intercept priors depend on the effective link?"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mo.md(f\"\"\"\n",
+    "# Understanding link functions in HSSM\n",
+    "\n",
+    "A link function is the bridge between an ordinary regression and a model\n",
+    "parameter that may be positive, bounded, or otherwise constrained. This\n",
+    "tutorial starts from that idea and then shows how links determine the scale\n",
+    "on which HSSM interprets regression coefficients and chooses safe priors.\n",
+    "\n",
+    "The examples use **HSSM {hssm.__version__}** and **Bambi {bmb.__version__}**.\n",
+    "They only construct models and inspect their structure; no MCMC is needed.\n",
+    "\n",
+    "By the end, you should be able to answer three questions:\n",
+    "\n",
+    "1. What does a link do to a linear predictor?\n",
+    "2. When should an HSSM parameter use identity, log, or generalized logit?\n",
+    "3. Why do HSSM's safe intercept priors depend on the effective link?\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vblA",
+   "metadata": {
+    "marimo": {
+     "md_prefix": "r"
+    }
+   },
+   "source": [
+    "## 1. A regression produces an unconstrained linear predictor\n",
+    "\n",
+    "For a predictor `x`, a simple regression first constructs\n",
+    "\n",
+    "$$\\eta_i = \\beta_0 + \\beta_1 x_i.$$\n",
+    "\n",
+    "The number $\\eta_i$ can be anywhere on the real line. That is fine for an\n",
+    "unbounded parameter such as drift rate $v$, but it can be invalid for a\n",
+    "boundary separation $a>0$ or a starting-point fraction $0<z<1$.\n",
+    "\n",
+    "A link $g$ connects the parameter scale to the predictor scale. HSSM uses\n",
+    "the inverse link when building the model:\n",
+    "\n",
+    "$$\\theta_i = g^{-1}(\\eta_i).$$\n",
+    "\n",
+    "The regression coefficients live on the **linear-predictor scale**. The\n",
+    "inverse link turns their result into a valid value on the **parameter scale**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bkHC",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>DDM parameter</th><th>support</th><th>support-respecting link</th><th>inverse link</th></tr></thead><tbody><tr><th>0</th><td>v (drift rate)</td><td>(-inf, inf)</td><td>identity</td><td>v = eta</td></tr><tr><th>1</th><td>a (boundary separation)</td><td>(0, inf)</td><td>log</td><td>a = exp(eta)</td></tr><tr><th>2</th><td>z (starting-point fraction)</td><td>(0, 1)</td><td>generalized logit</td><td>z = 1 / (1 + exp(-eta))</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "parameter_support_table = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"DDM parameter\": \"v (drift rate)\",\n",
+    "            \"support\": \"(-inf, inf)\",\n",
+    "            \"support-respecting link\": \"identity\",\n",
+    "            \"inverse link\": \"v = eta\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"DDM parameter\": \"a (boundary separation)\",\n",
+    "            \"support\": \"(0, inf)\",\n",
+    "            \"support-respecting link\": \"log\",\n",
+    "            \"inverse link\": \"a = exp(eta)\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"DDM parameter\": \"z (starting-point fraction)\",\n",
+    "            \"support\": \"(0, 1)\",\n",
+    "            \"support-respecting link\": \"generalized logit\",\n",
+    "            \"inverse link\": \"z = 1 / (1 + exp(-eta))\",\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "parameter_support_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "lEQa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABfQAAAHMCAYAAACTJinIAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAViAAAFYgBxNdAoAABAABJREFUeJzs3Qd0FNX3B/BLeg8hIZVASAKE3qWDSAcpCohIR5pUFUSKiAioNKVKFREUREC6iIAgvTcBgRRKaIGEENLr/s99/Ce/bHY2dft+P+fsmWRmy9vZZN/MnfvuK6FQKBQEAAAAAAAAAAAAAAAGzULfDQAAAAAAAAAAAAAAgPwhoA8AAAAAAAAAAAAAYAQQ0AcAAAAAAAAAAAAAMAII6AMAAAAAAAAAAAAAGAEE9AEAAAAAAAAAAAAAjAAC+gAAAAAAAAAAAAAARgABfQAAAAAAAAAAAAAAI4CAPgAAAAAAAAAAAACAEUBAHwAAAAAAAAAAAADACCCgDwAAAAAAAAAAAABgBBDQBwAAAAAAAAAAAAAwAgjoAwAAAAAAAAAAAAAYASt9NwCgIG7dukXp6enk5+dHbm5uhdpp9+/fp5cvX1KZMmWoZMmSet/h165dE8vKlSuTpaWl7H1u3LhBWVlZFBISQlZWVoV6rDm4c+cOJSYmUtmyZcnFxYXMWWxsLD18+JBcXV3J39/fZF8TAMDQ8bEGH3Nw/8z9NOhHeHg4JScnU/ny5cnR0TF7fWhoKKWmplJgYCA5ODgU6rEAAFA0CQkJFB0dLc5tPT09ycnJCbuyEOdbHL/gOEZ+6w1FWloa3b59u9DHQob0vtS1JSYmhh4/fqyTNsbHx9O9e/fE/wzf1ElKShJt4v8rLy8v0oUXL17QgwcPxM95HVPljMXljmuBZiBDH4xCq1atqHr16rRt27ZCP3bkyJHisTt27CBDwG3hG3cU6tSpU0fchw9+CvtYczBo0CCxH/766y8yd5s3bxb74qOPPjLp1wQAMHTcJ/F3Y/369fXdFLPWvXt38TmcO3dOaX3nzp3F+osXLxb6sQAAUHAcDJ0wYYII4jk7O4uLpEFBQeLnatWq0WeffUaPHj3CLi3A+Rbvx4KsNxQcwOX2NWrUqFCPM6T3pa4tGzZsEOsnTZqk9TaMHTtWvNbdu3dlt/NFEz6u4QS74OBg8vb2Fv9ny5YtI4VCodG28MW4Xbt20ccffyziVO7u7tlxqbyOqdi+ffvE/b7//nuNtgleQUAfAAAAAAAAAACKZd26dSLAuGDBAjHK3traWmQzV6hQQYy0v379Os2ePVvcZ+HChdjbALn8+++/tH79eurQoQO99tprKvvnypUrVK9ePdqzZ48I3nMgn0cNcPB/9OjR4qZJPAqga9eu9N1339GlS5fEhbmCGjx4sKiqMHPmTJGpD5qFgD6AAapataq48QEQAAAAABQMB4n4GKooJXOK81gAAHO3evVqMZI6JSVFjFbjrF4uzxEZGSkyip8/f05hYWE0f/58Kl26NM2aNUvfTTY6pUqVEv0Uyp6a7j6eOnWqyIqfMmWKyjZe37dvX1GSh7Pl+f8pIiKCnj17Rt9++624D2fD//HHHxprD5dP4tEAfJHu/Pnz9PTp0wI/luNZPNKBK0/w40GzUMQITAp/ufCXGw85KuzJGH85PnnyRNRm5/pj6mqz8/24xj3jL/oSJUqIdTxskGuz8he/jY2NbNtyfvndvHlTqaZ/znrwPJyLn5OHUBX0sRkZGaIN/L75Kq06Uu03rrMWEBBAmpjbgDMubG1tVbbzQRu3Sa7OnFwdfG4bPyav/a8O7x++6uvr65tnHbecMjMzxb7gg04fH588/2YM4b1yDUpuLx9k8FC3wuLX5Bv/XRW0xl5xXxMAAAqG+xjuR7hv4r7Mzs6uQI/jMnx8osQ1VqXjBj6e4XUcMNFkTVWpL+TAN7ePM8P4tbjuPPd9csc/mnqv/BipZivPqaTutebMmZNdB5/FxcWJYBLX9ZX65JzHULx/eD/JPZb7br4/133l0hF59ZWcGccnrpUqVVJ7v6ioKNEe7k/RpwKAKeE5SMaMGSN+fuedd+jnn3+WTU7j0jvjx4+nUaNGZQcg88Lfw9zP8HPxd7+6eeQ4oMnfsXzOwv1KzvMYPtcqTF9YnNeUaprzuTyfN+YkxQy4P+JzT3t7eyqsNm3aUJUqVZT6Maneen7yqsde0PecE78P7pe5D+f4i4WF9vOFeZ/zcU9h+lG5duZV619uH//3339i/zDux6W5DVl+fX9hSxbt3btX1KZv2rSpyvbdu3eL1+bX/P3336lcuXJiPR+ncDlczqDnWNJXX31FHTt21Eib+O+UL85JOO5UGO+99574n1+1ahVNmzYNtfQ1SQFgBPz8/LgQmGL16tWy2//66y9FjRo1xH34ZmVlpejcubMiPDxc0alTJ7Huxx9/lH3skydPFCNHjlS4u7tnP75EiRKKhg0bKg4cOKBy//j4+Oz78c+zZs1SeHp6Zq9zdHRUfPjhh4q0tDSlx02dOjX7PnK3LVu2ZN/X1tZWrHv8+HGBH3v58mXxs7OzsyIhIUHtvuzZs6e4Hz8nS01NVfz777/ilpSUpCjK58KPlbNkyRKxvU+fPirbWrRokd32PXv2KKpXr579fiwsLBTt2rVT3L17V/Z5cz5248aNigoVKmQ/1sbGRrxeVFSU2nbHxMQoRo8erShVqlT24ywtLRUtW7ZUnDhxwqDeK+NtXbt2FX/X0uP4Ofbu3atYvny5+L179+6yj01PT1csXLhQUbFiRaW/mbJlyyq+/fZbRWZmpsZfEwDAHPF3vHQcUBj8fct9Bz9O+r7l44Bu3bopbty4ofZx58+fVzRt2lTpu71x48aKM2fOKMaPHy9+//TTT1Uex8cuUr+fkZFRqLZKfeHFixcV3333ncLX1zf7tZ2cnBRjx47N8xikKO/19u3bYjv37zmP0ypXrqyYP3++IjExUen+NWvWFPc5fPiw+H3Dhg15HkPNnDlT7WOjo6MV1tbWYh0fU6ozY8YMcZ8uXbqobOP98fnnnyvKlCmj9LpVqlRR/PzzzwXY6wAAhm/YsGHiu83HxyfPfqCg9u3bJ/o4PkeTvjddXV0VH3zwgTiXy42/y/k+w4cPV9y6dUvRoUMHpcfyd67cub2mXvPq1auKNm3aZD82MDBQ3OfFixfiXKxRo0bZ/Qnf+Oe2bdsqLly4INsW6XyrV69e+a7fvn17nv2cdJs+fXqx3zPjmAEfZ7i4uGQ/hj/3OXPmKG7evJn9HIWh7v0yPl/lfVi+fHml9xMSEqL44Ycf1D4n/x2OGzdOxEekx3h7eyu+/vrrPNsp15acxy25b3xslBP//fEx1tOnTxWFNW3aNPGcvJQzYMAAsZ3P0+WcPn06+zhJiiVpGscXpPd+7NixAj3mzTffFPf//ffftdImc4WAPhh9QH/btm3ZHRAvg4KCFB4eHtlf2LVr11Yb0Ocvcum5+VayZEnRUUhBTA62rlu3Tm1An08wpdcNCAhQ2NvbZ28bMmSI0uMWL16sqFq1qlIHxL9LN74ooS6gX9DH1q9fX2xfu3at7H7kE1M+IeYv+IiICLEuNDQ0+3lPnTpVpM+lOEFu7oy4PdKBgPTZ8Y0/y9wn6jkfywdq0ufEB005L6xUqlRJ9iCEA/05g9ulS5cWr8PPwb/zZ//bb78ZzHu9f/++0t8oB0/4b03qqNu3b682uJ6SkiIuFkiPtbOzE/sp5wGJ3EFTcV4TAMBcFSWgf/36ddEP5TwpLFeuXPbvfBIqd6GZ+2sHB4fs+/F3tBQw5u/6119/XW1An0/epcc9e/asUO9R6huk/pcDEsHBwQo3N7fs52zevLlKUkNR3+vDhw+VEi68vLzE6+U83jp37pzSY3IH5Xfv3i2OlaQLAnycl/MYauXKlWofyzhIz+s4aK+OdFyRMzmD8f6tVauW0kUP7oel47ycCRYAAMaMv5/5O23KlCnFfi4pUC6dZ3MiUs6+gL9zc5/nSY/h8y6pT+KAs7+/f/b5F/dZfEFa06/ZrFmz7KAxxx+4b+FzsNx9LvdD3Afl7Au5P5M7By9MQP/QoUNK/VrumxTb4EB2cd8zJwK0bt1aKX7C/bLUx3bs2FFtoDwv6t5vVlaWokePHkr9KCfz5TwGGjVqlGzQWToH5xv/TfDjpP5XOo4paECf4yz82UqPybl/W7VqpfR46dgmZ8JAQXEMI6+4jBQTWrBggex2/nykfcOJeIYS0M/rgg0UHQL6YNQBfe5gpCxrDjI+evQo+4t/x44d4gtf+rLJHdDnLyK+Us/buMPlE00JB1Y/++yz7BNjPqGUC+hzEPjLL79UJCcnZ3+BSo/jbZGRkSrvpSAn0bkD+gV9LO8f3t6kSRPZ7ZxNx9u5E5boO6DPNx5NkXNf7d+/P7sjynmiLfdYDhzcu3cvextnXkgHIu+//77KY9966y2xje/z559/Zq/nz1gKfvPfzYMHDwzivUojTDhQc/Lkyez1//33X3bgQV1w/aOPPsoO9OzcuVP8X+S8ECb976xfv15jrwkAYK4KG9Dn72TpO5Uv6uYMTPP3rZSQwMEI6ThDOtaQAsj16tUTGew5s/Y5YCx9T2sroM+3d955RyQKSNlzv/zyizhmkgsaFPW9SpnvPAqTM95y4t8/+eQT8fic5ILyOU+S8zr5lHus9LlyIEAOj4iQghp8IT0n7vN5G7+/nK/Ln+GKFSuyAyDqRgcCABgDHsEk9Q18blMcHISUgt+clZ1zBDmPSK9Tp47Y3r9/f7XBaf6+z/m9yu2TAqE8Wl0br8l9RO4LzFLGNPfFPAot57kYJ9fl7COKE9DPy5o1a8T9+T3kHDlR1PcsxRP44ghnx0sj/WJjYxV9+/bN3h+aCugvW7ZMrOeLMvPmzRPVBRi3ly8eSa/H57Y58X15PcdV+FxXGpUeFxenGDp0aJ7tVNcW6b3Lne9rIqDPlSP4cXwBJuexkFyciGNd6kgxrkWLFikMJaDPx6d8f74oApqDgD4YdUCfOx8pOMuB9tyWLl2qNqDPJ57SSWLuEzAJf1nzfWbPni0b0OchXLlxR80Z9LydX0OXAX3upKXsAB59kJtU6uXXX39VysaWri5fuXJFURiaCHLzkHmpY87p448/Ftt79+6t9rEcNJHbF1yGRzpAkYINLCwsLDtDY/PmzbL7T8ryz50xp4/3mvNii9wQUX4/UsZF7uA6D/HjvyPenjvYIdm0aZN4LA8B1cRrAgCYs8IG9Hl0nfR9yyc6cuVppIBvzmOYP/74I/tk+s6dOyqPO378eJ4Bfd4u9ft8Al4YUl/IF4rlsvA5yUEahZazpFtR3ytfmOd1fHJdUJoO6PMxIgfreT0HZnIbM2aM2MYBgpy4jAKv50xMdcPupWBQv379Cvz+AAAMDScASd/x6sqncfKUVO4t541L0uQkjThX973PiVHSOQ4HZ3N/n/I2ufNgqe/k7+TcivuafOOLu4XFQVupX83dZk0E9A8ePCiOFThJK2eCYnHeszRqW+74goP7Ul+rqYC+lKSQu4/NPYquQYMGSut5tIG60jUcr5HiItoI6HMppdwjAAti69at4vn5WEQOH49If29HjhxR+zxcfpHvw8dkhhLQ52NG6TgvZyIKFI/2Z60A0KJDhw6J5dChQ8Ukr7kNGTKEnJ2dZR/LE4qwFi1aUGhoqJhcJPeNJ71lZ8+elX2OQYMGqazjSXJr164tfuZJb3SJJ3Xt3bu3+PmHH35Q2nbu3Dn6999/ycPDg956663s9TyJr/R+a9SoQbrWp08f2Ynt6tatm+8+7Nevn3g/ufXq1UtMTMST3Rw7dix7/d9//y0m8OPJY3r27Cm7/z744AOlvy19vlduL6tWrRq1bt1adlKpLl26yL7WX3/9JSZp5gl9eOIaub9vnqSX8Wz1r64XFe81AQCg4A4ePCiWLVu2zO4HcsrZV+Xskw4fPiyWnTt3lp3cvkmTJlSnTh21r8vbpX4g54RvhTF69GjZyQ7Hjh0rJpvjCQFv3LhR7PfKfQ7jydh4wj59sLW1zW4bT/KYE/evv/76a/YxidxxZoMGDcSkiXL9ME8unNdxJgCAMeDJxCXqJnr98ssvqXr16io36buS8Xcln7NyP1KrVi3Z780XL16ICUP5+/fixYsqr9OoUSPZCUqlvocnVeVJ1jX5mvXq1aPXXnst3/3Ej+dJT7l/5OcNCwujihUrim1Xr14lTeJJXHv06CH6sD179mRP2luc9xwRESEmgGcffvihymvyBLPjxo3T2HvgSen5NdmECRNk7/PJJ5+IJb+fly9fZreT9zOTJmrOHa+RW68p+/fvF/tw2LBhhXqctG95wmQ5HNuQyB2DSaR4A8cCDAW3V4rbSO8Tis9KA88BoDf8Jc9yz0wu4Q6MTwYvX74s28mxJUuWiFteoqOjZddLJ5q58Uz3LCUlhXRt+PDhYgbx9evXi9nNecbznAF+PuGUCyrrS3H2obrPnQ9O+OCIA+TS30juvxfuyOVwIJtJBw/6fK/5/X0zDtjzDPfq/r754JAPlvPCB7VxcXEisFOc1wQAgIKTvm+l5IGC9knS40JCQtQ+joMZckEHTVHXR7i6uoqgwYMHD0Q7pfYX9b1ywsaiRYto37594gS3TZs24oJEs2bNRABFXV+uaXzstHr1ahG8/+6777KPrfiknYNDfGGladOmsv0wB1L4VpTjTAAAY8Df/RIpqJqbn5+fUh9w69YtESyW+97MysoSgfn8yH135ne+JQU6pYCoJl5TujirDvcVc+bMoePHjytdTMjp+fPnpCncL3Xq1Ini4+Npx44dVLNmTaXtRX3PUl/u5uZG3t7eas8TNUV6PY7pqNvH0nkuv5d79+6J36XH8WdeunRp2cfJXfTRN2k/5/xbzcnBwSH757xiJNI2TlY0JPy+OD7Df5+gGQjog1GTvqzUfenltU3K9OIsZXVZ/Dkzx+RIJ3SGhLPy+MYn8nwC2a1bN5E1IWWQ8agFQ1KcfViQzz1nxoj0s7u7u9rHSdtyPk5f71UTf998wJUzI0ObrwkAAAVX1D5J+p7m73d9fU/n10dwQF8T/S9nc/EostmzZ9PWrVvFxWTpgjKPMPzss88KnQFXFBys56A9Z5X9+eef9Oabbypl7Pft21fl4oLUD3t5ecmOJszJxcVFa20HANA2/n7k70Ae8cvZ53KjvqdNmyZukjJlytDDhw9lvzc5+axChQr5vq7cCP3Cnm9p4jVzXtDIbe3atfT+++9n/879AfffUoId95ecWKUu0F9YfIzQtWtXEdRevHhxdn+lifes6/NE6XiAk844YU9d/8mfOV8cku5vCMdJRSF9LupGufAICH5PsbGx9OTJE7XPw6MkWX7HHromXZDQ14hLU2R40UiAQpA6z8jISLX3UbdN+oIfP368GCJuSvjkdsSIESIrnwP6fBLMBwqNGzfW6FVz6eSVr4jL4awAbSrI556znID0c16Pk4bn5S5DoI/3qom/b85g5PI7unhNAAAouKL2SdL3dO5ASE4cINAmbnPDhg3VbtNk/8tBn+XLl9P3338vMjpPnjxJf/zxh8g65FGJdnZ21L9/f9ImPgbgoP2sWbNEEJ8DJAkJCaIUEONt6vrht99+W7QdAMBU8QVZzr7nMiOcUPbuu+8W6Xmk700O3nJymi5GlWvzNTlIL5WE4RFnXHYod2b7O++8Q1u2bNHI6/EFlYEDB9KpU6dEaTx1ZWWK+p5zHn/wa8mNktPkeaJ0PPD06VMxqoIz9XPjjG9ppId0f0M4TioK6SIDlzvKa4QkHwflLGuYE4+Qkd5bXiPu9UF6X3kld0DhoIY+GDVpiFXOOum5O5ScJVfk6ujxEDhdkjo+qWa5Nh773nvviSvpPESdOzmp3I6ms/Olq/XSVeDcuGa/Nqn73HnIotTJ5Sw3I/3MJZj4AoecI0eOiGXuzBJ9vFepvZydqG5Ynbp9IP19nz59Wu3QV02/JgAAFO0YRt3FYrk+SSpNc+LECbU1Vvk7XJvU9QPc93LmmLr+t7DvNfcxEJcZGjx4sEhU+Oabb7KzHwtCyu4ryvFXzhr5HMTnfnXbtm2UlJQk6ibnVa+Z5wTIzMws0msCABgLaW45Dk5fv369SM/B3/9cCofPQf755x8Nt1D3r8k18vm8lEuf8IVduTI1V65c0djrTZ06lTZv3kwdO3akhQsXavw98/EH98X8OK5ZL+fo0aNFanter8f9trrnlY4deB9L5Zb44pLUTnXlB9UdQ2nzOCI/UnmgvMovNW/eXCw5sUEOjyLkYw7eH5zYZ0ik40N1ZZCg8BDQB6PG2efst99+kw2oTp8+XaU2n0TK5uIvw40bN6p9Df7C1mT5Fam8T0xMjNYey/fjzAj+MuehjdwB8nA0zgCQO/GXJr8p7PuUJvHZuXOnyrZLly5pLNtAHb5gwVeoc+OTfB7KxQdNOTMIufYu7xs+Ef/6669VHsd/Q9Lwec6o0/d75fZyZ8xZCTxkMjcuO6AuaNOqVStRaodHDvBEv3kdeOQc9lac1wQAgILjCer5hDM0NFQ2KM1ZjlxvN3efxEPpGZ9M7927V+VxPI9OXllpnFku9ftFDTSvWbNG1KrNTSqnwBPB5pzUrajvNa9h2VzKhhW0Fmtxjr+k4wAO3vOxEgfzpeOF3JPhSviYi0cP3L59m2bMmJHnc/OFAQAAY8YjpjigyueWXbp0ya7TXhicQMX9BRs5cqTaBCxNlu3Q5mtKAWDeJ9z35rZy5UrRR2jCjz/+KM5vOVjPpXa5PIum3zNnwLdo0UL8/Pnnn6ucX/KxhyZHpHGm/RtvvJH9ernLEnHbeNQD47856T3zCASea4d98cUXKs/Lxw3Lli0rdHsKehzBnykfYxW2VryUsJHX30Tv3r3F8RTHH6RRghL+O+M5FKVjKT4G0VTbNBHM59fktuc1nxIUDkrugFHjIc985ZEDjBzA5C96DuByp8QnjByo5y92uRNWngCGs7z4fnwydvDgQdGx8dBufjx3SHyyzFlgK1askK0/VxT8Rc1B6ClTpojZ4aWhVVzLP78aqoV5LA/r4xNu6cSZv/zlJkbhIe5S5hwPz1M3hF5Ojx49REfCByNcE407Ur6Awle8586dq7Wr1xL+bHnCH66hy1er+YT4l19+ERPXSYGFnDPAcyc8efJksf94YiKeeKZPnz5iPe/XmTNnivbz/uD1+n6v/Jl+/PHHol3cbh4d0L17d/GeuIwOH7Sp+/vmDpwne+Z28/8BB174b4JLLnF2JA/F49IFHJTgAAWXMyjuawIAwKvSbHyylBfONOe6tZzRyP00n1DzSRYH67kWLH/fShnonGknZWRJQ6g5WMzJDHzxnr+rW7duLfokvuj87bff5vk9zYHzDh06iJ/55KooNVb5pJHrynPiRO3atUV/ysdKXAaH5Q5gF/W98gkpB9D5vvwcfKGaM+549Jl00vr6668XqM18DHX27FnR/3M/zhcc+MSSLwwUNFuMjxf5OTjzkT9jbn+vXr1k78vPz4GGiRMnij6VRwdyaR6e2I/fE/fDnEjACQHcP0+YMKFAbQAAMER8nrl9+3Zq2bKlmNycJ2Ll70fub8qXLy++dzmpirP3OYucR5Gz3EFH7g/4vJyz2/k5uGwMXyTmx/Nj+JyGL2bznCbqyo4UlrZek/st7gv4fIqTpj799FMx3wBXEeDv/k2bNmnkvIqz1PmCCreX34vcBXfm6ekpbsV5zxwg58+YqxzweTg/jvtRHmnAfb+mL1Bz/8nvj/t9Du5zuWSe35DbzccBfDzBbeY4UE58fMLxod27d4tjCE5w43Zy3819c2FGsOcOuHN7ON7A8xZyGSA+T845Uq9t27Zi/3HbOU5RULz/ufwRx6H4byZnYoSEL9hwNQaOeXB8hz8PPg7iZDw+vuHPgfeH3IWM4rSNHyOVGM7598rVMKRSR/y3rK7MjzSig/ehIc5fYLQUAEbAz8+Po6WK1atXq2y7c+eOIiAgQGzPfevSpYuiffv24ucff/xR5bGpqamK4cOHyz5WullYWCgOHTqU/Zj4+PjsbcnJybLtHTVqlNg+c+ZMlW0bN26UfZ0tW7Zk38fW1lase/z4caEfm1OtWrWy73P+/HnZ+4SGhmbf59SpU4rCyMzMVLRr1062TSEhIYqpU6eKn/v06aPy2BYtWuTZ9n379ontDRo0UPvYL774QuHh4SH7+kOHDlVkZWXJtnnEiBFqP+9KlSopIiIiDOa9pqWlKd566y3Z1/X391dMnjxZ/Ny9e3fZ516/fr3C0dExz7/x8ePHa/Q1AQDMEX/H5/Vdm/MWGRkpHpOYmKjo1KmT2vs1adJEERMTo/JasbGxinr16sk+pnbt2orBgweLn6dPn662z+Hbs2fPinQ8Nm/ePIW9vb3Ka5coUULx1VdfyT62KO+1a9euee5H3gfPnz9XekzNmjXFtsOHDyutP3v2rMLKykrlOXIeq6l7rIT3l7W1dfZjO3funO8+mz17tuzr5rwtX7483+cBADAGfG7+xhtv5NsPlitXTrFhwwbZ57h06ZIiMDAwz8fz93VO/F3O6/ncXk56enr2Y/l8XhevyXbs2KG2D+jQoYOiZ8+e4uclS5YoPY77BV7fq1evfNfnF8+QbrmPCYryntm3334r+vvc9+UYBm/jn11dXRWFoe79SuezNjY2su1zcnJS7N27V/Y5586dK9tOOzs7xfz588XPXl5ehWoLn6/nfj4+NsqJ/7ZzH18UlBQ32LZtm9r7JCQkZN8v943P+3fv3q32sVLbZs2aVah2qYuD5Lzl9Zlz3Ibv8+GHHxbqdSFvyNAHo8CZbHzlT+5qHl/lvnr1qigPwleZ+cohZ9lzVhdnUvGEMDysR26Wc74CyhllfMWWr3JeuHBBDAfi+/r5+YmrpPw8Oa+O8pVHaZiQutnWOYOM7yNdAc+Jr6Tye1m/fj2Fh4eLLC3O7pYmb2H8WJ74JWd2eUEfm1PPnj1FRlitWrWya7nmxleVpfcjzTxeUPz++ao3D+/n7HXO9OMsN77yy/uUMwX5uf39/VUey5kanNGnru2cNc+PlWrhyT2WJ/nlbATOROcMe77Sztu4nBJn0KtrM2ej85XtDRs2iCwRzvbjvxnOIOEMQrkJd/T1XvlvgLPoeegkZ3HwFXv+G+Ar8ZwRwZmN/FgepSGH/wf4fa1bt06UXuKr/fx3z3/ffAWdR6Xw34cmXxMAwBzxd3xBhxFL/Tv3u1xuhvsVztbjkjSc+RQYGCjKCnJ2o9yxBn8n8wgx7pO4b+I+ho85+Pue+0XO+Jbup67PYZxhXhQ8IoD7WR6yzvVpuR/lYzV+bc7cl1OU98rZnty/82N4VBlntXObub/kbH5+TO73wBnwPFoh96jE+vXri+fi4z7ONuTyB3wMlfNYTd1jJTyagScclMr9Sfs5LzwqkI85fvrpJzESko8fuNwB98OcFcmj4Ph1AQBMAZ+b89whnJHL/ROfX3Mfxd/3PBkmj4TmTOt27dqpLQvD5yZcsocz+bkmOGcBc7kVPsfm5+fvf86+zom/y7lv4+9WOTlLfci9rjZek3F2OI/sWrp0qYhZcD/Hz8fnYNyHcR/Bz5F7olCOe8idW8qt59cvyPFH7thEUd4z++ijj0S1Az6n5sfzuSU/16hRo0T/xvP35Vd5IDd171c6n+VjCz7m4Ux9rqbA9+d1I0aMkJ2bgPGExE2aNBH9/s2bN8U5Po8q5JGCUp16ueOkvNrC58GLFi0S59Xcn/MxQ+7X52x93g9ysaD88DEGz2vAx0m5SwBL+Bjl77//FvErLofLIz54HVda4LgEf3ZyOHYkzQfII0YKg58zv7+xvD5zrnohvT/QnBIc1dfg8wGAAeETe+6c+QCCO1gAAAAwbXxoz8P8+cI/n3gW9qQtL3zxmy/ycu3W3BeDAQAAAIwBl8zlEkgcNOdENkPBQXe+oMKlDbmMjroEg6LgUkFcLokv0nAirK7whSxOYODECr64BZqDSXEBTBRnn3FtO3t7e5V68AAAAGC8+ERPXU4O13XlYD5n4vNINgAAAABzwxUP5ERFRYm5cFj79u3JkHDshkcQSHMDahLPocQmTZpEusQjKxjPfwCahQx9ABPCJWd4klseSsWTsHG5HR7+zsPMAAAAwDScP3+eBg8eLErM8RBoHu7NJ6g89JqHuvPEvDyMf/bs2Rp9XWToAwAAgDHg0k5cYrZ58+aiBC6XfTpz5gwtWLBAlPDj8rGcBKnJLHhNxXS4tCCX7eHyhEUtj5gbl6Lm8jxcKlhXeIJlLq3IGfpcLolLX4HmIKAPYEK4NhnXzc9Z65WHOMnNkA4AAADG6d9//xUnR+qy9HkIOc+BwnVtNQkBfQAAADAGXGOf5xuSw/Xt//jjD7XzDOobj7bkWv3z5883uFEEhcEjIdasWSPmW2jWrJm+m2NyENAHMCEHDhwQk9TwUC2ecGjq1KmyE60CAACAceNJ3Xk4NmeXcV17nmiXJ6bt0aOHmMhOG3gy3CdPnoh6szzpGwAAAIAhSkhIoI0bN4oJbDkzPTExUYxo5DryQ4YMIVdXV303EaBYENAHAAAAAAAAAAAAADACmBQXAAAAAAAAAAAAAMAIIKAPAAAAAAAAAAAAAGAEENAHAAAAAAAAAAAAADACCOgDAAAAAAAAAAAAABgBK303wFSEhIRQbGwsBQYG6rspAABg5CIiIsjNzY1u3ryp76ZAHtD3AwCApqDvNw7o+wEAwBD6fwT0NYSD+UlJSZp6OrOTmZkplpaWlvpuCmhZTEyMWLq7u2NfmzD8TxcP+hPjgL6/ePA9YT7Q95sP/F8XHfp+44C+v3jwHWE+0PebD/xf66f/R0BfQ6TM/FOnTmnqKc1KfHy8WDo7O+u7KaBlmzdvFstevXphX5sw/E8XT6NGjTT0SYA2oe8vHnxPmA/0/eYD/9dFh77fOKDvLx58R5gP9P3mA//X+un/EdAHAAAAo5GWlkb79u2jw4cPU3h4OCkUCqpSpQr17duXatSoofZxe/bsoS1bttCTJ0/I19eXevfuTW3bttVp2wEAAAAAAACKCwF9ANApa2tr7HEAKJK4uDgqX768GO6e0969e2nBggX01Vdf0aeffqryuBEjRtDKlSuV1q1bt44mTpxIc+bMwacBoGXo+wGgsOUbTp48STdu3CA7OzsaMGBAkXZgVlYWnThxQiQAlCxZkl5//XWxBADtQ98PoF1mF9DPyMigq1evUlhYmOjgK1euTDVr1tR3swDMRps2bfTdBAAwUunp6ZSYmEhdu3alli1bimHvXHOQh/Ru376dJk+eTK1bt6a6detmP+a3334TwXwnJyeaNm2a6PMvXLhAs2bNorlz51KrVq2QqQ+gZej7wRRlZSnonysvqKK/A/m621CJEiX03SSjd//+ffrss8/ojz/+UKq/XZSA/n///Ufdu3cXS4m9vT0tXryYhgwZotF2A4Aq9P0A2mVWAX0+OFizZg1FRUUpra9duzb9/PPPYsg+AAAAGCbOquOSOW5ubkrreU4OvnHwnsvx5AzoL1y4UCzXrl1LPXv2FD+3a9eOfHx8aPDgwfTdd98hoA8AAIUW+SyVPlkRIX52tLOgimUcqEWtktS3jRf2ZhHdvn2bNmzYQJaWltS0aVM6e/ZskZ6HL/63b99eXCAICAigFi1aiJ+5XN+wYcOobNmy6PsBAMCoWZAZWbFihRim/9prr4nauW+++Sa5uLjQpUuXREbfy5cv9d1EAAAAUMPKykolmC/p2LGjWPLou5wTNJ0+fVoE73v06KF0//79+4sLBH///bcYvQcAAFAYoQ+Ss39OTMmiS2EJdOfx/9ZB4ZUrV47Wr18vEvCOHTsmMuqLYtWqVSKAz4F8ztDnMnvc3y9ZskTMvcOJfgAAAMbMrAL68+fPp2fPntGZM2do48aNtHv3brp3754Yfv/48WMxYR4AaBdnz/INwBSlpmdRRqZC380wS+fPnxdLvkAvuXnzpjhxr1evnkopBM7+40x+nmSXa+sCgPag7wdTdCsySWVdhTIOemmLqahQoQL169dPlNkpjt9//10sv/nmG1GDXzJq1CgKDg6mc+fOiYA/AGgP+n4A7TKrkjsDBw5UWcfZeZytf+XKFYqOjtZLuwDMCQfXAEzRi4QMmrA8nMp52dJn/cqhlq4OnTp1SozC4yz8xo0bZ6+X6u96e3vLPo4z93PeT51GjRrJrr927ZqYi4dHAkDRSiKAeZBGzuB/xfSZ0//1jTuq3/3+7ooi/53zRLB8sRmKf65x+fJlMXcOj8zPiS/uc11vnk+PR+lz6R0A0A6c9wNol1kF9NXhjH2plj4AAEBhPXiWSmOXhNL9qFS6HJZAvh629H7HV8Fi0C4Oqnfp0oWqVq0q5snJSSqlw6V65EjrebJdAACAwgh/lKKyLtDHFjtRz7iMbkJCgjgusLBQLUhQvnx5sXz48GGez4OL+dphThf9zJ0U0MfFfNOH/+viKeoFfbMM6PNEO6mpqSIjb//+/WJynAEDBlCzZs3yfSw6du3AF4D5QMduHszpf/q/+8k05YdH9CIxM3vd8p2PyM0hi9rUdSnScyJLr2B4yDxPeufv70+HDh0iV1dXpe2Ojo55nkhI6zmLL78RAHkdEzg7OxewxSAH+8/0SSWv8FmbD1P/rGPj0yn65f/6febnYUM+niWL/JzIzteMpKRXpZAcHOTLH0nrpfsBAAAYI7MM6I8ZM4bi4uKyfx87diwtWLBAr20CAADjc/xaAs365TGlpquWklr1RzQ1r+FEttZmNV2NznAAv1u3bqLe7sGDB6lUqVKyk+ux0NBQ2ee4ffu20v0AAAAK4naOCXElFVE/3yDY2r4aJcFz5MjhxD6Ws7a+HFzM1y5Tv+gHuJhvjvB/rdsL+mYZ0O/fv7/IHuUM/bNnz9LixYtFDX2eFBdZevqFLwDThyw982LK/9ObDz+l+Zsfkdy0EGU9bWnx2ArkUapoQ++RpZe3bdu2UZ8+fah69er0119/kZubm+z9eFi9h4cHXbhwgZ48eaJUS//OnTuiXE9AQIC4DwAAQEHdlpkQt6K/PXagAeDRehzUf/Dggex2ab2np6eOWwYAAKA5Zpk2yAH8H374gXbs2EGRkZEiY/+ff/6huXPn6rtpAABg4LKyFLRw6wOa92ukbDC/RpAjrf00hMqURh1dbVi7di298847VKtWLZGZry6YL11A5PtyLf3hw4dTSsqresd8UZ9/5xJg7733nlbaCQAAput2pGqGfgVk6BsETorgCes5ee/mzZsq248dOyaWnBQAAABgrMwyQz93h88B/SVLltDJkyf13RwAk6duHgoAY5CSlkXTf7xDhy6+kN3eqk5JmjGoPNnZmOX1cq0LCwujIUOGiEA8T2TbtWtXlftwTf1JkyZl/z516lTasmUL7dq1i/z8/KhixYp069Ytio2NpTJlytCECRN0/C4AzA/6fjA1tx+oZuhXQoa+wejUqRNdvnyZZs+eLebPk/CovvPnz1NgYKAI+gOA9qDvB9AuswnoP3r0iOzt7WUz+Xbv3i2WuSfTAwDNyyubFsCQvUjIoI+XhdHVCPkJf/u18aIxb/uRhcWryR9B8zjDXppY++LFi7L34RI6Ofn6+opM/kGDBonHnD59Wqxv2LAhrVu3Dt9JADqAvh9MSWp6Ft198mrEl8TZwZK8S9norU2mZMWKFdk/cx18HmUnrbOyshIX9iUREREiSF+pUiVq2bJl9vrRo0eLUfk///wzRUdHU7t27ej+/fvZzzNlyhSdvicAc4S+H0C7zCagz9n3AwcOFNl83OFzvVwehnf06FExsZ5UWx8AACC3yKcpNHZJGEU+fTWRWk4cv5/Qy5/eaYlarNrGNfEPHz6c531y1smX1KhRQ9TR5xP/qKgo8vHxUQn8AwAAFETEo2TKzFJeV6GMffY8UVA8H3zwgdp1XBs/Z0CfL9TztgEDBigF9PlY4LfffqNevXrRn3/+KW45g/3vv/8+PiYAADBqZhPQ52H1Dg4OtHHjRpVtPMP9zJkzZYfuA4BmSVm1LVq0wK4Fo3A1PIE+/j5cZOjnZmtdgr4aGkgtapbUS9vMjaOjI73++utFfjwPsecbAOgW+n4wJbcfqNbPr4T6+RrDc9yoY21trfR7UFCQuL9caQ8uwccl9jZv3iwu6PNo/I4dO4oRegCgfej7AbTLbAL63HE/fPiQ9u3bR1euXBEleJydnalKlSqiY8cs9wC68eTJE+xqMBp/X4ylaWvvUGq66uy3pZyt6LvRwVQ1wFEvbQMAMBbo+8GU3I5UrZ9fEfXztVJyJz+1a9fO8/6cqT9u3DgNtQwACgN9P4B2mU1AX7qi36VLF3EDAADIy8aDUfTd1gf0/yXblZTzsqXFYyuQn4ctdiIAAIAZuR2pmqFfARn6AAAAoENmFdAHAADIT2aWgr7b8oB+/fup7PbawU40f2QQuTqiCwUAADAnWVkKuv1AOUPf0oIo0MdOb20CAAAA84NoBAAAwP9LScuiz364Q0cuv5DdJ23ru9H0AQFka22BfQYAAGBmHjxLpcQU5RlxA33tyQbHBQAAAKBDCOgDAAAQ0fOX6WLy22t3EmX3x8D23jSyqy9ZWJTA/gIAADBDN++r1s8PKeugl7YAAACA/iSnZtLViESqX8lZLzECBPQBAMDs3YtKobGLQ+lhdJrKvuC++dP3ylL35qXNfj8BAACYMwT0AQAAzFNiSiZdCUugC7fj6eLtBLpxL5Eys4g2T69CQb72Om8PAvoAoFOBgYHY42BQLocl0PjvwyguMVNlm72tBX09NJCaVnfVS9sAAEwB+n4wFTcjkaEPAFAQ6PvB2KWmZ4lYwZkbL+n87Xi6dT9JBPBzu3ArHgF9ADB9ISEh+m4CQLaDF2Lp87V3KC1DobJX3F2saOHoYKpczhF7DACgGND3gylQKBTiZD73KL6KZXSflQcAYOjQ94MxTnwf+jBZBPDP/PdSBPNT01XjBLldDE2gd1p6kq4hQx8AAMzypPznA1G0aNtD2e3lfexo8Zhg8nG31XnbAAAAwPA8eZ6mMpovwNuO7G0t9dYmAAAAKLq4xAw6eS2OTlx7FcSPjc8o9HNcvB0v4gslSui2jj4C+gCgUw8fvgqg4oo96EtmloLmb46kLUeeyW6vW9GJ5o0IIhdHdJEAAJqAvh9MtX5+JUyICwAgC30/GKq7T1Lo2NUXdOxqHF0JT5Ato1MQttYlqEagE9Wp6ETpGQqysUZAHwBM2JUrV8QSAX3Q10z0U9bcEZ23nA6vlaJp/cuRjbWFztsGAGCq0PeDKcCEuAAABYe+HwyplM6V8AQ6cvlVEP/+09QiPY+djQXVDHKkOhWdqW5FZ6oa4EDWVvqLGyD9EAAAzELMy3T6aGkY3binmmHHBnfwpg+6+up8qBwAAAAYvv9kMvRDkKEPAABgsEH8A+dj6e9LLyg6Lr3Qz2FpQVS1vCM1qOwibtXKO5KVpeHEChDQBwAAsxhWN3ZxKD2KSZPtqCf3KUfdmnropW0AAABg2Lg27k2ZhIBK/g56aQ8AAABoPohf1tOWGlR5FcCvV8mZnOwNd54cBPQBAMCk8SQ1E5aH08sk5YnsmIOtBX0zLJAaV3PVS9sAAADA8HFQ4HmuifL8PW0N+kQfAADAHIQ9TKa9p2Loz3PP6dmLwgXxOeOeA/fNarhS0+qu5OdhS8YCAX0AADBZ+889py/W3RWT1OTm4WpNi8YEI7sOAAAA8oT6+QAAAIYjNj6d/jz7nPaciqFbkcmFemxJJysRvOcgfsMqLuRoZ5wX5xHQBwAAkxwa/9P+KFq6/aHs9iBfO1o0pgJ5l7LRedsAAADAuCCgDwAAoF/pGVl09Goc7T0dQyf+jaPMrII/1svNmlrVcaM36rhR9UBHsrQwnFr4RYWAPgDolJOTE/Y4aFVGpoLm/nqffj8aLbv9tRBnmjsiCMPkAQB0BH0/GDsE9AEACgd9P2jKg2eptP3YM9p1MoZic5W/K0gQv009N6oa4EgWJhDEzwkBfQDQqebNm2OPg9YkpWTS5NURdOLaS9ntbzZyp6l9y5K1lQU+BQAAHUHfD6YY0MeEuAAA6qHvh+Im6R27+oK2HY2m0zfkz+3llC5pTW3qmm4QPycE9AEAwGQmrPtwaZjsSTcb+qYPDXvTh0qUMN1OHQAAADRfpzcqVnmSPR93G1GDFwAAADQn5mU6bfvnGW0/Hl3gCW5trUvQG7XdqFMjd6of4mwS5XQKAkchAKBT6emFm3UcoCAiHiXT2CVh9OR5mso2SwuiqX3LUZcmHtiZAAB6gL4fTK7cjr+DXtoCAGAs0PdDYYQ+SKKNB5/Sn+eeU3qGokCPqVPBSQTxuayOk71xTmxbHAjoA4BOHThwQCx79eqFPQ8acf5WPE1YHk4JyZkq2xztLGjO8CAxez0AAOgH+n4wuXI7ZRHQBwDIC/p+yE9WloJOXIsTgfxzt+ILtMM8S1pT16YeopSun4etWe9kBPQBAMBo/XE6hr5cf0/U2JPr7BeNCaYKZXDSDQAAAEVz455Mhj4C+gAAAEWSnpFF+848p3X7n9D9qNR8788VcxtVcaG3m5emptVdycrSPErq5AcBfQAAMDoKhYLW7ntCy3c+kt1eoYw9LRwdTF5uNjpvGwAAAJiOG3cTVdZVKYdkAQAAgMJIScuiHcejacNfT1TmppHj5mxF3Zp4ULdmHmafjS8HAX0AADAqnI3/zcb74mBADpfX+WZYoFnW0QMAAADNiY6TnxC3lIs1djMAAEABcGncLUee0sZDTyk2PiPf+3Ny3nutPKld/VJkY22BfawGAvoAAGA0ElMyadLKCDp146Xs9i5N3GlKn3IYhgcAAADFhux8AACAop+7bzr0lH4+ECU7313usjpcTqdPay+qW9GJSvAKyBMC+gAAYBSevUijcUvD6HZksuz2EV186f2O3uj8AQAAQGv186sEOGLvAgAA5FFahzPy1/35hOIS8w7k21qXoC6NPah3K08q62WHfVoICOgDAIDBC3uYTOOWhMrW2uNJcab1L0edGrrrpW0AAABgPhn6VRHQBwAAUJGW/qpGPs91xyXr8uJoZ0E9WpSm91p7kTvK2BUJAvoAoFMtWrTAHodCOfvfS/pkRTglpmSpbOM6+fNGBFL9EBfsVQAAA4W+H4yRQqGg67kC+lwBIKQsJsQFAMgP+n7zkZWloIOX4unH/XfpyfO0PO/r6mhJvVt50TuvlyYXR4SkiwN7DwB0ytERw5Sh4PaciqGZ6+9Spmosn7zcrGnx2AoU5GuPXQoAYMDQ94MxehidplIqIMDbTiQTAABA3tD3m4fzt+Jpweb7FPowNc/7uTlb0YB23vR2Mw9ysEM/qgkI6AMAgEFmxa3Z+5hW7n4su72Svz0tHB1MpUva6LxtAAAAYPowIS4AAIC8u09SaPHvD+jolbg8d5GzgyX1b+tFvVp6IpCvYQjoA4BOnT59WizbtGmDPQ+yMjIVNHvDPdp9KkZ2e+OqLvT1sEByxJV9AACjgL4fjBEmxFWVkZFB586do+PHj1NkZCTFxMSQk5MTeXp6Ut26dal58+ZUqlQpPXxaAGBo0PebphcJGbRq9yPadvSZ7Ch6iYOtBfVp7UXvtfYkZweEnrUBexUAdOr58+fY46BWQnImfboynM78Fy+7/a2mHvTpe2XFRLgAAGAc0PeDMcKEuP9z8+ZNWr58Oa1fv55evHihdp9ZWFhQ27ZtacSIEdS5c2fxOwCYJ/T9piUzS0E7j0fTsh0PVcrR5WRjVUJk4w9o700lnRBy1ibsXQAAMAhRsWk0bkkYhT1Mlt0+qpsvDWzvTSV4RjoAAAAALQYu/rufpLSOkwkqlDGveXsePnxIn332mQjk8/FXs2bNqHHjxlSvXj3y8vIiNzc3SkpKEpn6169fpzNnztCBAwfozz//pOrVq9P8+fNFgB8AAIwXTxA/Z9N9unFXuV/MrV19NxrVzY98PWx11jZzhoA+AADo3e3IJBq3NIyevUhX2WZtVYKmDwig9q9hCDcAAABo353HKZScqlxLoIKfPdlam1fGeZcuXejJkyf0zTffUN++fcnHx0ftfaXAfVpaGu3du5eWLFlC7dq1o6tXr4rgPgAAGF95Hc7I33E8mhQK9ferFmBHH3QuTQ2qeeqyeWYPAX0AANCr0zdeijI7iSlZspPozP8giOpWdNZL2wAAAMD8yE6IG+BA5mbatGnUvn17srOzK/BjbGxs6K233hK3f/75h9zd3bXaRgAA0CyFQkG7TsbQ4m0P8iyvU6a0LY1524/qB1tiFL0eIKAPAAB6s/NENH318z3ZCXV83G1o8ZhgKu9jXsPbAQAAQL8wIe4r3bp1K9Z+bNGihUY+DwAA0I0Hz1Jp9oZ7dO6W/Jx2zM7GgoZ08qH3WnmSjbUFxcervy9oDwL6AACgl6v+K3c/pjV7H8tur1zWgb4bHUwertY6bxsAAACYt+t3VDP0qwY46qUtAAAAupg7ZtOhp7R850NKTVdfX+eNOiXp457+5F3KBh+KniGgDwA6FRISgj1u5tIzsmjmhnv0x+nnstubVXel2UPKk4Odpc7bBgAAmoe+H4xJWnoWhT5MVlpnb2tB5X0KXnYGAMDcoe83HqEPksT5eV6T3pb1tKVP3vWnRlVdddo2UA8BfQDQqcDAQOxxMxaflEETV0SoHcLXo0VpmtDLn6wsS+i8bQAAoB3o+8GY3H6QTBmZytmJIf4OZGmBYxPGk+QuWLCAzpw5I8os8KjL3DZv3kyVKlXS2WcGAIYHfb/h477uh72Pae2+x7IlcJmNVQl6v5MP9WvjJcrrgOFAQB8AAHTiyfM0GrsklCIepchuH/u2H/Vr64UJdQAAAEBvrsmU2zHHCXHlxMTE0GuvvUaRkZFkYWFBWVlZ5OzsnF0/2c3NTUyKm5GRoe+mAgBAHu48TqZpa+/Szfvqs/LrVHCiqf3KUTkvjFAzRGYV0H/+/Dlt3bqVzp49S/fu3SN7e3uqW7cuDR48mPz9/fXdPACzEBERIZY1a9bUd1NAh/hA4cOlYRQdl66yzdqqBM0YGEBt65fCZwIAYILQ94MxuRqRoLKueqCTXtpiaJYvXy6C+ePGjaMjR47QlStX6OjRo+Tg4EC9e/em1NRU2rdvH86tAQB9v4HKylLQb0ee0ZLfH6itle9oZ0Fju5eht5p6kAVGpxksswno84FG69atKT1dOZi0e/dumjdvHv3666/05ptv6q19AObi5s2bYomAvvk4cS2OJq2KoORU1XF8Lg6WtGBkENWu4KyXtgEAgPah7wdjci1CNUO/eiAmxGXHjx8Xy/bt24uAvqRixYr0yy+/UJUqVej999+nv/76S4efGAAYIvT9hicqNo1mrLtLZ2/Kl7+V5rOb1Kcseblh0ltDZzYB/ZcvX4rhgD179qR69epRuXLlRP2/pUuXioz9fv36iWwDJydkXwAAaMrvR5/RnE33ZWvy+XnY0KIxFSjAG0P4AAAAQP94JOGjmDSldV5u1ghs5Ci5wzw8PMjS0lL8nJaWlj0Bpq+vLx08eFCMjC9VCiMvAQAMxZ9nn4vz8vikTNntro6W9Mm7ZaldfTeUwDUSZhPQb9GihQjgW1tbK63nAH+dOnXov//+o1OnTlGbNm301kYAAFPBE6T98GcM/XLouex2rkX73ahgcndR/k4GAAAAMKT6+dXKIztfwgF7KbDv7u4ufo6KisrebmdnJ44Bnz17hoA+AIABSE7NpLmbImn3qVcXZOU0ruZCn/cPIA9XnJsbE7OZopiz83MH86WDjubNm4uf+eADAACKJy09i2ZvfKI2mN+ipiut/LgigvkAAABgUP5F/fw8cSIcu3btGtWvX1/8vGvXrux1PF8GT5bLo+EBAEC/wh4mU7+vbqoN5tvZWNCk98rSotHBCOYbIbMJ6Ofl/PnzotROo0aN9N0UAACj9jIxg0YvDqVDl+Tr8vVqWZrmjggie9tXw7QBAAAADMW/qJ+fp0GDBolSO6tWraIhQ4aQo6MjrVmzRsyN1bRpU5Egx+s5aQ4AAPSDv4u3H3tGA77+j+4+SZG9D48+2/hZZerRojRK7Bgpsym5o87ChQvpwoUL9O2334os/vyoC/pzRkLlypUpPl795BKgXmKi6vBWME3SSBj8r5ieJ8/TadKah3TvqXLtWVaiBNEHnUtTj2YlKSkxQS/tMyaZmZnZtWkBAABA+zIyFXT9rvI5iZVlCQop64Dd///Kli1Lly9fppSUFFF+59ChQzRp0iS6dOkSeXp60siRI+nzzz/H/gIA0JOE5Ez66pd79Ne5WNntlhZEQ9/0pYHtvUUfB8bLrAP6v/32G02YMIH69u1LH330kb6bA2AWSpYsqe8mgBbcikyhyWsfUmy86iQ71lYlaGpvb2pRM/+LpgAAYHowOSYYS2mC1HTlEqyV/O3J1hqD2nOqVq1a9s8NGjSgw4cP6+wzAgDjgb5f925HJtHElRH04Fmq7Hae5P2roYFUM8hJ520DzTPbgP7atWtp2LBh1KtXL1q3bl2BH8cT5+aVuV+QLH9QD/vP9DVp0kQs8VmbjmNXX9Dk1Q8oJS1LZZuroyV9OyoYBw2FhOx8ADAlDRs21HcTAIpUP79GIIIeObVr146uX79Of/31F1WpUqXQ2wHAfKDv1619Z2Jo1oZ7KhemJc1rutL0AQHk6mi2YWCTY5af5Pz58+mTTz6h/v37048//igm7gEAgMLb+s8zmrvpPmXJHDf4ulvT0nEVqawX6qgCAACAYbsqUz+/WqCjXtpiqKKioujhw4eUlpaW5/b09HSdtw0AwFzLxS3a+oA2/f1UdjuX1RnX3Y/efcMTtfJNjNkF9LnG35w5c8SEPjyBD4L5APqZLwEZ+sYtK0tBS7Y/pA1/Rclur1LOjmYP8iV/BPPN0qNHj+j06dP05MkTevHiBbm5uZGPj48Yzebl5aXv5gGAjqHvB2Nw7Y5qQL8GAvqFEhcXJ5b29vbF+izu3btHGzdupPDwcFGus0OHDtSqVatCP8/58+fFaIG7d++Su7s71ahRg3r27ElWVmYXBgHQOfT92hfzMp0mr4qgi6Hyc9T5edjQ10MDqUoALk6bIrPpybKysuiDDz6gVatWiVI7K1aswNUpAD34559/xJLLXYFxSk3Poi9+vEsHLshPtNOydkn69B0P1Jw1M5yV98MPP9D69evp1q1bau9XtWpVMUKOL6yXLl1ap20EAP1A3w+GLjY+nSKfKtccdnexIu9SNmTudu3aRc+fPxc/S0tex5PjShQKBd24cUMEzh0dHSkgIKDIr7d9+3Yxx11SUlL2ugULFojjBj7OKFEi/0kcMzMzaciQIbKldb/44gvavXs3VaxYschtBID8oe/Xfpk4rpf/7IX8iKiWtUrS9IEB5GRvqeWWgL6YTUCfr/BzMJ8z8q9du0bNmjVTuQ+X4enatate2gcAYAxeJGTQhOXhdDlMPgvgvVaeNK5HGUpKlN8OpodP7r/88kv6/vvvxRD7wMBAeu+996hmzZrk4eFBLi4uImMvOjqaLl26JDL3P/30U/r8889p9OjR9Nlnn2GybAAAMMDsfCckgBGJ/vrKlStK+2b69Olq5wCaNWsW2dgU7ULIgwcPqE+fPpScnEw9evQQNfnv379PCxcuFKVy69WrRyNHjsz3eVavXi2C+TxSgAP71atXp5iYGHFB4Pbt2/T+++/TsWPHitRGAAB923Uimr7eeJ/SM1Tr3vI1z5FdfWlge2/0YSbObAL6KSkp2Zn6J0+elL0PZwIAAIC8B89SaeySULofpZzBJh04jH/HX9TmA/PBfWpQUJD4eezYsdSvXz8RyM/PhQsXaMOGDeKEm5ec3Q8AAKAvqJ+vHperjY2NzS5fy+VwvvnmGypXrlz2fThrni/g165dm7y9vYv8OSxdulQE84cOHSqS8SRcbuf111+nuXPnFiigv2/fPrHkZIOBAwdmr+fnDQ4OpuPHj1N8fDxKgAKAUcnMUtDSPMreujhY0uwh5alRVVedtw10z2wC+p07d873Kjx37gAAIJ+59tGyMIqNz1DZZmtdgma9X55a1nbDrjMzPMSeA/kfffRRobLs69atK26c9cdZdwAAAPp0TWZCXNTPf4Wz5CVc0z4yMlJk0ZcpU0bjn8Mff/whlhMnTlRa36JFC2rYsKEY5cej7atVq5bn8/BIAcbHGjlxHf3y5cuLEYOYSw8AjElSSiZNW3uH/rnyaq6S3CqWsad5HwSRn4etztsG+mE2AX2ehA8T8QEAFN6Ryy9o6poISk1XHdLn5mxF340KpmrlMdGOOeIT5hkzZhT58aVKlRLlegAAAPQlI1NB1+8qB/QtLYgql8OxTW5Tp07V2ufAde95Dh6eX0cu0a5JkyYFDui3bdtW1OJfu3Ytffvtt9llJ6THN23aVNT6BwAwBk+ep9HHy8Lo9oNk2e0dXitFU/uVIzsbC523DfTHbAL6AABQeL/+/ZQW/BZJCtVYPpX1tKXFYytQmdLIAgAAAADjFPYwmZJSs5TWVSzjgMBIHrge/c6dOyk0NFSUyOG56FJTU8VEtlyKj2vXFxbPt5OWlka+vr6y2/38/MTy2bNn+T4X180/e/asGAXIWf9cQ5/n8uFSO9w+rsefn0aNGsmu5wsClStXFiV7oPASE1VHw4DpjuRl+F8pnpv3U2jqjw/peXymyja+Vjm8kwe908KN0lMTKV21Mq5O4P+6+Be0pZFlhYGAPgAAqMjKUtCibQ/ol4NPZfdOzSBHWjAymEo6oRsBAAAA43U5LEFlXa0KTnppizHYvHmzCJgnJPxvv3Gd+k2bNoka9wsWLKCPP/640M/LFwSYugl1bW1tle6XFysrK1ES8M6dO3TkyBExEa5UcofnAZDm/wEAMGT/XImnrzY9oTSZyW/tbErQZ318qElV9FfmCpEYANCpNm3aYI8buJS0LPr8xzv098UXsttb13WjGYMCyNYaQ/pAHk+e99NPP9H169dF5l5unIHA2wHAPKDvB6ML6AcjQCK7ry5fpr59+4oM/J9//plmzZpFN2/ezJ5wlgP6XOamKAF9qQSOukxP6QJCQUrl8OiBd955h9zc3LID+DwCgMvwDB48mA4ePEi//PJLns9x6tSpPDP3nZ2d820HqIf9Z/q49BXDZ12ckfKPZUfKe7lZi7K3Ff0dyJDgsy6aomTnMwT0AUCnrK2tsccN2IuEDFGf76rM5HCsXxsvGvO2H1lYvKpFCpDbvXv3qHHjxvTo0SO1OwcBfQDzgr4fDLkkxKVQ1dIpNYMQ0Jfz/fffU0ZGBk2ePFlMjDt//vzsbVz33snJSVzM55I8nA1fGC4uLiIYxMcRcuUHeEJeVpDJeKULClwzPyAgQGl9hw4daOPGjfTBBx+IWvoAoB3o+4s+Un7J9oe04a8o2e1VAxzESHkPV8RVzB3SKwEAQIh8mkKD5tyUDeZz/H7iu/40rkcZBPMhT9OnTxfB/M8//1z8zifkPOR92bJl5ODgQIMGDaInT55gLwIAgN49jE6jmJcZSuv8PW0RKFGD68czdYFwKdgeFSUfiMpPnTp1RIb+yZMnldZnZWXRgQMHsu+Tl5SUFIqIiBC1+HMG8xlPjtuwYUPxM194AAAwJOkZWTT9x7tqg/lt6rnRyvGV0EeBgIA+AOjU0aNHxQ0My9XwBBo05xZFPlWtS2pnY0HzPwiid1p66qVtYFykE24e0i7hE+qRI0eKofk8ER1nxgGA+UDfD0ZVbgfZ+QXGAfKcXr58WeCyOHK6d+8ulhMnTlSq0c8jATg5gEcASpPjqmNnZ0clS5aku3fvihI7OXFCgXQM4uPjU6Q2AkDBoO8vnITkTBq3JIz2nX0uu31QB2/6akh5TNgO2RDQBwCd4oPznAfooH9/X4ylD767Lcrt5FbK2YpWja9IzWuW1EvbwPg8fvxYLDkzjvGweS5pwN5++22xXL16tR5bCAC6hr4fjCmgXxP189UKCQkRyytXrqgE9DlYzjdXV1fy9/cv0ufBdfi5dA+XyqlQoQL16NGDXnvtNfr000/FiL+vvvpK6f7nzp0TNf1XrVqltJ4n7ZWOO2rXrk09e/YUc3mUL1+eQkNDqVy5cpjbA0DL0PcXXHRcOg2bf4vO3oyXHSk/6b2yNKqbn8pFVDBvCOgDAJixjQej6NNVEZSarjrbToC3Hf04KYSqBBQtywrMU6lSpcSSJ8PlWrrs+fPnSts4aw4AAEDfMCFu4fTr108sFyxYoDJXzuzZs0VpHL6PhUXRwgycXb9v3z5RVocvDmzbtk0E7bm+/vr166lFixZK9+d6+zy5be4SPV9//TWNGTOGbGxsxES+W7duFRPhcjkeLrnz119/iYl9AQD07cGzVHp/7k26/SBZZZutdQmaOyKIerQorZe2gWHDpLgAAGYoM0tB3215QL/+/VR2e50KTjTvgyBydUQ3AYVTvXp1OnLkCN26dYtq1KghTrKPHTtG3bp1o1OnTill7wMAAOhLbHw63X2SorSupJMVlfOy1VubDF3Lli1p7NixtHjxYgoMDMwO3L/55pv08OFDqlSpEs2cObNYr8EZ+hcuXBA3roXPGf9cs5/n4cmNs/c3bNhAQUFBSuutrKxEG7/88ks6f/68mKSXLxZUqVJFZP4DABiC8EfJNGphqMjQz83FwZK+HRVMtTBqDNRApAYAwMykpGXRZz/coSOXX8hub1vfjb4YEEA21hjEBYXXv39/EdD/6aefxJB3Dui///77tGPHDvrjjz/EfXr37o1dCwAAenUlPFFlHQdOUNIgb4sWLaK6deuKJWe/s7S0NBo1apQIoHP9ek3g1+BbXsqWLStK7qjDbWndurVG2gMAoEn/3Uuk0YtCKS4xU2WbdykbWjI2mMr7YCQRqIeAPgCAGXn+Mp0+/j6crt1RPYllA9t708iuvmTBxfoAiuDdd98VwRDOpHvnnXdEeR0ems8Bfh76Pnr0aJoyZQr2LQAA6NUVuQlxkQlZ4Iv3fOMSO6mpqShfAwBQCBdvx9NHy8IoMSVLZVuwn70I5pcuaYN9CnlCQB8AwEzci0qhsYtD6WF0mso2jt9/+l5Z6t4c9fmgeLgm7cCBA7N/nzFjhgjgP336lHx8fMQweE3hyXY5kMAT5VlbW8veJyMjQ9zkcKkAvsgAAADmB/Xzi4/7UdSiBwAouJPX4uiTFeGyc9hVK+9Ii8cEkwvK3kIBoJ4CAOhUzZo1xQ10f9I6eM5N2WC+va2FqM+HYD4UF2fqtW/fnjp16qS03tbWlvz9/cWJv9z2wkhISKDff/+dBg0aRF5eXiKQ0LlzZ7X3/+KLL8R95G5c4x8AtA99Pxhi+cH/7iepTD5YyR/lDXKaM2cO3blzp2j7OCVF1LEPDw8v1mcFAMYJfb+qgxdixWh5uWB+/UrOtOzDCgjmQ4EhQx8AdMrPzw97XA8HDp+vvUNpGaoHDu4uVrRoTAUKKas60RhAUQL6+/fvFxnzRdleEEuXLqXJkycX+nGciZ+7LjJfaAAA7UPfD4bm+t1EyshUqGRGWlsh3y2ngwcP0rRp08TcNwMGDBCT4uY3x0BYWBj9/PPPtHr1anr+/Dl17NhRK58hABg29P3K/jz7XJyTZ6meklOzGq70zbBAssUcdlAICOgDAJgoLkfy84EoWrTtoez2QB87WjQmmHzcEdQE3UhOTi52IN3Z2ZneeustkZVfqVIlatKkSYEed+LECapXr16RXxcAAEwHyu0UDE9mv2zZMpo5cyatX7+ePD09qWHDhlSnTh0xSo4nnU1KSqKYmBi6fv06nTlzhm7evCmC/jynztdff03lypXT8qcJAGDY9p2Joek/3pUN5rd/rRR9MTCArCwxhx0UDgL6AKBTfJDP6tevjz2vRZlZCpq/OZK2HHkmu71uRSea/0EQOTugG4DiO3/+/Ku/u8xMlXUSrmO/d+9e8XNQUFCRX2vUqFHiJmUBAoDhQ98PhuZSKCbELQien+bDDz+kYcOG0a+//kpr164VQf5du3bJ3j8gIIA+/fRTGj58OJUvX17DnxoAGBP0/a/sPR1DM9bJB/Pfbu5Bn/YuS5Y8oR1AISGSAwA6FRERIZYI6GtPcmomTVlzh45djZPd3uG1UjStfzmywZA+0AAO1Of+f+bAvrr/cc7a4+CAPnDJH67jDwC6hb4fDAmX2smdoc+xlOqBTnprk6FzcHCgwYMHixvPZcOZ+A8ePBCZ+Y6OjiJbn7P2y5Ytq++mAoCBQN9PtOdUDM346S4pZIL5fVp70oc9yuRbxgxAHQT0AQBMSHRcOn28LIxu3FOe6E3yfkdvGtHFFwcOoDEcIJ86dWp2maevvvpK/H1NmTJF6X5cN79UqVKi/q4+JqPt16+fyOjntlWuXFn8Pm7cOJF9CAAA5uPG3UQxKW5OIeUcyMm+6PO7mBMnJydq1aqVvpsBAGC0wfz+bb1ozNt+OCeHYkFAHwDARNx5nEzjloTRo5g0lW2WFkST+5Sjbk099NI2MF0c0J81a1Z2Zv4///xDVlZW2esMhVTTly86XL16lT755BNRNuDPP/8UE+bmpVGjRrLrr127Ji4OxMfHa6nVpi0xMVHfTQAd4f87hv8V02cM/9enrj1XWVe9nK3e/z65Dy3OpPEAAGAYdp2Ippkb7skG8we086LRbyGYDwYa0L9x4wbduXOH0tPTVba5u7tTs2bNtPGyAABm6+LteBq/PJzik/5Xw1ziYGtBc4YHUqOqrnppG5gPDkQcP36cDIm3tzctWrSIOnXqJOr5RkdHi9q/XOP38OHD9P333+utBBAAAOje5XDVUYw1g+zxUcj4999/i3SRhkficZkeAABzzMxXF8wf1N6bRnbDaHkwwID+48eP6e2336bTp0+rvU+TJk0M7mQfAMCY/Xn2uRjOl56hetRQuqQ1LRwdTJX8cVIFupWSkkKnTp2iyMhIUWef6+7qw+jRo5V+9/T0pCFDhohAf+fOnWnHjh35BvT5feSVue/s7KzBFpsf7D/TJ9WHxWdtPgz1s+b6+dfupqjUz29cw1PvJXcMMTufy9NduXKl0I+7dOkS1apVSyttAgAwVAcvxNKXasrsDO7gTR90RTAfDDSgz7PZczCf6+Ny1ltQUBANGDCAfv31VwoNDaXx48dTw4YNNfmSAABmXcLgp/1RtHT7Q9ntQb52tGhMBfIulXc5EQBN435/7Nix9OzZs+wgBQf0a9euTZcvXxYlb6pXr67XHd+4cWOxlNoIAACm7797iZScmqt+flnUz8/roviTJ0+U1vFkuGvWrBET4fKFcRcXFxEDOHbsmLjQ3bFjR/Lx8dHaZwgAYIiOXnlBU9dEUJZMMH9IJx8a3tkHNfPBMAP6cXFxtHfvXtGhT58+XQT0Oftt2rRpIpD/2muv0bp16zCsHcDM8fcCaCbDbO6v9+n3o9Gy218Lcaa5I4L0nm0G5ufgwYPUp08fkZ05b948UateMmLECHH74YcfaOHChXpt599//y2W+E4C0D78n4GhuHA7QWVdnYqGOZrAEPCItpzu379P9evXp2rVqokAfs6RGF9++aWIAwwcOFAE+wHAvJlT33/6xkv6dFUEZSpfLxbe7+iNYD5ohYWmnig8PJyysrJEVj5PhpdzAiyun8eZenx1f8mSJZp6SQAwQnXq1BE3KLqklEwa/32Y2mD+m43cadGYYATzQS94Mlw+HlixYgV99NFHsiVq9u/fX+Tn52MLLufDt7S0VxNA8+vlXseioqJEqb9ffvlFzO/DyQc8YnDBggXZJYC4VCAAaBf6fjCkOYdyq1vRSS9tMUZz5syhp0+f0uTJk1XKKk2dOpUcHR1pypQpSn0xAJgnc+n7xVx234fJlr/t18aLRnRBmR0w8Ax9qeafhYUF2dnZiZ/j4/93wBQYGCiWFy9e1NRLAgCYnei4dPpwaRjdvK86oRsb9qYPDX0Tw/lAf86ePSuWPOQ+N56UVsrwK6oLFy6I7MCcDhw4QPb29rJz9Zw8eVLc5HAbuVwgAACYx+jGy2EJKvXzawUjoF+Y2vjM399fNh7ApXbCwsLo3r17VKFCBQ18agAAhuvanURxbp6arhrM79miNI3t7ocyO2D4Af3g4GDxhxoREZF9ws4/p6enk7W1tZgUj0nBfgAwT7GxsQY9WZohC3+UTOOWhNGT56pZT5YWRJ/1K0edG3vopW0AEikrj/t7aSJMCWfQMxubos/rwIkDtra2arfn3MZD/vkCw+rVq8XEtnwhgQP/XL//vffeE/P88PMBgHah7wdDwMkQSbnq51fydyBnB41OK2fSpIvn//77b/ZcNJKXL1+KQH7O+wGA+TL1vj/0QRKNWRyq0q+wzo3c6ZN3/RHMB63S2NELD69744036NChQ6L8TrNmzURdPa6V26VLF5o9e7a4X9OmTTX1kgBghDioxsqWLavvphiV87fiacLycEpIzlTZ5mhnIerlN6jsope2AeQUEBAgjgO4tE2VKlWUtt28eVMsK1asWOSdxkN3pQsDBcHZ/Lkz+gFAt9D3gyG4IFdup5JpBpq0pVOnTmIOmhkzZogRcVxLnyUmJooRb5zMxxfNy5Qpo++mAoCemXLf/+BZKo1eFErxSarn5m3qudFn/cuRBQ8BA9AijaalTZo0SXTyZ86coWXLllHp0qVp7dq11K1bN3FyzwH/0aNHa/IlAQBM3h+nY8QBg1ww37OkNa35pBKC+WAwpJr0c+fOVdnGxwasZ8+eOm8XAACYN7mAfp0KKLdTGKNGjRIJeo8fP6batWuLi+wtWrQQAbtff/2VnJycxKg4AABTLoE7auFtinmZobKtRU1Xmjm4PFkimA86oNHxha1btxY3ye3bt2nPnj30/Plzqly5stiWe/g9AACon/xz7b4ntHznI9ntFcvY08LRweTpVvTyJQCaxhPlbd++ndavX0///fdf9qS1fFH/8OHDVKNGDREQAAAA0Gn9/FDl+vl8WlobAf1C4bJ2Bw8eFJPL//TTT9k19d3c3EQpuy+++AK18wHAZMUnZYgyOw+jVUvgNqriQl8PDSQrS8Q8wcgC+lFRUbR7927y9vamN998U6wrWbIk9e3bN3v7Dz/8oLQdAADUn3h+s/E+7TgeLbtdHDAMCyQn+1cTkgMYCj6pP3HiBI0bN462bduWfXGKy/D17t2bli5ditq6AACgU7ciUT9fk0H9KVOmiFtGRoaYO8fBwUFjzw8AYIhS0rLoo2XhFPogWWVbjUBHmjsikGysMTcXGGFAn2vlDh06VNTSkwvY57cdAABe4dI6k1dF0KkbL2V3Sdcm7jS5Tzlc/QeD5enpSZs2baKEhATR/3NAPzg4mFxcMM8DAADo3rmbKLejDVZWVuIGAGDqyXZ8fn45THmkFwvytaPvRgeTvS0S7UC3dNb78tV7ZmmJP3IAAHWexqbRh0vD6LbMlX82oosvvd/RG+XLwChwLV2usQsAAKBPZ/9TTZKoH4IJcfPDJfRiYmLE/DilSpXK/j0/0v0BAIxdVpaCvlx/l479G6eyzdfdhpaOq0CujriwCbqns7+6ixcvZmftAYD5wjwa6oU9TKZxS0IpKjZdZRvX4pvWvxx1auiu1c8HoDC4Nv6WLVvonXfeKdL/dmZmJm3evFnU3QUA04W+H/RdJiF3VqWlBVGdigjo52fGjBl05coVqlevngjQS7/nR7o/AJgvU+n7l/z+kP44/VxlfSlnKxHML10S89mBEQb0z58/Tz169BA/p6amZq8LCAhQul9KSoqooc86d+5cnJcEACPXoUMHfTfBYDPHPlkRTokpWSrbuE7+vBGBVD8E5UrAsHApnT59+tDs2bPp448/pu7du5Ozc/4BktjYWPrtt9/ou+++o7t37yKgD2Di0PeDPl0NT6C0DIXSumrlHcnRDiPH88P9dFxcHJUvX17p9/xI9wcA82UKff+vfz+lDQdexTJzcrSzoMVjK1BZLzu9tAug2AF9CwsLsrOzyz6pz70u55D7GjVqiOB///79secBAHLYcyqGZq6/S5mqsXzyLmVDi8YEU5CvPfYZGBwuo3fp0iWaMGECDRo0iEaNGkWtW7emBg0aUPXq1cnDw0ME+F++fEnPnj2jy5cv06lTp+jw4cNiEr2OHTuK4fsAAADaclamfv5rSJIokJYtW+b5OwCAqTp8KZYW/Bapst7GqgR9OyqYQspiMnAw4oB+nTp16ObNm+Ln48ePU7NmzcQ6/hkAAPLGF0JX73lMq/Y8lt1eyd+eFo2pQB6u1tiVYLA4cL9//346efIkLV++nLZu3Uq7du1Se38HBweRkf/BBx/Qa6+9ptO2AgCA+Tl7U7V+/muVUW4HAADUj+z67Ic79P95y9ksShB9NTSQ6qJkG5hSDX3Oxnv8+DHZ2KB+FACod+DAgezJssxZekYWffXzfdp9Sn5iscbVXOiboYHkgOHgYCQaN24sbqtWraLTp0/T2bNnxXEBZ+eXLFmSfHx8xLEC32xtbfXdXADQIfT9oC8vEzPov3tJSuvsbS1EyR0o3hw6nMR37do1UXrX39+f3njjDdTNBwCj7/vvRaXQR8vCKDU9VzSfiCb08qfXa5XUS7sAtBbQt7a2Jm9vb6V18fHxYiIMLrljaHjoP9f/48l6MGEPgO6kp6tO+GpuEpIzaeLKcDr7n+oQcPZWMw/6tHdZMREugLGxt7cXQ/IxLB8AJOj7QV/O34pXybCsXcGJrK0s9NUko3fx4kUx0u7WrVsqI/B40lwuwwcAYIx9//OX6TR2cSjFJWaqbOvf1oveaempl3YByNH4kQxPitupUyfRobu4uFD79u3F5Hc9e/ak4cOHkz7duHFDHGTUq1ePvLy8qEKFCrR48WK9tgkAzEtUbBoNmXdLbTB/9Ft+NKUPgvkAAAAAxXUO9fM1ikfetW3bVgTz69atS99++y398MMPNHjwYEpJSaFPPvmE1qxZo9kXBQDQgeTUTJGZ/zA6TWVb2/pu4jwdwCQz9BlPcscBfK4LzZPgXrhwQax3c3Ojp0+firq6PGlew4YNSR+mTJlCO3fuFD/zxL180AEAoCu3I5No3NIwevZCNVvB2qoETR8QQO1fK4UPBEzCsWPH6Pfff6ewsDAxWi84OFhc3G/UqJG+mwYAAGbijFz9/BDUzy+qZcuWUUxMDLVo0YIOHTpElpaWYj0H9Ll/Hzp0qEigGzJkSLE+NwAAXcrIVNCUNXfo+l3lEm2sTkUn+mJAAFlwAX0AUw3o8wR3aWlptGXLFlF+hyfJlXTr1o2OHj0qtukroF+1alWqWbMmde7cmf777z/q37+/XtoBAObn9I2X9OnKcEpMyVLZ5uxgSfM/CMLkOmASMjMzxYn8unXrVLZ99913YrTe999/TxYWKHcAAADa8+R5Gt2PSlVa5+ZsRcF+9tjtRXTy5EmxHDduXHYwX8J9//jx4+nBgwcUGRkp6uoDABg6TkhesDmSjl2NU9kW6GNH80cEkY01zlvA8GjsrzI8PFwMvfPz86MePXqIbLycAgMDs8ve6Mvs2bOzS+7kbh8AgLbsPBFN45aEygbzfd1taO3ESgjmg8n45ptvRDCfR+fxsHs+sb9//z6tWLFClOJbuXKlCOwDAABo0zmZ7Pz6Ic7IsiyGhIQEsfT0lK8jXbp0aaX7AQAYul//fkpb/nmmst7D1ZoWj61ALo4azYMGMLyAfnR0tFj6+vqKZe6AOdfUZ5zBDwBgLlf7l+98SDPX36NM1Vg+VS7rQGs/DaHyPsgUA9OxevXq7GH577//vrjQz1l6nJm/cOFCsQ31dQEAQNvk5it6LcQFO74YypQpkz1vnlw84O7du2IEnhQTAAAwZMf/jaPvtjxQWe9ga0GLxgSTdykbvbQLoCA0dqnJw8NDLKOiomS3c4Ye4xN7Y6au9u+1a9eocuXKFB8vP9El5C0xMRG7yExUr15dLE39fyU9Q0HztjyhAxfk32ejyo40ra8P2VqkUHy86c3ngf/p4petyT2U3VhI/X2nTp1UtknrOGMfAMxH/fr19d0EMMOkirOon69xb731Fm3fvp1mzpwpyug2aNBArI+NjaUBAwaI45dWrVqRq6ur5l8cAIyKoff9YQ+TacrqCMpSKK+3tCCaMzyQKvm/SkoGMPmAflBQkMjA45P0c+fOqWToc8fPWrduramXBAAjVKqU6U/6mpCcSZ+ve0SXwpNlt3dp5Epju3mSpSVKf4FpZu/du3eP0tNVJ3+WRumVLVtWDy0DAH2RynAA6Erog2SKeZmhtM7Pw4Z8PWzxIRTDe++9R5s2baJ9+/ZR48aNqWLFiuTs7Czmp+MyO1xub8mSJdjHAGDQfX/My3T6cGkYJaWqDqP/tHdZalQVFyXB8Gm0GNQXX3whhtd3796d3nnnHbEuLi6OJkyYQLt376aQkBDq1asXGbNTp07lmbnPBzRQdNh/5sNUP2uegG3c8lCKeCSfdT/2bT/q19bLbObxMNXPWduMNTufffDBBzRp0iT67bffxM858To2atQoPbUOAADMwcnrqvXzEaDRzPHJrl276Ntvv6W1a9fSzZs3sxN2+vXrJ+arK1++vAZeCQBAO1LSsmj89+HivD2391p50tvNDfdCBIDWAvqDBw+mp0+f0vTp02nBggXZpWj4VrVqVdq5cyfZ2iIrAsCcXb16VSybNGlCpubm/SRxpT86TjUz2caqBM0YFEBt6pn+CAUwb126dKELFy7Qxx9/LMrwtW3bVpQ+4Gy++fPnU58+fcRoPSkIwPgCV6VKlfTabgDQHlPu+8Ewnboep7KuYRXUz9cEKysrmjhxorhlZGSI0XfSfHkAAIbc9/M5yYyf7tK1O6oln5tWd6VxPV7NEwJgDDQ+XTNn5fXt25f27NlDd+7cITs7O6pbty517NhRdP4AYN6k+tqmOKHO5NURlCwzbM/V0ZIWjAymWsFOemkbgK7wiX2VKlWyf+dMPb7l9Msvv4hb7ow/fiwAmCZT7fvBMCWmZNLlsASVmsj1QzBqUNP4/B7n+ABgLH3/qj2P6cD5WJX1wX72NHtIebK0MI9R9GAarLRVP3fEiBHaeGoAAIPz+9FnNGfTfcpUjeWLeq2LxlSgAG87fTQNQKcsLCxo3LhxZlViCAAADMv5W/Eqx2ScVOFoh74GAMBc/Xn2Oa3e81hlvbuLFS0cHYw+AoyOWaXMcz3/Z8+eiZ+5DAB7/vw5hYWFiZ95Eh93d3e9thEAjEdWloKW73xEP/75RHZ71QAH+m5UMJVysdZ52wD0FdBfuHAhdj4AAOjNKdTP16qXL1/SypUr6fz58/Tw4UPZEXYbNmygChUqaLchAAAF9G9EAn35012V9bbWJcRIeu9SNtiXYHTMKqDPBxZjxoxRWrdkyRJxY+PHjxf1fQEA8pOWniXq7+0/pzpkj7Wo6UqzhwSSnY0FdiaYlaysLBHYz0tMTAwuoAMAgFbqI5+8plo/v3FV1M/XhNDQUGratKmYN485OjrKltxJSUnRyOsBABTXsxdp9MmKCErLUKhs+2JgAFUr74idDEbJrAL6JUuWpKCgILXbPTw8dNoeADBOLxMzaMKKcLp4W7k+q6RXy9L08Tv+qMEHZoez9Dp06ECbNm1S26eeOnWK3nvvPTHPDgAAgCbdf5pKj2LSVMopVChjjx2tAbNmzRLB/GbNmon5cPz9/bFfAcBgpaZn0YTl4RQdl66ybUQXX2pTr5Re2gWgCWYV0OfJevkGAFBUj6JTadzSMLrzWDXzqEQJog97lKH3WnlSCf4FwMzw3/3ff/9NtWvXpi1btlDDhg2Vti9evJgmTJggLrADAADootxO46quOC7TkJs3b4rlZ599hmA+ABj8iK2vf7lP1+8mqWxrV9+N3u/orZd2AWgKakEAgE6VLVtW3IzRjbuJNGjOTdlgPtff+2ZYIPVp7YWTRjBbPLnt3r17KTk5mZo3b55d0i4+Pp569eolJsytVasWnTt3Tt9NBQAdMua+H4zLyeuq5XYaotyOxvj4+Iilra2t5p4UAEySvvv+jYee0p5TMSrrK5d1oGn9A3DODkbPrDL0AUD/qlWrRsbo6JUXNGXNHUpJy1LZ5upoKSa/rRHkpJe2ARiS9u3b04ULF6hnz540duxY+ueff+jatWt069YtGj58OC1atAiBAAAzY6x9PxhfaYULt+KV1vGAyQaVUT9fUwYMGEA7d+6kgwcPUosWLTT2vABgevTZ95++8ZIWbX2gsp5LsM0fGYR57sAkIKAPAJCPLUee0rxfIylLdR4d8ve0pUWjg6mslx32I8D/K1euHB0/fpxatmxJ27ZtE+u+++47+vDDD7GPAABAKy6FJlBquvLBWtUARyrphFNeTXnrrbfoyy+/pG+++YZKly5NXbt2JVdXV5X7OTs7i1F7AAC6Fvk0haasjlA5d7eyLEFzhgeRl5sNPhQwCRotuRMbG0t79uyhkydPyv4OABAVFSVuxiArS0GLtj2gOZvkg/nVyzvS2omVEMwHyCU9PZ0mTpwo+n8/Pz8xpJUD+mfPnsW+AjBDxtT3g/E6JVNupxHK7WjcG2+8QWXKlBFl9AICAsjNzU3l9u+//2r+hQHAqOij709MyaTx34fTy6RMlW2T3itLtYIxoh5Mh0bTFa5fv06dO3emJk2aiMy83L8DAHApDhYcHGzww7a/+PEuHbgQK7v9jTol6ctB5TFcDyCXhw8finI7p06dEssffviBjh07Rv369aNmzZrRt99+S6NGjcJ+AzAjxtL3g3E79q9qQL8xAvoadfToUWrdurW4cF+1alUKCQkhKyvVkAIH9QHAvOm67+dkvM/X3qEImfnu3nm9NHVr6qGTdgDoCsYfAgDk8iIhgyYsD6fLYQmy+6ZPa08a170MWViUwL4DyCErK4tq164tRugtWLCAPv74Y7G+Y8eOdPHiRerRoweNHj1aZO7/8ssv2HcAAKAR96JS6H5UqsocR1UCHLGHNWjhwoUimM8X5pcuXYp9CwAGY9Wex/TPFdULu/UqOdPH7/jrpU0ARlNyBwDA2D14lkqD596UDebzxGoTevnTRz39EcwHUBPQ50y9w4cPZwfzc9fVHzFiBP3222/YfwAAoDHHZbLzm1R3JUskX2jU48ePxfLdd98lbdqyZQu1a9dOZPbWq1ePpk2bRgkJ8ok2eUlJSREjA3lOnwoVKogl/56UlKSVdgOAfhy8EEtr9r76fsrJ192GvhkWKOrnA5gaZOgDAPy/a3cS6aNlYRQbn6GyT2ytS9DsIYH0eq2S2F8AavAEeJcuXSIvLy/Z7ba2trR8+XJq3rw59iEAAGjM8auqAf1m1VUna4Xi4RI7p0+fpvj4eK3tysmTJ4tJd3OX7ti5c6dIDHBxcSlwCUAuD3Tz5s3sdWFhYXTkyBG6ceMGrVmzRuNtBwDdC3uYTDN+uquy3s7GghaMDMLE6GCykKEPAEBERy6/oOELbskG892crWjl+EoI5gPkgye/VRfMz6l3797YlwAAoBEJyZl0MVQ5wGxpwRPiIqCvaePHjycHBwf66aefSBvOnTsngvl2dnaipE9oaCgdOnSIqlevLibanTFjRoGeJzMzk95++20RzK9RowZt27ZNPNf58+fp008/Fc8PAKbx/T9xRTglp2apbJsxKIAqlHHQS7sAdAEZ+gBg9n79+ykt+C2SFArVXVHW05YWj61AZUrbmv1+AiiMvXv30q5duygyMlKcWO/fv1+cUGdkZFD37t1lJ9EDAAAorFPX4ygzVyynTgVncrK3xM7UsCdPntCYMWNo/vz51KVLF+ratSu5uqpeOGnTpo3s+vysWLFCLGfOnCnq9DMuu7Nnzx5RMueHH36gr7/+mmxsbPIt2XP27FmqWLGiyOp3dnbO3la3bl1xXAIAxk1MgvvjHbr/VHn+FDa0kw+1qoPJucG04WwaAHTKkDJi+CBg0bYH9MvBp7LbawY50oKRwRimB1AIHLDv1asX/f7770qleNivv/5KW7dupR07doggAACYB0Pq+8H0HJOpn9+0BrLztWHChAl05coV8fPu3bvFTQ6X36tVq1ahn5/n4OHRfoMGDVJaX7ZsWXGRgJMFuPxOo0aN8nyeTZs2iSXX3s8ZzM99XAIAxtv3//jnEzp6Rb7c2tA3fbT62gCGAAF9ANCpN954wyD2eEpalrii//fFF7Lb29R1oy8GBZCtNSqTARTGvHnzRDC/SZMm4oSaT8IlAwcOFAF9HqqPgD6A+TCUvh9MT2aWgk7IBPSbI6CvFdOnT6eYmJh875ez7y+otLQ0unv3Lvn7+5O7u7vK9tq1a4uA/u3bt/MN6HN2Pl8Y4Il1586dK45HEhMTqVq1aiLzv1WrVoVuHwAYTt9/8locrdj1SGW9v6ctfTk4gCwwITqYAQT0AcDsxMan0/jvw+lqRKLs9n5tvWjMW344EAAognXr1onlwoULydfXV2lb5cqVxfLMmTPYtwAAUGz/RiRSXKJy+ZRyXrbk74lRIdrw1ltvkbbExcWRQqEgDw8P2e3S+tjY2Dyfh5/j6dOnYk4frvm/YcOG7G1cR3/79u20aNEiGjt2bJ7Po+6iwbVr18TxjDYnBjZlfGEFzIO2PuvHMek0dc09lXK5dtYl6It+3kSZyYR/T93C/3XxcBm4oowcQ+opAJiVyKcpNHjuLdlgPl/I/7S3P43rXgbBfIAiCg8PF0uehC43acLc58+fY/8CAECxHZfJzm9WoyT2rBHKyno1EYKFhXyIQgp2SPfL63n4Fh0dLebu4Xr/PKEuT4jLAX6pdBDP8QMAxkWMsv/pEcUnq34PTHjHiwJ9MO8dmA9k6AOATv3xxx9iyTW2de1qeAJ9tCxMJZOL2dlY0FdDylPzmjgJBCgOW1tbSkpKopSUFHJyclLaJmXVublhkioAc6LPvh9M27GrqqUTm6HcjtZwYDyvTEwOuru4uFD58uXznbg2N6nW/YsX8uUwpfVyNfFzt8HBwUEci/AEulIQX5oQl7P3OWufy/eMGDFC7fOcOnUqz8z9/NoBecP+M32a7vt59M38dXcp7JHqJLi9W3lSt+Z+GnkdKDr8XxdNUed10WhA38fHh4YPHy5mopf7HQBAXw5djKXP196h1PRcY/OIqJSzFS0cHUxVAhz10jYAU1KzZk1xEnzy5ElRuzanY8eOiWW9evX01DoAADAVj6JTKfxRitI6ZwdLqhmkfDEZNKdfv37Zk+Lmxdramlq3bk0zZ84UQfSC4CA8j+S7d+8eJScnk729vdL2GzduiGVQUFC+z8X34YsPzZo1U9nWvHlzEdB/9Ei1/jYAGK6t/zyjvadVR/nWqeAkRtgDmBuNltzhjnPFihViCJvc7wAA+rDxYBRNWhUhG8wP8LajHyeFIJgPoCFSthtnxIWFhWWvf/jwIc2YMUP8PHLkSOxvAAAolqNXVcvtNK7qQlaWJbBntWT06NGin+dswjJlyoifJ06cSC1atMjOXuc+vlKlSrRv3z5q3LgxHTlypMDPz/dPT0+nXbt2Ka1PSEigP//8U2T9F+QCQdOmTbNr5ufGk+qyUqVKFbhdAKBfV8ITaP5m1TJZpUta09fDAvG9D2YJNfQBwGRlZilEx//tlgcqk+ZIV/PXTqxEfh6otQegKf3796dhw4aJTLqKFSu++l/MzKRy5crRrVu3xEX+9u3bY4cDAECxHL6kOjkq6udrF/ffPKls7dq16ebNm7R8+XKaM2eOCNrPnj1bjNCrVasWXb58WYzUT0tLo48++qhQxxDs448/pgsXLmRPljtw4EBRtq9bt27k6uqa7/MMGjRILCdPnixGDDKuq79161ZasmQJlShRgtq2bVvEvQAAuhQdl06froygzFxl8/ni7ZxhgeTuYo0PBMwSAvoAYLIT5nDH/+vfT2W3t6vvRkvHVSAXR0wlAqBpK1eupB07dogTbw7qV6hQgTp27Eg7d+6kefPmYYcDAECxvEjIoEuhCSrBnabV8w/2QtFx8D4qKkpk5Ts6KpeqnDRpkljHQXS+kM/9PWfyc3D/2bNnBXp+Pm7g4wUuh8Pl+Tw8PKh06dJiclt3d3f65ptvVGp080gBvgCQU/369cVIgQcPHlCTJk1EXWduW8+ePcUcP2PHjqUqVargTwHAwGVkKmjyqggR1M9tQi9/qoESa2DGEMkCAJPz/GW6mPz2+t0k2e2D2nvTB119ycICQ7IBtKVr167iBgAAoGlHr7ygrFyjL+tXciYn+6JNLAcFc/HiRbH081OdfNLCwkLMocfl9rgOPl/M59F5ERERFBMTIwLzBbFlyxb67LPPaO3ateJx/LytWrWixYsXi8l2c+KJb7mk3/PnqnW1+f78+osWLcqul8+/84gBDugDgOFbtO0BXQpTvnjL3mzkTt2be+ilTQCGAgF9ADApd5+k0LglofQwOk1lG8fvP32vLHVvXrATCgAAAAAwPIcvv1BZ93rtknppizmxtX1VpvLatWui3n1O8fHxIpDPpAltuVyOugsAeU2O++2339L8+fNFQJ+z6+3s7GTv26lTJ4qMjFQZLcB4dACPJOAbl+vhMjslS+JvBMBYHLwQS5sOqY62r+RvT5PeKyv+pwHMGQL6AKBTPOxVWy6HJdD478MoLjFTZZu9rQV9PTQQQ7EBAABMqO8H85OUkklnbrxUWsdxnRY1EazVNi6Hc/jwYfryyy/FxLNS2ZrExEQxfw5PaFutWjVRBocnpOWAfOXKlUVQvrA4Mz+/rH6+cMCvlR83N7dCvz4A6K/vvxeVQjPX31VZ7+poSfNGBJGdDaqHAyCgDwA6VZCJrIp6Bf/ztXcoLUN19lt3FytaNKYChZR10MprAwAAgO77fjBPJ6+/VDneqx7oSB6umBhR20aPHk2///67mPy2Zs2aVL16dRGs54x9Lnvj5OREa9asEfflyXP5PlxbHwDMT1H7fmkuvMSULJULt7PeL0++Hq9GCgGYO41d1uKr8pcuXaJbt25p6ikBAPKlUChow19PaNKqCNlgfqCPHa2bFIJgPgAAAIAJOCJTbqdlLWTn6wKXvuEM/ZkzZ1JgYKA4/z969Kg4Hu/duzdduHCBGjRoIO7LpW54Qtx3331XJ20DANMwZ9N9CnuYrLJ+SCcfalQVCQIAGs/Qv3LlihhSw7fjx49r6mkBwMScP39eLFu2bKmRWe8XbI6kLf88k91er5IzzRsRSM4OGIwEAABgCn0/mLf0jCw6/u+ruuw5vY6Avk7r6POktXzjEjt847r3AADF7ft3noim3SdjVNY3qOwsAvoA8D8ai3J5enpmT4YDAKDO06eqE9sURXJqJk1ZfYeOyZzUsQ4NStHn/cuRtRXq6wEAAJhC3w9w/lY8JSQrz5UU5GtH/p7yk6aCdllbW4sbAEBx+/5bkUk0d9N9lfWeJa1FqR1LC0yCC6CVgH5wcDCFhISIyW94FnlMPAMA2hIdl04fLwujG/eSZLe/39GbRnTxxcz3AAAAACbksFy5ndqY8FRbuA4+T2z79ttvU6lSpbJ/z490fwCAguALtVw3PzVduYSupQXR18MCyc0ZFw4BctNoHYqff/6ZOnXqRP3796e1a9fmOys9AEBh3XmcTOOWhNGjmDSVbdzhT+5Tjro19cCOBQAAADAhmVkK+kcmoI9yO9ozY8YMUVq3Xr16IkAv/Z4f6f4AAPnhOThm/HSXHjxLVdk2tnsZqhnkhJ0IoM2APk+IM2DAADHkbs+ePeTt7U1ly5YlR0dHpfvVqVOH1q9fr6mXBQAzcvF2PI1fHk7xScpDrZmDrQXNGR6IiXIA9CwzM1P0/VZWVpSQkKDyOwAAQFFcCUugmJcZSut83G2okr89dqiWfPfddxQXF0fly5dX+j0/0v0BAPKz8dBTOnxJbvRVSXqv1avS3gCgxYB+RkYGvXjx6p/Qz89PLHmCHGmdBCfzAFAUf559Lq7cp2coD8NjpUta08LRwVTJHxNyARhClk1qaqo4LpD7HQAAoCgOXIhVWfdG7ZIosahFuSezxMTWAKBJV8ITaPG2Byrr/T1tafqAAHy/A+gioF+/fn168ED1HxEAoDg4GPjT/ihauv2h7PZgP3sRzPcuZYMdDQAAAGCi5Xb+vqga0G9TD2VdAACMUWx8Ok1eFUGZWcrrba1L0DfDAsnJ3lJfTQMwvxr6AAAFmUC7oDIyFTRn033afixadvtrlZ1p7vAgdPYAAAAm0vcDyLkUqlpuh5M5qgZgdKau7d+/n5KTk6l9+/ZkZ2dHL1++pPHjx9PZs2epRYsWNG/ePLK1tdV5uwDAePp+vkj72Q936OmLdJVtE3uXxch7AH0H9OPj48UQGScnTGIBAK9UrFixQLsiKSWTJq+OoBPXXspuf7ORO03tW5asrSywawEAAEyg7wdQ56BMuZ02dd1QjkHHzp07JwL5DRs2pG7duol1EyZMoJ9++kn8fPXqVXJxcaFZs2bpumkAYER9/5q9j+nMf/Eq6zs3cqeuTTy03DIA06DxSNj58+epU6dO5ODgIDpz7vBjY2OpZ8+eNHz4cE2/HACYoOi4dBq24LbaYP6wN31o+oByCOYDAAAAmDgesSlXbqd1PTe9tMecrV27Vizff/99sUxLS6ONGzfS6dOn6cSJE2LdqlWrRMlMAAA5p2+8FAF9uVK6n75XFjsNQB8B/cOHD1OTJk3owIEDVKVKlez1bm5u9PTpU9G5c2cPAObr/v374qZO+KNkGvjNTbp5P0llm6UF0RcDA2hYZ19kZAEAAJhI3w+Ql0uh8fQ8Xrncjp+HDVUph3I7unbr1i2xDAkJEcvLly+Tj48P1alTR8yp5+fnR8+ePRPn/gBg3uT6/ifP02jqmgjKfc3P0c6C5gwPJDsbjL4HKCiN/rd88MEH2VfpFy5cqLRNGpK3ZcsWTb4kABiZa9euiZuc87fi6f25t0RHnxt38ovHVhCldgAAAMA0+n6A/ByQKbfTGuV29CI9XbneNZfYqVmzZvbvUqndFy9e6LxtAGDYfX96RhZNWR1BcYmZKved1j+AynnZ6biFAMZNYwH98PBwccWer8r36NFDJXs2MDBQLG/cuKGplwQAE/LH6RgavSiUEpJVO3gvN2v6YWIINajsope2AQAAAIC+yu2oBofb1CuFj0MPypUrJ5bSqHsemd+gQQPxM5fZ4WxcjgP4+/vj8wEAJYt/f0hXIxJV9krvNzzFRVoA0FNAPzo6Wix9fX3FMndAn2vqM87gBwCQ8ME/19D7/Me74qQtt4pl7OnHT0NETT0AAAAAMB8XbsfTiwTlcjtlSttSJX8cF+pD7969xXL69OnUoUMH2rFjB7399tti3b///kvJyclUu3bt7HN/AAB26GIsbTqkWoqrenlHGtvdDzsJoAisSEM8PF7NRB0VFSW7/cGDB2LJGfz6xiMJDh48SAkJCVShQgVxMGJvj4NCAG3LSkshu+gHZJGeSvH/XSLbgBCasyWKdp6Ikb1/oyou9PWwQHKyt8SHAwAAAGBmDpxXLbfTBuV29KZTp040efJkWrZsGV25coWWL19OQUFBYhvPl8eGDBmivwYCgMGd94edOENfb1YNP7o6WopzfWsr1M0H0GtAnztyHlrHw+zOnTunkqG/fft2sWzdujXp08SJE2n+/PkiK1hSvnx52rVrF1WrVk2vbQMwVWnPn9LTPRsp+vAuKpP4Uqy7ffJ3SrVyJCvLxuRq15riLEoqPaZrE3ea3KccWVkqf5cAgGHj/t/d3Z2srKxkfwcAACiItPQskdWZW+t6KM2gT1999ZW45TZ79mz64osvqGRJ5WN6ADDv8/64k7/T5yUc6IRNEzr4/+f9HC6cObg8eZey0XeTAYyWRs+uuQN///33qXv37vTOO++IdXFxcTRhwgTavXs3hYSEUK9evUhfVqxYQfPmzSMbGxvRDh8fH9q3b58YHti5c2f677//yM4OE3EAaFLS3VsUOnsMZcQ9V9lmm5FIbTMOUIO0M7TYaSw9sHpVb/ODrr40uIO3yoVBADB8lpaW2WX45H4HAAAoiBPX4ig+SXlupbJetqIcIxgeV1dXfTcBAAz0vN9RkURtU/933t++62vUuBq+MwCKQ6NjWwYPHkxff/21KLuzYMECsY5nteafq1atSnv27CFbW1vSB87InzlzpviZa/2tX7+e5syZQxcuXKDXX3+d7t69S+vWrdNL2wBM+Qq9uk49J1fFSxqbsJjcKY6+HBRA73f0QTAfAADARLi4uIgbQGHsO6t6/NjhtVI4RgQAMOLz/vEpS2hgY4zcBSgujf8XTZo0ifr27SuC93fu3BEZ73Xr1qWOHTvqdbj9+fPn6dGjR9SkSRNRM19ibW0tRhZwUJ8D/SNGjNBbGwFMDQ+3y69Tz9m5z65ygeo1fEPr7QIA48cX6vmiPM/R4+XlRY0aNcr3/pcvX6YnT56Qr68v1axZU2dtBTB3TZs21XcTwMjEJ2XQsatxKus7NHDXS3sAAEAz5/0O6XEUvW8Tlek3DrsUoBg0FmHnrHwuq+Pt7U1vvvmmSmA893Zd40l7GAfuc+MgPwf2r169qvN2AZjyRDhcO68wrK7so6y0MWRhg9JXACCPy+QtWbJEJA48fvxYrGvXrh39+eefanfZ6dOnqV+/fhQWFpa9rkqVKrRx40YE9gEADNChiy8oPeN/c56x6uUdqUxp/Yz2BgAAzZ33Rx/eSb69huO8H8AQAvqhoaE0dOhQERyXC9jnt13bpJP+smXLqmzjkQN+fn507949kcGXV91udRmAXFqocuXKFB8fr8FWm4/ExER9NwE0LOn2Vcr8/4lwCioz4SVFX7tI9hWq4/MwcvifLp7MzExRex5U7d27l1avXi366kqVKtGtW7fy3E3ct7dv317M6cPHABzI54sCN27coLZt24qfPT09sasBtCg1NVUsnZ2dsZ+hQPadiVFZ16FBKew9AAADkxj+X5HO+5MibpJTSC2ttQvA1Gm0hn5eMjIyxFJfAYqUlBSxVDfpLa/nYL50wgEAxZOVXLSLNJlJCdj1AKBWjRo1aOXKlaLUDmfp52fWrFkimN+7d28KDw+nffv2UUREBHXr1o2ePn1Kc+fOxd4G0LJDhw6JG0BBPHmeRhdDlY8HLS2I2tRzww4EADAwOO8H0A+dFbW/ePGiWOorC04K5EuB/dx4PWf75Tdp76lTp/LM3EfmUfFg/5mOZKeiZVE5e3iSEzL4TAb+p4sG2fnq8Zw8kpwldORkZWXRtm3byMbGhhYvXpw9lw//zmV7du3aRZs3b6b58+cX8ZMCAABN23/uOSmUq+1Qo6qu5OZsjZ0NAGBgLOwdi/Q4SwcnjbcFwJxYFXei2R49eoifpcx2XhcQEKASLOca+qxz586kDz4+PmJ5//592dEDPGEuT6qXV7kdACh4ZtWEHVY0rIQDOSqSCrzbLJ1cyCEwBLsZADSCM/JjY2OpcePG5OHhobStTJkyItufJ8rlYxQ+BgAAAP3786zqxIrtX0O5HQAAQ+QYVJksHJwpK6ng5adx3g+g54C+hYVFduY7l6vJvU7i5OQkTpo5+N+/f3/Sh5o1a4rlkSNHVLadOHGC0tLSMDEegAbcikyiD5eG0bMXmXTCpgm1TT1Q4Md6tOyKiXEAjLz2f8WKFcWxAM+do29clocFBQXJbg8ODhYB/cjIyDwD+pg/Rzsw14b5kM4TMNeU6Svu//Wdx6kU+iBZaZ2dTQmqE2hp8n8/xjJ/Tp8+fcT8NTyxPPf5uX8HADNjZUtXSzanakl7C/wQnPcD6DmgX6dOHbp586b4+fjx49SsWTOxjn82NHXr1iVfX18RvOf6uR06dBDr09PT6YsvvhA/cz1dACi6U9fj6NOVEZSUmiV+P2jXmhqknSFXRf6T5FiVdCfPTu9h9wMYMQ5E8CT0PGqPy91wYN8QAkucWCBHWp+QgLk7AAAMwf7zqseMzao7kb2tfvsT+J/r16/TlStXKCkpSfZ3ADAva/c9oU2JzWlqiWM47wcwxhr6DRo0ECfxXJfWEHFQYdq0afTBBx+IwH2vXr1EgJ+D+1evXhVlggYOHKjvZgIYrR3Ho+nrX+5R5qtYvhBnUZIWO42lj5IWk1PmyzyD+RWmLCGbUqV101gA0Jp69erRsWPHRLmbChUq6HVPW1tbZ1+8lyOtx/w5+oW5NkyfVNISn7X5KMpnnZGpoIOXIlTWd2niZRZ/O8aQnQ8AkNO5my9p1e5HlPX/5/1jExbnGdTHeT+AAQb0+aTZ29tbaR0Pi+QDeHWZcbo2YsQIMYHet99+Sxs2bMhez8H83bt3q5QKAoCCDaNfsesR/fDHE9ntLkGVqFKfnynj6BaKPryTMhNeKtXO4+F2nJmPYD6Aafjqq6+oVatWNGPGDPrpp5/0GqCQ6uZzwoEcnj8n5/0AAEB/Tl6Lo5iXGUrrPEta02uVXfTWJgAAkPfsRRpNXXOHsv5/EvMHVv4022UqtU8/RK3oNCmScN4PYBQBfQlPijt9+nQ6fPgwJScnU5MmTUSwfNiwYVSqVClauXIl6dP8+fNpyJAhdPDgQTHEnrMHO3bsSPb29nptF4AxSs/Iopkb7tEfp1UnL2PNarjSV0PKk72tJVG/ceTbazg9vHCKspITyd23jJgA18IGF9IATAWX2eH+lcva/fLLL2IIfsuWLUX/n3vU3Oeff6719oSEhIgLCmfPnlUpAcTZ+RcuXBAX8wMDA7XeFgBzxt8DAPnZfTJGZV2nhu5kafFqhAcAABgGHlHFwfzn8coXYXmEfvWRE6hWLQec9wMYU0Cfg/jt27cXGbs8CS6fKDM3Nzd6+vQpbd26lQYNGkQNGzYkfeITfL4BQNHFJ2XQJysi6Pwt+QnKerYoTRPe9Vc6CePgfclq9cTPTmYwdBrA3HDQnDPzJdeuXRO33DjIrouAvqOjIzVt2pT++ecfMTJvwIAB2dtWr15NL1++pC5duqDMAYCWIXEG8hMbn05Hr75QWf9mY3fsPAAAA7N850O6GJogGwNo/9qrRB6c9wMYUUCf69OnpaXRli1bRPkdniRXwnXrjx49KrbpO6APAMXzOCaVxi0Jo4jHKbLbx3X3o75tvLJr5gKAebCysqJTp07le7/ifDe8ePGCjhw5In5+8uRVqS9OGtixY4f42d3dXen4Y/z48SKgP3z4cLp16xbVrFlTJBwsXLgwezsAAOjXvjPPleZhYjWDHKmcF0ZyAgAYkmNXX9BP+6NU1lcp50Af9SyjlzYBmCONBfR58js+Ufbz86MePXrQiRMnlLZLw9lv3LihqZcEAD24eT+Jxi0JValxymysStCMQQHUpp5yeY2cTp48KZbt2rXTajsBQD+0fdGe58J56623lNZdunQpex2X+jt+/Hj2ts6dO9PEiRNp7ty59PXXXytdVJg9ezY1b95cq+0FAPT9kDce3b37lGq5nc6NMb8JAIAheRSdStN/vKuy3tnBkr4eFkg21v8rb4nzfgAjCehHR0eLpa+vr2z2nYODg1hyBj8AGKfj/8bR5NURlJyaK4WKiFwdLWnByGCqFeyUb3YtAEBRcRm/rl27qt1epUoVlXVz5syhN998U4wSjIqKIh8fH3r33XcxYhBAR9D3Q15uRSZT6INkpXV2NhbUpp4bdhwAgIFIS8+iSasi6GVSpsq2GQMDyM/DVmkd+n4AIwnoe3i8yqDgE2U5Dx48EEvO4AcA4/P70Wc0Z9N9leHQzM/DhhaNqUAB3hgWDQCv7N27l3bt2kWRkZGUmZlJ+/fvp23btlFGRgZ1795dlOcpiqCgoOzyOoXBZXhyluIBAADDsOvEq8SwnFrVKUmOdpZ6aQ8AAKj6busDunEvSWV9/7Ze1LxmSewyAGMN6PMJtr+/P92/f5/OnTunkqG/fft2sWzdurWmXhIAdCArS0HLdz6iH/98Vas6t2rlHenbkUFUysUanwcAiIB9r1696Pfff1eaBJf9+uuvtHXrVhGQzyvLHgAAzCfjc/+55yrrUW4HAMBw8Pf0liPPVNbXqeBEI7shaRdAH/5X4EoDvvjiC7HkzDvOwmNxcXE0YcIE2r17N4WEhIiTfAAwnpOsaWvvqA3mv16rJK34uCKC+QCQbd68eSKYz7Xs+SJ/TgMHDhTLn376CXsMAADo70svKC4xU2XkJweJAABA/+4+SaFZG+6prC/lbEVfDQ0kK0vlZF4AMLIMfTZ48GB6+vQpTZ8+nRYsWCDWXbt2TdyqVq1KO3fuJFtb5bpaAGCY4hIz6JPl4XQxNEF2+7tveIpZ7C0t0IEDwP+sW7dOLBcuXJg9r46kcuXKYnnmzBnsMgAAECUd5bLzLXB8abAOHTpE6enp2SV3c/8OAKYjOTWTJq4MV5lDj7+iZw8pTx6uGKUPYBIBfTZp0iTq27cv7dmzh+7cuUN2dnZUt25d6tixY5Hr5QKAbj2MTqVxS8LE1fjcuJrWRz3K0HutvfCxAICK8PBwsaxRo4bKNi+vV98bz5+rllcAAADzcudxskriiKUFUdcm7nprE+TP3d09z98BwDQoFAr6ZuN9inikGhMY1tmX6oe46KVdAPCKViLsZcqUoREjRmjjqQFAy27cTaQPl4bR8/gMlW221iXoy8HlqVUdtyI/f5UqVYrZQgAwZDwSLykpiVJSUsjJSblkQmxsrFi6uRX9OwQAjA/6fpDz+zHVyXCb1ShJpUvaYIcBAOjZzhMxtPe0ahJO46ouNLiDd76PR98PYEQ19AHAuB298oKGLbgtG8wv6WRFyz+qWKxgPgsICBA3ADBNNWvWFMuTJ09SCR7Sk8OxY8fEsl69enppGwDoB/p+yC0lLYv2nopRWf92M5RtAQDQt5v3k2juJuW5sJiXm7VI8CtIWTT0/QBGmKH/7NkzUW6HM/F4mE5OnJXXoEEDbbwsABTDliNPad6vkZSl/C8r+Hva0uIxweTvaYd9DAB54hF6p06dovHjx1NQUFD2+ocPH9KMGTPEzyNHjsReBAAwY4cuxtLLJOXJcH3dbahhFZRwAADQ91x6E1eEU1qGcmCAJ7/9ZligSPQDAP3T6H8iB/HHjRtHu3fvVnufJk2a0PHjxzX5sgBQDFlZClry+0PacCBKdnuNQEf6dlSwxjrusLAwsaxdu7ZGng8ADEv//v3pxIkTtGrVKqpYsaJYl5mZSeXKlRPLCRMmUPv27fXdTADQIfT9UJDJcLs1xWS4AAD6jg1MW3uHHsWkqWwb192Pqgcql9PMC/p+ACMJ6HMm/ptvvkk3btyg4OBg6tWrl+xM935+fpp6SQAoptT0LJr+4106eOFVXevc3qhTkr4cVJ7sbDRXnev27dtiiYA+gOlauXIldezYkdatWyeOC/gYISQkhIYMGUJdunTRd/MAQMfQ90NO4Y+S6Up4ospkuF2aoNwOAIA+rdn7mE5ee6myvk1dN3r3Dc9CPRf6fgAjCejzCTvfeAK806dPY7Z7AAP3IiGDxn8fpnJCJenT2pPGdS9ToPp4AADZ3y0vXoja+V27dhU3ddtdXV2x0wAAzJBcdn6LWiXJw9VaL+0BAACiE9fiaPXexyq7oryPHU3rX05lbiwA0C+Npd1mZLyaRJOH17u7u2vqaQFACx48S6XBc2/KBvO5n57Qy58+6umPYD4AFPpYgOfKUXcckN92AAAwbYkpmbRHdjLc0nppDxTORx99JEbacaldADAdD6NTadoPdyjXFJjkYGtB80YEkYOdpb6aBgDaDuhzIL9kyZJi0rvcE+ECgOG4dieRBs25SfejUlW22VqXEB12YYfTAQAUhHR8gAwfAADzxMH8xJQspXVlStvSayHOemsTFNyZM2fEfHk82g4ATENKWpaYBDf3ROXs8wEBFOBtp5d2AYCOAvr29vY0Z84cioqKouXLl2vqaQFAg45cfkHDF9yi2PhXI2pycnO2opXjK9HrtUpinwOAVjx9+lQsXVxcsIcBAMxwssXfDr/qB3Lq+XppjAo1ElWqVBHL+/fva/21MjMz6cmTJ5SUlKSxY5C7d+9mH4sAwCtzf71PtyKTVXZH3zZe1LquG3YTgKnX0GfDhg0jW1tbGjRoEG3dupWqVq1KlpbKQ3MCAwNp7NixmnxZACiAX/9+Sgt+i1QZRsfKetnS4jEVRIYUAEBhZGVl0cSJE5Uy8HndhAkTVMrtnDhxQvxcr1497GQAADNz5r+XdC/XCFF7Wwvq0hhl2IzFhx9+SBs3bqQVK1aI0jvaGHGXmJhIU6ZMoR9//JHi4+PFa7Ro0YKWLFlC1apVK9JzRkZGiosRCQkJYn6fHTt2aLzdAMZox/Fo2nVCtQxanQpONPotP720CQD0ENA/cuQIjR8/XpzQHz58WNxya9KkCQL6ADrOhlq49QFtPCSfjVIr2InmfxBEJZ00+nWgloeHh05eBwB0g4P3CxYsUFrHxwG510n4hFrdNgAwTej7gW0+rDoZbqeG7uTsoJtjUCg+zpgfPXo0ffvtt9SsWTN65513yNfXV+V+bdq0IVdX10I/Px8/dO/enfbv3y9+9/LyotjYWBFnaN68OZ07d46CgoIK/byjRo0iOzs7EdAHgFdu3E2kOZtUR9vwBOVfDQ0kK8viXbBD3w+gXRo7ekpNTaXevXtTTEwM9e3bl4YPHy77D+zg4KCplwSAAtTDm7b2Dh2+JF/nsk1dN/piUADZWmus+la+XnvtNZ29FgBon5WVFf3777/Zw+Nr1aolRuddvnxZ6X68rlSpUuLkHADMC/p+iHyaQieuxansiHdex2S4xoRH3125ckX8zKPupJF3uV26dEkcDxTW9u3bRTDfz8+P9uzZI56Ds/SHDBlCv/32G02aNIm2bNlSqOfk+//xxx/0ww8/0MCBAwvdJgBT9CIhgyaujKD0DOXh+5YWRN8MCxRB/eJC3w9gJAH9mzdviiv23t7etG7dOpVSOwCgW7Hx6TT++3C6GpEou71fWy8a85YfapYCQLFJQ+A5s46HxFtYWBR5WDwAAJie3448Uyn7+FplZwr0tddXk6AIpk+fLhL48lO2bNki7d8NGzaIJY8AkC4IODs709q1a+nAgQO0c+dOiouLK3D2P9933Lhx9NFHH1HdunWL1CYAU5OZpaDPfrhDT56nqWz7sEcZMYIfAMwooM9D2JiPjw+C+QAGkAU1dkkYRT5VrlPKLEoQTexdlnq00E9GFGfZSAfnAGBauM4tD8UHAMgJfb95S0rJpF0nolXW92rpqZf2QNG99dZbWt19J0+eJGtra+rcubPSekdHR+rQoYOo33/+/Hlq1apVgZ7v008/FRUCZsyYQREREVpqNYBxWb3nMZ2+8VJlfZt6bvTuG5r7XkbfD2AkAf2KFSuKW1hYmJjIhjtdANC9q+EJ9NGyMIpLzFTZZmdjQV8PLU/NapTU20dz7NgxsezVq5fe2gAA2rd3717atWuXmIiOS/HwEPpt27aJyXG5Pi6X6gEA84C+37ztPhVDiSlZSuv8PGyoafXC11gH05WUlERPnz6lChUqkL296siNypUriyUH5gsS0OdyQKtXr6a//vqrSGV/GzVqJLv+2rVroi1SsBIKh2NFoD/H/o2nNXsfq6wv52VDH73lrtF5Jo4ePSqWnTp10thzgmHC/3Xx8LlyUarcWGkyK+/XX3+ljh070ogRI2jlypWolw+gY4cuxtLna+9QanquMc1E5O5iRd+NCqYqAbjYBgDawwF7vmD3+++/Z6+TDlD4OGHr1q20Y8cO6tq1Kz4GAAAzKO2w8WCUyvqer3uSJQ8bBaPEZXe4/E1oaCglJyfTJ598IubU46A8T1orF5DPjxQgV1dOp2TJVwlJL1+qZhbnlpaWRsOGDaMBAwYUOJsfwNTdfZJKX//6RGW9g60FfTnAl+xtdTevHgAUn8YC+jzxTb9+/UTG3c8//ywmnylfvrzKVYY6derQ+vXrNfWyAPD/das3HnpKC7c+UKlPygK87WjxmGDy9bDF/gIArZo3b54I5jdp0oQ2bdqkVEeXJ6PjgP5PP/2EgD4AgBk4fOkFPYxWrtPMQaMujd311iYons2bN4tJanNm8nL/zn3+3LlzacGCBfTxxx8X+nl5/h2WlaU8miNnBiMryAi/b775Rlx04LYU1alTp/LM3Ef50OLB/tOt+KQMmr7+HiWnqgYLpg8MoKpBbhp/TU76ZfiszQc+66Ip6hy0FprMyHvx4oUILPKs9B4eHuIqO6/LedPkEB4AeJX5NH9zJH23RT6YX6eCE62dWAnBfADQiXXr1onlwoULydfXV3a4/JkzZ/BpAACYOD4v3PCXajZot6Ye5OKIsmvG6PLly9S3b18RqOMkvpCQkOxtQ4cOFUuewLYoODOfn/fZs2ey26Ojo5Uy9dW5ffs2ffXVV2LUAE+Ke/fuXXF79OiR2M6jCPh3da8DYKqT4N6XmV9vUAdvalVH88F8ANA+jR1J1a9fnx48eKCppwOAAkhJy6KpayLonytxstvbv1aKPu9fjmysMXwOAHQjPDxcLGvUqKGyzcvLSyyfP3+OjwMAwMRdCU+k63eTlNZZWhD11uCki6Bb33//vUjkmzx5MvXp04fmz5+fvS04OJicnJzo+vXrIjve3b1wozBsbGwoICBABNs5eM8JgjldvHhRLCtVqpTn8/zxxx+i/M+ECRPELbcDBw6ISgJcHpBLAQKYupW7HtGJa6qlqhpXc6ERXZSTbwDAeCDKB2Cknr9Mp+ELbqkN5vPV9i8HBSCYDwA6ZWv7qrRXSkpK9lBbSWxsrFi6uSETCADA1Mll57eq64ZRo0aMJ4RlTZs2ld1epkwZsYyKUp03oSDeeOMNMbIjd5Y/B/k5EM/Z+XXr1s3zOVxcXKhcuXIqN2nUINf3599Lly5dpDYCGJO/L8bS2n2q38X+nrY0+/3ymMsEwIghoA9ghO4+SaFBc26qZD1JmU9T+pSlUd38yAKTjQGAjtWsWVMsT548qRLQP3bsmFjWq1cPnwsAgIkfqx69qpp00rf1q5FaYBpy9/PShLWOjo5Fer4RI0aI5/z8889p0aJFdPPmTfrrr7/ozTffpPT0dFG739raOvv+UvkcqRwPGzx4cHaZnZy3/fv3i+1t27YVvy9ZsqSI7xrAOIQ9TKbp6+7KToI7/4MgcnZA6TMAY6aV/+AbN27QnTt3RKebGw+9a9asmTZeFsAsXA5LoPHfh1Fc4quJoXJPMvbNsEBqUs2VDFW7du303QQA0CI+GeeJ5MaPH09BQUHZ6x8+fEgzZswQP48cORKfAYAZQd9vfjYeilKZ26luRSeqElC0QC8YBq6Zz338lStXxDl9zoD+kydPxI1r4fv7+xfp+fmC/5QpU2j27Nn04YcfqiQMcKA/d3mdnj170oABA7Ln8AEAopeJGTRheTglp6pOMj1jUAAF+dprfTeh7wcwooD+48eP6e2336bTp0+rvU+TJk3o+PHjmnxZALNx4Pxzmv7jXUrLUJ391t3FihaNqUAhZR3IFGfwBgDj0L9/fzpx4gStWrWKKlasKNZlZmaK4e285Hq27du313czAUCH0Pebl+fxGbT3VIzK+n5tvfXSHtCcfv360Y8//kgLFiwQ5/05cRA+KytL3MfCouiFAGbNmkV16tSh1atXU0REhLhA0LFjRzHJbe7Mf/6djy9y19tXV6Of7+vpiTkcwDwmwX3wTHUS3Pc7elPL2ropfYm+H8CIAvrDhw8XwfyWLVvS4cOHRWYeXy3nyWZCQ0NFtl7Dhg01+ZIAZoFrSW74K4oW//5Qdnugjx0tGhNMPu6valcDAOjTypUrxck3Z8vxqD3+DuOsPh4q36VLF3w4AAAmbMs/sZSarpx8Ut7HjhpXddFbm0Az+Dx/7NixtHjxYgoMDMwO3HNJHB6JxxPWzpw5s9ivwxcLcl8wkNOhQwdRPqcgOMmgoPcFMGYrdj6ik9dVJ8FtWt2VhnfGJLgApkJjNfTj4uJo7969YhKa6dOni3Xe3t40bdo0OnfunOhA+cQeAX2AwsnIVNDcTZFqg/n1KjnTDxMrGU0w/8iRI+IGAKata9eutH37drp16xbdvn2bdu3ahWA+gJlC328+XiZl0s5TL1TW923jhbmdTATXtv/pp5+oatWqlJr6KgM4LS2NRo0aJebP4YlrAUB/I/p//FN1EtyyXrY0c3CATr+H0fcDGElAPzw8XAyx46x8K6tXif+ckcccHBzElXyuqYfJZwAKLjk1kz5ZHk5b/nkmu71jw1K0ZGywUU1ow5NX8Q0AAADMA/p+8/H7sVhKTlXOzvdys6aODUrprU2gnfJ6Fy5cEHPm8f/306dPaenSpVSqFD5nAH25cTeRvpCZBNfRzoIW6GESXPT9AEYS0JfqY/GwOzs7O/FzfHx89nYekscuXryoqZcEMGnRcek0fMFtOvZvnOz2IZ18aMbAALK20ti/MQAAAABAkSQkZ9Lvx1Wz8we088bxqongSS7LlCkjyulJ5/729vZqtwOAbjx7kUbjl4erlDtjMwaVp/I+2p8EFwB0S2OX6IKDg8Us9zxxTfny5cU6/pmv2ltbW1NkZKRYJwX7AUC9O4+TadySMHoUk6ayzdKCaErfctS1Sf6TPwEA6MPff/9NCxcupP/++4+ioqLECL6ceCTfixeqQR8AADBeW/95RvHJyt/37i5W1AXHrCaD+3Sulc8ldvLazjEAANCNlLQsEcx/9kL1/27omz70ei2UwQIwRRoL6PMM82+88QYdOnRIlN9p1qwZHTt2jEaMGCFq5vKs96xp06aaekkAk3ThdjxNWB5O8UmZKtscbC1ozvBAalTVVS9tAwAoyIS43Pczf39/ql69urjgn5NUmg8AAEwnoLTxYJTK+j6tvcjOBqNJzQXPq8dyZu0DgPZwmeuZ6+/SjbuqJW1b13WjoZ18sPsBTJRGz6gnTZokMvDPnDlDy5Yto1atWtHatWvFjXHAf/To0Zp8SQCT8ufZ5zTjp7uUnqE6VM6zpDUtHB1MFf0d9NI2AICCkC7gf/311+K4AAAATN+O49H0PD5DaZ2royV1b1Fab20CzeBJ7Z8/fy5+lpa87vLly0pBRS6zc/fuXZHoFxAQgN0PoAM/7ntC+8/FqqwPKetAXwzU7SS4AGDEAf3WrVuLm+T27du0Z88e0fFXrlxZbMudpadLPOT/1KlTtHv3bvrzzz/FcP8PP/xQ3AD0iQ+Cf9ofRUu3P5TdHuxnT4vGBJOXm43O2wYAUBiPHj0SS1zABwAwn+z8n/Y/UVn/7hue5Gj3ap41MF6ff/45XblyRWnd9OnT1c6rN2vWLLKxwTkLgLYdvhRL3+98ddydu9TZgpFBGB0FYOI0FtBPTEwUAXwHBweqVKmSWFeyZEnq27cvGYrevXvTb7/9prQONXxB3zIyFTRn033afixadvtrlZ1p7vAgcrI3jROi2rVr67sJAKBFgYGBFBoaqra+LgCYH/T9pu33o89Uajc72llQr5aeemsTaM6cOXMoNvZVBjCPvLt37x598803VK5cuez7cNKei4uL+F/39vbG7gfQsluRSTRt7V2V9TZWJWjBSMNIBETfD2AkAX2+at+kSRNxO378OBmijIwMaty4MXXu3JlSUlJoxowZ+m4SmLmklEyavDqCTlx7Kbu9cyN3mtqvHFlZms5QOR8f1PEDMGXjxo0T2fnbtm2joUOH6rs5AGAA0PebruTUTFr3p2p2PgfzXRwxX4opaNeuXfbPPFdeZGQk9enTh8qUKaPXdgGYq5iX6fTxsjAxOiq3af3LUbXyjmQI0PcDaJfGjrI8PV9lYMTHx5Oh2rRpU/bwv59//lnfzQEz9+xFGn24NIxuRSbLbh/e2YeGdPLRa5kqAIDCGjVqlCi1N378eHr48CE1bdpUzK+TE3+vcQIAAAAYt9+OPFOpnc/Z+X3beOmtTaA9U6dOxe4F0CMO4k/4PpyiYpVHRbFB7b2pQwN3vbQLAIw4oB8cHEwhISFimD0PyXNzcyNDg1p+YCjCHyXT2MWhsh2xpQVfWQ+gNxuZZmfME2axBg0a6LspAKAFmZmZlJqaKuatUTcSjmvs8qg5ADAP6PtNU2JKJq2XqZ3fs7kbsvNNXExMDO3cuVOc+ycnJ9Mnn3wi+v6kpCQKCgoie3t7fTcRwORkZSnoi3V36d87iSrbWtR0pQ+6+pIhQd8PoF0aHQfJWe+dOnWi/v3709q1a6l06dKafHoAk3Du5kv6ZEUEJSRnqmzjjKa5I4KoQWUXMlV3776q9YeAPoBpmjx5Ms2bN4+cnJxoyJAhVLZsWZWRRhYWFnprHwDoHvp+0/Tr308pLlH5eNbZ3oK6NyuptzaB9m3evFn07wkJCdnrBg4cKEbDz507lxYsWEAff/wxPgoADVu24yEdvPBqPoucKpSxp5mDy5OFhWGN7EffD2AkAf1Lly7RgAEDyNramvbs2SMmw+GTeEdH5fpdderUofXr15OxatSokez6a9euUeXKlQ265JAh40mVzcGBCy9p7m9PKEM1lk+lXa3omyF+FOhTwqT/jhQKhVia8nsE8/mf1maWO2exG6Mff/xRLLdv306tW7fWd3MAAEAL4pMy6OcDUSrre71eipzsjbP/gvxdvnyZ+vbtKzLwOZlv1qxZdPPmTbGN583hgD4n9iGgD6BZ2489o5/2q37nurtY0bcjg8jBDt+7AOZGYwF9Hjr/4sUL8bOfn59YpqenZ6+T5LySX1g9e/akc+fOFfj+PDkvJusBQwli/3zoOa39M0Z2e5CvLX39vi+VdrXWedsAADRJuljXvHlz7FgAABO1/q8oik9SzlBxc7ait5siO9+Uff/99+K8n0fj8cS48+fPVyrBy6Pzrl+/LkryuLubZvlQAF07feMlfbPxvsp6W+sS9O2oYPJxt8WHAmCGNBbQr1+/Pj148IC06fHjx3Tv3r0C318b9XlPnTqVZ+a+s7Ozxl/TnJji/svIVNDXv9yjnSfkg/mNqrjQN8MDydFMrqpLpTdM8bMGVfici8ZYs/NZ3bp16eTJk/TkyRMxUg8AAEzL09g02nhQNVN0QDtvsrdFSTVTxqPSGU94L4eT6ThjPyoqCgF9AA0Ie5hMn64Mp8ws5fV8Sj17SCBVDVCuiAEA5kOjNfS1bevWrZSSklLg+yM7H/SN6+RPXhVBp268lN3erakHTXqvLFlZGla9OwCAouLh9q1atRLLpUuXYkcCAJiYVXseU2r6qxKKktIlralHi9KUnoqSe+Yk9xw5L1++OufJXXYXAAovOi6dxi0JpcSUXNF8IvqwRxl6vRZGRAGYM6MK6HNdfgBjyl4atzSMQh8ky27nWegHd/BWORAGADBWWVlZdODAAerQoQMtW7aMrly5Qk2aNCE7OzuVSXE///xzvbUTAACKJuJRMu06Ea2yfnhnX7KzsaD0VOxZUxYSEiJGrHP/3qxZM6XzGB6ZxzdXV1fy9/fXazsBjF1yaiZ9tDSMomLTVbb1bFGa3mvlqZd2AYCJB/Rv3LhBd+7cETX0c+Naetz5A5j60Di+mi7XAXM2/uf9y1HHhuZZV9LX11ffTQAALQb0Z8yYoTSXDd/kSgohoA9gPtD3m46lOx5SlnJyPpX3saP/a+8+wKOouj6An/RGegglBVIIvfcmvSmIIEWQIiCKdFREpL3SBBSkCgKKVEVEpEhHkI4UAQFpCSG0JJDe637PuTj5NtnZJJtks+3/e55148zszs0s2Ttz5txzuzc3zfNaUzN48GDasGEDLV68mHr37p1r3bx588R5AG/DN+4BoGiyshU07bsH9G9Yssq6lrWc6KP+PgaRFIi+H8CAAvpc45479vPnz6vdhjP15C7uS8OmTZtyAghJSS+Hgy5dupR++OEH8fN7771Hn332mU7aBsbjwr/x9MmaYNmhcWXsLOirDwKoUVXTrR9fr149XTcBALTE0tJS7VwzygzhIgQASg76fuNw9X4inbwWp7J8XC8vlI80Ee3ataPx48fT8uXLyd/fPydw3717d3ry5AlVrVqV5syZo+tmAhgshUIhJsCV+64N8rGj+SP9Deb7Fn0/gAEF9N9//30RzOeO/vjx4xQQEEBDhw6ln376ie7du0cfffQRNWvWjHSFa/rlnVQ3Li5OPFh0dLSOWgbGYu/ZFzR380OVSWtYeTdrWjYukAIq2umiaQAApUKX/TwAAGgvyLR852OV5fUDy1DrOs447CZk2bJl1LBhQ/F89epVsSw9PZ3GjBlDs2fPJhcX1PUGKKp1+57RrlOqZc08Xaxo6ZhAcrC1wMEFgJIN6HNQ/PfffycnJyeaNWuWCOhzzfsZM2aIQH6TJk1EJvzEiRNJV/jmAmcPqMP1/gCKepHDnS9PEianmq89LR0bSB7OViZ/gKOiosQxcHQ03VEKAAAApgR9v+E7fCmGroeoTng7/k0vjLoyQUOGDBEPLrGTlpZGdnZIWAIorp0nn8vGE+xtzOnrsYHk6WptUAcZfT+AgQT0g4ODRYfOWfk85F4KcjJ7e3sxNI8z+FesWEFz584lXeAAIoKIUNIyMrNp/pYw2nvuZaBars7dFyP9yR5304ULFy6I58qVK+MfIwAAgAlA32/YUtOzZbPz2zdwodr+ZXTSJtAPXHIHwXyA4jtxNZYWbgtTWW5hTrRoVABV9bE3uMOMvh9Au0psthqe4E68obk52draip8TEhJy1nONPXblypWS2iWAziWmZNGEFffVBvN7v+JBi0cHIpgPACblt99+E6V3+CY63+TP+5DOEwAAQP9tOhROETEZuZZxDeexb3jprE0AAMY0P8m09SEqE46z/71TmZrVcNJFswDAVDL0AwMDxXDLkJAQ8vPzE8v454yMDLKysqJHjx6JZbiIB2MRHp1OE1bco+CnqbLrx/byoqFdymEYMgCYlP3791Pv3r3J1dWVEhMTxXcgl927fv06paSkiEA/l+cDAADDON/deChcZfmADp7kWw43Z00Rz0v37bff0qVLl8REuJmZmSrbbN68mapUqaKT9gEYkuCnKTRp1X1Ky1CN5k/s403dmrrrpF0AYEIBfQcHB2rfvj0dO3ZMlN9p3bo1nTp1ikaNGkWvv/46zZs3T2zXqlWrktolgM7ceZRME1fep+exubOVmJWlmbiT3qWxm07aBgCgS1999ZUoubdx40bq0aOHGLl3/vx5evz4MXXt2pViY2Np7969+JAAAAzAil8fqwSa3BwtacSrFXTWJtCde/fuiev5yMjInBiAVG5XWWqqfMITAOS+YTp++T1KSM5SOSyDOpUTDwAArZfcYZ9++im99tprolbWqlWrqGzZsvT999/TG2+8IYL8HPAfO3ZsSe4SoNSduxlHI7+8IxvMd7K3oFUTqiCYDwAmizP2WIsWLXIt9/b2pi+//JJu375NU6dO1VHrAABAkzIQhy7GqCwf/YYXlbF7WW4VTAvPhcfBfE7eCwsLEyPx+EZ93kft2rV13VQAvRaXlCmC+XnLmbFuTdxofG+UNAOAUsrQZx07dhQPyd27d2nfvn0UHR1N1atXF+t46D2Aofrt9Av6YutDyspWXVfR3ZqWj69Clctj+DEAmK7k5GTx7OLiIvr8rKwsMRyfM/iaNm0q1h04cEDHrQQAgPxkZinoy59UJ2is6mNHPVqgBISp4pvybPr06eTj46Pr5gAYpKTULBHMD3mmOpKF6+XPHFqJzM0RNwOAUgzo58UX84MGDdLmLgBKBZePWL37KX1/QLWGKKtRyZ6+HhtI7k5W+EQKOYE2ABgnvsAPDQ2l8PBw8vT0pIiICFFup3LlymJeHZaQkKDrZgJAKULfb3h++fM53XmUorL84/4+ZIFAk8mqUOFlqSUbGxtdNwXAIKWmZ9NH3wTTzdCXCTDKqvva08L3/cnKskQLaegM+n4A7dLKNwUPvTt06JAot7Nt2za6ceOGNnYDUCoyMrNp5oZQtcH81nWc6duPghDML6QuXbqIBwAYp5YtW4rny5cviyH5bN26deLGKD8zHrUHAKYDfb9heRGXQat3P1FZ3qmRK9Wv4qiTNoF+GDp0qHg+evSorpsCYJAjn6auDaFLd1QTW7zL2tCycYHkYGs8yW/o+wEMLEN/4cKForYeB/WVNWnShH744QdcxINBSUjOpMlr5Dtd1rdtWWQqAQAoef/992nr1q20dOlSMUEul96bP38+LVmyREySx2V4Zs2ahWMGAKCnlux4REmpuetL2tuY06Q+3jprE+iHXr160ezZs2nBggVivryePXuSs7OzynaOjo7IzgVQkpWtoJkbHtCpf+JUjktZFytaOaEKuWG0PwDoKqA/b948UU+Ph9YMGzaMGjduTDExMSJL/6+//qI2bdrQ9evXqXz58iW5WwCteBaVRhNW3Jetbccm9vGmtzt6Yl4IAAAlnJWfkpIivht5SP6ZM2fo66+/ppCQEFF2Z9SoUTmZ+wAAoF/O34qnwzIT4b7/ekXydLXWSZtAv7Rv3562bNlCEyZMEA85f//9N9WrV6/U2wagj3iU6oKtYbLfrc4OFrRqQhWRoQ8AoJOAPk+CxwF9xgH8fv365aybPHkytWrVSgT1+aKes/gB9NntsGSasOIeRcVnqqyztjSj2cP9qGNDV520zdBxOS7Wp08fXTcFALTE1vb/Jwdv0KABbd68GccawISh7zcM6RnZtOhH1Ylwg7ztqH87T520CfTLyZMnqWPHjmJOnJo1a1K1atXEpPd5ubriOglACuYv2/mEdp1+oXJAHGzNRWa+f0U7ozxY6PsBDCSg/++//4qMPC8vr1zBfGZlZUXjxo2jwYMHi7v1APrs9D9xNHVdCKWk5R5qLN1BXzw6kOoFltFJ24xBVlaWrpsAAFr8+w4KCiJzc3O6d+8ejjMA5Hw3gP7bcCCcwiLTVJZ/OtCXLC3MdNIm0C9cTo+D+WPGjKGVK1fqujkAem/tvme05UiEynIbKzNaNq4KVa/kQMYKfT+AgQT0HRxefhF5eHjIrpeWS9sB6KOdJ5/Twm1hlK1QXeflYU3Lx1ehSuX+P/MUAAD+H5fce/bsGaWlpVF2drYI7AMAgP679ziZvj/wTGV5r1YeVCcAiSzwEvfx7K233sIhASjA+t+f0bp9qt+rfIP0qw8CkCQIAMVSYlfaVatWpYCAALp7966om5/X+fPnxXP37t1LapcAJSY7W0Erdz2hL7bKB/Nr+TnQhinVEMwHAChAo0aNRDA/ODgYxwoAwABkZilozqaHlJVncKpLGUsa08tLV80CPcQldlhCQoKumwKg177f/4zW7HmqstzcjGjeu37UvKbqZNIAADoJ6PPkdz/++KOY0X7QoEEUEfH/w4p2795NX375pSi5M3z48JLaJUCJ1Qud/v0D+uFguOz6dvVcaM2HQZh1HgCgEObPn0/W1tb0+eefY6gtAIAB+PFYBN16mKyy/OP+PiKoDyD56KOPyN7enjZu3IiDAqAGxxW+2a0azDczI5o5tDJ1aIA5JgCg+ErsDI1r4w8bNkxcxO/fv58qVqxIPj4+FBsbS3FxcWKynCtXrlDt2rVzvY4ny9u0aVNJNQNAI3FJmTR5dTBduZcou35Ae0+a2NebLPhWOgAA5Isz848ePUrdunWjrVu30rVr16hdu3bk5uaWazsuxTNz5kwcTQAAHQuLSJXNIm1d25m6NEbQCXILDw8Xc+N99dVX9Prrr1PPnj3J2Vk107hTp06yywGM3ebD4WLkv5xpgypR9+bupd4mADBOJRbQz8zMFMF7xhPjSsvKlCkjHkxarywxUT6QCqBtT16k0YQV9yk0PFX27vmkPt40sGM5fBAAABoE9DkzX3Ljxg3xkKu1j4A+AIDuS07O3fKQ0jJy15t0sDWnqW/7ihHYAMo+/vhjcbOe7d27VzzUJfvVq1cPBw9MytajEbRsp3ww/7O3femNVvLzTQIA6DSg37hxY3r8+HFJvR2AVt0MTaJJK+9TdEKm7Izzc4b7UXsMhdOKpk2baueNAUDneDTeuXPnCtwOQSIA04K+Xz/99EckXbmrmlw1sY83ebpa66RNoN9mzZpFUVFRBW7n6+tbKu0B0BfbjkbQ1zvk42GfDvSl3q+UJVODvh9Au1AUEUzOn9diadr6B5Sanmfmr/8m/1oyOoDqBLwcVQIlz90dwwwBjFmzZs103QQA0DPo+/VPyNMU2bIQjao6IosU1OrVqxeODkAeGw48o1W/qZYuY5+85UN92pheMJ+h7wfQLgT0waT8fDySvtr+iLJzjywWfDxtaPm4QPLxtNVF0wAAQAt+++032rdvn+y6ChUq0Jw5c3DcAcCkZGYpaOaGUErPzH1CbGttTtMHV8IoKgCAQlAoFGIOku/2h8uu54nF+7XzxLEEAK1AQB9Mpkboil+f0OYjEbLr6wQ40JLRgSJDH7Tr6tWr4rl169Y41ACgdZcuXaLvvvtOdl3VqlUR0AcoBej79cv635/R7bBkleWT+nqTd1kbnbQJAMDQgvlLf3lMW49Gyq7n0mVvtTftYD76fgDtQvQSjF5aRjbN2hBKRy/HyK5v38CFZg/zE1lJoH1Pn8oPRwQA48qKX7BgAd28eZNSUlJka+2npqpOSK5N06dPp0qVKuVa5uLiUqptADBV6Pv1x40HSaI8RF4tajlR79aYsBEKFh4eTosXL6YLFy5QQkKCCGzmtX37dnHTHMBYkwUX/fSIfvnzuez6yW/5UH9k5qPvB9AyBPTBqMUmZtJH39yna8FJsusHdSpH43t7kbm5Wam3DQDAGO3fv5969+5Nrq6ulJiYKEo3NGnShK5fvy6C+1xj38nJqdTb1bNnT2rUqFGp7xcAQF8kpmTR9O8eUFaeaaScHSxo5pDKKLUDBeIJcblPf/ToEZmbm1N2djY5OjqKwD7jvt/a2poyMzNxNMEoZWUraO6mh7T3nOrk0GZmRNMGVcI8JABQKpCSDEbr8fM0Gr7otmwwnztbrmnHQ+EQzAcAKDlfffWVyNbbuHGj+H++4D9//jzdvXuXatasSbGxsbR161YccgCAUsTfywu2hYnz47ymvl2JPJyt8HlAgVavXi2C+RMmTKDatWuLZSdPnqQ7d+5QgwYNqGLFinTx4kXR3wMYm/SMbJq+/oFsMJ/zAz9/pzKC+QBQahDQB6MdTjxs4W0Ki1C9aLGxMqMvRwWYfE07AABt1axnLVq0yLXc29ubvvzyS7p9+zZNnTq11A/+3r17RQBi0qRJtG7dOpFlCABgKvadi6KDf0WrLO/axI06NnTVSZvA8Jw+fVo8d+3aNdfyoKAgcbP+1q1bNGLECB21DkB7klKzaOKq+3REpoyvhTnR/JH+9Gozd3wEAFBqUHIHjM6Jq7E0bX0IpWWo1nN0c7SkJWMCqZafg07aBgBg7JKTk3Pq03O5naysLDH0nuvmN23aVKw7cOBAqbdr9uzZuf6fA/tr166lgQMHFvja5s2byy6/ceMGVa9ePafUAGgmKUm+HB4YH6nGNv5WdCMsMp0WbgtTWV7BzYrG9HAt0c8Ff9dFx/2lhYUF6TPpZriHh0dOW9PT08VztWrVRIb+0aNHKTo6mtzc3HTaVoCSEpOQQRNW3qdboaqTiVtZmtGi9/2pdR3MywQApQsBfTAqP/0RSYt/fkQyczNRpXI2tGxcFfIua6OLpgEAmAQfHx8KDQ0Vk+Z5enpSREQEPX78mCpXrkwZGRk6CerxxHzdunUjf39/ev78ucjWv3r1Kg0ZMoT8/PzUBuwBAIyhRMTsLc8oNU+iC2eUzhhUnsrY6XcAGfQLB+ylwL67+8tsZO7nJba2tuIGHve1COiDMXgWlUZjlt1TO/J/8ehAalaj9OeGAgBAQB+MZqb5pb88pm3HImXX1wssQ4tHB5CzA/7J6xoH9QDAeLVs2VIE9C9fvkytW7emX375RZS4mTt3rnhmnNVeWkaOHElz5szJNdkjZ+uPHz+eVqxYQcuXLy8woH/u3DnZ5dLreEJAKDocP+PHN84YPuvSN2/LQwp+qhqIGvOGFzWp6am1/eKz1py+Z+czrpO/Z88eMUKtcePGdOTIEfH/PXr0EMtCQkLE3DmVKlXSdVMBii34aQqNXXaPnse+TEhR5mRvQUvHBlKdgDI40mrguh9Au1BDHwxeano2TVkbojaY36mRK62aWAXBfD1Ro0YN8QAA4/T++++L56VLl9Jnn30msvXmz59P9vb2NGPGDBFYnzVrVqm1h4MKysF8yZQpU8TzzZs3S60tAKYKfb9u7DnzgnadeqGyvHkNJxrUqZxO2gSGbdiwYeLGA5ese/fdd8nBwYHWr19PdevWpVatWonsfF7OfX9x/f333yIpgEv4SOX8NBUcHEwHDx6knTt3ikSD7OzsYrcLTMO14EQa+eUd2WC+p4sVrZtcFcH8AqDvB9AupCuDwdez++ibYLoeIl+Hd0jncjS2lxeZ87TzAACgdZyVn5KSIoLoNjY2dObMGfr6669F1h5n6owaNUpso2tS2R8rKytdNwUAoMTdDkumBTJ1892dLOl/wyrj3BiKxNfXV5SsS01NFeV3jh07Rp9++qkIvnOZvdGjR9PMmTOLdXQ5CN+/f38RgJc4OzvT6tWracCAAYV6j8WLF4tRgXfu3FEZLcTv06VLl2K1EYzb0csxNGvDA9k5+biM76qJQVTezVonbQMAkCCgDwYrLCKVxq+4T4+fqw4j5vj9JwN8qU+bsjppG6j37Nkz8Yyh2ADGSzkzj4fnb968WSftiI+Pp99//5369u0rJuWV8GR9Y8eOFT9LE/UCgPag7y9dcUmZ9MmaYErPVK2bP3+kP7k74UYmFF2tWrVyfuY+9Pjx4yV2OPlGQdeuXen+/ftUvnx5UcYvLCyMLl68SIMHDxY3Edq0aVPg+3BJvYcPH1JAQAAFBgaKm/fnz5+nBw8eiPJAZ8+epUaNGpVYu8E48AiTTYcjaMWvT2TX16hsT8vHVSGXMgijFQb6fgDtQskdMNghcMMW3pYN5ttam4t6+Qjm6yfO4OEHAJiGpKSkIg+VLy7e78CBA0UAoH379iIYwFl5PHEvZxU6OTnRxx9/rJO2AZgS9P2lJytbQTO+f0BPo9JV1o3r7U0NgzDnBxTdpEmT6PXXXxeBcW3grHoO5jdr1ozu3bsnSu789ddftHDhQsrKyhKl/AqD+3bOzuf34pI7e/fuFW3mc4CMjAyRpQ+gLDNLQfO3hqkN5vPEt2smBSGYrwH0/QDahYA+GJxjV2LogyV3KS4pS3YY8dqPgqh1HRedtA0AAIhevHghMuArVKhAZcqUETV2vby8aMKECSI7vrTwEP0hQ4aI8jqcQbhlyxY6fPiwCPTzyAFe5u/vj48MAIzGql1P6OyNeJXlHRq40NsdtTcJLpiGCxcuiOB4bGysVt6fa92zRYsWifMH5QA9l8vhzPonT+QDrsr4HCQoKCjXMn6/zz//XPz8+PHjEm87GK7ElCyauPK+7JwjrGsTN/p6TADZ2+r/xNUAYDoQ0AeDGgK39WgEfbo2RGUIMfOrYEsbplSjGpUddNI+AAAgevTokQiWr1q1ihITE8UkeS1atKC4uDhavny5GOIeHh5eKofKzs6ONm7cKPZ34sQJ2rRpE+3YsYNu374tavNyOwEAjMXv56NEuYi8Kpe3pZlDK8tOEA6g6SSXjMvgaCujl5MA+LxBmbm5OXXq1En8fOXKlSK/f3r6y5ErVatWLWZLwViER6fTiEW36fwt1Ruh7N3XKtCc4ZXJyhKhMwDQLyj+BQYzfHjJz49o+/HnsusbBJWhr0YFkJMD/kkDAOjSJ598IoL6zZs3p127dlG5cuXE8qdPn4ph+hxInzp1Km3YsKFUM/ULU3MXAMBQ/ROSSHM3P1RZbm9jTove9ycHZJZCCZg4cSJt27aN1qxZI/r0krxJxPPe8INvGlhYqGZCcz384mbXf/HFF2RtbZ0zj05++DxGzo0bN6h69epi9B8UrRSjvrgRmkKzNj6l6ATVkf8858jHfctR18aOIkEFipaQyfC3Yvz06e/aEHFJObl+ryCIfoLeS03PpmnrQ+jPa3Fqh8DNHFKJrK1w1xwAQNf279+fMyGdFMxnXMd+2bJlImNf2gYAAEomw/Tj1cGUkWcEK8da54zwI/+KdjjMUCJ4xBsHw5csWUKtW7emfv36if49L86m55vpRQkIcYa+HKkET1EDR9OmTaMDBw7QN998o1KOB0zP7xfiaOmvEZSpGssnB1tzmj20IjWoYq+LpgEAFAoC+qDXouMzaNKq+3QzVH5CxWHdytMHr1ckc3MMIQYA0AepqaniuVatWirrpGXSNgAAUPzazx+uuk9R8Zkq68a84UVt6mJeKSg5XMv+2rVr4uczZ86Ih7rSOfXq1dPovW1sbHKVxckrLS0t13aamD59Os2fP5/mzJlDH3zwQaFec+7cuXwz9x0dMcF0cejq+PHktzzy/+cT8iP/K7pb09KxgbgRWgKkETz4WzEd+KyLpijZ+QwBfdBboeGpNGHFPXryIl12CNyUAb7U+5WyOmkbFJ29PTIdAIwZ16U/f/68KLsTGBiYax0vY1xHHwBMB/p+7QWmeG6pu49TVNZ1a+JGQ7v8/ygpgJIwa9YsioqKKnA7X19fjd+bM/qtrKxEiT450mS4ZcsW/vovOzubxo8fL+b1mTdvHn322WcatwuMR0xChvjOvHxXvoROzcr2tGRMILk7WZV624wR+n4A7bI01aGCDx8+FJPlVatWTdTRA/1y9X4iffTNfYpLypKtBfrFe/7UspZmwzhBP7Rt21bXTQAALVqwYAF17tyZZs6cSZs3b87JOMjMzBSBAFtbW5ElBwCmA32/dmoTz9vyUHYiRw5KTR9SCZPgQonr1auX1o4qny/wtfk///xD9+/fV0kKkEYDyI0AlJORkUFDhw6lH3/8kRYuXCjm+AHTdedRsihN9ixKfgTIq83c6LO3K5GtNcr4lhT0/QDaZTIB/YiICPr666/FJD5ShqBUo++9994TwQUOMoDuHbkUTbM2hFJ6njqgzMPZSgyBq+aLLG8AAH3DmXDHjx+nrl27igtoHpbfoUMHEXg6evQo3b59m958801Rw5YfEnNzc3EDAAAACmfdvme096xqpnR5N2taPDqQbDC3FBigV199VQT0Fy1aRGvXrs1Z/ueff4rRf5z5X5iAfkpKCvXu3ZsOHjxIixcvpg8//FDLLQd9tu9cFH2x9SGlZajGF7hy74Q+3jSwgyduggKAQTGZgP7FixfFnXnGk/RVqlRJZOqHhYWJQH9oaCj9+uuvum6mSeOAz6ZD4bT815fDKfPyr2hLy8dVERcqYNgzeAOA8Qb0P//885z/v3Xrlngo27lzp3jkzcpDQB/AeKHvL1m7Tj2ntfueqSx3tLeg5eMCRQIMgCHiCXeXL19O69ato5iYGOrSpYu4Xl+2bJlYP2XKlFzb87qTJ09SQEBATm171q1bN3ETgDOEPT09acuWLble5+LiQt27dy+l3wp0JTU9m778KYx2n5EvE+Vkb0HzR/pTsxpOpd42U4C+H0C7TCagX758eVEGYODAgeTj45OzfMeOHWLZrl27RNChRo0aOm2nqcrKUtDy3yJpz7k42fWNqjrSl6P8ydHeZP7JGq1Dhw6J5/79++u6KQBQwiwtLdVOIleYSbMAwDih7y/BY3kxmuZvDVNZbmVpRl99EICJHEHrOCmOs94vXLhACQkJIikrr+3bt1PVqlU1fm9vb2/aunUrvf322/TLL7+Ih+Sdd95RmdD2r7/+osGDB4vSOsoBfc7mZydOnBCPvGrWrImAvpELi0hVO8cI869gS4tHB5CPJ6o0aAv6fgDtMpnoKE/AJzcJX9++fUVQnx/BwcEI6OtASloWzfjhKZ37N0ltPbsZgyuRlSXq2QEA6LtmzZrpugkAAEbp1PVYmvn9A5KJn9KsoZWpYZCjLpoFJoQnxG3SpIkoYcvl8nhknqOjowjsM1dXVzE/Hc+bU5w6/Zxox4H9kJAQMVkul+Lp2LGjyrY86p6D/y1atMi1nBP20tPla6Uz5QQ/MD7HrsTQ7I2hlJSaLbu+TV1nmj3cjxxsX87zBABgiEwmoJ8fqXZ+5cqVdd0Uk/MiLoMmrbxP/4Yly64f+VoFeq9HBWRvAgAAAIDJunQngaZ8G0JZMvGp8b29qGsTN100C0zM6tWrRTB/woQJIvOd58rhkjf29vY0YMAASktLE3PkFDdgztfl06ZNK3C7xo0bq5TTYd9//32x9g+GKT0jm1bsekI/HouUXW9hTjT6DS8a3KkcmXPxfAAAA2byAX0+IeFyO3xXv3bt2gUeMOWhfMpu3LhB1atXz8lOgII9jEijKeufUERMpmxn+2GfcvRqE0dKTEzE4TQi0rBc/K0Yt6Qk+RE3UPiak1xXHgAA4MaDJPpw1X1Kz1RNzR/WtTwN6VIeBwlKxenTp8Vz165dc5WyCQoKEhn1XL52xIgRdPjwYXwiUKoePEuhad89oLuP5Evs8Nwi89/1owYYyQQARsKgAvp///03xcXJ11hXN+xfyr5XF3Dq3bu3CJps3LixhFoJhXE1OFmU2UlMUU0zsrcxp/8NqUCNqzrgYAIAAACAybodlkzjl9+j5DTVc+a+bcvS6Dcq6qRdYLold5iHh0dO4oFU2qZatWpUsWJFOnr0KEVHR5ObG0aNQOkki+08+YK+3vGI0jIU8iM5qjrS3Hf9yN0JE4YDgPEwqID+uHHj6MyZM4Xe/sGDB2rL6PCNAZ7Z/s6dO3Tw4EEKDAws1Huqm+xPytznGoKQv4N/RdPnG59QhkyWkaeLFS0dG0hBPvY4jEZKmvwSfyumAZ9z0SA7HwAAboUm0Zhl9yghOUvlYLzWzI0m9/dBWUooVRywlwL77u7u4ueIiIic9ZxMxwHW58+fI6APWheTkEGzNz2kU9flkz75snPEqxVoZPcKZIESOwBgZAwqoF+/fn2ytCx8k9Vl50dGRophgjwJLs+8ra6MDpQsPrn74WA4rfrtqex6/wrWtGJCVSrnao1DDwAAAAAmXWZn7LJ7lJiiGsxvV8+FZgypjBrQUOoaNGhAe/bsEeVmuX79kSNHxP/36NFDLONJbHmyXJ6sFkCbzt2Mo//9EEpR8fITMLs6WtLn71SmFrWc8UEAgFEyqID+ihUriv0eDx8+pE6dOomgPp+ANGnSpETaBvnLzFLQwm1htOv0C9n1jYLsadbgCgjmm4DWrVvrugkAAABQitD3a+ZacKIos5OUqlpmp2l1R5r3rh9ZWmBCRyh9w4YNozlz5tDatWvFKPdly5bR+vXr6a+//hLX2ZzANXLkyHzL3gIUR1JqFi3f+ViU2VGnRS0nmjW0Mkrs6Bj6fgDtMqiAfnHdunWLOnfuTMnJyXTs2DFq2LChrptkMp3u1HUhdPZGvOz6Hi3caXxPN1yYmAiUYAEAADAt6PsL7+97CTRhxX3ZmvnNazjRlx8EkLWVeYl+PgCF5evrS1evXqXU1FRRfoevqT/99FMx152npyeNHj2aZs6ciQMKWvHXv/E0Z/NDehb1ct6GvKwtzWj8m97Uv11ZlCPTA+j7AbTLZAL6N2/epDZt2lBMTAwtXryYEhIS6MSJE7m2CQoKyqkLCCXjeWw6TVx5n+6omW1+1OsVacSr5SkxMRGHHAAAAABM1pkbcTTl2xBKTVcN5req7UwL3/cnGwTzQcdq1aqV83PTpk3p+PHjOm0PGD8uPbb818f0az5Z+YFedjR3hJ94BgAwBSYT0OfJbHnyHjZp0iTZbVavXk2jRo0q5ZYZr+CnKWK4cERMhso6C3MStT+7N385mRKYDh6Syzp06KDrpgAAAEApQN9fsH3nomjOplDKUo3lU5u6zvTFSH9k5gOAybnAWfmbHlJ4tHxWPhvQ3pPG9vbCDU89g74fQLtMJqBfoUIFkaGfH2Tnl5yLt+Np8poQ2Ym8HGzN6ctRAdSkulMJ7hEMxYsX6jMrAAAAwPig71ePa45vPhxBy399Iru+XX0Xmv+uH1lZoswO6I/du3fTDz/8ICbCTU9PJx8fH3r11Vdp7Nix5OSEazwovpiEDFq284m42alOBXdrmjG4EuIKegp9P4B2mUxA/7XXXhMP0L7fz3OG0UMxEW5e5VytaNm4KhgKBwAAAAAmLTtbQUt/eUzbjkXKru/c2JVmD8MEuKBfN6BGjBhBGzZsEP9vb29PDg4OdObMGfFYt26dKMFTuXJlXTcVDPh7cc/ZKFrx62OKS1JNDpT0aVOWxvX2Igdbi1JtHwCAvkCqB5ToCd7635/RrA2hssH8IB87+uHTagjmAwAAAIBJS8vIppkbQtUG8/u1LUtzhyOYD/pl06ZNIphfpkwZ+uWXX8Q8aJGRkXT//n1q0aIFhYaG0vDhw3XdTDDgkr3vLb5Lczc/VBvMr+huTasnVaFPB/oimA8AJs1kMvRBuziAP3/rQ9pzRn5IXIuaTvTFe/7odAEAAADApEXFZ9Dk1cF0PSRJdv3onhVpWLfyZGZmVuptA8jPzz//LJ6nTZtGb775Zs7ygIAAsc7X11dk6HOQ39PTEwcTCiUlLYu+2x9Omw+Hy84jIunbtiyN6+VF9sjKBwBAQB+Kj+vkf7o2hM7fipdd/0YrD3EH3dICFyUAAAAAYLruPkqmD78Jlp3g0dyM6LNBlcS5M4A+iop6mbzVsmVLlXVeXl6i1E5ISAjFxMQgoA+FGuF/8K9oWvHrE4qMzVC7nV8FW5o60JcaBDniqAIA/AcZ+lAskTHpNGHlfbr3OEV2PTKMAAAAAACI/rwWS9O/e0ApaaopqDZWZjR/pD+1qeuCQwV6q2rVqnThwgURsJfDy7muPk+SC5CfGw+SaPH2R/TPA/mRStL34ruvVaBBncphYnAAgDwQ0Iciu/8khSasuEcRMap30zkbf9bQStStqTuOMOQSFBSEIwIAAGBCTL3v5yzUjYciaNVvT0ihOs0UuTla0lcfBFCdgDK6aB5AoX344Ye0Y8cO+uabb6hHjx65ykJt27ZNBPSnT58ugvoAcp7HZdC6/S/oyOWEfA8Ql+z9ZIAveZe1wYE0UKbe9wNoGwL6UCRcXmfKt8GUlKqaYVTGzkJclDSqiiFxoCowMBCHBQAAwISYct+fkJxJ//shlP68Fie7PtDLjr4eE0AV3BG0Av33/PlzGjNmDC1ZskSU3XnrrbfI0dGRzp8/T99//z01b96cateuLSbMVdapUydydnbWWbtB95JSs2jrkQjadDicUtNl7mz+x8PZij7u70MdGrhgHhEDZ8p9P0BpQEAfNLbnzAuat+Wh7IQ1FdytadnYQPKvaIcjCwAAAAAmXS//k29D6PHzNNn1res409wRfuSACR7BQHz88cd07do18fO5c+fEQ5ncMvb3339TvXr1Sq2doD/SM7Jp58nnYtLb2MRMtdtZWZrR2x3LiQnB8Z0IAFAwBPRBo+HCa/c9o3X7nsmur+ZrT0vHBoq76gDqhIaGimfO3gEAAADjZ4p9/96zL2jBtjBKy5DPRB3SuRyN6eVFFjwTLoCBmDVrVs7EuJrw9fXVSntAf2VlK+jAhWj6du9TehalOgm4snb1XWjCm94or2NkTLHvByhNCOhDoWRkZtO8LWG075z8CVyr2s40/10/skeGERTg1q1b4hkdOwAAgGkwpb4/OTWLvtz+iPaejVI7yePUtytR9+aYZwoMT69evXTdBNBz2dkKOnk9jlbvfkLBT1Pz3baKtx191M8HpXqNlCn1/QC6gIA+FCgxJYs+WRNMf92Wn7jmzVc8aPJbvmIiXAAAAAAAU3TjQRLN+P4BPYqUL7Hj42lDi973pyremDAUAIwvkP/H37H03f5ndO9xSr7bujla0Puve9EbrTwwSgkAoIgQ0Id8hUen04QV99TeXR/X20sMGTYzQzAfAAAAAEyztMQPB8Np7d6nsnNMsbb1XOh/71SmMnYWpd08AACtfv8dvRxD3/3+jEKe5Z+R72BrTm+1c6U3W7mSpwcmSQYAKA4E9EGtO4+SaeLK+/Q8NkN20hq+KOnS2A1HEAAAAABM0rOoNJq1IZSu3EuUXW9hTjS2lxcN6oQEGAAwrpK8hy7G0IYDz+hhhPyoJIm1pRn1b+dJQ7uWJwtF/tn7AABQOAjog6yzN+Lo07UhlJymmmbkZG9BX30QQA2CHHH0AAAAAMAky0vsPPmcVvz6RPZ8mVVwt6Y5w/2oXmCZUm8fAIC2yvHyd99Pf0TKJv7lvaH5WnN3eq97RSrvZi2WJchX8QUAAA0hoA8qfjv9gr7Y+lB2yLCXhzUtG1eFKpe3xZEDAAAAAJPzKDKV5mx6qDYrn3Vt4kafDvRFiR0AMJpSvD8eixCxgqRUNbXF8gTyh3UtTz6eiBsAAGgDAvqQQ6FQ0OrdT+n7A+GyR6VGZXv6ekwguTtZ4ahBkbm4uODoAQAAmBBj6fu5VvSPxyJp9e4nlJahUFsjmgP53Zq6l3r7AABKOj5wLTiJdpyIFHXy1c0RIrG0MKMeLdzpna7lycvDBh+GiTOWvh9AXyGgDzk18GZvekgHLkTLHpHWdZxp/rt+ZGeDibygeFq0aIFDCAAAYEKMoe+/8SCJFmwLo9thyWq3qRvgQLOH+yGQBQAGLTU9mw7+FU0/n4iku48KrnnP8+v1bOkhAvlSaR0AY+j7AfQZAvpACcmZNHlNCF26I1/Qrm/bsvRxfx+yMDfD0QIAAAAAkxGbmEmrdj2h3868IIV8Uj7ZWpuLiW/5nBnnywBgqMIiUkV9/D1noyghOavA7XluvTfblBUT3no4YxQ/AEBpQkDfxD2LSqMJK+5TyLNU2fUT+3jT2x09ycwMwXwoGSkpL7M8HB0xqTIAAIApMMS+nye95aDWil8fU1yS+sBWw6AyNGNIZfIui/ISAGB4UtKy6NiVWNpz5kW+84Ioq+huTQM7lqPXW7iTvS1G8IPx9P0AhgQBfRP278MkmrjyPkXFZ6qss7Y0E0OGOzZ01UnbwHgdP35cPPfv31/XTQEAAIBSYGh9P49aXfrL43zL69jbmNP4N72pd2sPMscoVgAwsNr410OSaO/ZKDp8MZqS0woojq80p96gjuWofQNXUS8fwJj6fgBDg4C+iTr9TxxNXRdCKTKdt7ODBS0eHUj1AsvopG0AAAAAAKXtYUQqLd/5mP68FpfvdpzwMqmvN5VzRa1oADAc4dHpojb+3rMv6GFEWqFew4l+nRu7iZJiNSs7aL2NAABQOAjomyCui7dwWxhly9QB9fKwpuXjq1Clcra6aBoAAAAAQKmKjs+g7w+E044TkZSVT6Kqr6cNfTLAl5rVcCrN5gEAFFlUfAYduxxDhy5G07XgpEK/roK7Nb35Sll6o5UHuZRB2AgAQN/gm9mEcC3Qb3Y/pR8Ohsuur+XnQF+PCSBXR0xoAwAAAADGLS4pk7YcjqAf/4ik1HT1kXwbKzMa1q0CDelcjqytzEu1jQAAmopPyqTjV2NFEP/S7QTZRD45FuZErWo7U8+WHtSytjMm+QYA0GMI6JuI9Ixs+t/GUDp8MUZ2fbt6LjRnhB/ZWuMiBQAAAACMV2JKFv30RyRtPhxOSan5147u2sSNxrxRkSq4Y9JbANBfL+Iy6OS1WDpxLZYu3k6gjMxCRvGJyK+CrQjid2vqRu5OSO4DADAECOibSPbR5NXBametH9Dekyb29cYdeAAAAAAwWrGJmbT9eCT9fDyS4pKy8t22boADTerrI0awAgDoo9DwVDpxNZb+vBpLN0KTSFH4GD452JqL2vgcyK9Z2Z7MzDDJLQCAIUFA38g9eZFG45ffk530hvvsD/t604AO5XTSNgAAAAAAbYuISaetRyLo11Mv8i2tw7zL2tC43l7Uvr4LAlwAoHej7q8FJ9LZm/F06nqcCOhrwtLCjFrUcqLOjdyoTV1nsrOx0FpbAQBAuxDQN2I3Q5No0sr7FJ2QKVsLdO4IP2pX31UnbQPT1aFDB103AQAAAEyg738YkUqbDoXT7+ejKTMr/9TVcq5WNOLVCvR6Sw8R9AIA0AePn6fR2RtxdO5WPF26k0ApafnflMzL3IyocTVHkY3PZXadHBACgtKB634A7cK3uZH681osTVv/QDYLiWep58lva/uX0UnbwLTZ2KAGLQAAgCkpzb4/O1tBF/6NFzXyOYu1oBIUbo6WNKxbeer9SlmywYS3AKAHpcGu3E2gi3cS6PyteHoUqTrSviA8Er9uQBnq3MiVOjR0RV180Alc9wNoFwL6Rojrgn61/ZHsbPa+nja0bFwg+Xja6qJpAAAAAAAlLik1i/adixI18sNkSk3m5e5kSQM7lqN+bcui7AQA6DSA//e9BLp8N1Fk4N9/klKk97G2NKOmNZyobT0Xal3bmdwwuS0AgFFDQN+IcEbSil+f0OYjEbLr6wQ40JLRgSJDH0BXTp8+LZ67deuGDwEAAMAEaLPv5+DXrlPPRTA/KbXgUhReHtY0uHN56tHCHRn5AFDqeAQ9Z95fvsNB/AS69yRFo8lslTnZW1DrOs7Upq4LNavhRPa2qIkP+gPX/QDahciukUjLyKZZG0Lp6OUY2fUdGrjQ58P8yNbavNTbBqAsPj4eBwQAAMCElHTfn5iSRYcuRtPuMy/oVmhyoV4T6GVH73QtTx0buqJGPgDoTHR8Bn28OrjIr69RyV4E71vUcqZafg74PgO9het+AO1CQN8I8DC9j765T9eCk2TXD+5Ujsb19iJznhEHAAAAAMAAR6JevZ8ogvicwJKWUbiU1ibVHWlAe09qVduZzLiwNACADlX0sKGK7tb0NCq9UNvzPB/NajpR8xpO1LS6E0rpAACAgIC+Ecx6P375PQqTmSyH4/cf9feh/u08ddI2AAAAAICiUigUdO9xCh38K5oOX4qh8OjCBcDsbMypezN36teuLPlVsMMHAAB6pWGQIz09FyW7roydBTUIKiO24UeQtx0S8wAAQAUC+gbsxoMkmrTqPsUkZKqss7Eyo/kj/UU9PQAAAAAAXchOTyXbF4/JPCONEv79mxwCqpO5tW2BCSsiiH8xmkKepRZ6X95lbcQkt1wf39EelzkAoJ8aVnWkvf8F9B1szalBFUexrFFVR6ribUcWGFkPAAAFwJmugTpxNZamrQ+RHW7Mw/KWjAkUNfUAAAAAAEpbenQkRe7bRi+O7yHvpJc19O+e/ZUsHJzIo93r5Nn9bbJ2K5uTiR/8NJWO/x1Dx6/G0t1HKYXej5WlGbWr70I9W3pQ46qOyGQFAL3XtLojTXjTSwTwg3zsEcAHAACNIaBvgH48FkFLdjwmhUzp0ErlbGjZuCoiQwkAAAAAoLQlh96he/PGUWZctMq6rKR4iti3haJO7ScaspBORJYViSqPZMpH5ofLULze0oO6NXUjZwdc0gCA4SjrYk2DO5fXdTMAAMCA4ezXgGRlK2jpL4/px2ORsuvrB5ahr0YH4KIG9FqtWrV03QQAAADQYma+umC+Ml4ft/Ij2uM0jeLMC1cikkehdmrkSt2bu1M1X3tMcgsAAKCncN0PoF0I6BuI1PRsmvH9Azr+d6zs+s6NXWnW0MpkY2Ve6m0D0ISvry8OGAAAgJHiMjsFBfMlzop46ph6lHba91G7DdeXbl/flbo0cRPlKSwtzEqwtQAAAKANuO4H0C4E9A1ATEIGfbgqmP55kCS7fmiXcjTmDS/UDAUAAAAAnclITaGIY7s1ek2L9LO0x+51yjCzzllmZ2NOLWs5U+dGrtSytjMSVgAAAAAATDmgf+/ePTpy5Ajdv3+fsrOzqXr16vTmm2+Sh4cH6aOwiFQav+I+PX6uWlfU3IzokwG+1KfNywnFAAzB3bt3xXPDhg113RQAAAAohswsBd1/kkKX7yaIR+yNKzQmJUGj9yijSCLfrDCKcqlGr9R1pnb1XKhJdScE8QEAAAwYrvsBtMukAvpdu3alQ4cOqSyfPHky/fDDD9S7d2/SJ9eCE+nDVfcpLilLZZ2ttTl9MdKPWtcpXM1RAH3BN9MYAvoAAACGJTYxk/4JSaTrIUn0T0gS3QxNopS07Jz1tTKSi/S+n7zhSnVfrYNyOgAgPH36lLZv307BwcHk4uJC3bp1o5YtW+rsfQBAc7juB9AukwroX758merWrUtt2rShgIAASkhIoL1799KFCxfo7bffFtn73t7epA+OXo6hmd8/oPRMhco6dydL+npMINWo7KCTtgEAAACAcUtJy6K7j1Podlgy/fswma6HJFJYhOqIUWWpZFukfVWt4olgPgAIv//+Ow0YMEBcq0vmzZtHH3zwAX3zzTel/j4AAAD6yKQC+sePH1eZafuzzz6j7t270/79++nAgQM0cuRI0iWFQkFbj0bSsp2PSaEayye/Cra0bGwgVfSw0UXzAAAAAMDIJKZk0Z1HySJ4z487YckUGp5K2TLnovl5aFmJkszsyUFR+Ex9izJOZO9fTfNGA4DRefbsGfXv35+SkpLENXqXLl0oLCxMBOBXr15N9evXL9T1ekm9DwAAgL4yqYB+3mA+MzMzExn7HNDPzMwkXcrKVtDi7Y/o5xPPZdc3DCpDX44KICcHk/rYAAAAAKAEZGRm08OINAp+mkLBT1JePj9NlZ2rqUjvb2ZNt9zaUOOoA4V+jUe7nmRuXbTMfgAwLitXrhRB+KFDh4qSuJLOnTtTp06d6IsvvihUIL6k3gcAAEBfmXxkODk5mXbu3Enm5ubUtm1bnX0QqenZNG19CP15LU52fdcmbjRzSCWytjIv9bYBAAAAgOFITs2isMg0CotIpYcRqSJoH/I0Rfyc9f8l74vNwpyoqo891fZ3oAZBjtQwyJHs033p3ykXKDMuusDXW7q4k+drA0uuQQBg0DjJjk2dOjXX8o4dO1Ljxo3p4sWLdOvWLapRo0apvA8AAIC+MsmA/vjx40UgPyoqik6dOkXx8fG0bNkyql69eoGvbd68uezyGzduiNcr1+grrPSMbJrwzWO6/ShVdv2gDm40vKs7paUmUZr8JgaPMyjANHBZKVaUvxUwHPibLp6srCyysLAooU8DAIwRnz9yZr0UuBfPkamizv2LuAyt7NPN0VIE72v7l6E6/g5iPidb67zJJmWpyrQVdG/euHyD+hzMr/LZCrJ2K6uVtgKA4Z37cJDd3d2dqlatqrK+devWIhDP1935BeJL6n0AAAD0mUEF9BcuXCgmrtVke+7I89q0aRPFxf1/JjxPjNOvXz/SFc66rx9opxLQNzcnmtTbk7o3c9FZ2wBKmtzfJAAAAOSWlpFN4dHp9CyKH2n0NOr/f+bn53EZsvMtlRRnBwuq6mtP1X3tqRo/V3IgLw9rUa6yIPaVq1L1hVsp8vdt9OL4bspKjM9VM5/L7HBmPoL5ACDh6/P09HTy9vaWPSheXl7iOTIyslTeRxuJfICkH1Pi5uYmnvG3YvyQzKebZD6DCujv3buXzpw5U+jtp0+fLhs8XLFiBaWmpooM/XPnztG3335Lu3fvFj/7+vrm+568TX4dvqOjIxXFpH5lKCqR6PDFGPH/9jbm9MV7/tSyljOZkqIePzAczZo1E8/4rE0DPueiQXY+gHHjUoucRf88Np0iY/k5Q/x/REw6hXPQPjpda1n2ctydLEXwvpoPB+5fBvDLuxUueK8OB+u9B0+giv3fpxc3rlBWciI5eniKCXBRMx8A8kpLezmXh7W1tezBsbGxEc98HV8a7wMAxVO7dm0cQgAtMqiA/qeffkrh4eGF3t7Dw0N2+eDBg3P9/5o1a0SWPk+Ow7Pe64K5uRnNGlqZnsdk0KPnabRsXKCoSQoAAAAA+i8rW0HxSZkUk5BJ0QmZFJuYSdHxL4P1z/8L3r98zqCE5CydtNHJ3oICKtpRgJcdBVS0JX/+uaIduZTR3iUBB+/tqry8qC+DxA0AUMPBwUE8c2nc/DJApe20/T7aSuSDl3D8TAc+a9OBz7p0k/kMKqDfvXt3rbxv+/btxfPt27dJl2yszOmr0QGUkpYtsqIAjJFU7gpf9gAAoM/zvSSlZosAfXxyFiUkvwzQc7A+RnpOyBA/x/4XwOdts7VYAqewOKm+gps1+ZazJR9PG/L1tCG/CnYU6GUnMvGLk3VfVOj7AaAgTk5O4vrg4cOHlJ2dTeZcf1bJgwcPcpXM0fb7AEDxoO8H0C6DCugXxz///EMxMTH0yiuv5FqekZFBixYtEj9XqlSJdM3ZwZKc808WADBoUtms/v3767opAGAiMjMzaeXKlbRjxw4x0q9ixYo0YMAAGjVqlMqFPhiHzCwFJadmUXJaNiXxc2qWCNAnpmSJwHtCCgfpsyg+OZMSkv57Fv//MnjPP+tDcF4dczOisi5W5FXWhip5/he4L2crgve8jJNE9An6fgAojHr16tGpU6fo/Pnz1KJFi1w3WY8cOSJ+rl+/fqm9DwAUHfp+AO0ymYD+nTt3qG/fvuTv7y9mu+dyPFINfQ70W1lZ0bhx43TdTAAAACjhYH6PHj3o4MGDOctCQkLo9OnTdOLECdq+fbtOMpbhZWAlI/NlmRquKc8Pngj2/39W5PzMj7wB+uTUbEpKe/n8MmD/cj3/zK81ZBbmRJ6u1lTB3ZoqutuIjHvxs4eNeC7nak2WFvh3CwDGpXfv3iIQz6V2Dx06RHZ2dmL58uXLKTg4mJo0aUI+Pj6l9j4AAAD6ymQC+nXq1KEuXbqIO/J8Ia+sRo0aInOvYcOGOmsfAAAAlLx169aJYD5n5a9YsYLq1q1Lly9fprFjx4qM/V69eolsfVMKomdlv8xg55rvHFDPyMym9EzVn9MzXv7M20o/57etWMbbZmZTRoaC0jKzKS1dPkAvBe4Vhh13LxJba3PydLEiDxcr8nSxprLOL3/mZ86657KLZV0QsAcA0/Pee+/RsmXLRDC+WrVq1Lp1awoLCxP/zzff582bl2t77s95DryWLVvSsGHDivw+AAAAhsZkAvpBQUHigv7Zs2d048YNevr0qaitx8F87uQBAADA+PDE92zr1q3Utm1b8XNAQADZ29uLzH0OBOgqoM/B9TV7nv5/gD3rZfA8M1uRE3CXlufdRlqXs23O8peTs8pu+996KHk2Vmbk6mhFrmUsydXRklwcLf/7+WWQXgrWc6DewdYco0IAAGRw33zgwAHq06cP3bx5U/Td0gS2fFO+Y8eOKvXwv/vuOzEaTzmgr+n7AAAAGBqTCehLKlSoIB4AAABg3KKjo+n69evk5+eXE8yXdO/encqXL09nz56l1NRUsrW1LfX2cZbghgPhel2r3RTZ25iTo70FOTlYvny2f/nM8xxxsF4K2osA/n//b2eDID0AQEngZDvuu7k0Lo+sd3Z2pjZt2ojnvBo1aiRG4nHyXnHeBwAAwNCYXEAfAAAATGf+nPwmvuNJ83j0HtfTrVmzJumChYUZZWciol9SOLDOAXkHWwuyFw9zcrB5+cz/X8bWIk+wnv8/98+oTQ8AoFs8YT2X0eFHfipXrkzvvvtusd8HAADA0CCgX0L4rn9ycjI1b968pN7SpGRlZYlnCwsLXTcFtIwno2ZLly7FsTZi+JsuHi4Nx8PFoXhiY2PFs4eHh+x6aXlMTEy+76Oub7906RLZ2NiIyfWK6nZYqsll6JubE5mb8QiFl6MU+GdzMzMy+2+5+Fk887b//zNvy5PF8nrxHv/9rLwsjV4+8v9EQVd/i4sXL8bBN3LZ2dk5gVTQzK1bt0RJGNBvuO4vHlwjmA5c95sO/F3r5tofAf0S4urqWlJvZZL+/fdf8VyrVi1dNwW0jOexYO7u7jjWRgx/08XDHTr6Fe0HlqSbyNJ2mrK0tBTBl+LcjK7p52DSJ68Mfb/xQ99vOtD/Fx33J+j79R8+o+LBd4TpQN9vOvB3rZtrfwT0S8jt27dL6q1MkpT9yDUOwbjhszYN+JxBHzg6OubKDs5LWi5tpw76Ju3A94TpwGdtOvBZg7HDdX/x4DvCdOCzNh34rHUDYyEBAADAKPn7++fKGpErb8ACAgJKtV0AAAAAAAAARYWAPgAAABglb29v8vHxoevXr9O9e/dyrbt27ZpYxpPhOjk56ayNAAAAAAAAAJpAQB8AAACM1pAhQ0ihUNDgwYPp8ePHYlloaCi988474uehQ4fquIUAAAAAAAAAhYca+gAAAGC0Jk+eTNu3b6cLFy5QpUqVyM3NjaKjo8VEuHXq1KGxY8fquokAAAAAAAAAhYYMfQAAADBazs7O9Oeff1K/fv3I0tKSXrx4QdbW1jRo0CA6evQo2dnZ6bqJAAAAAAAAAIVmpuBx6AAAAABGLiMjg2JjY8nV1VUE9wEAAAAAAAAMDQL6AAAAAAAAAAAAAAAGACV3AAAAAAAAAAAAAAAMAAL6AAAAAAAAAAAAAAAGAAF9AAAAAAAAAAAAAAADgIA+AAAAAAAAAAAAAIABQEAfAAAAAAAAAAAAAMAAIKAPeikxMZE2b95M/fr1o/r161NgYCB17NiRVqxYQenp6bpuHmgoOzub1qxZQ6+88or4LFu0aEFLliyhjIwMHEsj8uDBA5o3bx5169aNqlatSjVr1qS33nqLjh49quumAYAByMzMpAMHDtCIESOoefPm5O/vL/qLGTNm0IsXL3TdPCiC/fv3U/fu3alKlSrifG7y5MkUHR2NY2lEoqKiaPXq1dSrVy+qVasWBQUF0WuvvUabNm0S538AAAW5cOECTZw4kdq2bUsBAQHUoEEDGjNmDN25cwcHzwBdvXqV3n77bapevbq4Hhw2bBjdvXtX182CEpSamko7duwQn3OjRo3E322bNm1o4cKFlJSUhGNdSswUCoWitHYGUFi1a9emGzduyK5r0qQJHTt2jMqUKYMDagD4K6Z///7iCz+vLl260L59+8jS0lInbYOSc/v2bXHSpg4H5GbPno1DDgBqjRw5ktavXy+7rnz58vTnn3+KYCEYhq+++koE8PPiGzXnzp0jT09PnbQLSpajo6NIxJHDN3N2795N5ubIIQMAed9++y2NGjVKdp2NjQ3t2rVLJAuBYThy5Ii4qZs3cc/BwYFOnDghgr9g+Dp16qQ2aY8T+06dOkVly5Yt9XaZGpxdgV6ys7OjIUOG0M8//0xXrlyhmzdviux8Z2dn+uuvv0R2NxiGn376SQTz3d3dadu2bXT//n367bffyMvLiw4dOkTr1q3TdROhhDJrOUgzffp0kWHLAX7OtuEAHZs7d674OwYAyM+rr75K33//PZ09e1Zk5vF5AI/sCg8PF9l7YBju3btHU6dOFTfsFyxYIDLz+OKOR16EhITIBvrBMPG5+QcffCDO7f755x+Rmcl9vrW1tUja2LJli66bCAB6fg3RtGlTWrp0KR0/flz0F4cPH6bWrVtTWlqaGLWXlZWl62ZCIbO2ORufg/nvvfee6BP+/vtvGjhwoMjaHj58OEZuGQk+v+vbty9t3bqVLl68SP/++y999913VK5cOXH+PmvWLF030SQgQx/0tmOXy9rmgDAP62nfvr3I0gf9x0OvTp48KbIr3njjjZzlp0+fFidqPBrj+vXrOm0jFB+faFtYWMiue/PNN+nXX3+lb775Rlz0AwBo0vdzAJiH8trb22MYr4GYMmUKLVq0SDxzQF+5PAvf/E1JSaHIyEhycXHRaTtBe3+38+fPp2nTpokADl/kAwBo8h2SnJwsMn0fP35Mt27dynckMOgHTuLjkskdOnTIlb3N5dcaN24sEjV5tCWX4QXj/Lv9448/xOdfo0YNJPOVAmTog15SV4KF794zW1vbUm4RFAXPd8BZlpyd37Nnz1zrWrVqJU7S+M798+fPcYANnLpgvlQmi+HvFgCK0vdzANjDwwPfIQaEsywZB3OV8fkA11rn7D3O2AfDh3N2ANDGdwjfxOd5ORiuIQy77+eya5y5z5CUaRzQ9+sHBPTBoPDwO5Y3OAz6KTg4WNy9rVu3LpmZmams5wnyGCbJMf5ailwDk+dMAADQFA/X5klx0fcbDh5uzcEYuTkP0PebBpyzA0BxxMfHi/KdPJrbz88PB9MASJMYS/28MvT9pgF9f+lCQB8MBgd9P/vsM5Htm/euL+in2NhY8cyZlXKk5TExMaXaLig9q1evFpkYM2fOpIoVK+LQA4BGeLLNd955R/QXc+bMwdEzAAqFghISEtD3m7AzZ87Q119/LUZjdO7cWdfNAQAD7Ee4BjsH9VeuXKnr5kAJXPvjut/4PXv2jMaNG0dVqlShDz/8UNfNMQny45sAioknO+UJbAqLh2Dld6EeGhpKXbt2JVdXV1GLW90QH9AvXC9PGmaXX5kWaTswLtu3bxedOs97wZMjAoBx4/JpcllZ6vDord9//13teq6fy3Ov8GTqBw8eFJOpg/7jPp2DMej7TRPXSH799dfF3/cPP/yg6+YAQCng+ugczCssrouvDvcfEyZMoJ9//lkkBqHeunFc++O63/ivAThexyUV9+zZQ2XKlNF1k0wCoqKgFTzZ2ZMnTwq9fX4Z2jxjdqdOnUTJDq7Lhgt6w+Ho6Jjrbn1e0nJpOzAe69evp/fff58GDBhAGzdulC25BADGhSfH1qTvL1++vNp13D+89tprdO3aNdq/f7+YRB0MA1+029nZoe83QTwvQo8ePUR2Hpfbc3Jy0nWTAKAUcDBfk/4/v/OIkSNHipuBq1atEtcSYJjX/jxnjjJc9xuvR48eiXgdf8Y8KW61atV03SSTgYA+aAXfneM/7MJSdwfv4sWL1K1bN5GZz8F8b2/vEmwlaBtPZCjdlJFz69Yt8RwQEIAPw4gsWrSIpkyZQkOGDKENGzaozdIEAOPi6empUd9vbW0tuzw8PFzMuRESEkIHDhxAMN9A+/+bN2+KzzLvjRv0/caJR9v07duX6tSpI0bqOjs767pJAFBKLl26JOZNK460tDSRCPTbb7/RmjVrRMkdMLy+n2/s8rV/3ut79P3GO28CB/M5M5/jddWrV9d1k0wKAvqgFTwTfXGD70ePHhW1N7nuNt/pQ2a+4eEbNTyR0T///EOXL1+mhg0b5qzjQA0v438nvr6+Om0nlJxPPvmEvvzySzHPxbp16xDMBzAhfPOuuH0/9w1cc5uH7nJQsEWLFiXWPig9/LlxQH/nzp00ZsyYnOV8wcfBGta8eXN8JEZiy5Ytonwmz3PFN+GQmQ9gWvIbcVcYPO8Kl9g7ceKEGOWL+fIMt+/nkdnc93fv3j3Xuh07duRsA8ZzI4+TbzlB588//6SgoCBdN8nkIG0S9NKuXbtEJ+Dj4yO+HBDMN1ycpc34Qo8DNezp06c0aNAgUWdPWg+GjT9LHiLLwXzOqOGTcWTmA4AmOADcqlUrevHiBR0+fBgXfQZs8ODB4nnGjBl08uRJ8XNSUhJ98MEHYhRH+/btxTkeGD4ui8HncnyDhm/CIZgPAJqIiooSfQIH83lkL4L5hqt3797k4OBAmzZtEp8lXx9yGaWlS5fSvn37qFy5cmIEJhg+jtHx3y2XWEQwX3fMFDzrCICecXNzE3X1udSOvb29yno/Pz8xnAsMYz6FZs2a0fXr10Udda6nFx0dLTr4wMBAcWcXw7INH4+i6dChg/iZR9XI1cznLE1MjgsA6rz66qsiu5cvBl1cXGS34RFffG4A+o+DvJs3b845r0tMTKT09HTx+Z49e1aUZgHDFh8fn3MOV7ZsWdkyWjz/xY8//qiD1gGAIZg5cybNmTOHrKysROk+daOA2rZtW+ptA80tX75cTGos1dTna36+oc9++ukn6t+/Pw6rEahRo4YorcTnAHLls/lcj8vxgHah5A7o9QzpHNSXmzCXS/qAYeC7tseOHaOPPvqIfv75Z5F5ySdsfAd/2bJlCOYb2d+sNAJDTlxcXCm2CAAM9XuEL/yki7+8ONMLDAOP1KpUqRKtXr1aZGCyli1bikw9BPONr+/nMlly1C0HAFD+HuGSbOom1k1NTcXBMhDjx48XAd65c+fSgwcPxLKqVauK/+/Tp4+umwcl/HfL1/dy1/gc0AftQ4Y+6CUOCCpfJORlaWlZ7Fp9UPp4siS+QcOZlxzUB+PBE1kVdNHOw/AxFB8A1OEbvgVdtPMIIJTzMiw8GJgD+nxxxzf5wbg+W3UBOOUkHA8Pj1JrEwAY3kgffuSHRwDZ2NiUWpugZMTGxopR2xiNb3wiIiLETTh1+Fydz9lBuxDQBwAAAAAAAAAAAAAwAJgUFwAAAAAAAAAAAADAACCgDwAAAAAAAAAAAABgABDQBwAAAAAAAAAAAAAwAAjoAwAAAAAAAAAAAAAYAAT0AQAAAAAAAAAAAAAMAAL6AAAAAAAAAAAAAAAGAAF9AAAAAAAAAAAAAAADgIA+AAAAAAAAAAAAAIABQEAfAAAAAAAAAAAAAMAAIKAPAAAAAAAAAAAAAGAAENAHAAAAAAAAAAAAADAACOgDKOnfvz/NmzevwGWgXd999x316dOHnj9/nrPsyJEjYtnly5dx+AEAoMR89tlnNHz48AKXgXadOHFC9PPnz5/PWRYSEiKW/fzzzzj8AABQYn744QfRv4SHh+e7DLTr6dOn4phv2rQp13LEYAAKhoA+gJKdO3fSqVOnClwG2vX333+L456UlJSzLDg4WCx79uyZxu/3+++/ixOFq1evkqEwxDYDABiiP/74g/bs2VPgMtCu0NBQ0c8/fvw4Z1l0dLRYduvWLY3f7/bt26If5dcbCkNsMwCAIeJrLP6uTUxMzHcZaFd8fLw45tevXy+RGEx2drboRxcsWECGwhDbDPrBUtcNANB3nBXm6emp62aYvM6dO9OOHTuoUaNGGh+Le/fuiZOCd99912COoyG2GQDAWHzxxRe4oNcDAQEBou+vUaOGxq998eKF6Efr1atHhsIQ2wwAYCyGDRtGrVq1ogoVKui6KSavqDEYDo5zP5qammowx9AQ2wz6AQF9gAL07t0bx0gP+Pv7iwcAAIC2tWvXDgdZD7i6uoqsNQAAAG2rW7eueIDuIQYDUDAE9AEKwPXb6tSpQ9OmTRP/n5ycTEOGDBF37ydMmCDuHh89epQyMjKoZcuWNHToULK2tlZ5H37d9u3bRW3YhIQE8vHxERepjRs3lt0vDzE7duyYqB9rZWVFtWvXpoEDB6rcqVZuz/jx40V7jh8/Loap//TTT2RhYSH7/sqvGzduHG3ZsoVOnjxJCoWCXnnlFRo0aBBZWlpqvB8eFs/ZdPfv3xevr1+/vjgmzs7OsnejpeOXlZVFzZs3F9vK4Rr63377LU2dOpUaNmyoMkSd72pzVruNjY3IbOO2Ojg40KJFi2jbtm1iO54LYf369TlZfwsXLsxVXoHL3HBJHxcXF2rTpo34fPIeP97Pjz/+SHPnzqUyZcqIWou8fz5m7733HhWkMMenMG3mf0P8Pjw8MTIyksqVKycCUD169CAzM7MC2wEAAOpxDX2uofv999/nLOO+kq1YsUL0l9x/xcbGUq1atej9998XwWe5fm7v3r2ij+F5Ydzd3alr16702muvye7333//pd27d4v+LDMzkwIDA6lfv35UtWpVlW2V28P98W+//Sb6MO43qlSpovZ3U37doUOHxP64T+G+k0eF5e2vC7MfPlbcb/3zzz+i3UFBQaIfrlSpkmwb+H1+/fVXcfxq1qxJI0eOlN2Oz4E++eQTcQz4oYz7Pj7/4H6QzyGqVatGgwcPpooVK4q+euXKlWI73ka5fN0vv/yS8zO3lz/HBw8eiPMHHgXI5z+Ojo659sWv536fsze5v+e+/8qVK+KcTPlcQp3CHJ/CtJlfy/+eLly4QI8ePSInJydq1qyZODZ2dnYFtgMAANTj7/Z9+/aJ7+Ly5cuLZcuXLxd9/oYNG0Tfx+cF/P3r6+tLI0aMEP20nLNnz4rv67CwMLK3txdxggEDBoi+Ji/uz7gv4uvEuLg4ESd49dVXRX+Tl3J7uB18Dc99GPdd6s4t8r6OS9xxzXr+ffz8/MScQfys6X40jW/wOc7GjRtzjh/3qYWNwUhSUlLENbC0T0744+A/34jhPvZ///uf2I7n3VNOCOCRl9I5C//emzdvFsebYx98/sC/F7e/JOIsyq8v6PgUts2FjQ2BiVEAQA4LCwtFly5d8l0WExOj4D+dfv36Kfr37y9+Vn507txZkZ2dnes9rly5ovD29lbZlh8zZsxQ+QTatWsnu62Li4vi7NmzubaV2tO3b19F9+7dc22flpam9tNVfl23bt1U9tWyZUtFYmKiRvuZPn26wszMTOW9ypcvr7h27Vqu/fNr+Fjl3bZFixaKd999V/z84MGDnO1Xr14tlu3duzfX+0ybNk12n2XLlhXt79mzp+yxbNiwoXh9Zmam+CzltmnUqJHi+fPnufY3Z84csW7p0qUKV1fXnG1HjhxZ4F9SYY9PQW0+f/68wtHRUXYb/reanp5eYFsAAOClpk2bKtzd3QtcFhAQIB4LFixQ+e719/dXREdH59o+PDxc0bhxY9nv6tdff12RkZGRa/uPP/5YdltLS0vFd999p/JxSe3h8wjl7c+cOZPvRyu97rPPPlPZl6+vryI4OFij/fz0008KOzs7lfeytbVV/Prrryr7/+ijj1S29fHxUcyePVv8vGPHjpxtL168KJbNmjUr13ts27ZNYW9vr/I+3I7Lly/n9NVyD8m8efNk++SKFSuqnLMcOHBArONzjqCgoJxt69evn++x1uT4FNRmPg/jtsmt5zY9e/aswLYAAMBLEyZMEN+f9+7dy3fZ22+/LZZt3rxZ5bvcwcFBcenSpVyHlPt26TV5HzVr1lT5rv7xxx8V1tbWstuPHj1a5eOS3nvdunW5Xrd48eJ8P1rpdd9++63CyspKpe88dOiQRvvRNL7Bvyefzyhvx/34qlWrxM98blBQXIbPCeT2yX05nycdOXJEbT967tw58R4cS+DPTa5PVj7/KE6cRZPjU5g2axIbAtOCDH2AIuK793x39NNPP6Xq1auLO81ff/01HT58WKzjTGnGd2O7d+8uZnDnZ87M4+w3zr5bu3YtzZkzR9yx79KlS857811zvvPNd4P57jXf3eWJYvkO+QcffCA7USrvk+8ScyYb37G1tbXNlWGf3+/Br5syZYqoUcv75iy8M2fOiDviS5cuLdR+OKOBs9c4+5DvtnPGHY9a4KxEvjPN2WM3b97MuZPNd5z5WPGxGDt2rMhW46x13jf/roXBx48zBM3NzcUd6hYtWojREZw1x1kHvH/+vThrktvHv49Ul9bNzS0nG57vtnNm25gxY0SmJU/I980339ClS5dE1j1nEebFIwV4W8608Pb2LrAckCbHp6A2c5YnZ3e888474t8eH0PO/uMsS8625MwH1N4HACh5T548oZkzZ4q+gTOjeeI8zuS7e/eu6C8///zznG3feustunjxosjE4u94rskrZf3zhLuc2a2cecaZb02aNKFu3bqJEVmc3X/nzh2xPWeGvfnmmyrZ89we7k85S5D7QM7Ylsvml/s9eP/8Oj4H4WwzHg3GI844G+306dOF2g/315wVz/0wZ/g1bdpU9E+cZcbvxxlv3LdL9Yh5JNzixYvFeQP3U7w992k8Ao/fvzD++usv0UbOVu/YsaPIYuT+kTP/OOOOfxcpw23GjBnic+Bjp4zPP/jY84g2HiXHWZCcFcnnDnyO1atXL3Es+DxP2ZIlS6hs2bLi3IM/I+7T86PJ8SmozYV8MeoAABIcSURBVFxbl383bi+fF/DIvJiYGPrzzz/FeQxn+K1Zs6ZQxxAAADTDI/G4z+E+mvsGHrHN13E8oo+vvyTTp0+nrVu3UuXKlcX3NfcVHA/YtWuXGJXOI9I4c1/C1508sozPE/h6mK9leRmP6uLrUb7W5JhAXnxe0KFDBxEz4P6gsKWCJk6cKH6P119/XZxnSO3ia+ng4GCV8wy5/Wga3+A4CfeB3G/37NlT9Nvp6emi7/r4448L1W7u77gNPJqBYxbcf3p5edHDhw/FCDepLXxdzdn9PKKf4zQSPra8DR/PpKQkcQzeeOMNcT7C8Q1+cH/No+f5MytOnEWT48OjEPJrc1FjQ2AidH1HAcBQM/T5Lu7NmzdzbcuZVnnvMC9fvlws+9///qeyP85A5zvkvXv3zrU8LCxMcezYMcWUKVPE3fE+ffoo3nzzTZHBxu8VFRWl0h5zc3Nx17qwlF934cKFXOtCQkLEHXO+ey1lexe0H84OK1OmTK6sesnUqVPFa//444+cZRUqVBC/+z///JNr21u3buVkARSUoe/n5yfuyO/Zs0dln5GRkTlt//rrr8VrOcMuL852498pb0Yjv97Dw0O8jj+PvBl0rVu3VmRlZSkKS9Pjk1+bX7x4oXjy5Ili7dq1ivfff1+MMOB/Hz169BCvGTBgQKHbBQBg6jTJ0Ofv2J9//jnX8tDQUNGPtGnTJmcZZ0xJmfh5+4qkpCTxXpwNr4z7muvXrys+//xzxZAhQ3L6/jp16oj3yps9J7WH+wJNSK9bs2ZNruXJyck52efcjsLsZ+DAgWLdwYMHVdbt3LlTrFu0aFHOMinDbcuWLbm2jY+PF8ejMBn6nCmn7ryKfwdppMSpU6fEdtxv58WfC69buXKlSmYlf/a8bteuXSoZ+uXKlRPnQ4Wl6fHJr82pqamKR48eKbZv364YP3684q233hL/PvjB52xVqlQpdLsAAEydphn6H374Ya7X83Vm5cqVRXa7NDqf+3f+/8DAQEVsbKzKPnv16iXei6/jJPzzw4cPxbXfiBEjRB/H3+tt27YV2/I5gTKpPcOHD9fo95Ve984776isk/pV5X4+v/1oGt+YO3eu2H7s2LG5tuXj9uqrrxYqQ59HBvB2r732mhhhn/d9nj59mtOPS9vlNX/+fLFu0KBBKut4NASv4/hLceMsmh6f/NqsaWwITAsy9AGKiDPU+O5w3mXsxYsXuernMa53yhlXXKftv5tp4sGZWpyZLeE6sHznXC4rXPkOtZStLeEMQK79qil+HWcEKuMaenw3me+ac9YhZ5Pnt5+oqCixHddwk+4qS78f44xExr8n13nn/+fadXy3n7PclXHGOd8x379/f77t5rvznM3I7ZFGQyjjDLqCcDv4zjnX7pc+O+XX8116HnXBd8Dz1tTj7EzOuCsMTY9PQbgWI9/R56xGdf8+AACg5HFmet++fXMt4zronF0n1/dHRESIrLe8fT9npnHGGmf483wsjEdlzZo1K2fbwny3cyYfZ71pis898o7k4pFqvIwz0HikG2ehFbQf/j05S42zxPih3LelpaWJZ+VzHO5PeZ6at99+O9f7cM16HnU2e/bsAtvOtWi5PZwVmRf/DoWpJc8Z8pxhx5ltyvh34WxEbh8fA87eU8bncdz+wtL0+OQnPj5eZDVyvV056PsBALQnb5/JWfp8TcxznHDGN/fl3MdxjXf+nueMfqb8vc/Xroxrt/N5A+MR4Zw1zlnXmny35+2/CotHpOfFc+VwXXru9wqzH03jG9Lo+7z75lFyPFK/oOt+qe9nPEoyb+16fh9pJGBBfT+bNGmSyrqPPvpIjIiQOwaaxlk0PT75KWpsCEwDAvoARSQXMJYmueHhZBIews0OHDig9r34JEDCw+v4C5vLuHBpFi7lwpO7ckfFQ7R4cli5i30eflUU6iZSkZYrt03dfqTfkYPsPGRMHem9pOeC9p0fDoIw6WSoKKR28PBBOdJyaV9FPd6aHp+CjBo1SgTz+cK+U6dO4nhxcIM7fOWTBgAAKFnqbhZz/y/X9/PFHD/UkYIAfHHPwXyeOI+H4/ONdL55wDeOeRI0LqUi993Ow80LmpRNDl/4yb1OXd+vbj/8e/LvXdi+jX9WdwwLO7Eb98n8HnnL4WiC2+Hh4SF7Y76k+v6iHJ/8cEkdDuY3aNBAlGbgz4T/3fH5IZcskGsvAACU3rW/1Pdz6Rp+FPS9z+VXuZQd3wTgEjJcyo9LufGNYE7g4iCzuuu6krz2V9f3q9uPpvGN/K79Nen7tXntX9J9vybHJz9FjQ2BaUBAH0DLypcvn1N3NW+Wt4Qv4CVS3VquM8s11ZTlrWevrLDZ4nnx3WGun5f39devX5ft8OT2wx0xL+fsemmWdjlSth+fEHEnpC7LTN1yZdwuDi7wHX8+icqvjh3vSw63W2qH3DGQ6tFJn2FRj7emxye/NnNWJ9cPbt26tfg3ItdeAADQLanf4Gy0tm3bqt1OyvbmeWv4gmz58uUqmfB569mXRN/PI8N4RAEHtYva90u/J2ea8+gCdf0WX4RK+H05Q5Hry3JWvty+C8IX83zuwiPs8ruwV9ceqR1cy1buGJRU31+U45Nfm/nfAdfgPXfunLiJL+H359ENPOIAAAB0R+o3OnfuLG7Oq8MZ34znauF+iLfl4Kyyn376Kd99FbX/5+vevAFqdX2/uv1oGt+Q3pf33aZNG9l9F0Tq73luIuV+U9O+n127dk3cFNdm36/J8Smo7y9KbAhMQ9G+BQCg0HjCGXb8+HFRYoYnPVN+cJaccichXeAq39XnYDOXfuEL/pIWEhIiJmZRvrPLE7WdPHlSTAjDpQQKwtmFXCqGJ+/jC0ueyE35d+QSOsoX3px1yMPWbty4QV999ZVKxyQNh8sP35nmEwLOXuCAifJdbs5U56Ht0tBFqcPk8gbK+FhzuSE+1pwZycdZ8ttvv4mSQ9I2xaHp8cmvzXzjgssJcLa/cgYBlzAq6tBLAAAoWTyCir+vT5w4ISZYy9v384Sy3EdJ2X1yfT87ePCgViY65T6f+wzlIf48RHz16tUi851vGhf2HIffgy+E+Wfl35H/n7MPpZJCrH379uLGNA+xl0rOMB6FwEHvwuCJ4RiXxeG+L+9ktxwgya8fZdzvcp/PJRGUzx84sLBgwQLxM5+zFZemxye/NvO/ET5mPEGxhN+bSwAWNtMPAAC0hycs52A5B5050z5v388lXvn7Xbrmk/p+ntiVr18l3I8pT45akqZOnSquOyV8Lc2TxGvS72ka3+C+n02ePFlcw0p4Uvj8kt3k+n4uP8MBeWV8k5/PIxgn/PFNb3V9P+PSgjzxsITLI0pleKRtikPT45Nfm0s7NgQGRtdF/AEMdVLc/v37q7xeWseTlShP0sITnPByngCFJ1vjyUtbtmwpJlfLO9kbT3onTb7SvHlzRbdu3RSVKlUSy6pXr64yUU9+7cmP9DqetIf35e/vL/Yl7SPvpHUF7efatWti0lfehie8bd++vfi9a9eurbCxsRHLnz9/nrP9vn37cvbDbeB9S5PxVa1atVCT4l66dElMTszLXV1dFa+88oqiQ4cOirJly4pl0sR1586dE//Pk/x27dpVTCLzySefiHWHDx8WE+vyej7O3A5us9S2BQsW5Po9pUlxeeI6TWh6fPJrszT5LU/YyO1t1aqVmBCvRo0aYnnef8MAAFAyk+LyQw4v575L2cyZM8V3MvcxPLEtT/zG3/08iV7eyc94slOeSI+X16pVS0wey8/8/9J3+48//ljo9uSHX8OTvru5uSk8PT0VnTt3VjRu3FicC/B+Jk6cWOj98AS03Ifz65ycnEQ/zH1Uo0aNxP/nndw9ODhY9Gu8vHz58qK/atCggThGUt9f0KS43FdKE8HxMePPivtJ6bgeOXJEbJeQkCD6Vz6P48kFpQlkpYmMXVxcxPZ8LDp16iTex9LSUizjCeeUSZPi8qSFmtD0+OTXZp4YUfqdO3bsKB78b5Tfx8vLS+XfKwAAlNykuMrXaXnXKU+WzteqUn/K19fcv3AfVa1aNfHdrvxdzXEC6fqX+zU+L5D6Iqnv5zbJ7VOuPfmRXsd9LV+TtmnTRvRJfA3Jy1u0aJEzuW9B+9E0vsGTuvPvL/WF7dq1E9evfB0v9f0FTYrL++TrfOm8qm7duuK8qmbNmuJ4K08m37BhQ7Edn1/wRMTcj969e1eRlpYmXsfr+Pfm35/7WkdHR7GMPwue2Li4cRZNj09+bdY0NgSmBQF9AC0H9KVObPLkyTkdpvTgzog7+QsXLuTafsaMGTkXldLF28qVKxVjxowp8YA+v27NmjU5gXF+8M9LlixRu706V69eFR2V8u8oBZ45QMCdqLJ169blBLmlDo8D6NLvWVBAn505cyZXAJ4ffOyGDx+uSE9Pz9muX79+ubbhTlPCwQMOsiuv54DD/PnzVX7Hogb0i3J81LWZZ7qXOn3pwcEi/neBgD4AgH4E9NmqVatyLt6UH/Xr188VuGYcsJeCvNLF2+jRoxXr168v8YA+P44fP55zA1w6J3nvvfcUGRkZGu0nPDxc0bdv35wAhvK5BJ8PPX78ONf2J06cUHh7e+fadvDgwYq1a9cWKqAvBeT5RkTe48pBkydPnuRs98UXX6i0SzkpQLppIj34nO/dd99VJCcnl0hAvyjHR12b+VySL/KVl/NNkWPHjolzAgT0AQB0H9CXEsakgLzyw9fXV3zHK+O+yM/PL9d2HB84ffq0VgL63K/mvXbmoHZkZKRG+9E0vsHX9XwzW3nbZs2aiXOCwgT0WWJiomLkyJG54iTSdfD58+dzttu/f39O8oD04GQ59uzZM3GukPez4YQLTq5QVtQ4S1GOT35t1iQ2BKbFjP+j61ECAPqCJxzheuetWrVSu4yHR+/evVvUQ2vatGmu10vruEyNVBtPGU94wzXfuVYev2dgYKBK7VYJDyPnkjQ8BIvL03CZGh6yzUPTunXrJkrOFNSe/MTGxpKrqyv1799f1OiLjo6mS5cuiWH4XGKG18n9boXZDw8X+/fff8XQQR52WKVKlVz1XpVxHV2eMJDr4PNEb3xcpN+TSxZIw8+5NBDPOs+fg1xtOx6ayEPReOh6rVq1xDDHvO7evSseqampYqibNPyP8f75/bmuMNeo5WMuHeO8++HPhUvoyO2jMDQ5PurazEPtuA4hvxfXAOSSDuyXX34Rx0f53zAAAKjHQ6K5hFmPHj3yXcblb1jXrl1V3oPX8fBprpubF3/X8/BwLpXCfTlPaKaupipPpMZ9IH/nc63UChUqiKH4PHyfJ8tTrhubX3vyw+cejPtZ3g/3wfy78v7k2lXY/fB5BLedy79wO7lvUy4nk/ecgvfLvy/PL8PHRPo9mzdvnlPbNiYmRgyjr1GjhnjkxUPmpXOlatWqybafz6f4+HO7+ByHh7tL+P95qD7X9efyR3weIndexsPxT506JcopSMdPU5ocn/zazLX/+cHzL/C5JpdI+uOPP8S2yv9eAQBAPf6O5e9S5etquWXcL3H/xGVU8l6vSet69uwpO1E7X8NxX8sl+CpXriz6D7l67FxOjff9/PlzsQ2X5eNr5EOHDom+om7duir7lGtPfnjS3a1bt4p98DUsX/fzdS/3vzVr1lTZvrD70SS+wbgf5OtX7q+5T5V+T/6dleeTk4vLKMcxeJ9cdo5LBPNr89ahj4+PF78jb8vXzXwNzdfSyqWG+PyB8XmIn5+fyn6KGmcp6vHJr82FjQ2BaUFAH8BE5Q3oAwAAgPFTDugDAACA8VMO6OcXcAcAw4FJcQEAAAAAAAAAAAAADAAC+gAAAAAAAAAAAAAABsBS1w0AAN3gOms7duxQW8cXAAAAjM/KlSt13QQAAAAoRRMmTKA33nhD1F4HAOOAGvoAAAAAAAAAAAAAAAYAJXcAAAAAAAAAAAAAAAwAAvoAAAAAAAAAAAAAAAYAAX0AAAAAAAAAAAAAAAOAgD4AAAAAAAAAAAAAgAFAQB8AAAAAAAAAAAAAwAAgoA8AAAAAAAAAAAAAYAAQ0AcAAAAAAAAAAAAAMAAI6AMAAAAAAAAAAAAAGAAE9AEAAAAAAAAAAAAADAAC+gAAAAAAAAAAAAAABgABfQAAAAAAAAAAAAAAA4CAPgAAAAAAAAAAAACAAUBAHwAAAAAAAAAAAACA9N//AYtcMYyU+nqTAAAAAElFTkSuQmCC' alt='Identity, log, and generalized-logit inverse-link curves' />"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "eta_grid = np.linspace(-3.0, 3.0, 301)\n",
+    "link_curves_figure, _axes = plt.subplots(1, 3, figsize=(11, 3.4))\n",
+    "_curves = [\n",
+    "    (\"Identity: unbounded\", eta_grid, (-3.2, 3.2), \"parameter = eta\"),\n",
+    "    (\"Log: positive\", np.exp(eta_grid), (0.0, 20.5), \"parameter = exp(eta)\"),\n",
+    "    (\n",
+    "        \"Generalized logit: (0, 1)\",\n",
+    "        1.0 / (1.0 + np.exp(-eta_grid)),\n",
+    "        (-0.03, 1.03),\n",
+    "        \"parameter = sigmoid(eta)\",\n",
+    "    ),\n",
+    "]\n",
+    "for _axis, (_title, _values, _limits, _label) in zip(_axes, _curves, strict=True):\n",
+    "    _axis.plot(eta_grid, _values, color=\"#3366cc\", linewidth=2.5)\n",
+    "    _axis.axvline(0.0, color=\"0.65\", linestyle=\"--\", linewidth=1)\n",
+    "    _axis.scatter([0.0], [_values[len(_values) // 2]], color=\"#cc5533\", zorder=3)\n",
+    "    _axis.set_title(_title)\n",
+    "    _axis.set_xlabel(\"linear predictor eta\")\n",
+    "    _axis.set_ylabel(_label)\n",
+    "    _axis.set_ylim(*_limits)\n",
+    "    _axis.grid(alpha=0.2)\n",
+    "link_curves_figure.tight_layout()\n",
+    "_plot_buffer = BytesIO()\n",
+    "link_curves_figure.savefig(_plot_buffer, format=\"png\", dpi=140, bbox_inches=\"tight\")\n",
+    "link_curves_image = mo.image(\n",
+    "    _plot_buffer.getvalue(),\n",
+    "    alt=\"Identity, log, and generalized-logit inverse-link curves\",\n",
+    ")\n",
+    "link_curves_image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "PKri",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "The three panels use the same horizontal predictor scale but different\n",
+    "parameter scales:\n",
+    "\n",
+    "- **Identity** leaves the predictor unchanged and does not impose a bound.\n",
+    "- **Log** maps every real predictor to a positive value.\n",
+    "- **Generalized logit** maps every real predictor into finite lower and upper\n",
+    "  bounds. For `(0, 1)`, it is the familiar logistic sigmoid.\n",
+    "\n",
+    "Notice the red points at `eta = 0`: identity maps zero to `0`, log maps it to\n",
+    "`1`, and generalized logit maps it to the midpoint `0.5`. This fact matters\n",
+    "when interpreting intercept priors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Xref",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>x</th><th>eta = 0.2 + 0.5*x</th><th>identity parameter</th><th>positive parameter (log link)</th><th>bounded parameter (0, 1)</th></tr></thead><tbody><tr><th>0</th><td>-1.0</td><td>-0.3</td><td>-0.3</td><td>0.741</td><td>0.426</td></tr><tr><th>1</th><td>0.0</td><td>0.2</td><td>0.2</td><td>1.221</td><td>0.550</td></tr><tr><th>2</th><td>1.0</td><td>0.7</td><td>0.7</td><td>2.014</td><td>0.668</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "example_x = np.array([-1.0, 0.0, 1.0])\n",
+    "example_eta = 0.2 + 0.5 * example_x\n",
+    "coefficient_example_table = pd.DataFrame(\n",
+    "    {\n",
+    "        \"x\": example_x,\n",
+    "        \"eta = 0.2 + 0.5*x\": example_eta,\n",
+    "        \"identity parameter\": example_eta,\n",
+    "        \"positive parameter (log link)\": np.exp(example_eta),\n",
+    "        \"bounded parameter (0, 1)\": 1.0 / (1.0 + np.exp(-example_eta)),\n",
+    "    }\n",
+    ").round(3)\n",
+    "coefficient_example_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "SFPL",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "The coefficients in the table are identical in every column. What changes is\n",
+    "their parameter-scale meaning. The inverse link transforms the **complete**\n",
+    "predictor `0.2 + 0.5*x`; it does not transform the intercept and slope\n",
+    "separately. With a non-identity link, a one-unit change in `x` is additive on\n",
+    "`eta`, not on the final DDM parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "BYtC",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>eta</th><th>identity</th><th>log</th><th>generalized logit (0, 1)</th></tr></thead><tbody><tr><th>0</th><td>-2.0</td><td>-2.0</td><td>0.135</td><td>0.119</td></tr><tr><th>1</th><td>0.0</td><td>0.0</td><td>1.000</td><td>0.500</td></tr><tr><th>2</th><td>2.0</td><td>2.0</td><td>7.389</td><td>0.881</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "eta_landmarks = np.array([-2.0, 0.0, 2.0])\n",
+    "landmark_table = pd.DataFrame(\n",
+    "    {\n",
+    "        \"eta\": eta_landmarks,\n",
+    "        \"identity\": eta_landmarks,\n",
+    "        \"log\": np.exp(eta_landmarks),\n",
+    "        \"generalized logit (0, 1)\": 1.0 / (1.0 + np.exp(-eta_landmarks)),\n",
+    "    }\n",
+    ").round(3)\n",
+    "landmark_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "RGSE",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "These three landmarks make the scale change concrete. In the\n",
+    "[Molab notebook](https://molab.marimo.io/github/lnccbrown/HSSM/blob/main/docs/tutorials/link_functions.py),\n",
+    "edit `eta_landmarks` and rerun the cell to explore other values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Kclp",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "## 2. Where the link sits in an HSSM regression\n",
+    "\n",
+    "In an HSSM formula such as `a ~ 1 + x`, Bambi constructs the intercept and\n",
+    "slope, combines them into `eta`, and the model family applies the inverse\n",
+    "link before passing trial-wise `a` values to the likelihood.\n",
+    "\n",
+    "HSSM exposes two model-level choices for regression parameters:\n",
+    "\n",
+    "- `link_settings=None` (the default) uses identity unless a parameter says\n",
+    "  otherwise;\n",
+    "- `link_settings=\"log_logit\"` keeps unbounded parameters on identity, uses\n",
+    "  log for positive parameters, and uses HSSM's generalized logit for\n",
+    "  parameters with finite lower and upper bounds.\n",
+    "\n",
+    "You can override the link for an individual regression by adding `\"link\"`\n",
+    "to that parameter's `include` specification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "emfo",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>rt</th><th>response</th><th>x</th></tr></thead><tbody><tr><th>0</th><td>0.420</td><td>-1</td><td>-1.000000</td></tr><tr><th>1</th><td>0.435</td><td>1</td><td>-0.818182</td></tr><tr><th>2</th><td>0.450</td><td>-1</td><td>-0.636364</td></tr><tr><th>3</th><td>0.465</td><td>1</td><td>-0.454545</td></tr><tr><th>4</th><td>0.480</td><td>-1</td><td>-0.272727</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "tutorial_data = pd.DataFrame(\n",
+    "    {\n",
+    "        \"rt\": 0.42 + 0.015 * np.arange(12),\n",
+    "        \"response\": np.where(np.arange(12) % 2, 1, -1),\n",
+    "        \"x\": np.linspace(-1.0, 1.0, 12),\n",
+    "    }\n",
+    ")\n",
+    "regression_specs = [\n",
+    "    {\"name\": _parameter, \"formula\": f\"{_parameter} ~ 1 + x\"}\n",
+    "    for _parameter in (\"v\", \"a\", \"z\", \"t\")\n",
+    "]\n",
+    "model_kwargs = {\n",
+    "    \"data\": tutorial_data,\n",
+    "    \"model\": \"ddm\",\n",
+    "    \"loglik_kind\": \"analytical\",\n",
+    "    \"include\": regression_specs,\n",
+    "    \"p_outlier\": 0.0,\n",
+    "    \"prior_settings\": \"safe\",\n",
+    "    \"process_initvals\": False,\n",
+    "    \"initval_jitter\": 0.0,\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def build_silent_model(**kwargs):\n",
+    "    \"\"\"Construct an HSSM model without its initialization status message.\"\"\"\n",
+    "    with redirect_stdout(StringIO()):\n",
+    "        return hssm.HSSM(**kwargs)\n",
+    "\n",
+    "\n",
+    "tutorial_data.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Hstk",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "identity_model = build_silent_model(**model_kwargs, link_settings=None)\n",
+    "transformed_model = build_silent_model(**model_kwargs, link_settings=\"log_logit\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nWHF",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>parameter</th><th>support</th><th>default link</th><th>log_logit preset</th><th>preset maps eta=0 to</th></tr></thead><tbody><tr><th>0</th><td>v</td><td>(-inf, inf)</td><td>identity</td><td>identity</td><td>0.0</td></tr><tr><th>1</th><td>a</td><td>(0.0, inf)</td><td>identity</td><td>log</td><td>1.0</td></tr><tr><th>2</th><td>z</td><td>(0.0, 1.0)</td><td>identity</td><td>gen_logit</td><td>0.5</td></tr><tr><th>3</th><td>t</td><td>(0.0, inf)</td><td>identity</td><td>log</td><td>1.0</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def link_name(link):\n",
+    "    \"\"\"Return a consistent display name for string and object links.\"\"\"\n",
+    "    return link if isinstance(link, str) else link.name\n",
+    "\n",
+    "\n",
+    "def inverse_link_value(link, eta):\n",
+    "    \"\"\"Map one predictor value back to its parameter scale.\"\"\"\n",
+    "    _link = bmb.Link(link) if isinstance(link, str) else link\n",
+    "    return float(np.asarray(_link.linkinv(eta)))\n",
+    "\n",
+    "\n",
+    "model_link_table = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"parameter\": _parameter,\n",
+    "            \"support\": str(identity_model.params[_parameter].bounds),\n",
+    "            \"default link\": link_name(identity_model.params[_parameter].link),\n",
+    "            \"log_logit preset\": link_name(transformed_model.params[_parameter].link),\n",
+    "            \"preset maps eta=0 to\": inverse_link_value(\n",
+    "                transformed_model.params[_parameter].link, 0.0\n",
+    "            ),\n",
+    "        }\n",
+    "        for _parameter in (\"v\", \"a\", \"z\", \"t\")\n",
+    "    ]\n",
+    ")\n",
+    "assert model_link_table.set_index(\"parameter\")[\"log_logit preset\"].to_dict() == {\n",
+    "    \"v\": \"identity\",\n",
+    "    \"a\": \"log\",\n",
+    "    \"z\": \"gen_logit\",\n",
+    "    \"t\": \"log\",\n",
+    "}\n",
+    "model_link_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "iLit",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "For this analytical DDM, the preset follows support rather than parameter names: an unbounded\n",
+    "parameter remains on identity, a lower-bounded positive parameter uses log,\n",
+    "and a parameter with two finite bounds uses generalized logit.\n",
+    "\n",
+    "The configured likelihood supplies those bounds. A likelihood with finite\n",
+    "training bounds can therefore resolve a parameter differently—for example,\n",
+    "a finitely bounded neural `v` can receive generalized logit. The preset uses\n",
+    "log only for the exact `(0, inf)` shape; unusual one-sided bounds are left on\n",
+    "identity with a warning. Fixed or otherwise non-regression parameters do not\n",
+    "have a linear predictor and are not assigned links by this preset.\n",
+    "\n",
+    "With HSSM's identity default, coefficients keep a direct response-scale\n",
+    "interpretation and safe intercepts can retain HDDM-derived priors. The\n",
+    "`log_logit` preset is an explicit alternative that often gives hierarchical\n",
+    "regressions an unconstrained coefficient space. Neither spelling is\n",
+    "universally preferable; the link is part of the scientific model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZHCJ",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>parameter</th><th>identity intercept prior</th><th>log_logit link</th><th>log_logit intercept prior</th><th>slope prior in both models</th></tr></thead><tbody><tr><th>0</th><td>v</td><td>Normal(mu: 2.0, sigma: 3.0)</td><td>identity</td><td>Normal(mu: 2.0, sigma: 3.0)</td><td>Normal(mu: 0.0, sigma: 0.25)</td></tr><tr><th>1</th><td>a</td><td>Gamma(mu: 1.5, sigma: 0.75)</td><td>log</td><td>Normal(mu: 0.0, sigma: 0.25)</td><td>Normal(mu: 0.0, sigma: 0.25)</td></tr><tr><th>2</th><td>z</td><td>Beta(alpha: 10.0, beta: 10.0)</td><td>gen_logit</td><td>Normal(mu: 0.0, sigma: 0.25)</td><td>Normal(mu: 0.0, sigma: 0.25)</td></tr><tr><th>3</th><td>t</td><td>Gamma(mu: 0.2, sigma: 0.2)</td><td>log</td><td>Normal(mu: 0.0, sigma: 0.25)</td><td>Normal(mu: 0.0, sigma: 0.25)</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def format_prior(prior):\n",
+    "    \"\"\"Format a Bambi prior compactly for a comparison table.\"\"\"\n",
+    "    return str(prior)\n",
+    "\n",
+    "\n",
+    "prior_scale_table = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"parameter\": _parameter,\n",
+    "            \"identity intercept prior\": format_prior(\n",
+    "                identity_model.params[_parameter].prior[\"Intercept\"]\n",
+    "            ),\n",
+    "            \"log_logit link\": (\n",
+    "                transformed_model.params[_parameter].link\n",
+    "                if isinstance(transformed_model.params[_parameter].link, str)\n",
+    "                else transformed_model.params[_parameter].link.name\n",
+    "            ),\n",
+    "            \"log_logit intercept prior\": format_prior(\n",
+    "                transformed_model.params[_parameter].prior[\"Intercept\"]\n",
+    "            ),\n",
+    "            \"slope prior in both models\": format_prior(\n",
+    "                transformed_model.params[_parameter].prior[\"x\"]\n",
+    "            ),\n",
+    "        }\n",
+    "        for _parameter in (\"v\", \"a\", \"z\", \"t\")\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "assert identity_model.params[\"a\"].prior[\"Intercept\"].name == \"Gamma\"\n",
+    "assert identity_model.params[\"z\"].prior[\"Intercept\"].name == \"Beta\"\n",
+    "assert transformed_model.params[\"a\"].prior[\"Intercept\"].name == \"Normal\"\n",
+    "assert transformed_model.params[\"z\"].prior[\"Intercept\"].name == \"Normal\"\n",
+    "assert all(\n",
+    "    format_prior(identity_model.params[_parameter].prior[\"x\"])\n",
+    "    == format_prior(transformed_model.params[_parameter].prior[\"x\"])\n",
+    "    for _parameter in (\"v\", \"a\", \"z\", \"t\")\n",
+    ")\n",
+    "prior_scale_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ROlb",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "## 3. The link determines the scale of a safe intercept prior\n",
+    "\n",
+    "This is the core logic behind HSSM's generated `prior_settings=\"safe\"`\n",
+    "defaults:\n",
+    "\n",
+    "- With an **identity link**, the intercept is itself a value of the DDM\n",
+    "  parameter. HSSM can therefore use its response-scale HDDM prior, such as a\n",
+    "  positive `Gamma` for `a` or a `(0, 1)` `Beta` for `z` in the analytical\n",
+    "  DDM used here.\n",
+    "- With a **transformed link**, the intercept is an unconstrained coefficient\n",
+    "  inside `eta`. HSSM uses `Normal(0, 0.25)` on that coefficient scale. The\n",
+    "  inverse link then maps it into valid parameter values.\n",
+    "- Ordinary slopes are coefficients on `eta` in either case, so their safe\n",
+    "  default remains `Normal(0, 0.25)`.\n",
+    "- An explicitly supplied prior always takes precedence over a generated\n",
+    "  safe prior.\n",
+    "\n",
+    "The HDDM-derived response-scale intercepts shown here apply to analytical\n",
+    "and black-box `ddm`, `ddm_sdv`, and `full_ddm` regressions. Neural\n",
+    "`approx_differentiable` likelihoods use generic safe priors informed by their\n",
+    "configured training bounds. Setting `prior_settings=None` does not remove\n",
+    "priors; it delegates missing regression-term priors to Bambi, while simple\n",
+    "HSSM parameters retain their configured defaults.\n",
+    "\n",
+    "For example, `a_Intercept = 0` under a log link means `a = exp(0) = 1`.\n",
+    "It would be a mistake to truncate that coefficient at `a`'s response-scale\n",
+    "lower bound: the transform already enforces positivity.\n",
+    "\n",
+    "Conversely, an identity-link prior that keeps the **intercept** inside a\n",
+    "parameter's bounds cannot guarantee that every trial-wise value remains\n",
+    "valid once slopes or group effects are added. A support-respecting link is\n",
+    "the structural way to enforce support on the full predictor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qnkX",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>user spelling</th><th>effective link</th><th>safe a intercept prior</th></tr></thead><tbody><tr><th>0</th><td>link omitted</td><td>identity</td><td>Gamma(mu: 1.5, sigma: 0.75)</td></tr><tr><th>1</th><td>link=\"identity\"</td><td>identity</td><td>Gamma(mu: 1.5, sigma: 0.75)</td></tr><tr><th>2</th><td>bambi.Link(\"identity\")</td><td>identity</td><td>Gamma(mu: 1.5, sigma: 0.75)</td></tr><tr><th>3</th><td>hssm.Link(\"identity\")</td><td>identity</td><td>Gamma(mu: 1.5, sigma: 0.75)</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "identity_link_specs = [\n",
+    "    (\"link omitted\", None),\n",
+    "    ('link=\"identity\"', \"identity\"),\n",
+    "    ('bambi.Link(\"identity\")', bmb.Link(\"identity\")),\n",
+    "    ('hssm.Link(\"identity\")', hssm.Link(\"identity\")),\n",
+    "]\n",
+    "_base_kwargs = {\n",
+    "    _key: _value for _key, _value in model_kwargs.items() if _key != \"include\"\n",
+    "}\n",
+    "_identity_rows = []\n",
+    "for _label, _link in identity_link_specs:\n",
+    "    _a_spec = {\"name\": \"a\", \"formula\": \"a ~ 1 + x\"}\n",
+    "    if _link is not None:\n",
+    "        _a_spec[\"link\"] = _link\n",
+    "    _model = build_silent_model(**_base_kwargs, include=[_a_spec])\n",
+    "    _identity_rows.append(\n",
+    "        {\n",
+    "            \"user spelling\": _label,\n",
+    "            \"effective link\": (\n",
+    "                _model.params[\"a\"].link\n",
+    "                if isinstance(_model.params[\"a\"].link, str)\n",
+    "                else _model.params[\"a\"].link.name\n",
+    "            ),\n",
+    "            \"safe a intercept prior\": format_prior(\n",
+    "                _model.params[\"a\"].prior[\"Intercept\"]\n",
+    "            ),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "identity_equivalence_table = pd.DataFrame(_identity_rows)\n",
+    "assert identity_equivalence_table[\"effective link\"].eq(\"identity\").all()\n",
+    "assert identity_equivalence_table[\"safe a intercept prior\"].nunique() == 1\n",
+    "identity_equivalence_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "TqIu",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "The four rows are semantically the same model and now receive the same safe\n",
+    "response-scale prior. HSSM decides from the **effective link**, not from\n",
+    "whether the user happened to omit a value or wrap it in a Link object. This\n",
+    "equivalence is the behavior corrected by\n",
+    "[#1232](https://github.com/lnccbrown/HSSM/issues/1232)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Vxnm",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>term</th><th>source</th><th>resolved prior</th></tr></thead><tbody><tr><th>0</th><td>Intercept</td><td>explicit user prior</td><td>StudentT(nu: 4.0, mu: 1.2, sigma: 0.4)</td></tr><tr><th>1</th><td>x</td><td>missing term filled by safe settings</td><td>Normal(mu: 0.0, sigma: 0.25)</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "explicit_intercept_prior = bmb.Prior(\"StudentT\", nu=4.0, mu=1.2, sigma=0.4)\n",
+    "_explicit_base_kwargs = {\n",
+    "    _key: _value for _key, _value in model_kwargs.items() if _key != \"include\"\n",
+    "}\n",
+    "explicit_prior_model = build_silent_model(\n",
+    "    **_explicit_base_kwargs,\n",
+    "    include=[\n",
+    "        {\n",
+    "            \"name\": \"a\",\n",
+    "            \"formula\": \"a ~ 1 + x\",\n",
+    "            \"prior\": {\"Intercept\": explicit_intercept_prior},\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "assert explicit_prior_model.params[\"a\"].prior[\"Intercept\"] is explicit_intercept_prior\n",
+    "explicit_prior_table = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"term\": \"Intercept\",\n",
+    "            \"source\": \"explicit user prior\",\n",
+    "            \"resolved prior\": format_prior(\n",
+    "                explicit_prior_model.params[\"a\"].prior[\"Intercept\"]\n",
+    "            ),\n",
+    "        },\n",
+    "        {\n",
+    "            \"term\": \"x\",\n",
+    "            \"source\": \"missing term filled by safe settings\",\n",
+    "            \"resolved prior\": format_prior(explicit_prior_model.params[\"a\"].prior[\"x\"]),\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "explicit_prior_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DnEU",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "`prior_settings=\"safe\"` fills gaps; it does not rewrite the explicit\n",
+    "`StudentT` intercept. Here it supplies only the missing slope prior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ulZA",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "## 4. Built-in links versus custom links\n",
+    "\n",
+    "For built-in names such as `\"identity\"`, `\"log\"`, and `\"logit\"`, Bambi\n",
+    "already knows all required numerical and symbolic functions. A custom link\n",
+    "needs three related callables:\n",
+    "\n",
+    "1. `link`: numerical parameter-to-predictor mapping;\n",
+    "2. `linkinv`: numerical predictor-to-parameter mapping, used outside the\n",
+    "   PyMC graph for operations such as prediction; and\n",
+    "3. `linkinv_backend`: the symbolic inverse used to build the PyTensor graph.\n",
+    "\n",
+    "This is why NumPy functions are appropriate for the first two roles, while\n",
+    "the backend inverse should be written with PyTensor operations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecfG",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>argument</th><th>direction</th><th>execution</th></tr></thead><tbody><tr><th>0</th><td>link=np.log</td><td>parameter -&gt; predictor</td><td>numerical, outside the PyMC graph</td></tr><tr><th>1</th><td>linkinv=np.exp</td><td>predictor -&gt; parameter</td><td>numerical prediction and utilities</td></tr><tr><th>2</th><td>linkinv_backend=pt.exp</td><td>predictor -&gt; parameter</td><td>symbolic, inside the PyMC graph</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "custom_log_link = hssm.Link(\n",
+    "    \"custom_log\",\n",
+    "    link=np.log,\n",
+    "    linkinv=np.exp,\n",
+    "    linkinv_backend=pt.exp,\n",
+    ")\n",
+    "_response_values = np.array([0.5, 1.0, 2.0])\n",
+    "_predictor_values = custom_log_link.link(_response_values)\n",
+    "assert np.allclose(custom_log_link.linkinv(_predictor_values), _response_values)\n",
+    "_symbolic_eta = pt.scalar(\"tutorial_eta\")\n",
+    "_symbolic_parameter = custom_log_link.linkinv_backend(_symbolic_eta)\n",
+    "assert _symbolic_parameter.owner is not None\n",
+    "\n",
+    "_custom_base_kwargs = {\n",
+    "    _key: _value for _key, _value in model_kwargs.items() if _key != \"include\"\n",
+    "}\n",
+    "custom_link_model = build_silent_model(\n",
+    "    **_custom_base_kwargs,\n",
+    "    include=[\n",
+    "        {\n",
+    "            \"name\": \"a\",\n",
+    "            \"formula\": \"a ~ 1 + x\",\n",
+    "            \"link\": custom_log_link,\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "assert custom_link_model.params[\"a\"].link is custom_log_link\n",
+    "assert custom_link_model.model.family.link[\"a\"] is custom_log_link\n",
+    "\n",
+    "custom_link_roles = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"argument\": \"link=np.log\",\n",
+    "            \"direction\": \"parameter -> predictor\",\n",
+    "            \"execution\": \"numerical, outside the PyMC graph\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"argument\": \"linkinv=np.exp\",\n",
+    "            \"direction\": \"predictor -> parameter\",\n",
+    "            \"execution\": \"numerical prediction and utilities\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"argument\": \"linkinv_backend=pt.exp\",\n",
+    "            \"direction\": \"predictor -> parameter\",\n",
+    "            \"execution\": \"symbolic, inside the PyMC graph\",\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "custom_link_roles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Pvdt",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "HSSM's `gen_logit` is the special built-in used for arbitrary finite bounds.\n",
+    "For example, `hssm.Link(\"gen_logit\", bounds=(0.2, 0.8))` maps every real\n",
+    "predictor into `(0.2, 0.8)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZBYS",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table border=\"1\" class=\"dataframe\"><thead><tr style=\"text-align: right;\"><th></th><th>parameter support</th><th>usual choice</th><th>eta=0 means</th><th>main tradeoff</th></tr></thead><tbody><tr><th>0</th><td>unbounded</td><td>identity</td><td>parameter=0</td><td>direct interpretation; no support transform</td></tr><tr><th>1</th><td>positive</td><td>log</td><td>parameter=1</td><td>valid positivity; multiplicative parameter effects</td></tr><tr><th>2</th><td>finite (lower, upper)</td><td>gen_logit</td><td>parameter at midpoint</td><td>valid bounds; nonlinear parameter effects</td></tr></tbody></table>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "link_choice_guide = pd.DataFrame(\n",
+    "    [\n",
+    "        {\n",
+    "            \"parameter support\": \"unbounded\",\n",
+    "            \"usual choice\": \"identity\",\n",
+    "            \"eta=0 means\": \"parameter=0\",\n",
+    "            \"main tradeoff\": \"direct interpretation; no support transform\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"parameter support\": \"positive\",\n",
+    "            \"usual choice\": \"log\",\n",
+    "            \"eta=0 means\": \"parameter=1\",\n",
+    "            \"main tradeoff\": \"valid positivity; multiplicative parameter effects\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"parameter support\": \"finite (lower, upper)\",\n",
+    "            \"usual choice\": \"gen_logit\",\n",
+    "            \"eta=0 means\": \"parameter at midpoint\",\n",
+    "            \"main tradeoff\": \"valid bounds; nonlinear parameter effects\",\n",
+    "        },\n",
+    "    ]\n",
+    ")\n",
+    "link_choice_guide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aLJB",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "## 5. A practical workflow\n",
+    "\n",
+    "1. **Start from support.** Ask whether the parameter is unbounded, positive,\n",
+    "   or bounded on both sides.\n",
+    "2. **Choose an interpretation.** Identity coefficients are additive on the\n",
+    "   parameter scale; transformed coefficients are additive on `eta` and\n",
+    "   nonlinear on the parameter scale.\n",
+    "3. **Inspect the resolved model.** `model.params[\"a\"].link` and\n",
+    "   `model.params[\"a\"].prior` show what HSSM actually built.\n",
+    "4. **Remember the prior scale.** A coefficient prior under a transformed\n",
+    "   link is not a prior directly on the DDM parameter.\n",
+    "5. **Use prior predictive checks.** They reveal the parameter-scale behavior\n",
+    "   implied jointly by the coefficients and inverse link.\n",
+    "\n",
+    "An individual override looks like:\n",
+    "\n",
+    "```python\n",
+    "model = hssm.HSSM(\n",
+    "    data,\n",
+    "    include=[{\"name\": \"a\", \"formula\": \"a ~ 1 + x\", \"link\": \"log\"}],\n",
+    "    prior_settings=\"safe\",\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Or use `link_settings=\"log_logit\"` to apply the support-aware preset to all\n",
+    "regression parameters at once."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nHfw",
+   "metadata": {
+    "marimo": {
+     "md_prefix": ""
+    }
+   },
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "A link is not merely a numerical guardrail. It determines what regression\n",
+    "coefficients mean, where priors live, and how an unconstrained predictor is\n",
+    "translated into a valid SSM parameter. HSSM therefore treats every semantic\n",
+    "spelling of identity alike, uses response-scale safe intercept priors for\n",
+    "identity, and uses coefficient-scale priors for transformed links.\n",
+    "\n",
+    "Continue with:\n",
+    "\n",
+    "- the [`hssm.Link` API](https://lnccbrown.github.io/HSSM/api/link/) for supported and custom links;\n",
+    "- [Specify priors and fix parameters](https://lnccbrown.github.io/HSSM/how_to/specify_priors/) for\n",
+    "  explicit prior control;\n",
+    "- [Set initial values](https://lnccbrown.github.io/HSSM/tutorials/initial_values/) for links and initialization;\n",
+    "- [Random-slope prior diagnostics](https://lnccbrown.github.io/HSSM/tutorials/random_slope_safe_priors/) for\n",
+    "  common and group-specific regression terms; and\n",
+    "- [#1225](https://github.com/lnccbrown/HSSM/issues/1225) for the intentionally\n",
+    "  separate policy question around unmatched group-only terms."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  },
+  "marimo": {
+   "app_config": {
+    "width": "medium"
+   },
+   "header": "# /// script\n# requires-python = \">=3.12,<3.15\"\n# dependencies = [\n#     \"bambi==0.20.0\",\n#     \"hssm @ git+https://github.com/lnccbrown/HSSM.git@11752a02b2f7150d911b644d74b3912abd0bbea3\",\n#     \"marimo==0.24.0\",\n#     \"matplotlib==3.11.1\",\n#     \"numpy==2.4.6\",\n#     \"pandas==3.0.5\",\n#     \"pymc==6.3.1\",\n# ]\n# ///\n\n\"\"\"Explain link functions, their HSSM role, and link-aware safe priors.\n\nThis construction-only marimo tutorial introduces link functions from first\nprinciples, compares HSSM's identity and ``log_logit`` settings, and verifies\nthe link-aware safe-prior behavior corrected in HSSM #1232. No sampling is\nrequired.\n\nRun the pinned standalone environment locally or in Molab::\n\n    uvx marimo edit --sandbox docs/tutorials/link_functions.py\n\nTo exercise an active HSSM checkout instead, ignore the inline environment::\n\n    uv run --group notebook --group docs marimo edit --no-sandbox \\\n        docs/tutorials/link_functions.py\n    uv run --group notebook --group docs marimo check --strict \\\n        docs/tutorials/link_functions.py\n    uv run --group notebook --group docs marimo export html --no-sandbox \\\n        docs/tutorials/link_functions.py \\\n        --output /tmp/link-functions.html --force\n    uv run --group notebook --group docs marimo export ipynb --no-sandbox \\\n        docs/tutorials/link_functions.py \\\n        --output docs/tutorials/link_functions.ipynb \\\n        --include-outputs --force\n    uv run ruff format docs/tutorials/link_functions.ipynb\n\"\"\"\n\n# ruff: noqa: B018, D401, E501, PLR1711  (generated marimo notebook: prose, cell display expressions, and bare returns)\n",
+   "marimo_version": "0.24.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/link_functions.py
+++ b/docs/tutorials/link_functions.py
@@ -1,0 +1,743 @@
+# /// script
+# requires-python = ">=3.12,<3.15"
+# dependencies = [
+#     "bambi==0.20.0",
+#     "hssm @ git+https://github.com/lnccbrown/HSSM.git@11752a02b2f7150d911b644d74b3912abd0bbea3",
+#     "marimo==0.24.0",
+#     "matplotlib==3.11.1",
+#     "numpy==2.4.6",
+#     "pandas==3.0.5",
+#     "pymc==6.3.1",
+# ]
+# ///
+
+"""Explain link functions, their HSSM role, and link-aware safe priors.
+
+This construction-only marimo tutorial introduces link functions from first
+principles, compares HSSM's identity and ``log_logit`` settings, and verifies
+the link-aware safe-prior behavior corrected in HSSM #1232. No sampling is
+required.
+
+Run the pinned standalone environment locally or in Molab::
+
+    uvx marimo edit --sandbox docs/tutorials/link_functions.py
+
+To exercise an active HSSM checkout instead, ignore the inline environment::
+
+    uv run --group notebook --group docs marimo edit --no-sandbox \
+        docs/tutorials/link_functions.py
+    uv run --group notebook --group docs marimo check --strict \
+        docs/tutorials/link_functions.py
+    uv run --group notebook --group docs marimo export html --no-sandbox \
+        docs/tutorials/link_functions.py \
+        --output /tmp/link-functions.html --force
+    uv run --group notebook --group docs marimo export ipynb --no-sandbox \
+        docs/tutorials/link_functions.py \
+        --output docs/tutorials/link_functions.ipynb \
+        --include-outputs --force
+    uv run ruff format docs/tutorials/link_functions.ipynb
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711  (generated marimo notebook: prose, cell display expressions, and bare returns)
+import marimo
+
+__generated_with = "0.24.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import logging
+    import os
+    import warnings
+    from contextlib import redirect_stderr, redirect_stdout
+    from io import BytesIO, StringIO
+    from tempfile import gettempdir
+
+    # This notebook does not use GPU computation. Molab can expose an unusable
+    # CUDA plugin, so keep JAX on CPU before importing the HSSM stack.
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    os.environ["JAX_SKIP_CUDA_CONSTRAINTS_CHECK"] = "1"
+    os.environ.setdefault("MPLCONFIGDIR", f"{gettempdir()}/hssm-link-matplotlib")
+
+    warnings.filterwarnings("ignore")
+    logging.getLogger("jax._src.xla_bridge").setLevel(logging.CRITICAL)
+    logging.getLogger("matplotlib").setLevel(logging.ERROR)
+
+    import bambi as bmb
+    import marimo as mo
+    import numpy as np
+    import pandas as pd
+    import pytensor.tensor as pt
+
+    with redirect_stderr(StringIO()):
+        import matplotlib.pyplot as plt
+
+    import hssm
+
+    logging.getLogger("hssm").setLevel(logging.ERROR)
+    hssm.set_floatX("float64")
+    pd.set_option("display.max_colwidth", 80)
+    return BytesIO, StringIO, bmb, hssm, mo, np, pd, plt, pt, redirect_stdout
+
+
+@app.cell
+def _(bmb, hssm, mo):
+    mo.md(f"""
+    # Understanding link functions in HSSM
+
+    A link function is the bridge between an ordinary regression and a model
+    parameter that may be positive, bounded, or otherwise constrained. This
+    tutorial starts from that idea and then shows how links determine the scale
+    on which HSSM interprets regression coefficients and chooses safe priors.
+
+    The examples use **HSSM {hssm.__version__}** and **Bambi {bmb.__version__}**.
+    They only construct models and inspect their structure; no MCMC is needed.
+
+    By the end, you should be able to answer three questions:
+
+    1. What does a link do to a linear predictor?
+    2. When should an HSSM parameter use identity, log, or generalized logit?
+    3. Why do HSSM's safe intercept priors depend on the effective link?
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(r"""
+    ## 1. A regression produces an unconstrained linear predictor
+
+    For a predictor `x`, a simple regression first constructs
+
+    \[
+    \eta_i = \beta_0 + \beta_1 x_i.
+    \]
+
+    The number \(\eta_i\) can be anywhere on the real line. That is fine for an
+    unbounded parameter such as drift rate \(v\), but it can be invalid for a
+    boundary separation \(a>0\) or a starting-point fraction \(0<z<1\).
+
+    A link \(g\) connects the parameter scale to the predictor scale. HSSM uses
+    the inverse link when building the model:
+
+    \[
+    \theta_i = g^{-1}(\eta_i).
+    \]
+
+    The regression coefficients live on the **linear-predictor scale**. The
+    inverse link turns their result into a valid value on the **parameter scale**.
+    """)
+    return
+
+
+@app.cell
+def _(pd):
+    parameter_support_table = pd.DataFrame(
+        [
+            {
+                "DDM parameter": "v (drift rate)",
+                "support": "(-inf, inf)",
+                "support-respecting link": "identity",
+                "inverse link": "v = eta",
+            },
+            {
+                "DDM parameter": "a (boundary separation)",
+                "support": "(0, inf)",
+                "support-respecting link": "log",
+                "inverse link": "a = exp(eta)",
+            },
+            {
+                "DDM parameter": "z (starting-point fraction)",
+                "support": "(0, 1)",
+                "support-respecting link": "generalized logit",
+                "inverse link": "z = 1 / (1 + exp(-eta))",
+            },
+        ]
+    )
+    parameter_support_table
+    return (parameter_support_table,)
+
+
+@app.cell
+def _(BytesIO, mo, np, plt):
+    eta_grid = np.linspace(-3.0, 3.0, 301)
+    link_curves_figure, _axes = plt.subplots(1, 3, figsize=(11, 3.4))
+    _curves = [
+        ("Identity: unbounded", eta_grid, (-3.2, 3.2), "parameter = eta"),
+        ("Log: positive", np.exp(eta_grid), (0.0, 20.5), "parameter = exp(eta)"),
+        (
+            "Generalized logit: (0, 1)",
+            1.0 / (1.0 + np.exp(-eta_grid)),
+            (-0.03, 1.03),
+            "parameter = sigmoid(eta)",
+        ),
+    ]
+    for _axis, (_title, _values, _limits, _label) in zip(_axes, _curves, strict=True):
+        _axis.plot(eta_grid, _values, color="#3366cc", linewidth=2.5)
+        _axis.axvline(0.0, color="0.65", linestyle="--", linewidth=1)
+        _axis.scatter([0.0], [_values[len(_values) // 2]], color="#cc5533", zorder=3)
+        _axis.set_title(_title)
+        _axis.set_xlabel("linear predictor eta")
+        _axis.set_ylabel(_label)
+        _axis.set_ylim(*_limits)
+        _axis.grid(alpha=0.2)
+    link_curves_figure.tight_layout()
+    _plot_buffer = BytesIO()
+    link_curves_figure.savefig(_plot_buffer, format="png", dpi=140, bbox_inches="tight")
+    link_curves_image = mo.image(
+        _plot_buffer.getvalue(),
+        alt="Identity, log, and generalized-logit inverse-link curves",
+    )
+    link_curves_image
+    return eta_grid, link_curves_figure, link_curves_image
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    The three panels use the same horizontal predictor scale but different
+    parameter scales:
+
+    - **Identity** leaves the predictor unchanged and does not impose a bound.
+    - **Log** maps every real predictor to a positive value.
+    - **Generalized logit** maps every real predictor into finite lower and upper
+      bounds. For `(0, 1)`, it is the familiar logistic sigmoid.
+
+    Notice the red points at `eta = 0`: identity maps zero to `0`, log maps it to
+    `1`, and generalized logit maps it to the midpoint `0.5`. This fact matters
+    when interpreting intercept priors.
+    """)
+    return
+
+
+@app.cell
+def _(np, pd):
+    example_x = np.array([-1.0, 0.0, 1.0])
+    example_eta = 0.2 + 0.5 * example_x
+    coefficient_example_table = pd.DataFrame(
+        {
+            "x": example_x,
+            "eta = 0.2 + 0.5*x": example_eta,
+            "identity parameter": example_eta,
+            "positive parameter (log link)": np.exp(example_eta),
+            "bounded parameter (0, 1)": 1.0 / (1.0 + np.exp(-example_eta)),
+        }
+    ).round(3)
+    coefficient_example_table
+    return coefficient_example_table, example_eta, example_x
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    The coefficients in the table are identical in every column. What changes is
+    their parameter-scale meaning. The inverse link transforms the **complete**
+    predictor `0.2 + 0.5*x`; it does not transform the intercept and slope
+    separately. With a non-identity link, a one-unit change in `x` is additive on
+    `eta`, not on the final DDM parameter.
+    """)
+    return
+
+
+@app.cell
+def _(np, pd):
+    eta_landmarks = np.array([-2.0, 0.0, 2.0])
+    landmark_table = pd.DataFrame(
+        {
+            "eta": eta_landmarks,
+            "identity": eta_landmarks,
+            "log": np.exp(eta_landmarks),
+            "generalized logit (0, 1)": 1.0 / (1.0 + np.exp(-eta_landmarks)),
+        }
+    ).round(3)
+    landmark_table
+    return eta_landmarks, landmark_table
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    These three landmarks make the scale change concrete. In the
+    [Molab notebook](https://molab.marimo.io/github/lnccbrown/HSSM/blob/main/docs/tutorials/link_functions.py),
+    edit `eta_landmarks` and rerun the cell to explore other values.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2. Where the link sits in an HSSM regression
+
+    In an HSSM formula such as `a ~ 1 + x`, Bambi constructs the intercept and
+    slope, combines them into `eta`, and the model family applies the inverse
+    link before passing trial-wise `a` values to the likelihood.
+
+    HSSM exposes two model-level choices for regression parameters:
+
+    - `link_settings=None` (the default) uses identity unless a parameter says
+      otherwise;
+    - `link_settings="log_logit"` keeps unbounded parameters on identity, uses
+      log for positive parameters, and uses HSSM's generalized logit for
+      parameters with finite lower and upper bounds.
+
+    You can override the link for an individual regression by adding `"link"`
+    to that parameter's `include` specification.
+    """)
+    return
+
+
+@app.cell
+def _(StringIO, hssm, np, pd, redirect_stdout):
+    tutorial_data = pd.DataFrame(
+        {
+            "rt": 0.42 + 0.015 * np.arange(12),
+            "response": np.where(np.arange(12) % 2, 1, -1),
+            "x": np.linspace(-1.0, 1.0, 12),
+        }
+    )
+    regression_specs = [
+        {"name": _parameter, "formula": f"{_parameter} ~ 1 + x"}
+        for _parameter in ("v", "a", "z", "t")
+    ]
+    model_kwargs = {
+        "data": tutorial_data,
+        "model": "ddm",
+        "loglik_kind": "analytical",
+        "include": regression_specs,
+        "p_outlier": 0.0,
+        "prior_settings": "safe",
+        "process_initvals": False,
+        "initval_jitter": 0.0,
+    }
+
+    def build_silent_model(**kwargs):
+        """Construct an HSSM model without its initialization status message."""
+        with redirect_stdout(StringIO()):
+            return hssm.HSSM(**kwargs)
+
+    tutorial_data.head()
+    return build_silent_model, model_kwargs, regression_specs, tutorial_data
+
+
+@app.cell
+def _(build_silent_model, model_kwargs):
+    identity_model = build_silent_model(**model_kwargs, link_settings=None)
+    transformed_model = build_silent_model(**model_kwargs, link_settings="log_logit")
+    return identity_model, transformed_model
+
+
+@app.cell
+def _(bmb, identity_model, np, pd, transformed_model):
+    def link_name(link):
+        """Return a consistent display name for string and object links."""
+        return link if isinstance(link, str) else link.name
+
+    def inverse_link_value(link, eta):
+        """Map one predictor value back to its parameter scale."""
+        _link = bmb.Link(link) if isinstance(link, str) else link
+        return float(np.asarray(_link.linkinv(eta)))
+
+    model_link_table = pd.DataFrame(
+        [
+            {
+                "parameter": _parameter,
+                "support": str(identity_model.params[_parameter].bounds),
+                "default link": link_name(identity_model.params[_parameter].link),
+                "log_logit preset": link_name(
+                    transformed_model.params[_parameter].link
+                ),
+                "preset maps eta=0 to": inverse_link_value(
+                    transformed_model.params[_parameter].link, 0.0
+                ),
+            }
+            for _parameter in ("v", "a", "z", "t")
+        ]
+    )
+    assert model_link_table.set_index("parameter")["log_logit preset"].to_dict() == {
+        "v": "identity",
+        "a": "log",
+        "z": "gen_logit",
+        "t": "log",
+    }
+    model_link_table
+    return inverse_link_value, link_name, model_link_table
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    For this analytical DDM, the preset follows support rather than parameter names: an unbounded
+    parameter remains on identity, a lower-bounded positive parameter uses log,
+    and a parameter with two finite bounds uses generalized logit.
+
+    The configured likelihood supplies those bounds. A likelihood with finite
+    training bounds can therefore resolve a parameter differently—for example,
+    a finitely bounded neural `v` can receive generalized logit. The preset uses
+    log only for the exact `(0, inf)` shape; unusual one-sided bounds are left on
+    identity with a warning. Fixed or otherwise non-regression parameters do not
+    have a linear predictor and are not assigned links by this preset.
+
+    With HSSM's identity default, coefficients keep a direct response-scale
+    interpretation and safe intercepts can retain HDDM-derived priors. The
+    `log_logit` preset is an explicit alternative that often gives hierarchical
+    regressions an unconstrained coefficient space. Neither spelling is
+    universally preferable; the link is part of the scientific model.
+    """)
+    return
+
+
+@app.cell
+def _(identity_model, pd, transformed_model):
+    def format_prior(prior):
+        """Format a Bambi prior compactly for a comparison table."""
+        return str(prior)
+
+    prior_scale_table = pd.DataFrame(
+        [
+            {
+                "parameter": _parameter,
+                "identity intercept prior": format_prior(
+                    identity_model.params[_parameter].prior["Intercept"]
+                ),
+                "log_logit link": (
+                    transformed_model.params[_parameter].link
+                    if isinstance(transformed_model.params[_parameter].link, str)
+                    else transformed_model.params[_parameter].link.name
+                ),
+                "log_logit intercept prior": format_prior(
+                    transformed_model.params[_parameter].prior["Intercept"]
+                ),
+                "slope prior in both models": format_prior(
+                    transformed_model.params[_parameter].prior["x"]
+                ),
+            }
+            for _parameter in ("v", "a", "z", "t")
+        ]
+    )
+
+    assert identity_model.params["a"].prior["Intercept"].name == "Gamma"
+    assert identity_model.params["z"].prior["Intercept"].name == "Beta"
+    assert transformed_model.params["a"].prior["Intercept"].name == "Normal"
+    assert transformed_model.params["z"].prior["Intercept"].name == "Normal"
+    assert all(
+        format_prior(identity_model.params[_parameter].prior["x"])
+        == format_prior(transformed_model.params[_parameter].prior["x"])
+        for _parameter in ("v", "a", "z", "t")
+    )
+    prior_scale_table
+    return format_prior, prior_scale_table
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 3. The link determines the scale of a safe intercept prior
+
+    This is the core logic behind HSSM's generated `prior_settings="safe"`
+    defaults:
+
+    - With an **identity link**, the intercept is itself a value of the DDM
+      parameter. HSSM can therefore use its response-scale HDDM prior, such as a
+      positive `Gamma` for `a` or a `(0, 1)` `Beta` for `z` in the analytical
+      DDM used here.
+    - With a **transformed link**, the intercept is an unconstrained coefficient
+      inside `eta`. HSSM uses `Normal(0, 0.25)` on that coefficient scale. The
+      inverse link then maps it into valid parameter values.
+    - Ordinary slopes are coefficients on `eta` in either case, so their safe
+      default remains `Normal(0, 0.25)`.
+    - An explicitly supplied prior always takes precedence over a generated
+      safe prior.
+
+    The HDDM-derived response-scale intercepts shown here apply to analytical
+    and black-box `ddm`, `ddm_sdv`, and `full_ddm` regressions. Neural
+    `approx_differentiable` likelihoods use generic safe priors informed by their
+    configured training bounds. Setting `prior_settings=None` does not remove
+    priors; it delegates missing regression-term priors to Bambi, while simple
+    HSSM parameters retain their configured defaults.
+
+    For example, `a_Intercept = 0` under a log link means `a = exp(0) = 1`.
+    It would be a mistake to truncate that coefficient at `a`'s response-scale
+    lower bound: the transform already enforces positivity.
+
+    Conversely, an identity-link prior that keeps the **intercept** inside a
+    parameter's bounds cannot guarantee that every trial-wise value remains
+    valid once slopes or group effects are added. A support-respecting link is
+    the structural way to enforce support on the full predictor.
+    """)
+    return
+
+
+@app.cell
+def _(bmb, build_silent_model, format_prior, hssm, model_kwargs, pd):
+    identity_link_specs = [
+        ("link omitted", None),
+        ('link="identity"', "identity"),
+        ('bambi.Link("identity")', bmb.Link("identity")),
+        ('hssm.Link("identity")', hssm.Link("identity")),
+    ]
+    _base_kwargs = {
+        _key: _value for _key, _value in model_kwargs.items() if _key != "include"
+    }
+    _identity_rows = []
+    for _label, _link in identity_link_specs:
+        _a_spec = {"name": "a", "formula": "a ~ 1 + x"}
+        if _link is not None:
+            _a_spec["link"] = _link
+        _model = build_silent_model(**_base_kwargs, include=[_a_spec])
+        _identity_rows.append(
+            {
+                "user spelling": _label,
+                "effective link": (
+                    _model.params["a"].link
+                    if isinstance(_model.params["a"].link, str)
+                    else _model.params["a"].link.name
+                ),
+                "safe a intercept prior": format_prior(
+                    _model.params["a"].prior["Intercept"]
+                ),
+            }
+        )
+
+    identity_equivalence_table = pd.DataFrame(_identity_rows)
+    assert identity_equivalence_table["effective link"].eq("identity").all()
+    assert identity_equivalence_table["safe a intercept prior"].nunique() == 1
+    identity_equivalence_table
+    return identity_equivalence_table, identity_link_specs
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    The four rows are semantically the same model and now receive the same safe
+    response-scale prior. HSSM decides from the **effective link**, not from
+    whether the user happened to omit a value or wrap it in a Link object. This
+    equivalence is the behavior corrected by
+    [#1232](https://github.com/lnccbrown/HSSM/issues/1232).
+    """)
+    return
+
+
+@app.cell
+def _(bmb, build_silent_model, format_prior, model_kwargs, pd):
+    explicit_intercept_prior = bmb.Prior("StudentT", nu=4.0, mu=1.2, sigma=0.4)
+    _explicit_base_kwargs = {
+        _key: _value for _key, _value in model_kwargs.items() if _key != "include"
+    }
+    explicit_prior_model = build_silent_model(
+        **_explicit_base_kwargs,
+        include=[
+            {
+                "name": "a",
+                "formula": "a ~ 1 + x",
+                "prior": {"Intercept": explicit_intercept_prior},
+            }
+        ],
+    )
+    assert (
+        explicit_prior_model.params["a"].prior["Intercept"] is explicit_intercept_prior
+    )
+    explicit_prior_table = pd.DataFrame(
+        [
+            {
+                "term": "Intercept",
+                "source": "explicit user prior",
+                "resolved prior": format_prior(
+                    explicit_prior_model.params["a"].prior["Intercept"]
+                ),
+            },
+            {
+                "term": "x",
+                "source": "missing term filled by safe settings",
+                "resolved prior": format_prior(
+                    explicit_prior_model.params["a"].prior["x"]
+                ),
+            },
+        ]
+    )
+    explicit_prior_table
+    return explicit_intercept_prior, explicit_prior_model, explicit_prior_table
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    `prior_settings="safe"` fills gaps; it does not rewrite the explicit
+    `StudentT` intercept. Here it supplies only the missing slope prior.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 4. Built-in links versus custom links
+
+    For built-in names such as `"identity"`, `"log"`, and `"logit"`, Bambi
+    already knows all required numerical and symbolic functions. A custom link
+    needs three related callables:
+
+    1. `link`: numerical parameter-to-predictor mapping;
+    2. `linkinv`: numerical predictor-to-parameter mapping, used outside the
+       PyMC graph for operations such as prediction; and
+    3. `linkinv_backend`: the symbolic inverse used to build the PyTensor graph.
+
+    This is why NumPy functions are appropriate for the first two roles, while
+    the backend inverse should be written with PyTensor operations.
+    """)
+    return
+
+
+@app.cell
+def _(build_silent_model, hssm, model_kwargs, np, pd, pt):
+    custom_log_link = hssm.Link(
+        "custom_log",
+        link=np.log,
+        linkinv=np.exp,
+        linkinv_backend=pt.exp,
+    )
+    _response_values = np.array([0.5, 1.0, 2.0])
+    _predictor_values = custom_log_link.link(_response_values)
+    assert np.allclose(custom_log_link.linkinv(_predictor_values), _response_values)
+    _symbolic_eta = pt.scalar("tutorial_eta")
+    _symbolic_parameter = custom_log_link.linkinv_backend(_symbolic_eta)
+    assert _symbolic_parameter.owner is not None
+
+    _custom_base_kwargs = {
+        _key: _value for _key, _value in model_kwargs.items() if _key != "include"
+    }
+    custom_link_model = build_silent_model(
+        **_custom_base_kwargs,
+        include=[
+            {
+                "name": "a",
+                "formula": "a ~ 1 + x",
+                "link": custom_log_link,
+            }
+        ],
+    )
+    assert custom_link_model.params["a"].link is custom_log_link
+    assert custom_link_model.model.family.link["a"] is custom_log_link
+
+    custom_link_roles = pd.DataFrame(
+        [
+            {
+                "argument": "link=np.log",
+                "direction": "parameter -> predictor",
+                "execution": "numerical, outside the PyMC graph",
+            },
+            {
+                "argument": "linkinv=np.exp",
+                "direction": "predictor -> parameter",
+                "execution": "numerical prediction and utilities",
+            },
+            {
+                "argument": "linkinv_backend=pt.exp",
+                "direction": "predictor -> parameter",
+                "execution": "symbolic, inside the PyMC graph",
+            },
+        ]
+    )
+    custom_link_roles
+    return custom_link_model, custom_link_roles, custom_log_link
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    HSSM's `gen_logit` is the special built-in used for arbitrary finite bounds.
+    For example, `hssm.Link("gen_logit", bounds=(0.2, 0.8))` maps every real
+    predictor into `(0.2, 0.8)`.
+    """)
+    return
+
+
+@app.cell
+def _(pd):
+    link_choice_guide = pd.DataFrame(
+        [
+            {
+                "parameter support": "unbounded",
+                "usual choice": "identity",
+                "eta=0 means": "parameter=0",
+                "main tradeoff": "direct interpretation; no support transform",
+            },
+            {
+                "parameter support": "positive",
+                "usual choice": "log",
+                "eta=0 means": "parameter=1",
+                "main tradeoff": "valid positivity; multiplicative parameter effects",
+            },
+            {
+                "parameter support": "finite (lower, upper)",
+                "usual choice": "gen_logit",
+                "eta=0 means": "parameter at midpoint",
+                "main tradeoff": "valid bounds; nonlinear parameter effects",
+            },
+        ]
+    )
+    link_choice_guide
+    return (link_choice_guide,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 5. A practical workflow
+
+    1. **Start from support.** Ask whether the parameter is unbounded, positive,
+       or bounded on both sides.
+    2. **Choose an interpretation.** Identity coefficients are additive on the
+       parameter scale; transformed coefficients are additive on `eta` and
+       nonlinear on the parameter scale.
+    3. **Inspect the resolved model.** `model.params["a"].link` and
+       `model.params["a"].prior` show what HSSM actually built.
+    4. **Remember the prior scale.** A coefficient prior under a transformed
+       link is not a prior directly on the DDM parameter.
+    5. **Use prior predictive checks.** They reveal the parameter-scale behavior
+       implied jointly by the coefficients and inverse link.
+
+    An individual override looks like:
+
+    ```python
+    model = hssm.HSSM(
+        data,
+        include=[{"name": "a", "formula": "a ~ 1 + x", "link": "log"}],
+        prior_settings="safe",
+    )
+    ```
+
+    Or use `link_settings="log_logit"` to apply the support-aware preset to all
+    regression parameters at once.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## Takeaway
+
+    A link is not merely a numerical guardrail. It determines what regression
+    coefficients mean, where priors live, and how an unconstrained predictor is
+    translated into a valid SSM parameter. HSSM therefore treats every semantic
+    spelling of identity alike, uses response-scale safe intercept priors for
+    identity, and uses coefficient-scale priors for transformed links.
+
+    Continue with:
+
+    - the [`hssm.Link` API](https://lnccbrown.github.io/HSSM/api/link/) for supported and custom links;
+    - [Specify priors and fix parameters](https://lnccbrown.github.io/HSSM/how_to/specify_priors/) for
+      explicit prior control;
+    - [Set initial values](https://lnccbrown.github.io/HSSM/tutorials/initial_values/) for links and initialization;
+    - [Random-slope prior diagnostics](https://lnccbrown.github.io/HSSM/tutorials/random_slope_safe_priors/) for
+      common and group-specific regression terms; and
+    - [#1225](https://github.com/lnccbrown/HSSM/issues/1225) for the intentionally
+      separate policy question around unmatched group-only terms.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ validation:
 # phase-2 consolidation targets, deliberately unlisted until then
 not_in_nav: |
   tutorials/attentional_ddm.py
+  tutorials/link_functions.py
   tutorials/random_slope_safe_priors.py
 
 nav:
@@ -77,6 +78,7 @@ nav:
   - Explanations:
       - Coming from HDDM: explanations/coming_from_hddm.md
       - Understanding likelihoods in HSSM: tutorials/likelihoods.ipynb
+      - Link functions and safe priors: tutorials/link_functions.ipynb
       - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
       - Random-slope prior diagnostics: tutorials/random_slope_safe_priors.ipynb
       - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
@@ -116,6 +118,7 @@ plugins:
         tutorials/variational_inference_hierarchical.md: https://lnccbrown.github.io/HSSM/tutorials/variational_inference/
   - mkdocs-jupyter:
       ignore:
+        - tutorials/link_functions.py
         - tutorials/random_slope_safe_priors.py
       execute: true
       execute_ignore:
@@ -126,6 +129,7 @@ plugins:
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
         - tutorials/attentional_ddm.py
+        - tutorials/link_functions.ipynb
         - tutorials/random_slope_safe_priors.ipynb
         - tutorials/hsgp_regression.ipynb
         - tutorials/ddm_hierarchical_tutorial.ipynb

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -234,6 +234,19 @@ def generate_prior(
     return prior
 
 
+def _is_identity_link(link: str | bmb.Link | None) -> bool:
+    """Return whether a link leaves coefficients on the response scale.
+
+    A missing link is semantically identity because ``RegressionParam.validate``
+    normalizes it to ``"identity"`` after safe-prior generation.
+    """
+    if link is None:
+        return True
+    if isinstance(link, str):
+        return link == "identity"
+    return link.name == "identity"
+
+
 # AF-TODO: Docstring could benefit from some more details here.
 def get_default_prior(
     term_type: str,

--- a/src/hssm/prior.py
+++ b/src/hssm/prior.py
@@ -287,10 +287,10 @@ def get_default_prior(
     if term_type == "common":
         prior = generate_prior("Normal", bounds=None)
     elif term_type == "common_intercept":
-        # We ignore bounds if link is used, since boundaries loose their meaning.
+        # Bounds are response-scale constraints, so they only apply under identity.
         # TODO: This is a temporary solution, this can prob benefit form a bit of a
         # refactoring, to define settings in a more general way.
-        if (link is not None) or (bounds is None):
+        if not _is_identity_link(link) or bounds is None:
             prior = generate_prior("Normal")
         elif bounds is not None:
             if any(np.isinf(b) for b in bounds):
@@ -323,7 +323,7 @@ def get_hddm_default_prior(
     elif term_type == "common_intercept":
         # TODO: This is a temporary solution, this can prob benefit form a bit of a
         # refactoring, to define settings in a more general way.
-        if link is not None:
+        if not _is_identity_link(link):
             prior = generate_prior("Normal")
         else:
             prior = generate_prior(HDDM_MU[param], bounds=bounds)

--- a/tests/unit/param/test_identity_safe_prior_graph.py
+++ b/tests/unit/param/test_identity_safe_prior_graph.py
@@ -1,0 +1,62 @@
+"""PyMC graph regression for identity-link common-intercept safe priors."""
+
+import bambi as bmb
+import pymc as pm
+import pytensor.tensor as pt
+from pytensor.graph.basic import equal_computations
+
+import hssm
+
+
+def _build_a_regression(data, link=...):
+    """Build a small analytical DDM without sampling or initial-point processing."""
+    parameter = {"name": "a", "formula": "a ~ 1 + theta"}
+    if link is not ...:
+        parameter["link"] = link
+
+    return hssm.HSSM(
+        data=data.head(8),
+        model="ddm",
+        include=[parameter],
+        prior_settings="safe",
+        v=0.5,
+        z=0.5,
+        t=0.2,
+        p_outlier=0.0,
+        process_initvals=False,
+        initval_jitter=0,
+    )
+
+
+def test_identity_link_spellings_build_equivalent_common_intercept_prior_graphs(
+    cavanagh_test,
+):
+    """Explicit identity links retain the omitted-link truncated Gamma graph."""
+    reference = _build_a_regression(cavanagh_test)
+    reference_prior = reference.params["a"].prior["Intercept"]
+    reference_rv = reference.pymc_model.named_vars["a_Intercept"]
+
+    assert reference_prior.name == "Gamma"
+    assert reference_prior.is_truncated
+    assert reference_prior.bounds == (0.0, float("inf"))
+
+    explicit_models = [
+        _build_a_regression(cavanagh_test, "identity"),
+        _build_a_regression(cavanagh_test, bmb.Link("identity")),
+        _build_a_regression(cavanagh_test, hssm.Link("identity")),
+    ]
+
+    for model in explicit_models:
+        candidate_prior = model.params["a"].prior["Intercept"]
+        candidate_rv = model.pymc_model.named_vars["a_Intercept"]
+        reference_value = pt.scalar("reference_value", dtype=reference_rv.dtype)
+        candidate_value = pt.scalar("candidate_value", dtype=candidate_rv.dtype)
+
+        assert candidate_prior == reference_prior
+        assert type(candidate_rv.owner.op) is type(reference_rv.owner.op)
+        assert equal_computations(
+            [pm.logp(reference_rv, reference_value)],
+            [pm.logp(candidate_rv, candidate_value)],
+            in_xs=[reference_value],
+            in_ys=[candidate_value],
+        )

--- a/tests/unit/param/test_regression_param.py
+++ b/tests/unit/param/test_regression_param.py
@@ -416,6 +416,168 @@ ddm_bounds = ddm_config["likelihoods"]["blackbox"]["bounds"].values()
 param_and_bounds_ddm = list(zip(ddm_params, ddm_bounds, [True] * len(ddm_params)))
 
 
+HDDM_LOCATION_PRIOR_CASES = [
+    pytest.param(
+        "v",
+        (-np.inf, np.inf),
+        "Normal",
+        {"mu": 2.0, "sigma": 3.0},
+        False,
+        id="v",
+    ),
+    pytest.param(
+        "a",
+        (0.0, np.inf),
+        "Gamma",
+        {"mu": 1.5, "sigma": 0.75},
+        True,
+        id="a",
+    ),
+    pytest.param(
+        "z",
+        (0.0, 1.0),
+        "Beta",
+        {"alpha": 10.0, "beta": 10.0},
+        True,
+        id="z",
+    ),
+    pytest.param(
+        "t",
+        (0.0, np.inf),
+        "Gamma",
+        {"mu": 0.2, "sigma": 0.2},
+        True,
+        id="t",
+    ),
+    pytest.param(
+        "sv",
+        (0.0, np.inf),
+        "HalfNormal",
+        {"sigma": 2.0},
+        True,
+        id="sv",
+    ),
+    pytest.param(
+        "sz",
+        (0.0, np.inf),
+        "HalfNormal",
+        {"sigma": 0.5},
+        True,
+        id="sz",
+    ),
+    pytest.param(
+        "st",
+        (0.0, np.inf),
+        "HalfNormal",
+        {"sigma": 0.3},
+        True,
+        id="st",
+    ),
+    pytest.param(
+        "p_outlier",
+        None,
+        "Beta",
+        {"alpha": 5.0, "beta": 100.0},
+        False,
+        id="p-outlier",
+    ),
+]
+
+IDENTITY_LINK_CASES = [
+    pytest.param(None, id="omitted"),
+    pytest.param("identity", id="string"),
+    pytest.param(bmb.Link("identity"), id="bambi-object"),
+    pytest.param(hssm.Link("identity"), id="hssm-object"),
+]
+
+
+def _assert_scalar_prior_contract(
+    prior,
+    *,
+    name,
+    args,
+    bounds,
+    is_truncated,
+):
+    """Assert the complete scalar prior contract, including hidden bound args."""
+    assert isinstance(prior, Prior)
+    assert prior.name == name
+    assert prior.bounds == bounds
+    assert prior.is_truncated is is_truncated
+    assert (prior.dist is not None) is is_truncated
+
+    effective_args = prior._args if prior.is_truncated else prior.args
+    assert set(effective_args) == set(args)
+    for key, expected in args.items():
+        np.testing.assert_allclose(effective_args[key], expected)
+
+
+@pytest.mark.parametrize("link", IDENTITY_LINK_CASES)
+@pytest.mark.parametrize(
+    ("param_name", "bounds", "prior_name", "prior_args", "is_truncated"),
+    HDDM_LOCATION_PRIOR_CASES,
+)
+def test_hddm_safe_common_intercept_uses_response_scale_prior_for_identity_links(
+    cavanagh_test,
+    param_name,
+    bounds,
+    prior_name,
+    prior_args,
+    is_truncated,
+    link,
+):
+    """Route every identity spelling through RegressionParam before validation."""
+    param = RegressionParam(
+        name=param_name,
+        formula=f"{param_name} ~ 1 + theta",
+        bounds=bounds,
+        link=link,
+    )
+
+    param.make_safe_priors(cavanagh_test, {}, is_ddm=True)
+    param.process_prior()
+
+    _assert_scalar_prior_contract(
+        param.prior["Intercept"],
+        name=prior_name,
+        args=prior_args,
+        bounds=bounds,
+        is_truncated=is_truncated,
+    )
+    _assert_scalar_prior_contract(
+        param.prior["theta"],
+        name="Normal",
+        args={"mu": 0.0, "sigma": 0.25},
+        bounds=None,
+        is_truncated=False,
+    )
+    assert getattr(param.link, "name", param.link) == "identity"
+
+
+@pytest.mark.parametrize(
+    "link",
+    [*IDENTITY_LINK_CASES, pytest.param("log", id="log-control")],
+)
+def test_safe_priors_preserve_explicit_common_priors_across_links(cavanagh_test, link):
+    """Never replace exact user intercept or slope priors based on link semantics."""
+    intercept_prior = bmb.Prior("StudentT", nu=4.0, mu=1.0, sigma=0.5)
+    slope_prior = bmb.Prior("Laplace", mu=-0.2, b=0.3)
+    param = RegressionParam(
+        name="a",
+        formula="a ~ 1 + theta",
+        prior={"Intercept": intercept_prior, "theta": slope_prior},
+        bounds=(0.0, np.inf),
+        link=link,
+    )
+
+    param.make_safe_priors(cavanagh_test, {}, is_ddm=True)
+    param.process_prior()
+
+    assert set(param.prior) == {"Intercept", "theta"}
+    assert param.prior["Intercept"] is intercept_prior
+    assert param.prior["theta"] is slope_prior
+
+
 @pytest.mark.parametrize(
     ("param_name", "bounds", "is_ddm"),
     param_and_bounds_angle,

--- a/tests/unit/test_prior.py
+++ b/tests/unit/test_prior.py
@@ -14,9 +14,43 @@ from hssm.param.parameterization_check import (
     check_user_priors_for_location_overparameterization,
     find_disconnected_free_rvs,
 )
-from hssm.prior import _is_identity_link
+from hssm.prior import (
+    _is_identity_link,
+    get_default_prior,
+    get_hddm_default_prior,
+)
 
 hssm.set_floatX("float32")
+
+
+IDENTITY_LINKS = [
+    pytest.param(None, id="omitted"),
+    pytest.param("identity", id="string"),
+    pytest.param(bmb.Link("identity"), id="bambi-object"),
+    pytest.param(hssm.Link("identity"), id="hssm-object"),
+]
+
+TRANSFORMED_LINKS = [
+    pytest.param("log", id="log-string"),
+    pytest.param("logit", id="logit-string"),
+    pytest.param(bmb.Link("log"), id="bambi-log"),
+    pytest.param(bmb.Link("logit"), id="bambi-logit"),
+    pytest.param(hssm.Link("log"), id="hssm-log"),
+    pytest.param(hssm.Link("logit"), id="hssm-logit"),
+    pytest.param(hssm.Link("gen_logit", bounds=(0.0, 1.0)), id="hssm-gen-logit"),
+]
+
+
+def _assert_prior_spec(prior, name, args, bounds):
+    """Assert a generated HSSM prior's distribution, arguments, and support."""
+    assert isinstance(prior, Prior)
+    assert prior.name == name
+    actual_args = prior._args if prior.is_truncated else prior.args
+    assert actual_args == args
+    assert prior.bounds == bounds
+    expected_truncated = bounds is not None and any(np.isfinite(bounds))
+    assert prior.is_truncated is expected_truncated
+    assert callable(prior.dist) is expected_truncated
 
 
 class TestPriorUnit:
@@ -77,13 +111,7 @@ class TestPriorUnit:
 
     @pytest.mark.parametrize(
         "link",
-        [
-            None,
-            "identity",
-            bmb.Link("identity"),
-            hssm.Link("identity"),
-        ],
-        ids=["omitted", "string", "bambi-object", "hssm-object"],
+        IDENTITY_LINKS,
     )
     def test_identity_link_classification(self, link):
         """Recognize every spelling of the effective identity link."""
@@ -91,28 +119,127 @@ class TestPriorUnit:
 
     @pytest.mark.parametrize(
         "link",
-        [
-            "log",
-            "logit",
-            bmb.Link("log"),
-            bmb.Link("logit"),
-            hssm.Link("log"),
-            hssm.Link("logit"),
-            hssm.Link("gen_logit", bounds=(0.0, 1.0)),
-        ],
-        ids=[
-            "log-string",
-            "logit-string",
-            "bambi-log",
-            "bambi-logit",
-            "hssm-log",
-            "hssm-logit",
-            "hssm-gen-logit",
-        ],
+        TRANSFORMED_LINKS,
     )
     def test_transformed_link_classification(self, link):
         """Classify non-identity strings and link objects as transformed."""
         assert not _is_identity_link(link)
+
+    @pytest.mark.parametrize("link", IDENTITY_LINKS)
+    @pytest.mark.parametrize(
+        ("bounds", "expected_args"),
+        [
+            pytest.param((-2.0, 3.0), {"mu": 0.5, "sigma": 0.25}, id="finite"),
+            pytest.param((0.0, np.inf), {"mu": 0.0, "sigma": 0.25}, id="lower-bounded"),
+            pytest.param(
+                (-np.inf, 4.0), {"mu": 0.0, "sigma": 0.25}, id="upper-bounded"
+            ),
+            pytest.param((-np.inf, np.inf), {"mu": 0.0, "sigma": 0.25}, id="unbounded"),
+            pytest.param(None, {"mu": 0.0, "sigma": 0.25}, id="no-bounds"),
+        ],
+    )
+    def test_generic_common_intercept_identity_equivalence(
+        self, link, bounds, expected_args
+    ):
+        """Use response-scale bounds for every spelling of identity."""
+        prior = get_default_prior("common_intercept", "x", bounds, link)
+
+        _assert_prior_spec(prior, "Normal", expected_args, bounds)
+
+    @pytest.mark.parametrize("link", TRANSFORMED_LINKS)
+    def test_generic_common_intercept_transformed_link(self, link):
+        """Keep transformed-link intercept priors on the coefficient scale."""
+        prior = get_default_prior("common_intercept", "x", (-2.0, 3.0), link)
+
+        _assert_prior_spec(prior, "Normal", {"mu": 0.0, "sigma": 0.25}, bounds=None)
+
+    @pytest.mark.parametrize("link", IDENTITY_LINKS)
+    @pytest.mark.parametrize(
+        ("param", "bounds", "name", "expected_args"),
+        [
+            pytest.param(
+                "v",
+                (-np.inf, np.inf),
+                "Normal",
+                {"mu": 2.0, "sigma": 3.0},
+                id="v",
+            ),
+            pytest.param(
+                "a",
+                (0.0, np.inf),
+                "Gamma",
+                {"mu": 1.5, "sigma": 0.75},
+                id="a",
+            ),
+            pytest.param("z", (0.0, 1.0), "Beta", {"alpha": 10, "beta": 10}, id="z"),
+            pytest.param(
+                "t",
+                (0.0, np.inf),
+                "Gamma",
+                {"mu": 0.2, "sigma": 0.2},
+                id="t",
+            ),
+            pytest.param(
+                "sv",
+                (0.0, np.inf),
+                "HalfNormal",
+                {"sigma": 2.0},
+                id="sv",
+            ),
+            pytest.param(
+                "sz",
+                (0.0, np.inf),
+                "HalfNormal",
+                {"sigma": 0.5},
+                id="sz",
+            ),
+            pytest.param(
+                "st",
+                (0.0, np.inf),
+                "HalfNormal",
+                {"sigma": 0.3},
+                id="st",
+            ),
+            pytest.param(
+                "p_outlier",
+                None,
+                "Beta",
+                {"alpha": 5, "beta": 100},
+                id="p-outlier",
+            ),
+        ],
+    )
+    def test_hddm_common_intercept_identity_equivalence(
+        self, link, param, bounds, name, expected_args
+    ):
+        """Retain every HDDM location prior under explicit identity links."""
+        prior = get_hddm_default_prior("common_intercept", param, bounds, link)
+
+        _assert_prior_spec(prior, name, expected_args, bounds)
+
+    @pytest.mark.parametrize("link", TRANSFORMED_LINKS)
+    def test_hddm_common_intercept_transformed_link(self, link):
+        """Keep transformed HDDM intercepts on the coefficient scale."""
+        prior = get_hddm_default_prior("common_intercept", "z", (0.0, 1.0), link)
+
+        _assert_prior_spec(prior, "Normal", {"mu": 0.0, "sigma": 0.25}, bounds=None)
+
+    @pytest.mark.parametrize("link", [*IDENTITY_LINKS, *TRANSFORMED_LINKS])
+    def test_common_slopes_are_link_invariant(self, link):
+        """Keep ordinary and HDDM common slopes independent of link spelling."""
+        generic = get_default_prior("common", "x", (-2.0, 3.0), link)
+        hddm = get_hddm_default_prior("common", "z", (0.0, 1.0), link)
+
+        for prior in (generic, hddm):
+            _assert_prior_spec(prior, "Normal", {"mu": 0.0, "sigma": 0.25}, bounds=None)
+
+    def test_hddm_group_only_identity_policy_is_deferred(self):
+        """Leave the link-presence policy for unmatched group terms to #1225."""
+        omitted = get_hddm_default_prior("group_intercept", "z", None, None)
+        explicit = get_hddm_default_prior("group_intercept", "z", None, "identity")
+
+        assert omitted.name == "Beta"
+        assert explicit.name == "Normal"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_prior.py
+++ b/tests/unit/test_prior.py
@@ -14,6 +14,7 @@ from hssm.param.parameterization_check import (
     check_user_priors_for_location_overparameterization,
     find_disconnected_free_rvs,
 )
+from hssm.prior import _is_identity_link
 
 hssm.set_floatX("float32")
 
@@ -73,6 +74,45 @@ class TestPriorUnit:
         assert hssm_prior == bounded_prior2
 
         assert dist_hssm_prior == dist_bmb_prior
+
+    @pytest.mark.parametrize(
+        "link",
+        [
+            None,
+            "identity",
+            bmb.Link("identity"),
+            hssm.Link("identity"),
+        ],
+        ids=["omitted", "string", "bambi-object", "hssm-object"],
+    )
+    def test_identity_link_classification(self, link):
+        """Recognize every spelling of the effective identity link."""
+        assert _is_identity_link(link)
+
+    @pytest.mark.parametrize(
+        "link",
+        [
+            "log",
+            "logit",
+            bmb.Link("log"),
+            bmb.Link("logit"),
+            hssm.Link("log"),
+            hssm.Link("logit"),
+            hssm.Link("gen_logit", bounds=(0.0, 1.0)),
+        ],
+        ids=[
+            "log-string",
+            "logit-string",
+            "bambi-log",
+            "bambi-logit",
+            "hssm-log",
+            "hssm-logit",
+            "hssm-gen-logit",
+        ],
+    )
+    def test_transformed_link_classification(self, link):
+        """Classify non-identity strings and link objects as transformed."""
+        assert not _is_identity_link(link)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1232

## Summary

- classify omitted, string, Bambi-object, and HSSM-object identity links semantically;
- preserve response-scale generic and HDDM safe common-intercept priors for every identity spelling;
- cover all eight HDDM location priors, generic bound shapes, transformed-link controls, explicit priors, slopes, and PyMC graph equivalence;
- add a didactic link-functions tutorial that explains predictor and parameter scales, support-preserving links, HSSM's `log_logit` preset, safe-prior defaults, and the separate numerical/PyTensor roles in custom links;
- publish both the runnable marimo source and an output-bearing static notebook in the HSSM documentation;
- leave unmatched group-only behavior unchanged for #1225.

## Review the tutorial

- [Run the immutable tutorial in Molab](https://molab.marimo.io/github/lnccbrown/HSSM/blob/717921efaa64a7cb1769c6b25f5f7a999f3a675f/docs/tutorials/link_functions.py)
- [Inspect the immutable static notebook artifact](https://github.com/lnccbrown/HSSM/blob/717921efaa64a7cb1769c6b25f5f7a999f3a675f/docs/tutorials/link_functions.ipynb)

The tutorial is construction-only and does not sample. Its assertions exercise real HSSM models and priors rather than duplicating the expected behavior in standalone examples.

## Validation

- `pytest tests -m "not slow"`: 813 passed, 371 deselected;
- focused prior/regression/graph suite: 196 passed;
- Bambi 0.19.0 floor suite: 127 passed, 69 deselected;
- strict marimo validation and both active-checkout and exact PEP 723 sandbox exports passed;
- the exported notebook has 27 cells, no execution errors or local-path leaks, one embedded plot, and ten static tables;
- CI-style nbconvert re-execution passed;
- configured Ruff, Pyrefly, mypy, whitespace, EOF, large-file, and merge-conflict hooks passed;
- documentation weight checks and `mkdocs build --strict` passed;
- independent ecosystem review found no blockers.

No dependencies, lockfiles, or public APIs change. All new model checks are construction-only.
