### PR TITLE
Define the repeated JEAM recovery protocol

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -13,11 +13,13 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
+      - "scripts/benchmark_jeam_repeated_recovery.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
       - "tests/integration/test_jeam_objective_parity.py"
       - "tests/integration/test_jeam_predictive.py"
+      - "tests/integration/test_jeam_repeated_recovery.py"
       - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
 
@@ -53,3 +55,8 @@ jobs:
         run: >-
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam_bayesian_recovery.py
+
+      - name: Verify the repeated-recovery protocol contract
+        run: >-
+          uv run --group jeam-prototype pytest
+          tests/integration/test_jeam_repeated_recovery.py

--- a/scripts/benchmark_jeam_repeated_recovery.py
+++ b/scripts/benchmark_jeam_repeated_recovery.py
@@ -1,0 +1,457 @@
+"""Define the JEAM/HSSM four-scenario deterministic recovery-smoke protocol.
+
+The frozen scenarios span opposing drifts and different threshold/nondecision-time
+scales. Fixed-budget JEAM estimates remain distinct from HSSM posterior means; the
+compiled optimizer checks objective preservation only. This is a non-calibration
+protocol definition, not durable evidence or an execution entry point.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import asdict, dataclass, is_dataclass
+from numbers import Real
+
+import numpy as np
+
+from scripts import benchmark_jeam_bayesian_recovery as bayesian
+from scripts import benchmark_jeam_objective_parity as objective
+
+DEFAULT_TRIALS = objective.DEFAULT_TRIALS
+DEFAULT_MAXITER = objective.DEFAULT_MAXITER
+DEFAULT_POPSIZE = objective.DEFAULT_POPSIZE
+HDI_PROBABILITY = bayesian.HDI_PROBABILITY
+PRIOR_RT_QUANTILES = bayesian.PRIOR_RT_QUANTILES
+RT_QUANTILES = bayesian.RT_QUANTILES
+DEFAULT_REPEATED_TUNE = 1_000
+DEFAULT_REPEATED_DRAWS = 1_000
+DEFAULT_REPEATED_PRIOR_DRAWS = bayesian.DEFAULT_PRIOR_DRAWS
+DEFAULT_REPEATED_PREDICTIVE_DRAWS = 40
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """One deterministic data-generating and inference configuration."""
+
+    name: str
+    truth: tuple[float, float, float, float]
+    data_seed: int
+    optimizer_seed: int
+    chain_seeds: tuple[int, int, int, int]
+    prior_seed: int
+    predictive_seed: int
+
+
+DEFAULT_SCENARIOS = (
+    Scenario(
+        name="baseline_asymmetric",
+        truth=(1.20, 0.15, 0.80, -0.50),
+        data_seed=1492,
+        optimizer_seed=8675309,
+        chain_seeds=(3101, 3102, 3103, 3104),
+        prior_seed=6101,
+        predictive_seed=7291,
+    ),
+    Scenario(
+        name="reversed_drift",
+        truth=(1.05, 0.10, -0.90, 0.65),
+        data_seed=2603,
+        optimizer_seed=54021,
+        chain_seeds=(4201, 4202, 4203, 4204),
+        prior_seed=7101,
+        predictive_seed=8291,
+    ),
+    Scenario(
+        name="high_threshold_strong_drift",
+        truth=(1.60, 0.22, 1.25, 0.30),
+        data_seed=3714,
+        optimizer_seed=64031,
+        chain_seeds=(5301, 5302, 5303, 5304),
+        prior_seed=8101,
+        predictive_seed=9291,
+    ),
+    Scenario(
+        name="low_threshold_negative_drift",
+        truth=(0.75, 0.07, -0.45, -1.15),
+        data_seed=4825,
+        optimizer_seed=74041,
+        chain_seeds=(6401, 6402, 6403, 6404),
+        prior_seed=9101,
+        predictive_seed=10291,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ParameterLimits:
+    """Immutable parameter-specific gate limits with name lookup."""
+
+    a: float
+    t: float
+    v_x: float
+    v_y: float
+
+    def __getitem__(self, name: str) -> float:
+        """Return the limit for a named model parameter."""
+        return {"a": self.a, "t": self.t, "v_x": self.v_x, "v_y": self.v_y}[name]
+
+
+@dataclass(frozen=True)
+class RecoveryThresholds:
+    """Predeclared smoke-test and numerical-parity criteria."""
+
+    objective_absolute_error: float
+    optimizer_parameter_absolute_error: float
+    optimizer_objective_absolute_error: float
+    maximum_rhat: float
+    minimum_bulk_ess: float
+    minimum_tail_ess: float
+    minimum_hdi_inclusion_fraction: float
+    maximum_mcse_sd_ratio: float
+    minimum_prior_to_observed_rt_ratio: float
+    maximum_prior_to_observed_rt_ratio: float
+    maximum_rt_quantile_absolute_error: float
+    maximum_mean_angle_distance: float
+    maximum_resultant_length_absolute_error: float
+    maximum_absolute_bias: ParameterLimits
+    maximum_rmse: ParameterLimits
+
+
+DEFAULT_THRESHOLDS = RecoveryThresholds(
+    objective_absolute_error=5e-5,
+    optimizer_parameter_absolute_error=1e-12,
+    optimizer_objective_absolute_error=5e-5,
+    maximum_rhat=1.01,
+    minimum_bulk_ess=500.0,
+    minimum_tail_ess=500.0,
+    minimum_hdi_inclusion_fraction=0.75,
+    maximum_mcse_sd_ratio=0.05,
+    minimum_prior_to_observed_rt_ratio=bayesian.PRIOR_RT_RATIO_BOUNDS[0],
+    maximum_prior_to_observed_rt_ratio=bayesian.PRIOR_RT_RATIO_BOUNDS[1],
+    maximum_rt_quantile_absolute_error=0.12,
+    maximum_mean_angle_distance=0.10,
+    maximum_resultant_length_absolute_error=0.08,
+    maximum_absolute_bias=ParameterLimits(a=0.12, t=0.04, v_x=0.20, v_y=0.20),
+    maximum_rmse=ParameterLimits(a=0.18, t=0.05, v_x=0.28, v_y=0.28),
+)
+
+
+@dataclass(frozen=True)
+class ScenarioParameterResult:
+    """Fixed-budget optimizer and posterior summaries for one parameter."""
+
+    name: str
+    truth: float
+    jeam_fixed_budget_estimate: float
+    posterior_mean: float
+    posterior_sd: float
+    interval_lower: float
+    interval_upper: float
+    hdi_contains_truth: bool
+    rhat: float
+    ess_bulk: float
+    ess_tail: float
+    mcse_mean: float
+    mcse_sd_ratio: float
+    ess_bulk_per_second: float
+
+
+@dataclass(frozen=True)
+class ScenarioRuntime:
+    """Descriptive wall-clock timings for one scenario."""
+
+    direct_jeam_fixed_budget_optimizer_seconds: float
+    compiled_hssm_fixed_budget_optimizer_seconds: float
+    hssm_prior_predictive_seconds: float
+    hssm_sampling_seconds: float
+    hssm_predictive_seconds: float
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    """Complete recovery-smoke result for one generating scenario."""
+
+    name: str
+    truth: tuple[float, ...]
+    data_seed: int
+    optimizer_seed: int
+    chain_seeds: tuple[int, ...]
+    prior_seed: int
+    predictive_seed: int
+    direct_objectives: tuple[float, ...]
+    compiled_objectives: tuple[float, ...]
+    objective_candidates: tuple[tuple[float, ...], ...]
+    maximum_objective_absolute_error: float
+    direct_jeam_fixed_budget_optimizer: objective.FitSummary
+    compiled_hssm_fixed_budget_optimizer: objective.FitSummary
+    maximum_optimizer_parameter_absolute_error: float
+    optimizer_objective_absolute_error: float
+    minimum_observed_rt: float
+    initial_point: tuple[float, ...]
+    initial_logp: float
+    parameters: tuple[ScenarioParameterResult, ...]
+    slice_diagnostics: bayesian.SliceDiagnostics
+    prior_predictive: bayesian.PriorPredictiveCheck
+    predictive: bayesian.PredictiveRecovery
+    runtime: ScenarioRuntime
+
+
+@dataclass(frozen=True)
+class AggregateParameterResult:
+    """Multi-scenario descriptive metrics for one parameter."""
+
+    name: str
+    scenarios: int
+    jeam_fixed_budget_bias: float
+    jeam_fixed_budget_rmse: float
+    hssm_posterior_bias: float
+    hssm_posterior_rmse: float
+    hdi_inclusion_fraction: float
+    maximum_rhat: float
+    minimum_bulk_ess: float
+    minimum_tail_ess: float
+    maximum_mcse_sd_ratio: float
+    mean_bulk_ess_per_second: float
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of all predeclared numerical and scientific checks."""
+
+    passed: bool
+    failures: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MultiScenarioRecoveryResult:
+    """Machine-readable multi-scenario recovery-smoke protocol result."""
+
+    schema_version: int
+    benchmark: str
+    interpretation: str
+    generated_at_utc: str
+    reproduction_command: str
+    parameter_order: tuple[str, ...]
+    jeam_revision: str
+    pytensor_floatx: str
+    sampler: str
+    trials_per_scenario: int
+    chains: int
+    tune: int
+    draws: int
+    hdi_probability: float
+    prior_draws: int
+    predictive_draws: int
+    optimizer_maxiter: int
+    optimizer_popsize: int
+    thresholds: RecoveryThresholds
+    scenarios: tuple[ScenarioResult, ...]
+    aggregate: tuple[AggregateParameterResult, ...]
+    total_runtime_seconds: float
+    gate: GateResult
+
+
+def _mcse_sd_ratio(mcse_mean: float, posterior_sd: float) -> float:
+    """Return a scale-aware Monte Carlo error, invalidating nonpositive scales."""
+    return mcse_mean / posterior_sd if posterior_sd > 0.0 else math.inf
+
+
+def aggregate_results(
+    scenarios: Sequence[ScenarioResult],
+) -> tuple[AggregateParameterResult, ...]:
+    """Aggregate descriptive errors, HDI inclusion, and diagnostics by parameter."""
+    if not scenarios:
+        raise ValueError("At least one completed scenario is required.")
+    by_name = {
+        name: [
+            next(
+                parameter for parameter in scenario.parameters if parameter.name == name
+            )
+            for scenario in scenarios
+        ]
+        for name in objective.PARAMETER_ORDER
+    }
+    aggregate: list[AggregateParameterResult] = []
+    for name, parameters in by_name.items():
+        truth = np.asarray([parameter.truth for parameter in parameters])
+        fixed_budget = np.asarray(
+            [parameter.jeam_fixed_budget_estimate for parameter in parameters]
+        )
+        posterior = np.asarray([parameter.posterior_mean for parameter in parameters])
+        fixed_budget_error = fixed_budget - truth
+        posterior_error = posterior - truth
+        aggregate.append(
+            AggregateParameterResult(
+                name=name,
+                scenarios=len(parameters),
+                jeam_fixed_budget_bias=float(np.mean(fixed_budget_error)),
+                jeam_fixed_budget_rmse=float(
+                    np.sqrt(np.mean(np.square(fixed_budget_error)))
+                ),
+                hssm_posterior_bias=float(np.mean(posterior_error)),
+                hssm_posterior_rmse=float(np.sqrt(np.mean(np.square(posterior_error)))),
+                hdi_inclusion_fraction=float(
+                    np.mean([parameter.hdi_contains_truth for parameter in parameters])
+                ),
+                maximum_rhat=float(
+                    np.max([parameter.rhat for parameter in parameters])
+                ),
+                minimum_bulk_ess=float(
+                    np.min([parameter.ess_bulk for parameter in parameters])
+                ),
+                minimum_tail_ess=float(
+                    np.min([parameter.ess_tail for parameter in parameters])
+                ),
+                maximum_mcse_sd_ratio=float(
+                    np.max([parameter.mcse_sd_ratio for parameter in parameters])
+                ),
+                mean_bulk_ess_per_second=float(
+                    np.mean([parameter.ess_bulk_per_second for parameter in parameters])
+                ),
+            )
+        )
+    return tuple(aggregate)
+
+
+def _nonfinite_metric_paths(value: object, path: str) -> Iterator[str]:
+    """Yield paths to nonfinite numeric values in nested protocol results."""
+    if is_dataclass(value) and not isinstance(value, type):
+        value = asdict(value)
+    if isinstance(value, Mapping):
+        for name, item in value.items():
+            yield from _nonfinite_metric_paths(item, f"{path}.{name}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            yield from _nonfinite_metric_paths(item, f"{path}[{index}]")
+    elif isinstance(value, Real) and not isinstance(value, (bool, int)):
+        if not math.isfinite(float(value)):
+            yield path
+
+
+def _scenario_gate_failures(
+    scenario: ScenarioResult,
+    thresholds: RecoveryThresholds,
+) -> list[str]:
+    """Return parity, predictive, sampler, and MCSE failures for one scenario."""
+    predictive = scenario.predictive
+    rt_error = max(
+        abs(predicted - observed)
+        for predicted, observed in zip(
+            predictive.predictive_rt_quantiles,
+            predictive.observed_rt_quantiles,
+            strict=True,
+        )
+    )
+    checks = {
+        "objective parity": (
+            scenario.maximum_objective_absolute_error,
+            thresholds.objective_absolute_error,
+        ),
+        "optimizer parameter parity": (
+            scenario.maximum_optimizer_parameter_absolute_error,
+            thresholds.optimizer_parameter_absolute_error,
+        ),
+        "optimizer objective parity": (
+            scenario.optimizer_objective_absolute_error,
+            thresholds.optimizer_objective_absolute_error,
+        ),
+        "posterior predictive RT quantiles": (
+            rt_error,
+            thresholds.maximum_rt_quantile_absolute_error,
+        ),
+        "posterior predictive mean angle": (
+            predictive.mean_angle_distance,
+            thresholds.maximum_mean_angle_distance,
+        ),
+        "posterior predictive resultant length": (
+            abs(
+                predictive.predictive_resultant_length
+                - predictive.observed_resultant_length
+            ),
+            thresholds.maximum_resultant_length_absolute_error,
+        ),
+    }
+    failures = [
+        f"{scenario.name}: {label}"
+        for label, (value, limit) in checks.items()
+        if value > limit
+    ]
+    diagnostics = scenario.slice_diagnostics
+    if diagnostics.sample_stats != ("nstep_in", "nstep_out"):
+        failures.append(f"{scenario.name}: Slice sample statistics")
+    if diagnostics.mean_steps_in <= 0.0 or diagnostics.mean_steps_out <= 0.0:
+        failures.append(f"{scenario.name}: Slice steps")
+    failures.extend(
+        f"{scenario.name}: {parameter.name} MCSE/SD"
+        for parameter in scenario.parameters
+        if parameter.mcse_sd_ratio > thresholds.maximum_mcse_sd_ratio
+    )
+    failures.extend(
+        f"{scenario.name}: {failure}"
+        for failure in bayesian._preflight_failures(
+            scenario.minimum_observed_rt,
+            scenario.initial_point,
+            scenario.initial_logp,
+            scenario.prior_predictive,
+            prior_rt_ratio_bounds=(
+                thresholds.minimum_prior_to_observed_rt_ratio,
+                thresholds.maximum_prior_to_observed_rt_ratio,
+            ),
+        )
+    )
+    return failures
+
+
+def evaluate_gate(
+    scenarios: Sequence[ScenarioResult],
+    aggregate: Sequence[AggregateParameterResult],
+    thresholds: RecoveryThresholds,
+    *,
+    total_runtime_seconds: float | None = None,
+) -> GateResult:
+    """Evaluate every predeclared criterion and retain all failure messages."""
+    failures = [
+        failure
+        for scenario in scenarios
+        for failure in _scenario_gate_failures(scenario, thresholds)
+    ]
+    for parameter in aggregate:
+        bias_limit = thresholds.maximum_absolute_bias[parameter.name]
+        rmse_limit = thresholds.maximum_rmse[parameter.name]
+        for estimator, bias, rmse in (
+            (
+                "JEAM fixed-budget optimizer",
+                parameter.jeam_fixed_budget_bias,
+                parameter.jeam_fixed_budget_rmse,
+            ),
+            (
+                "HSSM posterior",
+                parameter.hssm_posterior_bias,
+                parameter.hssm_posterior_rmse,
+            ),
+        ):
+            if abs(bias) > bias_limit:
+                failures.append(f"{parameter.name}: {estimator} bias")
+            if rmse > rmse_limit:
+                failures.append(f"{parameter.name}: {estimator} RMSE")
+        if parameter.hdi_inclusion_fraction < thresholds.minimum_hdi_inclusion_fraction:
+            failures.append(f"{parameter.name}: HDI inclusion fraction")
+        if parameter.maximum_rhat > thresholds.maximum_rhat:
+            failures.append(f"{parameter.name}: R-hat")
+        if parameter.minimum_bulk_ess < thresholds.minimum_bulk_ess:
+            failures.append(f"{parameter.name}: bulk ESS")
+        if parameter.minimum_tail_ess < thresholds.minimum_tail_ess:
+            failures.append(f"{parameter.name}: tail ESS")
+    finite_metrics = {
+        "thresholds": thresholds,
+        "scenarios": tuple(scenarios),
+        "aggregate": tuple(aggregate),
+    }
+    if total_runtime_seconds is not None:
+        finite_metrics["total_runtime_seconds"] = total_runtime_seconds
+    failures.extend(
+        f"nonfinite metric: {path}"
+        for path in _nonfinite_metric_paths(finite_metrics, "result")
+    )
+    return GateResult(passed=not failures, failures=tuple(failures))

--- a/scripts/benchmark_jeam_repeated_recovery.py
+++ b/scripts/benchmark_jeam_repeated_recovery.py
@@ -335,13 +335,12 @@ def _scenario_gate_failures(
 ) -> list[str]:
     """Return parity, predictive, sampler, and MCSE failures for one scenario."""
     predictive = scenario.predictive
-    rt_error = max(
-        abs(predicted - observed)
-        for predicted, observed in zip(
-            predictive.predictive_rt_quantiles,
-            predictive.observed_rt_quantiles,
-            strict=True,
-        )
+    expected_rt_probabilities = tuple(float(value) for value in RT_QUANTILES)
+    valid_rt_quantiles = (
+        predictive.rt_probabilities == expected_rt_probabilities
+        and len(predictive.observed_rt_quantiles)
+        == len(predictive.predictive_rt_quantiles)
+        == len(expected_rt_probabilities)
     )
     checks = {
         "objective parity": (
@@ -355,10 +354,6 @@ def _scenario_gate_failures(
         "optimizer objective parity": (
             scenario.optimizer_objective_absolute_error,
             thresholds.optimizer_objective_absolute_error,
-        ),
-        "posterior predictive RT quantiles": (
-            rt_error,
-            thresholds.maximum_rt_quantile_absolute_error,
         ),
         "posterior predictive mean angle": (
             predictive.mean_angle_distance,
@@ -377,6 +372,19 @@ def _scenario_gate_failures(
         for label, (value, limit) in checks.items()
         if value > limit
     ]
+    if not valid_rt_quantiles:
+        failures.append(f"{scenario.name}: posterior predictive RT quantile schema")
+    else:
+        rt_error = max(
+            abs(predicted - observed)
+            for predicted, observed in zip(
+                predictive.predictive_rt_quantiles,
+                predictive.observed_rt_quantiles,
+                strict=True,
+            )
+        )
+        if rt_error > thresholds.maximum_rt_quantile_absolute_error:
+            failures.append(f"{scenario.name}: posterior predictive RT quantiles")
     diagnostics = scenario.slice_diagnostics
     if diagnostics.sample_stats != ("nstep_in", "nstep_out"):
         failures.append(f"{scenario.name}: Slice sample statistics")

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -1,12 +1,21 @@
 """Fast contracts for the multi-scenario JEAM recovery protocol."""
 
-from dataclasses import astuple, replace
+from dataclasses import asdict, astuple, replace
 
 import numpy as np
 import pytest
 
 pytest.importorskip("jeam")
 
+from scripts.benchmark_jeam_bayesian_recovery import (
+    PredictiveRecovery,
+    PriorPredictiveCheck,
+    SliceDiagnostics,
+)
+from scripts.benchmark_jeam_objective_parity import (
+    PARAMETER_ORDER,
+    FitSummary,
+)
 from scripts.benchmark_jeam_repeated_recovery import (
     DEFAULT_MAXITER,
     DEFAULT_POPSIZE,
@@ -29,16 +38,6 @@ from scripts.benchmark_jeam_repeated_recovery import (
     evaluate_gate,
 )
 
-from scripts.benchmark_jeam_bayesian_recovery import (
-    PredictiveRecovery,
-    PriorPredictiveCheck,
-    SliceDiagnostics,
-)
-from scripts.benchmark_jeam_objective_parity import (
-    PARAMETER_ORDER,
-    FitSummary,
-)
-
 LIMITS = DEFAULT_THRESHOLDS
 
 
@@ -58,7 +57,7 @@ def _parameter(name: str, truth: float, error: float) -> ScenarioParameterResult
         ess_bulk=LIMITS.minimum_bulk_ess,
         ess_tail=LIMITS.minimum_tail_ess,
         mcse_mean=mcse_mean,
-        mcse_sd_ratio=_mcse_sd_ratio(mcse_mean, posterior_sd),
+        mcse_sd_ratio=LIMITS.maximum_mcse_sd_ratio,
         ess_bulk_per_second=10.0,
     )
 
@@ -170,10 +169,16 @@ def test_protocol_defaults_are_frozen_independently():
     # fmt: off
     assert astuple(LIMITS) == (
         5e-5, 1e-12, 5e-5, 1.01, 500.0, 500.0, 0.75, 0.05, 0.1, 20.0, 0.12, 0.10, 0.08,
+        (0.12, 0.04, 0.20, 0.20), (0.18, 0.05, 0.28, 0.28),
+    )
+    # fmt: on
+    limits = asdict(LIMITS)
+    assert (limits["maximum_absolute_bias"], limits["maximum_rmse"]) == (
         {"a": 0.12, "t": 0.04, "v_x": 0.20, "v_y": 0.20},
         {"a": 0.18, "t": 0.05, "v_x": 0.28, "v_y": 0.28},
     )
-    # fmt: on
+    with pytest.raises(KeyError):
+        LIMITS.maximum_absolute_bias["unknown"]
 
 
 def test_aggregate_results_use_fixed_budget_and_hdi_terminology():
@@ -193,6 +198,7 @@ def test_aggregate_results_use_fixed_budget_and_hdi_terminology():
             parameter.hdi_inclusion_fraction,
             parameter.maximum_mcse_sd_ratio,
         ) == pytest.approx((0.1, 0.1, -0.1, 0.1, 1.0, 0.05))
+    assert _mcse_sd_ratio(0.01, 0.2) == pytest.approx(0.05)
     assert all(np.isinf(_mcse_sd_ratio(0.1, scale)) for scale in (0.0, -1.0, np.nan))
     with pytest.raises(ValueError, match="At least one completed scenario"):
         aggregate_results(())

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -1,0 +1,307 @@
+"""Fast contracts for the multi-scenario JEAM recovery protocol."""
+
+from dataclasses import astuple, replace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+from scripts.benchmark_jeam_repeated_recovery import (
+    DEFAULT_MAXITER,
+    DEFAULT_POPSIZE,
+    DEFAULT_REPEATED_DRAWS,
+    DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+    DEFAULT_REPEATED_PRIOR_DRAWS,
+    DEFAULT_REPEATED_TUNE,
+    DEFAULT_SCENARIOS,
+    DEFAULT_THRESHOLDS,
+    DEFAULT_TRIALS,
+    HDI_PROBABILITY,
+    PRIOR_RT_QUANTILES,
+    RT_QUANTILES,
+    GateResult,
+    ScenarioParameterResult,
+    ScenarioResult,
+    ScenarioRuntime,
+    _mcse_sd_ratio,
+    aggregate_results,
+    evaluate_gate,
+)
+
+from scripts.benchmark_jeam_bayesian_recovery import (
+    PredictiveRecovery,
+    PriorPredictiveCheck,
+    SliceDiagnostics,
+)
+from scripts.benchmark_jeam_objective_parity import (
+    PARAMETER_ORDER,
+    FitSummary,
+)
+
+LIMITS = DEFAULT_THRESHOLDS
+
+
+def _parameter(name: str, truth: float, error: float) -> ScenarioParameterResult:
+    posterior_sd = 0.2
+    mcse_mean = posterior_sd * LIMITS.maximum_mcse_sd_ratio
+    return ScenarioParameterResult(
+        name=name,
+        truth=truth,
+        jeam_fixed_budget_estimate=truth + error,
+        posterior_mean=truth - error,
+        posterior_sd=posterior_sd,
+        interval_lower=truth - 0.2,
+        interval_upper=truth + 0.2,
+        hdi_contains_truth=True,
+        rhat=LIMITS.maximum_rhat,
+        ess_bulk=LIMITS.minimum_bulk_ess,
+        ess_tail=LIMITS.minimum_tail_ess,
+        mcse_mean=mcse_mean,
+        mcse_sd_ratio=_mcse_sd_ratio(mcse_mean, posterior_sd),
+        ess_bulk_per_second=10.0,
+    )
+
+
+def _scenario(name: str, offset: float = 0.0, error: float = 0.0) -> ScenarioResult:
+    truth = tuple(1.0 + offset + index for index in range(len(PARAMETER_ORDER)))
+    parameters = tuple(
+        _parameter(parameter_name, value, error)
+        for parameter_name, value in zip(PARAMETER_ORDER, truth, strict=True)
+    )
+    predictive = PredictiveRecovery(
+        rt_probabilities=(0.1, 0.5, 0.9),
+        observed_rt_quantiles=(0.0, 0.0, 0.0),
+        predictive_rt_quantiles=(LIMITS.maximum_rt_quantile_absolute_error,) * 3,
+        observed_mean_angle=0.0,
+        predictive_mean_angle=LIMITS.maximum_mean_angle_distance,
+        mean_angle_distance=LIMITS.maximum_mean_angle_distance,
+        observed_resultant_length=0.0,
+        predictive_resultant_length=LIMITS.maximum_resultant_length_absolute_error,
+    )
+    fit = FitSummary(truth, 10.0, 900, 14)
+    return ScenarioResult(
+        name=name,
+        truth=truth,
+        data_seed=101,
+        optimizer_seed=202,
+        chain_seeds=(301, 302, 303, 304),
+        prior_seed=501,
+        predictive_seed=401,
+        direct_objectives=(10.0,),
+        compiled_objectives=(10.0,),
+        objective_candidates=(truth,),
+        maximum_objective_absolute_error=LIMITS.objective_absolute_error,
+        direct_jeam_fixed_budget_optimizer=fit,
+        compiled_hssm_fixed_budget_optimizer=fit,
+        maximum_optimizer_parameter_absolute_error=(
+            LIMITS.optimizer_parameter_absolute_error
+        ),
+        optimizer_objective_absolute_error=(LIMITS.optimizer_objective_absolute_error),
+        minimum_observed_rt=0.2,
+        initial_point=(1.0, 0.1, 0.0, 0.0),
+        initial_logp=-10.0,
+        parameters=parameters,
+        slice_diagnostics=SliceDiagnostics(("nstep_in", "nstep_out"), 1.0, 1.0),
+        prior_predictive=PriorPredictiveCheck(
+            shape=(1, 100, 20, 2),
+            all_finite=True,
+            minimum_rt=np.nextafter(0.0, 1.0),
+            maximum_rt=2.0,
+            minimum_angle=-np.pi,
+            maximum_angle=np.nextafter(np.pi, -np.inf),
+            rt_probabilities=(0.5, 0.9),
+            observed_rt_quantiles=(1.0, 1.0),
+            prior_rt_quantiles=(0.1, 20.0),
+            prior_to_observed_rt_ratios=(0.1, 20.0),
+        ),
+        predictive=predictive,
+        runtime=ScenarioRuntime(1.0, 1.0, 0.25, 2.0, 0.5),
+    )
+
+
+def test_protocol_defaults_are_frozen_independently():
+    """The protocol must not silently change scenarios or gate policy."""
+    actual = tuple(
+        (
+            scenario.name,
+            scenario.truth,
+            scenario.data_seed,
+            scenario.optimizer_seed,
+            scenario.chain_seeds,
+            scenario.prior_seed,
+            scenario.predictive_seed,
+        )
+        for scenario in DEFAULT_SCENARIOS
+    )
+    # fmt: off
+    expected = (
+        ("baseline_asymmetric", (1.20, 0.15, 0.80, -0.50), 1492, 8675309, (3101, 3102, 3103, 3104), 6101, 7291),  # noqa: E501
+        ("reversed_drift", (1.05, 0.10, -0.90, 0.65), 2603, 54021, (4201, 4202, 4203, 4204), 7101, 8291),  # noqa: E501
+        ("high_threshold_strong_drift", (1.60, 0.22, 1.25, 0.30), 3714, 64031, (5301, 5302, 5303, 5304), 8101, 9291),  # noqa: E501
+        ("low_threshold_negative_drift", (0.75, 0.07, -0.45, -1.15), 4825, 74041, (6401, 6402, 6403, 6404), 9101, 10291),  # noqa: E501
+    )
+    # fmt: on
+    assert actual == expected
+    protocol = (
+        DEFAULT_TRIALS,
+        DEFAULT_REPEATED_TUNE,
+        DEFAULT_REPEATED_DRAWS,
+        DEFAULT_REPEATED_PRIOR_DRAWS,
+        DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+        DEFAULT_MAXITER,
+        DEFAULT_POPSIZE,
+        HDI_PROBABILITY,
+        tuple(PRIOR_RT_QUANTILES),
+        tuple(RT_QUANTILES),
+    )
+    assert protocol == (
+        300,
+        1_000,
+        1_000,
+        100,
+        40,
+        14,
+        15,
+        0.94,
+        (0.5, 0.9),
+        (0.1, 0.5, 0.9),
+    )
+    # fmt: off
+    assert astuple(LIMITS) == (
+        5e-5, 1e-12, 5e-5, 1.01, 500.0, 500.0, 0.75, 0.05, 0.1, 20.0, 0.12, 0.10, 0.08,
+        {"a": 0.12, "t": 0.04, "v_x": 0.20, "v_y": 0.20},
+        {"a": 0.18, "t": 0.05, "v_x": 0.28, "v_y": 0.28},
+    )
+    # fmt: on
+
+
+def test_aggregate_results_use_fixed_budget_and_hdi_terminology():
+    """Aggregation must separate optimizer and posterior summaries."""
+    scenarios = (
+        _scenario("first", error=0.1),
+        _scenario("second", offset=1.0, error=0.1),
+    )
+    aggregate = aggregate_results(scenarios)
+
+    for parameter in aggregate:
+        assert (
+            parameter.jeam_fixed_budget_bias,
+            parameter.jeam_fixed_budget_rmse,
+            parameter.hssm_posterior_bias,
+            parameter.hssm_posterior_rmse,
+            parameter.hdi_inclusion_fraction,
+            parameter.maximum_mcse_sd_ratio,
+        ) == pytest.approx((0.1, 0.1, -0.1, 0.1, 1.0, 0.05))
+    assert all(np.isinf(_mcse_sd_ratio(0.1, scale)) for scale in (0.0, -1.0, np.nan))
+    with pytest.raises(ValueError, match="At least one completed scenario"):
+        aggregate_results(())
+
+
+def test_gate_accepts_exact_boundaries_and_retained_diagnostics():
+    """Every declared inclusive boundary must pass with diagnostics retained."""
+    scenarios = (_scenario("boundary"),)
+    aggregate = tuple(
+        replace(
+            parameter,
+            jeam_fixed_budget_bias=LIMITS.maximum_absolute_bias[parameter.name],
+            jeam_fixed_budget_rmse=LIMITS.maximum_rmse[parameter.name],
+            hssm_posterior_bias=-LIMITS.maximum_absolute_bias[parameter.name],
+            hssm_posterior_rmse=LIMITS.maximum_rmse[parameter.name],
+            hdi_inclusion_fraction=LIMITS.minimum_hdi_inclusion_fraction,
+        )
+        for parameter in aggregate_results(scenarios)
+    )
+    gate = evaluate_gate(scenarios, aggregate, LIMITS, total_runtime_seconds=4.0)
+
+    assert gate == GateResult(passed=True, failures=())
+    assert scenarios[0].slice_diagnostics.sample_stats == ("nstep_in", "nstep_out")
+    assert scenarios[0].predictive.rt_probabilities == (0.1, 0.5, 0.9)
+
+
+def test_gate_rejects_invalid_slice_mcse_and_nonfinite_metrics():
+    """Invalid sampler, precision, and finite-value diagnostics must fail."""
+    scenario = _scenario("invalid")
+    epsilon = 1e-6
+    first = replace(
+        scenario.parameters[0],
+        posterior_sd=float("nan"),
+        mcse_sd_ratio=LIMITS.maximum_mcse_sd_ratio + epsilon,
+    )
+    scenario = replace(
+        scenario,
+        maximum_objective_absolute_error=LIMITS.objective_absolute_error + epsilon,
+        maximum_optimizer_parameter_absolute_error=(
+            LIMITS.optimizer_parameter_absolute_error + epsilon
+        ),
+        optimizer_objective_absolute_error=(
+            LIMITS.optimizer_objective_absolute_error + epsilon
+        ),
+        initial_point=(1.55, 2.0, 0.0, 0.0),
+        initial_logp=float("nan"),
+        parameters=(first, *scenario.parameters[1:]),
+        predictive=replace(
+            scenario.predictive,
+            predictive_rt_quantiles=(
+                LIMITS.maximum_rt_quantile_absolute_error + epsilon,
+            )
+            * 3,
+            mean_angle_distance=LIMITS.maximum_mean_angle_distance + epsilon,
+            predictive_resultant_length=(
+                LIMITS.maximum_resultant_length_absolute_error + epsilon
+            ),
+        ),
+        slice_diagnostics=replace(
+            scenario.slice_diagnostics,
+            sample_stats=("nstep_in",),
+            mean_steps_out=0.0,
+        ),
+        runtime=replace(scenario.runtime, hssm_predictive_seconds=float("inf")),
+        prior_predictive=replace(
+            scenario.prior_predictive,
+            shape=(5, 20, 2),
+            all_finite=False,
+            minimum_rt=0.0,
+            maximum_angle=np.pi,
+            rt_probabilities=(0.5,),
+            prior_to_observed_rt_ratios=(
+                np.nextafter(0.1, 0.0),
+                np.nextafter(20.0, np.inf),
+            ),
+        ),
+    )
+    first, *remaining = aggregate_results((scenario,))
+    bias_limit = LIMITS.maximum_absolute_bias[first.name]
+    rmse_limit = LIMITS.maximum_rmse[first.name]
+    aggregate = (
+        replace(
+            first,
+            jeam_fixed_budget_bias=bias_limit + epsilon,
+            jeam_fixed_budget_rmse=rmse_limit + epsilon,
+            hssm_posterior_bias=-(bias_limit + epsilon),
+            hssm_posterior_rmse=rmse_limit + epsilon,
+            hdi_inclusion_fraction=LIMITS.minimum_hdi_inclusion_fraction - epsilon,
+            maximum_rhat=LIMITS.maximum_rhat + epsilon,
+            minimum_bulk_ess=LIMITS.minimum_bulk_ess - epsilon,
+            minimum_tail_ess=LIMITS.minimum_tail_ess - epsilon,
+        ),
+        *remaining,
+    )
+
+    gate = evaluate_gate(
+        (scenario,), aggregate, LIMITS, total_runtime_seconds=float("nan")
+    )
+
+    failure_text = "\n".join(gate.failures)
+    # fmt: off
+    expected_failures = (
+        "Slice sample statistics", "Slice steps", "MCSE/SD", "resolved initial point support",  # noqa: E501
+        "objective parity", "optimizer parameter parity", "optimizer objective parity",  # noqa: E501
+        "posterior predictive RT", "posterior predictive mean angle", "posterior predictive resultant length", "initial logp",  # noqa: E501
+        "JEAM fixed-budget optimizer bias", "JEAM fixed-budget optimizer RMSE",  # noqa: E501
+        "HSSM posterior bias", "HSSM posterior RMSE", "HDI inclusion fraction", "R-hat", "bulk ESS", "tail ESS",  # noqa: E501
+        "prior predictive finiteness", "prior predictive shape", "prior predictive RT support", "prior predictive RT quantiles",  # noqa: E501
+        "prior predictive RT scale", "prior predictive angular support", "nonfinite metric",  # noqa: E501
+    )
+    # fmt: on
+    assert all(expected in failure_text for expected in expected_failures)

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -225,6 +225,25 @@ def test_gate_accepts_exact_boundaries_and_retained_diagnostics():
     assert scenarios[0].predictive.rt_probabilities == (0.1, 0.5, 0.9)
 
 
+@pytest.mark.parametrize(
+    "predictive",
+    (
+        replace(_scenario("grid").predictive, rt_probabilities=(0.2, 0.5, 0.8)),
+        replace(_scenario("length").predictive, observed_rt_quantiles=(0.0, 0.0)),
+    ),
+)
+def test_gate_rejects_predictive_quantile_schema(predictive):
+    """Wrong probability grids and mismatched quantile lengths must fail cleanly."""
+    scenario = replace(_scenario("invalid predictive schema"), predictive=predictive)
+
+    gate = evaluate_gate((scenario,), aggregate_results((scenario,)), LIMITS)
+
+    assert not gate.passed
+    assert gate.failures == (
+        "invalid predictive schema: posterior predictive RT quantile schema",
+    )
+
+
 def test_gate_rejects_invalid_slice_mcse_and_nonfinite_metrics():
     """Invalid sampler, precision, and finite-value diagnostics must fail."""
     scenario = _scenario("invalid")


### PR DESCRIPTION
#1239 is merged into `dev`.

## Purpose

Freeze the four-scenario JEAM/HSSM recovery-smoke protocol before adding or running its executor.

## Scope

- declare four asymmetric generating scenarios with exact truth values and data, optimizer, chain, prior-predictive, and posterior-predictive seeds
- freeze the trial, tuning, draw, prior, posterior-predictive, and fixed-budget differential-evolution settings
- distinguish the JEAM fixed-budget optimizer estimate from the HSSM posterior summary; this makes no MLE or optimizer-convergence claim
- define immutable result schemas for scenario, aggregate, timing, Slice, prior-predictive, posterior-predictive, and gate evidence
- predeclare objective/parity, bias, RMSE, 94% HDI inclusion, R-hat, ESS, MCSE/SD, prior-support, prior-scale, and posterior-predictive thresholds
- evaluate inclusive gate boundaries and recursively reject nonfinite metrics

The parameter-specific bias and RMSE limits use a frozen `ParameterLimits` value object, so the global protocol cannot be modified through a nested dictionary while `asdict()` still produces the intended JSON-object shape.

## Deliberate exclusions

This PR cannot execute a scenario. It adds no `run_scenario`, `run_benchmark`, CLI, JSON writer, benchmark-execution workflow, HSSM sampling call, result artifact, dependency, lockfile, or library-source edit. Its only workflow change makes the fast protocol tests run in the existing optional-JEAM job. Executor-only #1202 remains stacked on this protocol.

This is a deterministic four-scenario recovery smoke, not a calibration study and not durable scientific evidence. Raw datasets, traces, environment identity, hashes, and an independent verifier remain a separate evidence successor.

## Verification

- exact pinned Python 3.12 optional-JEAM environment: 6 passed
- focused coverage: 214/214 statements, 100%
- HSSM imported from this stacked worktree and JEAM resolved to `a9f547b3630ae8ff31ccec1b904e0c02fdba6d99`
- focused mypy passed for both new files
- `ruff check` and `ruff format --check` passed
- optional-JEAM workflow parses cleanly and now executes the fast protocol tests
- all four reviewed commits are patch-identical after replay onto `dev` (`range-diff` reports `=`)
- `git diff --check`
- no MCMC or canonical benchmark was run

## Stack

This is the second of three small PRs. It contains three focused protocol/test commits plus a seven-line CI commit (+804/−0 across three files). After #1239 was squash-merged, the four commits were replayed patch-identically onto merge commit `642c5ed2`; executor-only #1202 remains based on this branch.
