### PR TITLE
Improve documentation routing and public reference coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,202 +1,58 @@
-<div style="position: relative; width: 100%;">
-  <img src="docs/images/mainlogo.png" alt="HSSM logo" style="width: 175px;">
-  <a href="https://ccbs.carney.brown.edu/brainstorm" style="position: absolute; right: 0; top: 50%; transform: translateY(-50%);">
-    <img src="docs/images/Brain-Bolt-%2B-Circuits.gif" alt="BRAINSTORM logo" style="width: 100px;">
-  </a>
-</div>
+<img src="docs/images/mainlogo.png" alt="HSSM logo" width="175">
 
-# HSSM - Hierarchical Sequential Sampling Modeling
+# HSSM — Hierarchical Sequential Sampling Modeling
 
 [![Paper DOI](https://img.shields.io/badge/paper-10.64898%2F2026.06.05.730398-blue)](https://doi.org/10.64898/2026.06.05.730398)
 [![PyPI](https://img.shields.io/pypi/v/hssm)](https://pypi.org/project/hssm/)
-[![Downloads](https://static.pepy.tech/badge/hssm/month)](https://pepy.tech/projects/hssm)
-[![GitHub stars](https://img.shields.io/github/stars/lnccbrown/HSSM)](https://github.com/lnccbrown/HSSM/stargazers)
-![Python](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)
 [![Run tests](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml/badge.svg)](https://github.com/lnccbrown/HSSM/actions/workflows/run_tests.yml)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![License](https://img.shields.io/github/license/lnccbrown/HSSM)](LICENSE)
 [![codecov](https://codecov.io/gh/lnccbrown/HSSM/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/HSSM)
 
-HSSM is a Python toolbox for hierarchical Bayesian neurocognitive modeling of
-choice, response time, and covariate-rich trial data.
+HSSM is a Python toolbox for hierarchical Bayesian modeling of choice and
+response-time data with sequential sampling models. It supports trial-wise and
+hierarchical regression, reinforcement-learning models, posterior diagnostics,
+model comparison, and custom likelihoods through a high-level PyMC and Bambi
+interface. HSSM is a
+[BRAINSTORM](https://ccbs.carney.brown.edu/brainstorm) project at Brown
+University.
 
-It supports a broad family of sequential-sampling models, reinforcement
-learning sequential-sampling models (RLSSMs), behavioral, neural,
-eye-tracking, and SCR covariates, hierarchical regression, posterior
-diagnostics, posterior predictive checks, and Bayesian model comparison.
+## Install
 
-HSSM is a [BRAINSTORM](https://ccbs.carney.brown.edu/brainstorm) project in
-collaboration with the Center for Computation and Visualization and the Center
-for Computational Brain Science within the Carney Institute at Brown University.
-
-## At a Glance
-
-| Use HSSM to... | What this means in practice |
-| --- | --- |
-| Fit sequential-sampling models | Build DDM, LBA, race, angle, and related choice/RT models from a high-level Python API. |
-| Model behavioral, neural, and other trial-wise covariates | Regress model parameters on trial-level predictors such as EEG, eye-tracking, SCR, task condition, or stimulus features. |
-| Use hierarchical and mixed-effects parameter models | Estimate participant-level variation and within- or between-subject effects with Bambi-style formulas. |
-| Work with RLSSMs | Combine reinforcement-learning dynamics with sequential-sampling decision models. |
-| Diagnose and compare Bayesian models | Use ArviZ summaries, trace diagnostics, posterior predictive checks, and model-comparison workflows. |
-| Extend models with custom likelihoods | Register new models and likelihoods when built-in model definitions are not enough. |
-
-## Installation
-
-Install HSSM in a fresh virtual environment with Python 3.12, 3.13, or 3.14.
-
-### CPU
+Use Python 3.12, 3.13, or 3.14 in a fresh environment:
 
 ```bash
 pip install hssm
 ```
 
-You can also add HSSM to a `uv` project:
+The [installation guide](https://lnccbrown.github.io/HSSM/getting_started/installation/)
+covers uv, CUDA extras, Colab, development installs, and troubleshooting.
 
-```bash
-uv add hssm
-```
+## Start with the documentation
 
-### CUDA
+The [HSSM documentation](https://lnccbrown.github.io/HSSM/) is the canonical
+source for durable guidance. Begin with the
+[quickstart](https://lnccbrown.github.io/HSSM/getting_started/getting_started/),
+then follow the
+[main tutorial](https://lnccbrown.github.io/HSSM/tutorials/main_tutorial/).
+The [ecosystem map](https://lnccbrown.github.io/HSSM/ecosystem/) explains when
+work belongs in HSSM or one of its sibling projects.
 
-For NVIDIA GPUs, install HSSM with the extra matching your CUDA version:
+## Contributing and support
 
-```bash
-pip install "hssm[cuda12]"  # CUDA 12
-pip install "hssm[cuda13]"  # CUDA 13
-```
-
-or with `uv`:
-
-```bash
-uv add "hssm[cuda12]"  # CUDA 12
-uv add "hssm[cuda13]"  # CUDA 13
-```
-
-> **Note:** JAX's CUDA wheels are Linux-only and require a compatible NVIDIA
-> driver (>= 525 for CUDA 12, >= 580 for CUDA 13).
-
-### Apple Silicon, AMD, and Other Accelerators
-
-JAX supports several accelerator backends. Follow the
-[official JAX installation guide](https://jax.readthedocs.io/en/latest/installation.html)
-for your platform, then install HSSM in the same environment.
-
-### Development Version
-
-Install the current development version directly from GitHub:
-
-```bash
-pip install git+https://github.com/lnccbrown/HSSM.git
-```
-
-With `uv`:
-
-```bash
-uv add git+https://github.com/lnccbrown/HSSM.git
-```
-
-### Google Colab
-
-Google Colab already includes PyMC and JAX, so a standard pip install is enough:
-
-```bash
-!pip install hssm
-```
-
-### Troubleshooting
-
-HSSM is tested on Python 3.12, 3.13, and 3.14. If installation fails, start from
-a fresh virtual environment using one of those Python versions and check
-[GitHub Discussions](https://github.com/lnccbrown/HSSM/discussions) for known
-platform-specific fixes.
-
-## Quick Start
-
-```python
-import arviz as az
-import hssm
-
-# Load a package-supplied choice/response-time dataset.
-data = hssm.load_data("cavanagh_theta")
-
-# Build a basic drift-diffusion model.
-model = hssm.HSSM(data=data, model="ddm")
-
-# Draw posterior samples. Increase draws/tune/chains for publication analyses.
-idata = model.sample(draws=1000, tune=1000, chains=4)
-
-# Inspect convergence and posterior summaries with ArviZ.
-az.summary(idata)
-az.plot_trace_dist(idata)
-```
-
-For diagnostics, interpretation, regression formulas, and model comparison, see
-the [getting started guide](https://lnccbrown.github.io/HSSM/getting_started/getting_started/)
-and the [main tutorial](https://lnccbrown.github.io/HSSM/tutorials/main_tutorial/).
-
-## Where HSSM Fits
-
-HSSM is the user-facing modeling layer in the HSSM ecosystem. It builds on
-[PyMC](https://www.pymc.io/) for Bayesian inference,
-[Bambi](https://bambinos.github.io/bambi/) for formula-based and hierarchical
-regression, [ArviZ](https://python.arviz.org/) for diagnostics and model
-comparison, and JAX/PyTensor for computation.
-
-Within the broader ecosystem,
-[ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) supplies simulator
-and model definitions, while
-[LANfactory](https://lnccbrown.github.io/LANfactory/) supports likelihood
-approximation workflows used to develop new likelihoods. The canonical
-[ecosystem map](https://lnccbrown.github.io/HSSM/ecosystem/) routes
-cross-repository questions and contributor work.
+- Read the [contribution guide](docs/CONTRIBUTING.md) and
+  [local development setup](docs/local_development.md).
+- Ask modeling questions in
+  [GitHub Discussions](https://github.com/lnccbrown/HSSM/discussions).
+- Report bugs and request features through
+  [GitHub Issues](https://github.com/lnccbrown/HSSM/issues).
 
 ## Citation
 
-Please cite the current HSSM paper:
-
-Fengler, A., Xu, Y., Bera, K., Paniagua, C., Omar, A., and Frank, M. J.
-HSSM: A Widely Applicable Toolbox for Hierarchical Bayesian Neurocognitive
-Modeling. bioRxiv 2026.06.05.730398.
-
-- DOI: [https://doi.org/10.64898/2026.06.05.730398](https://doi.org/10.64898/2026.06.05.730398)
-- bioRxiv: [https://www.biorxiv.org/content/10.1101/2026.06.05.730398v1](https://www.biorxiv.org/content/10.1101/2026.06.05.730398v1)
-- Software archive DOI, when needed for reproducibility:
-  [https://doi.org/10.5281/zenodo.17247695](https://doi.org/10.5281/zenodo.17247695)
-
-## Next Steps
-
-- [Documentation](https://lnccbrown.github.io/HSSM/)
-- [HSSM ecosystem map](https://lnccbrown.github.io/HSSM/ecosystem/)
-- [Getting started](https://lnccbrown.github.io/HSSM/getting_started/getting_started/)
-- [Main tutorial](https://lnccbrown.github.io/HSSM/tutorials/main_tutorial/)
-- [Scientific workflow tutorial](https://lnccbrown.github.io/HSSM/tutorials/scientific_workflow_hssm/)
-- [RLSSM basic tutorial](https://lnccbrown.github.io/HSSM/tutorials/rlssm_basic/)
-- [RLSSM custom models](https://lnccbrown.github.io/HSSM/tutorials/rlssm_advanced/)
-- [Plotting and model checking](https://lnccbrown.github.io/HSSM/tutorials/plotting/)
-- [GitHub Discussions](https://github.com/lnccbrown/HSSM/discussions)
-- [Contribution guide](docs/CONTRIBUTING.md)
-
-## Support
-
-For questions, please
-[open a discussion](https://github.com/lnccbrown/HSSM/discussions).
-
-For bug reports and feature requests, please
-[open an issue](https://github.com/lnccbrown/HSSM/issues) using the
-corresponding template.
-
-## Contribution
-
-If you want to contribute to this project, please follow our
-[contribution guidelines](docs/CONTRIBUTING.md).
+Please cite Fengler et al., *HSSM: A Widely Applicable Toolbox for Hierarchical
+Bayesian Neurocognitive Modeling* ([paper DOI](https://doi.org/10.64898/2026.06.05.730398)).
+For version-specific software citation, use the
+[Zenodo archive](https://doi.org/10.5281/zenodo.17247695).
 
 ## License
 
-HSSM is licensed under
-[Copyright 2023, Brown University, Providence, RI](LICENSE).
-
-## Acknowledgements
-
-We are grateful to the Bambi project for inspiration, guidance, and support.
-[Tomas Capretto](https://github.com/tomicapretto), a key contributor to Bambi,
-provided invaluable assistance during HSSM development.
+HSSM carries the Brown University license in [LICENSE](LICENSE). Copyright
+2023 Brown University. All Rights Reserved.

--- a/docs/api/addm.md
+++ b/docs/api/addm.md
@@ -1,0 +1,21 @@
+# Attentional drift-diffusion models
+
+## `hssm.aDDM`
+
+::: hssm.aDDM
+    handler: python
+    options:
+        show_root_heading: true
+        show_signature_annotations: true
+        show_object_full_path: false
+        show_signature: true
+
+## `hssm.aDDMConfig`
+
+::: hssm.aDDMConfig
+    handler: python
+    options:
+        show_root_heading: true
+        show_signature_annotations: true
+        show_object_full_path: false
+        show_signature: true

--- a/docs/api/model_registry.md
+++ b/docs/api/model_registry.md
@@ -1,0 +1,21 @@
+# Model discovery and registration
+
+## `hssm.list_models`
+
+::: hssm.list_models
+    handler: python
+    options:
+        show_root_heading: true
+        show_signature_annotations: true
+        show_object_full_path: false
+        show_signature: true
+
+## `hssm.register_model`
+
+::: hssm.register_model
+    handler: python
+    options:
+        show_root_heading: true
+        show_signature_annotations: true
+        show_object_full_path: false
+        show_signature: true

--- a/docs/explanations/likelihoods.md
+++ b/docs/explanations/likelihoods.md
@@ -1,0 +1,70 @@
+# Likelihood kinds in HSSM
+
+Every HSSM model needs a function that scores the observed response and reaction
+time under a set of model parameters. HSSM calls that function a likelihood and
+supports three kinds. The distinction matters because it determines which
+samplers are available, where the numerical implementation comes from, and how
+a custom model must be configured.
+
+## Analytical likelihoods
+
+An `analytical` likelihood is a differentiable numerical implementation owned
+by HSSM. It may use PyTensor operations directly or provide a JAX callable that
+HSSM wraps for use inside a PyTensor graph. Gradient-based PyMC samplers can use
+either backend. The label describes the implementation route; some functions
+use accurate numerical approximations rather than a single closed-form
+expression.
+
+HSSM uses the analytical route by default whenever a built-in model provides
+one. This includes the DDM and DDM-SDV, the LBA models, racing diffusion,
+Poisson race, and the softmax choice models. See the
+[built-in model and likelihood matrix](../reference/models-and-likelihoods.md)
+for the current list.
+
+## Approximate differentiable likelihoods
+
+An `approx_differentiable` likelihood is a learned or otherwise approximate
+function that HSSM can differentiate. The usual artifact is a single-trial ONNX
+network translated to JAX, although a compatible JAX callable can also provide
+the likelihood. HSSM vectorizes the single-trial function across observations.
+
+This route makes models without an analytical likelihood available to
+gradient-based samplers. Its validity depends on the training domain and on
+simulation-based validation: differentiability does not guarantee that a
+network is accurate outside the parameter region it learned.
+
+ONNX artifacts must satisfy the exact
+[ONNX likelihood contract](../how_to/custom_onnx_likelihoods.md). To choose an
+external training route, use [Bring your own likelihood](../how_to/external_trainers.md).
+
+## Black-box likelihoods
+
+A `blackbox` likelihood is an ordinary Python, PyTensor, or ONNX-backed function
+for which HSSM cannot provide gradients. It is the most flexible route, but it
+requires a sampler that does not depend on likelihood gradients. The black-box
+ONNX walkthrough deliberately permits a batched dynamic graph; that is a
+different execution path from the concrete single-trial graph required by the
+approximate differentiable route.
+
+Use [Custom models from ONNX files](../tutorials/blackbox_contribution_onnx_example.ipynb)
+for the black-box procedure. Do not apply its dynamic-axis rewrite to an
+`approx_differentiable` artifact.
+
+## Defaults and overrides
+
+When `loglik_kind` is omitted for a built-in `hssm.HSSM` model, HSSM selects the
+first available kind in this order:
+
+1. `analytical`;
+2. `approx_differentiable`; and
+3. `blackbox`.
+
+Passing `loglik_kind` requests a specific configured route. Passing `loglik`
+overrides the corresponding default function or artifact. A custom model also
+needs the response columns, parameter order, choices, and likelihood metadata
+described by [`hssm.ModelConfig`](../api/model_config.md) or
+[`hssm.register_model`](../api/model_registry.md).
+
+The [built-in model and likelihood matrix](../reference/models-and-likelihoods.md)
+is the canonical catalog. Exact constructor rules live in the
+[`hssm.HSSM` API reference](../api/hssm.md).

--- a/docs/how_to/custom_onnx_likelihoods.md
+++ b/docs/how_to/custom_onnx_likelihoods.md
@@ -1,0 +1,106 @@
+# ONNX likelihood contract
+
+This page is the canonical contract for an ONNX file used with
+`loglik_kind="approx_differentiable"`, regardless of whether LANfactory, sbi,
+BayesFlow, or another tool trained the network.
+
+!!! info "Validation status"
+
+    Documentation CI strictly builds this static contract. HSSM's loader and
+    package tests enforce the concrete-dimension rule and smoke-load compliant
+    artifacts; exporter parity and scientific recovery remain the artifact
+    producer's responsibility.
+
+## Required graph shape
+
+An approximate differentiable ONNX likelihood represents exactly one trial:
+
+- **Input:** one flat vector containing model parameters in `list_params` order,
+  followed by the observed data columns. Its shape may be `(D,)` or `(1, D)`.
+- **Output:** that trial's log-likelihood. It may be a scalar, `(1,)`, or
+  `(1, 1)`, provided it squeezes to one value.
+- **Dimensions:** every input dimension must be a concrete integer. Symbolic
+  dimensions and `dynamic_axes` are forbidden.
+
+HSSM batches the per-trial function itself with `jax.vmap`. Do not export a
+dynamic or multi-trial batch axis for this route. A concrete singleton leading
+dimension such as `(1, D)` remains valid.
+
+## Why dynamic dimensions are rejected
+
+`jaxonnxruntime` traces an ONNX graph against its construction-time input shape
+and can bake those shapes into the translated closure. A symbolic batch axis can
+therefore produce numerically wrong values at another batch size without a
+clear runtime failure, especially when a graph contains a batch-dependent
+`Reshape` or a flow log-determinant accumulator.
+
+Single-trial export followed by HSSM-side vectorization is mathematically
+equivalent for a per-trial likelihood and removes that silent-corruption path.
+HSSM rejects symbolic input dimensions when it loads the graph.
+
+## Rank is exporter-specific
+
+Rank is not the invariant; concrete dimensions are. Supported ecosystem
+exporters legitimately produce both forms:
+
+| Exporter | Traced input | Typical lowering |
+| --- | --- | --- |
+| LANfactory Torch LAN/CPN/OPN | `(1, D)` | `Gemm` |
+| LANfactory JAX LAN/CPN/OPN | `(1, D)` | `Gemm` |
+| LANfactory sbi | `(D,)` | `MatMul` + `Add` |
+| LANfactory BayesFlow | `(D,)` | `MatMul` + `Add` |
+
+Flow graphs that slice a combined parameter/observation vector must use a
+rank-1 dummy. A `(1, D)` flow trace can emit `Slice` operations on axis 1 that
+fail after HSSM vectorizes the function. Plain feed-forward LANs work at either
+rank. Match the exporter and rely on its contract assertion rather than copying
+another exporter's dummy shape.
+
+## Precision constraint for flow graphs
+
+Flow-based exports can contain the `INT64_MAX` sentinel used for open-ended
+slices. With `hssm.set_floatX("float32")`, truncating that constant would change
+the graph. HSSM raises a `ValueError` instead. Use HSSM's default float64 setting
+for flow-based ONNX likelihoods.
+
+## Input ordering
+
+HSSM supplies values in this order:
+
+1. model parameters in `list_params` order; then
+2. the observed data columns, normally reaction time and response.
+
+The exporter and `ModelConfig` must agree on that order. A dimensionally valid
+graph with a different column order can still return plausible but incorrect
+likelihoods.
+
+## Producer verification checklist
+
+Before publishing an artifact:
+
+1. inspect the ONNX input and confirm that every dimension is concrete;
+2. compare the source model and ONNX Runtime across in-bounds parameter draws;
+3. use an exporter tolerance appropriate to the model (the ecosystem exporters
+   use `atol=1e-4` as the outer parity bound);
+4. smoke-load the file in a real `hssm.HSSM` model and require a finite initial
+   log-probability; and
+5. run parameter recovery before using the likelihood for scientific claims.
+
+LANfactory exporters provide
+`lanfactory.onnx.contract.assert_single_trial_contract` for the first check,
+plus ONNX checker, runtime-session, input-width, and optional operator checks.
+It does not construct an HSSM model or evaluate its log-probability. The
+exporter documentation owns framework-specific training constraints; HSSM owns
+this consumer contract and its model-level smoke test.
+
+## Black-box ONNX is a separate route
+
+The [black-box ONNX walkthrough](../tutorials/blackbox_contribution_onnx_example.ipynb)
+uses ONNX Runtime inside an ordinary Python function and may rewrite a graph to
+accept dynamic batches. HSSM never translates that graph to JAX. That procedure
+applies only to `loglik_kind="blackbox"` and is deliberately incompatible with
+the approximate differentiable contract above.
+
+See [Likelihood kinds in HSSM](../explanations/likelihoods.md) for the choice
+between routes and [Bring your own likelihood](external_trainers.md) for the
+supported external-trainer paths.

--- a/docs/how_to/external_trainers.md
+++ b/docs/how_to/external_trainers.md
@@ -24,7 +24,7 @@ and transfer the pattern:
 1. **Simulate** training data from a known ground truth (`ssm-simulators` or `hssm.simulate_data`).
 2. **Train** the surrogate in its home library.
 3. **Export** — for the ONNX routes, via LANfactory's exporters, which enforce
-   [the ONNX likelihood contract](custom_onnx_likelihoods.ipynb) by construction
+   [the ONNX likelihood contract](custom_onnx_likelihoods.md) by construction
    (see LANfactory's [sbi](https://lnccbrown.github.io/LANfactory/exporting_sbi_models/)
    and [BayesFlow](https://lnccbrown.github.io/LANfactory/exporting_bayesflow_models/)
    export guides for the framework-specific constraints).
@@ -36,6 +36,6 @@ and transfer the pattern:
 
 ## See also
 
-- [The ONNX likelihood contract](custom_onnx_likelihoods.ipynb) — the rules an ONNX artifact must satisfy, runnable
+- [The ONNX likelihood contract](custom_onnx_likelihoods.md) — the rules an ONNX artifact must satisfy
 - [Custom models from JAX callables](../tutorials/jax_callable_contribution_onnx_example.ipynb) — the same callable gesture without an external trainer
-- [Understanding likelihood functions in HSSM](../tutorials/likelihoods.ipynb) — where `approx_differentiable` fits among the likelihood kinds
+- [Likelihood kinds in HSSM](../explanations/likelihoods.md) — where `approx_differentiable` fits among the likelihood kinds

--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -1,0 +1,43 @@
+# How-to guides
+
+Use these guides when you already know what you want to accomplish. Each route
+focuses on a concrete modeling, inference, analysis, or extension task.
+
+## Build and parameterize a model
+
+- [Specify priors and fix parameters](specify_priors.ipynb).
+- [Use stimulus coding](../tutorials/tutorial_stim_coding.ipynb).
+- [Add smooth effects with `hsgp()`](../tutorials/hsgp_regression.ipynb).
+- [Model outliers with lapse probabilities](../tutorials/lapse_prob_and_dist.ipynb)
+  or [regress on `p_outlier`](../tutorials/tutorial_p_outlier_regression.ipynb).
+
+## Choose and run an inference method
+
+- [Set initial values](../tutorials/initial_values.ipynb).
+- [Use an alternative sampler with Bayeux](../tutorials/tutorial_bayeux.ipynb).
+- [Run variational inference](../tutorials/variational_inference.ipynb).
+
+## Work with fitted models
+
+- [Plot posteriors and predictions](../tutorials/plotting.ipynb), then consult
+  the [posterior-predictive](../tutorials/ppc_gallery.ipynb) or
+  [model-cartoon](../tutorials/cartoon_gallery.ipynb) gallery.
+- [Compare and interpret models](compare_models.ipynb).
+- [Extract trial-wise parameters](../tutorials/tutorial_trial_wise_parameters.ipynb).
+- [Run a Bayesian t-test on posterior draws](../tutorials/tutorial_bayesian_t_test.ipynb).
+- [Simulate interventions with the do-operator](../tutorials/do_operator.ipynb).
+- [Save and load fitted models](../tutorials/save_load_tutorial.ipynb).
+
+## Extend HSSM
+
+Begin with the [custom-likelihood route table](external_trainers.md). For ONNX,
+read the [ONNX likelihood contract](custom_onnx_likelihoods.ipynb) before using
+the sbi, BayesFlow, JAX-callable, or black-box walkthrough linked there.
+
+For a contribution to HSSM itself, follow the
+[local development setup](../local_development.md) and then the
+[contribution guide](../CONTRIBUTING.md).
+
+For concepts rather than procedures, return to the
+[learning index](../learn/index.md). For exact APIs, use the
+[reference index](../reference/index.md).

--- a/docs/how_to/index.md
+++ b/docs/how_to/index.md
@@ -31,7 +31,7 @@ focuses on a concrete modeling, inference, analysis, or extension task.
 ## Extend HSSM
 
 Begin with the [custom-likelihood route table](external_trainers.md). For ONNX,
-read the [ONNX likelihood contract](custom_onnx_likelihoods.ipynb) before using
+read the [ONNX likelihood contract](custom_onnx_likelihoods.md) before using
 the sbi, BayesFlow, JAX-callable, or black-box walkthrough linked there.
 
 For a contribution to HSSM itself, follow the

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,8 +98,8 @@ model.sample()
 
     For models HSSM does not ship, or likelihoods you trained yourself:
 
-    1. [Understanding likelihoods in HSSM](tutorials/likelihoods.ipynb) — analytical, `approx_differentiable`, and blackbox, and when each applies.
-    2. [The ONNX likelihood contract](how_to/custom_onnx_likelihoods.ipynb) — the rules an ONNX file must satisfy, demonstrated live.
+    1. [Likelihood kinds in HSSM](explanations/likelihoods.md) — analytical, `approx_differentiable`, and blackbox, and when each applies.
+    2. [The ONNX likelihood contract](how_to/custom_onnx_likelihoods.md) — the exact rules an approximate differentiable ONNX file must satisfy.
     3. [Bring your own likelihood](how_to/external_trainers.md) — the route table for networks trained in sbi or BayesFlow.
     4. Then the walkthrough for your route — [sbi NRE](tutorials/sbi_nre_integration.ipynb), [BayesFlow NLE](tutorials/bayesflow_nle_onnx_integration.ipynb), [BayesFlow LRE](tutorials/bayesflow_lre_integration.ipynb), or [JAX callables](tutorials/jax_callable_contribution_onnx_example.ipynb).
     5. [Use the low-level API with PyMC](tutorials/pymc.ipynb) — when the formula interface is the constraint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,9 +106,11 @@ model.sample()
 
 </div>
 
-Beyond the paths, the docs are organised by what you are doing: **Learn** for
-guided material, **How-to guides** for a specific task, **Explanations** for
-the reasoning behind a choice, and **Reference** for the API.
+Beyond the paths, the docs are organised by what you are doing:
+[Learn](learn/index.md) for guided material,
+[How-to guides](how_to/index.md) for a specific task, **Explanations** for the
+reasoning behind a choice, and [Reference](reference/index.md) for exact APIs
+and project metadata.
 
 ## Part of a larger toolchain
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,9 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/lnccbrown/HSSM)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-**HSSM** (Hierarchical Sequential Sampling Modeling) is a modern open-source
-Python toolbox for computational modeling in cognitive neuroscience. It supports
+**HSSM** (Hierarchical Sequential Sampling Modeling) is a modern,
+source-available Python toolbox for computational modeling in cognitive
+neuroscience. It supports
 a broad range of sequential sampling models used to study decision-making,
 learning, and other cognitive processes — from basic research to the analysis of
 clinical effects. HSSM provides state-of-the-art likelihood approximation

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,0 +1,51 @@
+# Learn HSSM
+
+Use this section for guided material that builds understanding through complete
+examples. If you are new to HSSM, follow the first path in order; the remaining
+paths assume that you can already fit and inspect a basic model.
+
+## Start with a complete workflow
+
+1. [Install HSSM](../getting_started/installation.md).
+2. [Fit and check a first DDM](../getting_started/getting_started.ipynb).
+3. [Work through the main HSSM tutorial](../tutorials/main_tutorial.ipynb).
+4. [Add hierarchical structure](../getting_started/hierarchical_modeling.ipynb).
+5. [See one analysis from data to interpretation](../tutorials/scientific_workflow_hssm.ipynb).
+
+## Learn a model family
+
+- [Hierarchical DDM regressions](../tutorials/ddm_hierarchical_tutorial.ipynb)
+  connect an experimental design to parameter formulas.
+- [Choice-only models](../tutorials/choice_only_models.ipynb) cover decisions
+  without response times.
+- [Poisson race models](../tutorials/poisson_race.ipynb) introduce a
+  multi-accumulator model.
+- [HMMs with DDM emissions](../tutorials/hmm_ddm_regime_switching.ipynb) model
+  regime changes across trials.
+- [Attentional DDMs](../tutorials/attentional_ddm.py) connect fixation
+  covariates to evidence accumulation.
+
+## Learn reinforcement-learning models
+
+Start with [RLSSM basics](../tutorials/rlssm_basic.ipynb), then choose the route
+that matches your data:
+
+- [choice-only RLSSMs](../tutorials/choice_only_rlssm.ipynb);
+- [custom RLSSMs with `ssms.rl`](../tutorials/rlssm_advanced.ipynb);
+- [restless learners](../tutorials/rlssm_restless_learner.ipynb); or
+- [registering a custom RLSSM](../tutorials/rlssm_hssm_custom_models.ipynb).
+
+## Understand modeling choices
+
+- [Coming from HDDM](../explanations/coming_from_hddm.md) maps familiar HDDM
+  concepts to HSSM.
+- [Understanding likelihoods](../tutorials/likelihoods.ipynb) explains the
+  available likelihood kinds.
+- [Centered and non-centered parameterizations](../tutorials/centered_vs_noncentered_basic_logic.ipynb)
+  establish the basic trade-off.
+- [Random-slope prior diagnostics](../tutorials/random_slope_safe_priors.ipynb)
+  show how parameterization decisions affect real models.
+
+Ready to solve a specific problem? Continue to the
+[how-to guide index](../how_to/index.md). For exact signatures and supported
+helpers, use the [reference index](../reference/index.md).

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -39,7 +39,7 @@ that matches your data:
 
 - [Coming from HDDM](../explanations/coming_from_hddm.md) maps familiar HDDM
   concepts to HSSM.
-- [Understanding likelihoods](../tutorials/likelihoods.ipynb) explains the
+- [Likelihood kinds in HSSM](../explanations/likelihoods.md) explains the
   available likelihood kinds.
 - [Centered and non-centered parameterizations](../tutorials/centered_vs_noncentered_basic_logic.ipynb)
   establish the basic trade-off.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,11 +7,17 @@ This section records the public HSSM interfaces and project metadata. Use the
 ## Core modeling interfaces
 
 - [`hssm.HSSM`](../api/hssm.md) builds and fits an HSSM model.
+- [`hssm.aDDM` and `hssm.aDDMConfig`](../api/addm.md) provide the specialized
+  attentional drift-diffusion interface.
 - [`hssm.Param`](../api/param.md), [`hssm.Prior`](../api/prior.md), and
   [`hssm.Link`](../api/link.md) describe parameter formulas, priors, and links.
 - [`hssm.ModelConfig`](../api/model_config.md) describes registered model
   configurations.
 - [`hssm.rl`](../api/rl.md) contains the reinforcement-learning interfaces.
+- [Built-in models and likelihoods](models-and-likelihoods.md) records every
+  `hssm.HSSM(model=...)` name, configured likelihood kind, parameter, and choice.
+- [The ONNX likelihood contract](../how_to/custom_onnx_likelihoods.md) records
+  the portable artifact boundary for approximate differentiable likelihoods.
 
 ## Functions and specialized modules
 
@@ -20,6 +26,8 @@ This section records the public HSSM interfaces and project metadata. Use the
 - [`hssm.show_defaults`](../api/show_defaults.md) inspects model defaults.
 - [`hssm.set_floatX`](../api/set_floatx.md) selects floating-point precision.
 - [`hssm.check_data_for_rl`](../api/check_data_for_rl.md) validates RLSSM data.
+- [`hssm.list_models` and `hssm.register_model`](../api/model_registry.md)
+  discover and extend the HSSM model registry.
 - [`hssm.likelihoods`](../api/likelihoods.md) records likelihood interfaces.
 - [`hssm.distribution_utils`](../api/distribution_utils.md) records distribution
   helpers.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,44 @@
+# Reference
+
+This section records the public HSSM interfaces and project metadata. Use the
+[learning index](../learn/index.md) for guided examples or the
+[how-to index](../how_to/index.md) for task-oriented procedures.
+
+## Core modeling interfaces
+
+- [`hssm.HSSM`](../api/hssm.md) builds and fits an HSSM model.
+- [`hssm.Param`](../api/param.md), [`hssm.Prior`](../api/prior.md), and
+  [`hssm.Link`](../api/link.md) describe parameter formulas, priors, and links.
+- [`hssm.ModelConfig`](../api/model_config.md) describes registered model
+  configurations.
+- [`hssm.rl`](../api/rl.md) contains the reinforcement-learning interfaces.
+
+## Functions and specialized modules
+
+- [`hssm.load_data`](../api/load_data.md) loads package-supplied datasets.
+- [`hssm.simulate_data`](../api/simulate_data.md) simulates supported models.
+- [`hssm.show_defaults`](../api/show_defaults.md) inspects model defaults.
+- [`hssm.set_floatX`](../api/set_floatx.md) selects floating-point precision.
+- [`hssm.check_data_for_rl`](../api/check_data_for_rl.md) validates RLSSM data.
+- [`hssm.likelihoods`](../api/likelihoods.md) records likelihood interfaces.
+- [`hssm.distribution_utils`](../api/distribution_utils.md) records distribution
+  helpers.
+- [`hssm.plotting`](../api/plotting.md) records plotting functions.
+
+## Project reference
+
+- [Changelog](../changelog.md) — release-by-release behavior changes.
+- [Ecosystem map](../ecosystem/index.md) — package ownership and contributor
+  routes across the native HSSM ecosystem.
+- [Contribution guide](../CONTRIBUTING.md) and
+  [local development setup](../local_development.md).
+- [Credits](../credits.md) and [license](../license.md).
+
+## Historical tutorial snapshots
+
+These archives preserve the material presented at a specific event. Prefer the
+current Learn and How-to pages above for maintained guidance.
+
+- [Winterbrain 2025 — Talk 1](../archive/hssm_tutorial_workshop_1.ipynb).
+- [Winterbrain 2025 — Talk 2](../archive/hssm_tutorial_workshop_2.ipynb).
+- [PyMC to HSSM — MathPsych 2025](../archive/pymc_to_hssm.ipynb).

--- a/docs/reference/models-and-likelihoods.md
+++ b/docs/reference/models-and-likelihoods.md
@@ -1,0 +1,46 @@
+# Built-in models and likelihoods
+
+`hssm.HSSM(model=...)` accepts the built-in model names below. The table is
+tested against `hssm.list_models()` and each model's default configuration, so a
+code change that leaves this catalog stale fails CI.
+
+When `loglik_kind` is omitted, HSSM prefers `analytical`, then
+`approx_differentiable`, then `blackbox` among the kinds configured for that
+model.
+
+| Model | Available likelihood kinds | Default | Parameters | Choices |
+| --- | --- | --- | --- | --- |
+| `ddm` | `analytical`, `approx_differentiable`, `blackbox` | `analytical` | `v`, `a`, `z`, `t` | `-1`, `1` |
+| `ddm_sdv` | `analytical`, `approx_differentiable`, `blackbox` | `analytical` | `v`, `a`, `z`, `t`, `sv` | `-1`, `1` |
+| `full_ddm` | `blackbox` | `blackbox` | `v`, `a`, `z`, `t`, `sz`, `sv`, `st` | `-1`, `1` |
+| `angle` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `theta` | `-1`, `1` |
+| `levy` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `alpha`, `t` | `-1`, `1` |
+| `ornstein` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `g`, `t` | `-1`, `1` |
+| `weibull` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `alpha`, `beta` | `-1`, `1` |
+| `race_no_bias_angle_4` | `approx_differentiable` | `approx_differentiable` | `v0`, `v1`, `v2`, `v3`, `a`, `z`, `t`, `theta` | `0`, `1`, `2`, `3` |
+| `ddm_seq2_no_bias` | `approx_differentiable` | `approx_differentiable` | `vh`, `vl1`, `vl2`, `a`, `t` | `0`, `1`, `2`, `3` |
+| `lba3` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1`, `v2` | `0`, `1`, `2` |
+| `lba4` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1`, `v2`, `v3` | `0`, `1`, `2`, `3` |
+| `lba2` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1` | `0`, `1` |
+| `racing_diffusion_3` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1`, `v2`, `t` | `0`, `1`, `2` |
+| `poisson_race` | `analytical` | `analytical` | `r1`, `r2`, `k1`, `k2`, `t` | `-1`, `1` |
+| `softmax_inv_temperature_2` | `analytical` | `analytical` | `beta`, `logit1` | `-1`, `1` |
+| `softmax_inv_temperature_3` | `analytical` | `analytical` | `beta`, `logit1`, `logit2` | `0`, `1`, `2` |
+
+## Specialized model families
+
+The table covers the `hssm.HSSM(model=...)` registry. Two specialized public
+classes have separate configuration and discovery surfaces:
+
+- [`hssm.aDDM`](../api/addm.md) models attentional evidence accumulation from
+  trial and fixation data.
+- [`hssm.RLSSM`](../api/rl.md) combines reinforcement-learning updates with an
+  SSM observation model; its class-level and module-level `list_models`
+  functions enumerate the RL registry.
+
+Use [`hssm.list_models`](../api/model_registry.md) to discover the built-in HSSM
+names programmatically. Custom HSSM configurations can be added with
+[`hssm.register_model`](../api/model_registry.md).
+
+For the conceptual difference between the likelihood kinds, see
+[Likelihood kinds in HSSM](../explanations/likelihoods.md).

--- a/docs/tutorials/attentional_ddm.py
+++ b/docs/tutorials/attentional_ddm.py
@@ -66,6 +66,11 @@ def _(mo):
     This notebook: **(1)** poke the simulator, **(2)** see the covariate handshake,
     **(3)** fit a trial-wise regression and recover it. The simulator is driven via
     ssm-simulators' high-level `Simulator` class — the same path HSSM's PPC uses.
+
+    **Execution status.** This interactive marimo notebook is maintained and run
+    manually. Documentation CI renders the page but deliberately does not click
+    its button-gated sampling cells or validate the full recovery run. Run the
+    notebook locally before relying on newly generated results.
     """)
     return
 

--- a/docs/tutorials/main_tutorial.ipynb
+++ b/docs/tutorials/main_tutorial.ipynb
@@ -17,7 +17,7 @@
    "id": "0aaef866",
    "metadata": {},
    "source": [
-    "HSSM is an open-source Python toolkit for Bayesian hierarchical sequential-sampling modeling. It helps researchers model **choices and response times together** to study latent decision and learning processes in cognitive (neuro)science. HSSM can be used to analyze behavioral (choice, rt), neural (EEG, fMRI) and other covariate (eye-tracking, SCR) data.\n",
+    "HSSM is a source-available Python toolkit for Bayesian hierarchical sequential-sampling modeling. It helps researchers model **choices and response times together** to study latent decision and learning processes in cognitive (neuro)science. HSSM can be used to analyze behavioral (choice, rt), neural (EEG, fMRI) and other covariate (eye-tracking, SCR) data.\n",
     "\n",
     "This tutorial is designed for new HSSM users. You will build a simple model from simulated data, learn how to inspect and validate it, and then extend the same workflow with priors, regressions, participant hierarchies, and model comparison."
    ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,6 @@ validation:
 
 # phase-2 consolidation targets, deliberately unlisted until then
 not_in_nav: |
-  tutorials/attentional_ddm.py
   tutorials/link_functions.py
   tutorials/random_slope_safe_priors.py
 
@@ -22,15 +21,8 @@ exclude_docs: |
 nav:
   - Home:
       - Overview: index.md
-      - Credits: credits.md
-      - License: license.md
-      - Changelog: changelog.md
-      - The HSSM ecosystem: ecosystem/index.md
-      - Archive:
-          - Winterbrain 2025 — Talk 1 (snapshot): archive/hssm_tutorial_workshop_1.ipynb
-          - Winterbrain 2025 — Talk 2 (snapshot): archive/hssm_tutorial_workshop_2.ipynb
-          - PyMC to HSSM — MathPsych 2025 (snapshot): archive/pymc_to_hssm.ipynb
   - Learn:
+      - Overview: learn/index.md
       - Get started:
           - Installation: getting_started/installation.md
           - Quickstart: getting_started/getting_started.ipynb
@@ -42,6 +34,7 @@ nav:
           - Choice-only models: tutorials/choice_only_models.ipynb
           - Poisson race models: tutorials/poisson_race.ipynb
           - HMM with DDM emissions: tutorials/hmm_ddm_regime_switching.ipynb
+          - Attentional DDM (aDDM): tutorials/attentional_ddm.py
       - Reinforcement learning models:
           - RLSSM basics: tutorials/rlssm_basic.ipynb
           - Choice-only RLSSM: tutorials/choice_only_rlssm.ipynb
@@ -49,6 +42,7 @@ nav:
           - A restless learner: tutorials/rlssm_restless_learner.ipynb
           - Registering custom RLSSMs in HSSM: tutorials/rlssm_hssm_custom_models.ipynb
   - How-to guides:
+      - Overview: how_to/index.md
       - Building models:
           - Specify priors and fix parameters: how_to/specify_priors.ipynb
           - Model outliers with lapse probabilities: tutorials/lapse_prob_and_dist.ipynb
@@ -89,6 +83,7 @@ nav:
       - Random-slope prior diagnostics: tutorials/random_slope_safe_priors.ipynb
       - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
   - Reference:
+      - Overview: reference/index.md
       - HSSM core classes:
           - hssm.HSSM: api/hssm.md
           - hssm.Param: api/param.md
@@ -108,6 +103,15 @@ nav:
           - hssm.distribution_utils: api/distribution_utils.md
       - Plotting:
           - hssm.plotting: api/plotting.md
+      - Project and site:
+          - Changelog: changelog.md
+          - The HSSM ecosystem: ecosystem/index.md
+          - Credits: credits.md
+          - License: license.md
+      - Historical tutorial snapshots:
+          - Winterbrain 2025 — Talk 1: archive/hssm_tutorial_workshop_1.ipynb
+          - Winterbrain 2025 — Talk 2: archive/hssm_tutorial_workshop_2.ipynb
+          - PyMC to HSSM — MathPsych 2025: archive/pymc_to_hssm.ipynb
 plugins:
   - search
   - autorefs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ not_in_nav: |
 
 exclude_docs: |
   overrides/
+  tutorials/likelihoods.ipynb
+  how_to/custom_onnx_likelihoods.ipynb
 
 nav:
   - Home:
@@ -63,7 +65,6 @@ nav:
           - Simulate data with the do-operator: tutorials/do_operator.ipynb
           - Save and load models: tutorials/save_load_tutorial.ipynb
       - Custom likelihoods and models:
-          - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.ipynb
           - Bring your own likelihood (external trainers): how_to/external_trainers.md
           - Custom models from JAX callables: tutorials/jax_callable_contribution_onnx_example.ipynb
           - Custom models from ONNX files (blackbox): tutorials/blackbox_contribution_onnx_example.ipynb
@@ -77,21 +78,25 @@ nav:
           - Contribution guide: CONTRIBUTING.md
   - Explanations:
       - Coming from HDDM: explanations/coming_from_hddm.md
-      - Understanding likelihoods in HSSM: tutorials/likelihoods.ipynb
+      - Likelihood kinds in HSSM: explanations/likelihoods.md
       - Link functions and safe priors: tutorials/link_functions.ipynb
       - Centered vs. non-centered parameterizations: tutorials/centered_vs_noncentered_basic_logic.ipynb
       - Random-slope prior diagnostics: tutorials/random_slope_safe_priors.ipynb
       - Choosing a parameterization per parameter: tutorials/parameterization_per_parameter.ipynb
   - Reference:
       - Overview: reference/index.md
+      - Built-in models and likelihoods: reference/models-and-likelihoods.md
+      - The ONNX likelihood contract: how_to/custom_onnx_likelihoods.md
       - HSSM core classes:
           - hssm.HSSM: api/hssm.md
+          - hssm.aDDM and hssm.aDDMConfig: api/addm.md
           - hssm.Param: api/param.md
           - hssm.ModelConfig: api/model_config.md
           - hssm.Prior: api/prior.md
           - hssm.Link: api/link.md
           - hssm.rl: api/rl.md
       - Useful functions:
+          - Model discovery and registration: api/model_registry.md
           - hssm.load_data: api/load_data.md
           - hssm.simulate_data: api/simulate_data.md
           - hssm.set_floatX: api/set_floatx.md
@@ -118,6 +123,7 @@ plugins:
   - redirects:
       redirect_maps:
         api/defaults.md: api/show_defaults.md
+        tutorials/likelihoods.md: explanations/likelihoods.md
         tutorials/hssm_tutorial_workshop_1.md: https://lnccbrown.github.io/HSSM/archive/hssm_tutorial_workshop_1/
         tutorials/hssm_tutorial_workshop_2.md: https://lnccbrown.github.io/HSSM/archive/hssm_tutorial_workshop_2/
         tutorials/pymc_to_hssm.md: https://lnccbrown.github.io/HSSM/archive/pymc_to_hssm/
@@ -130,7 +136,6 @@ plugins:
       execute_ignore:
         - getting_started/getting_started.ipynb
         - how_to/specify_priors.ipynb
-        - how_to/custom_onnx_likelihoods.ipynb
         - how_to/compare_models.ipynb
         - getting_started/hierarchical_modeling.ipynb
         - tutorials/main_tutorial.ipynb
@@ -141,7 +146,6 @@ plugins:
         - tutorials/ddm_hierarchical_tutorial.ipynb
         - tutorials/choice_only_models.ipynb
         - tutorials/choice_only_rlssm.ipynb
-        - tutorials/likelihoods.ipynb
         - tutorials/variational_inference.ipynb
         - tutorials/centered_vs_noncentered_basic_logic.ipynb
         - tutorials/parameterization_per_parameter.ipynb

--- a/tests/test_docs_public_reference.py
+++ b/tests/test_docs_public_reference.py
@@ -1,0 +1,84 @@
+"""Keep reader-facing model and API reference aligned with public code."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from hssm.config import Config
+from hssm.modelconfig import get_default_model_config, list_models
+
+ROOT = Path(__file__).parent.parent
+MODEL_REFERENCE = ROOT / "docs/reference/models-and-likelihoods.md"
+
+
+def _code_values(cell: str) -> tuple[str, ...]:
+    """Return the ordered code spans in one Markdown table cell."""
+    return tuple(re.findall(r"`([^`]+)`", cell))
+
+
+def _model_rows() -> tuple[
+    tuple[str, tuple[str, ...], str, tuple[str, ...], tuple[str, ...]], ...
+]:
+    rows: list[tuple[str, tuple[str, ...], str, tuple[str, ...], tuple[str, ...]]] = []
+    for line in MODEL_REFERENCE.read_text().splitlines():
+        cells = tuple(cell.strip() for cell in line.strip().strip("|").split("|"))
+        if len(cells) != 5 or not cells[0].startswith("`"):
+            continue
+        model_values = _code_values(cells[0])
+        default_values = _code_values(cells[2])
+        assert len(model_values) == len(default_values) == 1
+        rows.append(
+            (
+                model_values[0],
+                _code_values(cells[1]),
+                default_values[0],
+                _code_values(cells[3]),
+                _code_values(cells[4]),
+            )
+        )
+    return tuple(rows)
+
+
+def test_builtin_model_matrix_matches_defaults() -> None:
+    """Require the documented built-in matrix to match current configurations."""
+    rows = _model_rows()
+    models = tuple(list_models())
+    assert tuple(row[0] for row in rows) == models
+    assert len({row[0] for row in rows}) == len(rows)
+
+    for model, kinds, default, params, choices in rows:
+        config = get_default_model_config(model)
+        runtime_default = Config.from_defaults(model, None)
+        assert runtime_default is not None
+        assert (kinds, default, params, choices) == (
+            tuple(config["likelihoods"]),
+            runtime_default.loglik_kind,
+            tuple(config["list_params"]),
+            tuple(str(choice) for choice in config["choices"]),
+        )
+
+
+def test_previously_missing_top_level_apis_are_documented() -> None:
+    """Keep specialized top-level public exports in the API reference."""
+    expectations = {
+        "docs/api/addm.md": ("hssm.aDDM", "hssm.aDDMConfig"),
+        "docs/api/model_registry.md": ("hssm.list_models", "hssm.register_model"),
+    }
+    for relative_path, names in expectations.items():
+        contents = (ROOT / relative_path).read_text()
+        assert all(name in contents for name in names)
+
+
+def test_onnx_reference_states_the_enforced_contract() -> None:
+    """Keep the central ONNX invariants visible on the canonical page."""
+    contract = " ".join(
+        (ROOT / "docs/how_to/custom_onnx_likelihoods.md").read_text().split()
+    )
+    for required in (
+        "every input dimension must be a concrete integer",
+        "Symbolic dimensions and `dynamic_axes` are forbidden",
+        "HSSM batches the per-trial function itself with `jax.vmap`",
+        "model parameters in `list_params` order",
+    ):
+        assert required in contract


### PR DESCRIPTION
## Summary

- Reorganize the public site into the five profile-driven sections and add guided landing pages with explicit next steps.
- Establish canonical likelihood, ONNX-contract, and built-in-model reference pages; keep the model table tied to runtime ordering and defaults.
- Publish the attentional-DDM tutorial with an explicit validation-status disclosure and align public wording with HSSM's Brown All Rights Reserved license.
- Add focused regression coverage for public API/reference completeness and ONNX contract wording.
- This changes documentation and tests only; there is no runtime API or behavior change.

## Verification

- `./scripts/docs.sh build` — passed strict MkDocs build, 179-file weight guard, and 45-notebook machine-path guard.
- `uv run --python 3.12 --group dev --group notebook --group docs --no-sync pytest -q tests/test_docs_public_reference.py` — 3 passed.
- `.venv/bin/ruff check tests/test_docs_public_reference.py docs/tutorials/attentional_ddm.py` — passed.
- `.venv/bin/ruff format --check tests/test_docs_public_reference.py docs/tutorials/attentional_ddm.py` — passed.
- `.venv/bin/marimo check --strict docs/tutorials/attentional_ddm.py` — passed.
- Custom nav/content audit — exact five-section nav, 76 valid destinations, zero content orphans across 80 page-like sources.
- Offline rendered-file audit — 7,490 local targets resolved across 83 HTML files.

## Scope

- Sampling-heavy notebook freshness and re-execution remain separate and explicitly deferred to #1243; this PR does not fold that work into the documentation-quality change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured Learn, How-to, and Reference hubs for easier navigation.
  * Documented built-in models, likelihood types, public APIs, model registration, and custom ONNX likelihood requirements.
  * Condensed the README and linked readers to comprehensive online guides.
  * Improved tutorial organization, navigation, and page redirects.
* **Tests**
  * Added checks to keep model references, public APIs, and ONNX guidance consistent with the software.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->