### PR TITLE
Harden the JEAM recovery preflight

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -49,8 +49,7 @@ jobs:
           tests/integration/test_jeam_predictive.py
           tests/integration/test_jeam_simulator.py
 
-      - name: Run the marked-slow Bayesian recovery gate
+      - name: Run the Bayesian recovery preflight and gate
         run: >-
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam_bayesian_recovery.py
-          -m slow

--- a/scripts/benchmark_jeam_bayesian_recovery.py
+++ b/scripts/benchmark_jeam_bayesian_recovery.py
@@ -14,6 +14,7 @@ import argparse
 import json
 from dataclasses import asdict, dataclass
 from time import perf_counter
+from typing import TYPE_CHECKING
 
 import arviz as az
 import numpy as np
@@ -27,18 +28,27 @@ from scripts.benchmark_jeam_objective_parity import (
     DEFAULT_DATA_SEED,
     DEFAULT_TRIALS,
     DEFAULT_TRUTH,
+    HSSM_BOUNDS,
     PARAMETER_ORDER,
     _installed_jeam_revision,
     simulate_dataset,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 DEFAULT_CHAINS = 4
 DEFAULT_TUNE = 1_500
 DEFAULT_DRAWS = 1_500
+HDI_PROBABILITY = 0.94
+DEFAULT_PRIOR_DRAWS = 100
 DEFAULT_PREDICTIVE_DRAWS = 100
 DEFAULT_CHAIN_SEEDS = (3101, 3102, 3103, 3104)
+DEFAULT_PRIOR_SEED = 6101
 DEFAULT_PREDICTIVE_SEED = 7291
 RT_QUANTILES = np.array([0.1, 0.5, 0.9])
+PRIOR_RT_QUANTILES = np.array([0.5, 0.9])
+PRIOR_RT_RATIO_BOUNDS = (0.1, 20.0)
 
 
 @dataclass(frozen=True)
@@ -49,6 +59,7 @@ class ParameterRecovery:
     truth: float
     posterior_mean: float
     mean_error: float
+    posterior_sd: float
     interval_lower: float
     interval_upper: float
     rhat: float
@@ -82,6 +93,22 @@ class SliceDiagnostics:
 
 
 @dataclass(frozen=True)
+class PriorPredictiveCheck:
+    """Shape, support, and broad RT-scale prior-predictive checks."""
+
+    shape: tuple[int, ...]
+    all_finite: bool
+    minimum_rt: float
+    maximum_rt: float
+    minimum_angle: float
+    maximum_angle: float
+    rt_probabilities: tuple[float, ...]
+    observed_rt_quantiles: tuple[float, ...]
+    prior_rt_quantiles: tuple[float, ...]
+    prior_to_observed_rt_ratios: tuple[float, ...]
+
+
+@dataclass(frozen=True)
 class RecoveryResult:
     """Machine-readable HSSM Bayesian recovery benchmark."""
 
@@ -95,13 +122,21 @@ class RecoveryResult:
     chains: int
     tune: int
     draws: int
+    hdi_probability: float
     chain_seeds: tuple[int, ...]
+    prior_draws: int
+    prior_seed: int
     predictive_draws: int
     predictive_seed: int
+    minimum_observed_rt: float
+    initial_point: tuple[float, ...]
+    initial_logp: float
+    prior_predictive_seconds: float
     sampling_seconds: float
     predictive_seconds: float
     parameters: tuple[ParameterRecovery, ...]
     slice_diagnostics: SliceDiagnostics
+    prior_predictive: PriorPredictiveCheck
     predictive: PredictiveRecovery
 
 
@@ -133,35 +168,99 @@ def _summary_interval_columns(summary: pd.DataFrame) -> tuple[str, str]:
     return lower[0], upper[0]
 
 
-def run_recovery(
-    *,
-    trials: int = DEFAULT_TRIALS,
-    data_seed: int = DEFAULT_DATA_SEED,
-    chains: int = DEFAULT_CHAINS,
-    tune: int = DEFAULT_TUNE,
-    draws: int = DEFAULT_DRAWS,
-    chain_seeds: tuple[int, ...] = DEFAULT_CHAIN_SEEDS,
-    predictive_draws: int = DEFAULT_PREDICTIVE_DRAWS,
-    predictive_seed: int = DEFAULT_PREDICTIVE_SEED,
-) -> RecoveryResult:
-    """Fit the fixed circular model and collect recovery diagnostics."""
-    if len(chain_seeds) != chains:
-        raise ValueError("Provide exactly one random seed per MCMC chain.")
-
-    data = simulate_dataset(trials=trials, seed=data_seed)
-    model = hssm.HSSM(
-        data=pd.DataFrame(data, columns=["rt", "response"]),
-        model="circular_diffusion",
-        p_outlier=None,
+def _resolved_initial_point(minimum_observed_rt: float) -> tuple[float, ...]:
+    """Return the frozen untransformed point inside model and data support."""
+    values = (1.0, min(0.1, minimum_observed_rt / 2.0), 0.0, 0.0)
+    in_model_bounds = all(
+        HSSM_BOUNDS[name][0] < value < HSSM_BOUNDS[name][1]
+        for name, value in zip(PARAMETER_ORDER, values, strict=True)
     )
-    slice_steps = [
-        pm.Slice(vars=[model.pymc_model[name]], model=model.pymc_model)
-        for name in PARAMETER_ORDER
-    ]
-    started = perf_counter()
-    traces = model.sample(
+    if not (
+        np.isfinite(minimum_observed_rt)
+        and 0.0 < values[1] < minimum_observed_rt
+        and in_model_bounds
+    ):
+        raise ValueError("Data leave no valid deterministic initial point.")
+    return values
+
+
+def _preflight_failures(
+    minimum_observed_rt: float,
+    initial_point: tuple[float, ...],
+    initial_logp: float,
+    prior: PriorPredictiveCheck,
+    *,
+    prior_rt_ratio_bounds: tuple[float, float] = PRIOR_RT_RATIO_BOUNDS,
+) -> tuple[str, ...]:
+    """Return initialization and prior-predictive protocol failures."""
+    failures = []
+    try:
+        if initial_point != _resolved_initial_point(minimum_observed_rt):
+            failures.append("resolved initial point support")
+    except ValueError:
+        failures.append("resolved initial point support")
+    if not np.isfinite(initial_logp):
+        failures.append("initial logp")
+    if not prior.all_finite:
+        failures.append("prior predictive finiteness")
+    if not (
+        len(prior.shape) == 4
+        and prior.shape[0] == 1
+        and prior.shape[-1] == 2
+        and prior.shape[1] > 0
+        and prior.shape[2] > 0
+    ):
+        failures.append("prior predictive shape")
+    if prior.minimum_rt <= 0.0 or prior.maximum_rt < prior.minimum_rt:
+        failures.append("prior predictive RT support")
+    if not (
+        prior.rt_probabilities == tuple(PRIOR_RT_QUANTILES)
+        and len(prior.observed_rt_quantiles)
+        == len(prior.prior_rt_quantiles)
+        == len(prior.prior_to_observed_rt_ratios)
+        == len(PRIOR_RT_QUANTILES)
+    ):
+        failures.append("prior predictive RT quantiles")
+    lower_ratio, upper_ratio = prior_rt_ratio_bounds
+    if any(
+        ratio < lower_ratio or ratio > upper_ratio
+        for ratio in prior.prior_to_observed_rt_ratios
+    ):
+        failures.append("prior predictive RT scale")
+    if (
+        prior.minimum_angle < -np.pi
+        or prior.maximum_angle >= np.pi
+        or prior.maximum_angle < prior.minimum_angle
+    ):
+        failures.append("prior predictive angular support")
+    return tuple(failures)
+
+
+def _sample_with_resolved_init(
+    model: hssm.HSSM,
+    slice_steps: Sequence[object],
+    initial_point: tuple[float, ...],
+    *,
+    minimum_observed_rt: float,
+    initial_logp: float,
+    prior_predictive: PriorPredictiveCheck,
+    chains: int,
+    tune: int,
+    draws: int,
+    chain_seeds: tuple[int, ...],
+) -> object:
+    """Run Slice with the same explicit supported point for every chain."""
+    if failures := _preflight_failures(
+        minimum_observed_rt,
+        initial_point,
+        initial_logp,
+        prior_predictive,
+    ):
+        raise RuntimeError(f"Recovery preflight failed: {'; '.join(failures)}")
+    return model.sample(
         sampler="pymc",
         step=slice_steps,
+        initvals=dict(zip(PARAMETER_ORDER, initial_point, strict=True)),
         chains=chains,
         cores=1,
         tune=tune,
@@ -170,6 +269,91 @@ def run_recovery(
         progressbar=False,
         idata_kwargs={"log_likelihood": False},
     )
+
+
+def run_recovery(
+    *,
+    truth: Sequence[float] = tuple(DEFAULT_TRUTH),
+    trials: int = DEFAULT_TRIALS,
+    data_seed: int = DEFAULT_DATA_SEED,
+    chains: int = DEFAULT_CHAINS,
+    tune: int = DEFAULT_TUNE,
+    draws: int = DEFAULT_DRAWS,
+    chain_seeds: tuple[int, ...] = DEFAULT_CHAIN_SEEDS,
+    prior_draws: int = DEFAULT_PRIOR_DRAWS,
+    prior_seed: int = DEFAULT_PRIOR_SEED,
+    predictive_draws: int = DEFAULT_PREDICTIVE_DRAWS,
+    predictive_seed: int = DEFAULT_PREDICTIVE_SEED,
+) -> RecoveryResult:
+    """Fit the fixed circular model and collect recovery diagnostics."""
+    if len(chain_seeds) != chains:
+        raise ValueError("Provide exactly one random seed per MCMC chain.")
+    truth_values = np.asarray(truth, dtype=np.float64)
+    if truth_values.shape != (len(PARAMETER_ORDER),):
+        raise ValueError(
+            f"truth must follow {PARAMETER_ORDER} and have shape "
+            f"({len(PARAMETER_ORDER)},)."
+        )
+
+    data = simulate_dataset(truth=truth_values, trials=trials, seed=data_seed)
+    model = hssm.HSSM(
+        data=pd.DataFrame(data, columns=["rt", "response"]),
+        model="circular_diffusion",
+        p_outlier=None,
+    )
+    minimum_observed_rt = float(np.min(data[:, 0]))
+    initial_point = _resolved_initial_point(minimum_observed_rt)
+    initial_values = dict(zip(PARAMETER_ORDER, initial_point, strict=True))
+    initial_logp = float(model.compile_logp()(initial_values))
+    started = perf_counter()
+    prior = model.sample_prior_predictive(
+        draws=prior_draws,
+        random_seed=prior_seed,
+    )
+    prior_predictive_seconds = perf_counter() - started
+    prior_values = np.asarray(
+        prior["prior_predictive"].to_dataset()["rt,response"].values
+    )
+    expected_prior_shape = (1, prior_draws, trials, 2)
+    if prior_values.shape != expected_prior_shape:
+        raise RuntimeError(
+            f"Expected prior-predictive shape {expected_prior_shape}, "
+            f"received {prior_values.shape}."
+        )
+    observed_rt = np.quantile(data[:, 0], PRIOR_RT_QUANTILES)
+    prior_rt = np.quantile(prior_values[..., 0], PRIOR_RT_QUANTILES)
+    prior_predictive = PriorPredictiveCheck(
+        shape=prior_values.shape,
+        all_finite=bool(np.all(np.isfinite(prior_values))),
+        minimum_rt=float(np.min(prior_values[..., 0])),
+        maximum_rt=float(np.max(prior_values[..., 0])),
+        minimum_angle=float(np.min(prior_values[..., 1])),
+        maximum_angle=float(np.max(prior_values[..., 1])),
+        rt_probabilities=tuple(float(value) for value in PRIOR_RT_QUANTILES),
+        observed_rt_quantiles=tuple(float(value) for value in observed_rt),
+        prior_rt_quantiles=tuple(float(value) for value in prior_rt),
+        prior_to_observed_rt_ratios=tuple(
+            float(prior_value / observed_value)
+            for prior_value, observed_value in zip(prior_rt, observed_rt, strict=True)
+        ),
+    )
+    slice_steps = [
+        pm.Slice(vars=[model.pymc_model[name]], model=model.pymc_model)
+        for name in PARAMETER_ORDER
+    ]
+    started = perf_counter()
+    traces = _sample_with_resolved_init(
+        model,
+        slice_steps,
+        initial_point,
+        minimum_observed_rt=minimum_observed_rt,
+        initial_logp=initial_logp,
+        prior_predictive=prior_predictive,
+        chains=chains,
+        tune=tune,
+        draws=draws,
+        chain_seeds=chain_seeds,
+    )
     sampling_seconds = perf_counter() - started
     if not isinstance(traces, xr.DataTree):
         raise RuntimeError("Expected PyMC sampling to return an xarray DataTree.")
@@ -177,18 +361,19 @@ def run_recovery(
     summary = az.summary(
         traces,
         var_names=list(PARAMETER_ORDER),
-        ci_prob=0.94,
+        ci_prob=HDI_PROBABILITY,
         ci_kind="hdi",
         round_to=8,
     )
     interval_lower, interval_upper = _summary_interval_columns(summary)
-    truth_by_name = dict(zip(PARAMETER_ORDER, DEFAULT_TRUTH, strict=True))
+    truth_by_name = dict(zip(PARAMETER_ORDER, truth_values, strict=True))
     parameter_recovery = tuple(
         ParameterRecovery(
             name=name,
             truth=float(truth_by_name[name]),
             posterior_mean=float(summary.loc[name, "mean"]),
             mean_error=float(summary.loc[name, "mean"] - truth_by_name[name]),
+            posterior_sd=float(summary.loc[name, "sd"]),
             interval_lower=float(summary.loc[name, interval_lower]),
             interval_upper=float(summary.loc[name, interval_upper]),
             rhat=float(summary.loc[name, "r_hat"]),
@@ -239,7 +424,7 @@ def run_recovery(
 
     return RecoveryResult(
         parameter_order=PARAMETER_ORDER,
-        truth=tuple(float(value) for value in DEFAULT_TRUTH),
+        truth=tuple(float(value) for value in truth_values),
         trials=trials,
         data_seed=data_seed,
         jeam_revision=_installed_jeam_revision(),
@@ -248,13 +433,21 @@ def run_recovery(
         chains=chains,
         tune=tune,
         draws=draws,
+        hdi_probability=HDI_PROBABILITY,
         chain_seeds=chain_seeds,
+        prior_draws=prior_draws,
+        prior_seed=prior_seed,
         predictive_draws=predictive_draws,
         predictive_seed=predictive_seed,
+        minimum_observed_rt=minimum_observed_rt,
+        initial_point=initial_point,
+        initial_logp=initial_logp,
+        prior_predictive_seconds=prior_predictive_seconds,
         sampling_seconds=sampling_seconds,
         predictive_seconds=predictive_seconds,
         parameters=parameter_recovery,
         slice_diagnostics=slice_diagnostics,
+        prior_predictive=prior_predictive,
         predictive=predictive_recovery,
     )
 
@@ -264,6 +457,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--trials", type=int, default=DEFAULT_TRIALS)
     parser.add_argument("--tune", type=int, default=DEFAULT_TUNE)
     parser.add_argument("--draws", type=int, default=DEFAULT_DRAWS)
+    parser.add_argument("--prior-draws", type=int, default=DEFAULT_PRIOR_DRAWS)
     parser.add_argument(
         "--predictive-draws", type=int, default=DEFAULT_PREDICTIVE_DRAWS
     )
@@ -278,6 +472,7 @@ def main() -> None:
         trials=args.trials,
         tune=args.tune,
         draws=args.draws,
+        prior_draws=args.prior_draws,
         predictive_draws=args.predictive_draws,
     )
     print(json.dumps(asdict(result), indent=None if args.compact else 2))

--- a/tests/integration/test_jeam_bayesian_recovery.py
+++ b/tests/integration/test_jeam_bayesian_recovery.py
@@ -1,7 +1,8 @@
-"""Marked-slow Bayesian recovery gate for the circular JEAM handshake."""
+"""Bayesian recovery protocol and marked-slow gate for the JEAM handshake."""
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, replace
+from unittest.mock import Mock
 
 import numpy as np
 import pytensor
@@ -10,9 +11,16 @@ import pytest
 import hssm
 
 pytest.importorskip("jeam")
-pytestmark = pytest.mark.slow
 
-from scripts.benchmark_jeam_bayesian_recovery import run_recovery
+from scripts.benchmark_jeam_bayesian_recovery import (
+    DEFAULT_PRIOR_DRAWS,
+    DEFAULT_PRIOR_SEED,
+    PriorPredictiveCheck,
+    _resolved_initial_point,
+    _sample_with_resolved_init,
+    run_recovery,
+)
+from scripts.benchmark_jeam_objective_parity import HSSM_BOUNDS, PARAMETER_ORDER
 
 PINNED_JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
 MEAN_ERROR_LIMITS = {"a": 0.10, "t": 0.04, "v_x": 0.15, "v_y": 0.15}
@@ -37,6 +45,126 @@ def recovery_result():
         hssm.set_floatX(original_floatx)
 
 
+def _valid_prior_predictive() -> PriorPredictiveCheck:
+    """Return a supported prior-predictive summary without drawing samples."""
+    return PriorPredictiveCheck(
+        shape=(1, DEFAULT_PRIOR_DRAWS, 300, 2),
+        all_finite=True,
+        minimum_rt=np.nextafter(0.0, 1.0),
+        maximum_rt=2.0,
+        minimum_angle=-np.pi,
+        maximum_angle=np.nextafter(np.pi, -np.inf),
+        rt_probabilities=(0.5, 0.9),
+        observed_rt_quantiles=(1.0, 1.0),
+        prior_rt_quantiles=(0.1, 20.0),
+        prior_to_observed_rt_ratios=(0.1, 20.0),
+    )
+
+
+def test_supported_recovery_preflight_passes_initial_point_to_sampling():
+    """Pass the frozen supported point explicitly to every Slice chain."""
+    minimum_rt = 0.15
+    initial_point = _resolved_initial_point(minimum_rt)
+    prior = _valid_prior_predictive()
+    model = Mock()
+    sampling = {
+        "minimum_observed_rt": minimum_rt,
+        "initial_logp": -10.0,
+        "chains": 4,
+        "tune": 10,
+        "draws": 10,
+        "chain_seeds": (1, 2, 3, 4),
+    }
+
+    _sample_with_resolved_init(
+        model, [], initial_point, prior_predictive=prior, **sampling
+    )
+
+    assert initial_point == (1.0, 0.075, 0.0, 0.0)
+    assert all(
+        HSSM_BOUNDS[name][0] < value < HSSM_BOUNDS[name][1]
+        for name, value in zip(PARAMETER_ORDER, initial_point, strict=True)
+    )
+    assert model.sample.call_args.kwargs["initvals"] == dict(
+        zip(PARAMETER_ORDER, initial_point, strict=True)
+    )
+
+
+@pytest.mark.parametrize(
+    ("initial_point", "initial_logp", "prior_overrides", "expected_failure"),
+    [
+        (
+            (1.0, 0.15, 0.0, 0.0),
+            -10.0,
+            {},
+            "resolved initial point support",
+        ),
+        ((1.0, 0.075, 0.0, 0.0), np.nan, {}, "initial logp"),
+        (
+            (1.0, 0.075, 0.0, 0.0),
+            -10.0,
+            {"all_finite": False},
+            "prior predictive finiteness",
+        ),
+        (
+            (1.0, 0.075, 0.0, 0.0),
+            -10.0,
+            {"shape": (100, 300, 2)},
+            "prior predictive shape",
+        ),
+        (
+            (1.0, 0.075, 0.0, 0.0),
+            -10.0,
+            {
+                "minimum_rt": 0.0,
+                "prior_to_observed_rt_ratios": (np.nextafter(0.1, 0.0), 1.0),
+            },
+            "prior predictive RT support; prior predictive RT scale",
+        ),
+        (
+            (1.0, 0.075, 0.0, 0.0),
+            -10.0,
+            {"rt_probabilities": (0.5,)},
+            "prior predictive RT quantiles",
+        ),
+        (
+            (1.0, 0.075, 0.0, 0.0),
+            -10.0,
+            {"maximum_angle": np.pi},
+            "prior predictive angular support",
+        ),
+    ],
+)
+def test_invalid_recovery_preflight_stops_before_sampling(
+    initial_point, initial_logp, prior_overrides, expected_failure
+):
+    """Reject every preflight failure family before MCMC starts."""
+    model = Mock()
+
+    with pytest.raises(RuntimeError, match=expected_failure):
+        _sample_with_resolved_init(
+            model,
+            [],
+            initial_point,
+            minimum_observed_rt=0.15,
+            initial_logp=initial_logp,
+            prior_predictive=replace(_valid_prior_predictive(), **prior_overrides),
+            chains=4,
+            tune=10,
+            draws=10,
+            chain_seeds=(1, 2, 3, 4),
+        )
+
+    model.sample.assert_not_called()
+
+
+def test_recovery_rejects_truth_outside_the_declared_parameter_order():
+    """Custom truth must provide one value for every ordered parameter."""
+    with pytest.raises(ValueError, match="truth must follow"):
+        run_recovery(truth=(1.0, 0.1, 0.2))
+
+
+@pytest.mark.slow
 def test_truth_is_recovered_with_converged_slice_chains(recovery_result):
     """Every truth should be covered with small bias and reliable diagnostics."""
     for parameter in recovery_result.parameters:
@@ -46,10 +174,14 @@ def test_truth_is_recovered_with_converged_slice_chains(recovery_result):
         assert parameter.ess_bulk >= MIN_ESS
         assert parameter.ess_tail >= MIN_ESS
         assert parameter.mcse_mean <= MAX_MCSE_MEAN
+        assert np.isfinite(parameter.posterior_sd)
+        assert 0.0 < parameter.posterior_sd
+        assert parameter.mcse_mean / parameter.posterior_sd <= 0.05
         assert np.isfinite(parameter.ess_bulk_per_second)
         assert parameter.ess_bulk_per_second > 0.0
 
 
+@pytest.mark.slow
 def test_recovery_uses_the_declared_gradient_free_sampler(recovery_result):
     """The integration must use PyMC Slice and expose no NUTS statistics."""
     diagnostics = recovery_result.slice_diagnostics
@@ -60,8 +192,35 @@ def test_recovery_uses_the_declared_gradient_free_sampler(recovery_result):
     assert diagnostics.mean_steps_out > 0.0
     assert recovery_result.chains == 4
     assert recovery_result.tune == recovery_result.draws == 1_500
+    assert recovery_result.hdi_probability == 0.94
 
 
+@pytest.mark.slow
+def test_prior_predictive_and_initial_logp_are_valid(recovery_result):
+    """The black-box path must initialize and respect its response support."""
+    prior = recovery_result.prior_predictive
+
+    assert recovery_result.initial_point == (
+        1.0,
+        min(0.1, recovery_result.minimum_observed_rt / 2.0),
+        0.0,
+        0.0,
+    )
+    assert 0.0 < recovery_result.initial_point[1] < recovery_result.minimum_observed_rt
+    assert np.isfinite(recovery_result.initial_logp)
+    assert recovery_result.prior_draws == DEFAULT_PRIOR_DRAWS
+    assert recovery_result.prior_seed == DEFAULT_PRIOR_SEED
+    assert recovery_result.prior_predictive_seconds > 0.0
+    assert prior.shape == (1, DEFAULT_PRIOR_DRAWS, 300, 2)
+    assert prior.all_finite
+    assert 0.0 < prior.minimum_rt <= prior.maximum_rt
+    assert -np.pi <= prior.minimum_angle <= prior.maximum_angle < np.pi
+    assert prior.rt_probabilities == (0.5, 0.9)
+    assert len(prior.observed_rt_quantiles) == len(prior.prior_rt_quantiles) == 2
+    assert all(0.1 <= ratio <= 20.0 for ratio in prior.prior_to_observed_rt_ratios)
+
+
+@pytest.mark.slow
 def test_posterior_predictive_recovers_rt_and_circular_summaries(recovery_result):
     """Predictive RT quantiles and circular moments should reproduce the data."""
     predictive = recovery_result.predictive
@@ -81,11 +240,14 @@ def test_posterior_predictive_recovers_rt_and_circular_summaries(recovery_result
     )
 
 
+@pytest.mark.slow
 def test_recovery_report_records_provenance_and_efficiency(recovery_result):
     """The scientific gate should remain reproducible and machine-readable."""
     assert recovery_result.jeam_revision == PINNED_JEAM_REVISION
     assert recovery_result.pytensor_floatx == "float64"
     assert recovery_result.trials == 300
+    assert recovery_result.prior_draws == DEFAULT_PRIOR_DRAWS
+    assert recovery_result.prior_seed == DEFAULT_PRIOR_SEED
     assert recovery_result.predictive_draws == 100
     assert recovery_result.predictive_seed == 7291
     assert recovery_result.sampling_seconds > 0.0


### PR DESCRIPTION
## Purpose

Harden the existing one-dataset fixed-CDM recovery gate before the repeated-recovery protocol is layered on top.

## Scope

- parameterize the generating truth while preserving the current default scenario
- evaluate and record a deterministic untransformed initialization strictly inside both the model bounds and observed RT support
- run 100 deterministic prior-predictive draws and validate shape, finiteness, RT support, circular support, and broad RT scale before MCMC
- abort before `model.sample()` when initialization or prior-predictive preflight fails
- record posterior standard deviations and the frozen 94% HDI probability alongside the existing Slice, predictive, timing, and revision provenance

This changes only the benchmark script, its integration test, and the optional-JEAM workflow invocation needed to execute the new fast preflight cases. It does not modify HSSM's public API, model configuration, package dependencies, lockfile, or library source.

## Numerical intent

HSSM's former default point could place `t` beyond the minimum observed RT while the black-box likelihood floor kept the joint log-density finite. The runner now evaluates a fixed supported point `(a, t, v_x, v_y) = (1, min(0.1, min_rt / 2), 0, 0)`, records its joint log-density, and passes that exact point to every Slice chain.

Prior-predictive checks use predeclared median and 90th-percentile RT ratios in the inclusive range `[0.1, 20]`. These are broad preflight diagnostics, not calibration claims.

## Verification

- exact pinned Python 3.12 environment with JEAM `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`: 7 passed in 47.21 seconds before the final test-only rejection-matrix expansion; production is unchanged
- final fast preflight matrix: 9 passed, 5 slow tests deselected; every failure family asserts that sampling never starts
- optional-JEAM workflow now runs the complete file, with the module-scoped MCMC fixture still evaluated once
- `ruff check` and `ruff format --check` on both changed files
- `git diff --check`

## Stack

This is the first of three deliberately small PRs. The next PR freezes the four-scenario protocol and pure gates without running it; the existing #1202 will then contain only execution, JSON/CLI exposure, and CI wiring.
