### PR TITLE
ci: dedupe drift issues on the exact marker, not full-text search

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -101,9 +101,18 @@ jobs:
             FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
           fi
 
-          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label drift \
-            --state open --search "in:body \"$KEY\"" \
-            --json number --jq '.[0].number // empty')
+          # Match the exact marker this job writes, not GitHub's full-text
+          # search. `--search 'in:body "drift-key: HSSM-scheduled"'` tokenizes
+          # and drops punctuation, so an issue that merely *quotes* the key in
+          # prose scores as a match. #1220 — a hand-filed report *about* this
+          # workflow, which necessarily quotes the key — was picked up that way
+          # and silently absorbed every "Still failing" comment for two weeks,
+          # while the real drift issue was never filed. Filtering the labelled
+          # set locally on the literal HTML comment makes that impossible.
+          MARKER="<!-- $KEY -->"
+          EXISTING=$(MARKER="$MARKER" gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label drift --state open --limit 100 --json number,body \
+            --jq 'map(select(.body // "" | contains(env.MARKER))) | .[0].number // empty')
 
           if [ -z "$FAILED_JOBS" ]; then
             if [ -n "$SUCCEEDED" ] && [ -z "$CANCELLED_JOBS" ]; then


### PR DESCRIPTION
## Purpose

The drift issue queue — the durable signal the spine's healing agent drains —
has been silently swallowing real failures since 2026-08-17.

The `report` job finds its existing issue with:

```bash
gh issue list --label drift --state open --search "in:body \"$KEY\""
```

GitHub's full-text search tokenizes and drops punctuation, so `"drift-key:
HSSM-scheduled"` is **not** matched as an exact substring. Any `drift`-labelled
issue that merely *quotes* the key in prose scores as a hit.

#1220 is precisely that: a hand-filed report *about this workflow*, which
necessarily quotes the drift key in order to explain it. It has been the match
ever since. The consequences:

- 2026-08-18 — all four notebook shards failed → comment on #1220, no issue filed.
- 2026-08-24 — six of nine slow legs failed → comment on #1220, no issue filed.

Both real failures were invisible to the queue. They surfaced only because the
spine's freshness scoreboard tracks these budgets independently.

## Implementation

Filter the `drift`-labelled set locally on the literal `<!-- drift-key: ... -->`
HTML comment that this job itself writes. Prose cannot collide with a marker
that is compared as an exact substring. The key stays defined once in `KEY`.

`env.MARKER` is used so the jq filter stays in single quotes rather than
escaping nested double quotes inside a `run:` block.

## Verification

Run against the live repository:

| query | result |
|---|---|
| old, open issues | `1220` ← the false match |
| new, open issues | *(empty)* ← correctly ignores #1220 |
| new, closed issues | `1185` ← still matches a genuine bot-filed issue |

The positive control confirms both that the marker match works and that
`env.MARKER` is supported by the jq engine `gh` embeds.

Once this merges, the next failing run files a proper drift issue again; #1220
stops absorbing them without needing to be edited or relabelled.

## Related but out of scope

#1220 additionally proposes giving each cron slot its own drift key so one
slot's green run cannot close the other's issue. That is a separate design
decision and is untouched here — the two fixes compose.

The same `in:body` pattern is present in the drift workflows of
`ssm-simulators`, `LANfactory`, `LAN_pipeline_minimal` and `HSSMCortex`. It is
latent there (no hand-filed issue currently quotes those keys) and is left for
a follow-up batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drift issue detection by matching the exact required marker in issue content.
  * Prevented false matches from issues that only reference or quote the drift key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->