### PR TITLE
ci: point the slow-test matrix at tests/integration

### DIFF
--- a/.github/workflows/run_slow_tests.yml
+++ b/.github/workflows/run_slow_tests.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         include:
           - batch: "Missing Data"
-            test_args: "tests/slow/test_missing_data_mcmc.py tests/slow/test_missing_data_and_deadline_mcmc.py"
+            test_args: "tests/integration/test_missing_data_mcmc.py tests/integration/test_missing_data_and_deadline_mcmc.py"
           - batch: "Core MCMC"
-            test_args: "tests/slow/test_mcmc.py tests/slow/test_choice_only.py"
+            test_args: "tests/integration/test_mcmc.py tests/integration/test_choice_only.py"
           - batch: "Remaining Slow"
-            test_args: "-m slow --ignore=tests/slow/test_missing_data_mcmc.py --ignore=tests/slow/test_missing_data_and_deadline_mcmc.py --ignore=tests/slow/test_mcmc.py --ignore=tests/slow/test_choice_only.py"
+            test_args: "-m slow --ignore=tests/integration/test_missing_data_mcmc.py --ignore=tests/integration/test_missing_data_and_deadline_mcmc.py --ignore=tests/integration/test_mcmc.py --ignore=tests/integration/test_choice_only.py"
     uses: ./.github/workflows/run_tests.yml
     with:
       run_slow_tests: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def _slow_test_memory(request):
     buffers) that Python allocators never see. Without releasing it between tests
     a serial run grows RSS until the process is OOM-killed. Gated on the ``slow``
     marker so the fast suite is unaffected, and applies wherever the slow test
-    lives (not just ``tests/slow/``).
+    lives (not just ``tests/integration/``).
 
     Reclamation and RSS logging live in one fixture on purpose: two separate
     autouse fixtures have no guaranteed teardown order, so the logged RSS could


### PR DESCRIPTION
## Purpose

The weekly drift run's slow suite has been failing every leg since the
2026-08-24 scheduled run. Six of the nine legs never collected a single test:

```
ERROR: file or directory not found: tests/slow/test_mcmc.py
ERROR: file or directory not found: tests/slow/test_missing_data_mcmc.py
```

`85f2f032` ("moved all slow tests to integration folder") relocated every slow
test to `tests/integration/` and landed on main on 2026-08-17 15:02 — after
that morning's green drift run, which is why 2026-08-24 was the first run to
see it. `run_slow_tests.yml` was not updated with it.

## Implementation

- Repoint the `Missing Data` and `Core MCMC` batches at `tests/integration/`.
- Repoint the four `--ignore=` paths in the `Remaining Slow` batch. These were
  not merely cosmetic: a non-matching `--ignore` is silently accepted by
  pytest, so `Remaining Slow` had been re-collecting the Core MCMC and Missing
  Data files that the dedicated batches already own.
- Refresh the one stale `tests/slow/` mention in the `tests/conftest.py`
  docstring for `_slow_test_memory`.

No test code or markers changed — only the paths naming it.

## Verification

Each of the four referenced files was confirmed to exist at its new
`tests/integration/` path on `main`; `tests/slow/` no longer exists in the
tree. Beyond that this change is verified by its own CI: the slow suite is the
thing under repair, so this PR's run is the test.

## Out of scope

The `Remaining Slow` legs fail for an unrelated, genuine reason —
`tests/test_hssm.py::test_transform_params_general[include4-IndexError]` now
raises `KeyError: 'invalid_formula'` instead of `IndexError`. That is a
behaviour change, tracked separately; this PR is expected to fix the six
collection-error legs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated slow-test workflow batches to use the integration test suite.
  - Revised test documentation to reflect the current integration test location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->