### PR TITLE
Validate prior and link setting presets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,8 @@
 
 6. **Safe common-intercept priors now recognize every identity-link spelling consistently** (#1232). An omitted link, `"identity"`, `bambi.Link("identity")`, and `hssm.Link("identity")` all retain response-scale priors, including HDDM-derived priors; transformed links use a coefficient-scale `Normal(mu=0, sigma=0.25)`. Explicit priors still win, and unmatched group-only terms remain unchanged pending [#1225](https://github.com/lnccbrown/HSSM/issues/1225). See [Link functions and safe priors](tutorials/link_functions.ipynb) for the underlying model-design logic.
 
+7. **Invalid model-level prior and link presets now fail fast** (#1233). `prior_settings` accepts only `"safe"` or `None`, and `link_settings` accepts only `"log_logit"` or `None`; wrong-case strings, booleans, mappings, and other unsupported values now raise a clear `ValueError` instead of silently changing prior, link, initial-value, or display behavior. The API documentation now clarifies that both presets act on regression parameters: `prior_settings=None` delegates missing regression-term priors to Bambi but leaves HSSM's simple-parameter defaults unchanged. The Poisson-race tutorial has also been migrated to marimo and no longer presents `prior_settings` as a prior dictionary.
+
 ### 0.4.0
 
 This version contains major breaking updates for HSSM. Please read the release notes below to migrate to HSSM 0.4.0.

--- a/docs/tutorials/poisson_race.ipynb
+++ b/docs/tutorials/poisson_race.ipynb
@@ -1,45 +1,34 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "c6ec77a6",
-   "metadata": {},
-   "source": [
-    "# Poisson race models\n",
-    "\n",
-    "This short tutorial shows how to (1) simulate synthetic reaction times with the Poisson race simulator from `ssms-simulators`, (2) fit the analytical Poisson race likelihood provided by HSSM, and (3) inspect the recovered parameters with ArviZ.\n"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "ecd0c85b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-29T18:29:57.841472Z",
-     "iopub.status.busy": "2026-06-29T18:29:57.841406Z",
-     "iopub.status.idle": "2026-06-29T18:29:59.423555Z",
-     "shell.execute_reply": "2026-06-29T18:29:59.423231Z"
-    }
-   },
+   "execution_count": null,
+   "id": "Hbol",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setting PyTensor floatX type to float32.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Setting PyTensor floatX type to float32.\n",
       "Setting \"jax_enable_x64\" to False. If this is not intended, please set `jax` to False.\n"
      ]
     }
    ],
    "source": [
+    "import logging\n",
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "# This tutorial does not need a GPU. Keep Molab and headless documentation\n",
+    "# builds away from host CUDA plugins before importing HSSM/JAX.\n",
+    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\"\n",
+    "os.environ[\"JAX_SKIP_CUDA_CONSTRAINTS_CHECK\"] = \"1\"\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "logging.getLogger(\"jax._src.xla_bridge\").setLevel(logging.CRITICAL)\n",
+    "\n",
     "import arviz as az\n",
+    "import marimo as mo\n",
     "import numpy as np\n",
     "\n",
     "import hssm\n",
@@ -47,174 +36,122 @@
     "hssm.set_floatX(\"float32\")\n",
     "az.style.use(\"seaborn-v0_8-whitegrid\")\n",
     "\n",
-    "rng = np.random.default_rng(123)"
+    "FULL_RUN = os.environ.get(\"FULL_RUN\") == \"1\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cd360964",
-   "metadata": {},
+   "id": "MJUe",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r"
+    }
+   },
    "source": [
-    "## Simulate with ssms-simulators\n",
+    "# Poisson race models\n",
     "\n",
-    "`hssm.simulate_data` wraps the `ssms-simulators` Poisson race generator. The simulator names its accumulator-specific parameters with zero-based indices (`r0`/`r1` and `k0`/`k1`). We mirror those values into an HSSM-friendly dict so posterior checks line up with the likelihood parameterization (`r1`, `r2`, `k1`, `k2`, `t`).\n"
+    "This short tutorial shows how to:\n",
+    "\n",
+    "1. simulate synthetic reaction times with the Poisson race simulator from\n",
+    "   `ssm-simulators`;\n",
+    "2. fit HSSM's analytical Poisson race likelihood; and\n",
+    "3. compare the recovered posterior with the generating parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vblA",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r"
+    }
+   },
+   "source": [
+    "## Simulate with ssm-simulators\n",
+    "\n",
+    "`hssm.simulate_data` wraps the `ssm-simulators` Poisson race generator.\n",
+    "The simulator and HSSM likelihood share the same accumulator-specific\n",
+    "parameter names: `r1`, `r2`, `k1`, `k2`, and the non-decision time `t`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "8d61c39a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-29T18:29:59.424863Z",
-     "iopub.status.busy": "2026-06-29T18:29:59.424785Z",
-     "iopub.status.idle": "2026-06-29T18:29:59.433052Z",
-     "shell.execute_reply": "2026-06-29T18:29:59.432785Z"
-    }
-   },
+   "execution_count": null,
+   "id": "bkHC",
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>rt</th>\n",
-       "      <th>response</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.938074</td>\n",
-       "      <td>-1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0.444526</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0.609057</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0.914047</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0.509135</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "         rt  response\n",
-       "0  0.938074      -1.0\n",
-       "1  0.444526       1.0\n",
-       "2  0.609057       1.0\n",
-       "3  0.914047       1.0\n",
-       "4  0.509135       1.0"
+      "text/markdown": [
+       "|       rt |   response |\n",
+       "|---------:|-----------:|\n",
+       "| 0.938074 |         -1 |\n",
+       "| 0.444526 |          1 |\n",
+       "| 0.609057 |          1 |\n",
+       "| 0.914047 |          1 |\n",
+       "| 0.509135 |          1 |"
       ]
      },
-     "execution_count": 2,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "\"\"\"\n",
-    "ssms_params = {\n",
-    "    \"r0\": 2.8,\n",
-    "    \"r1\": 3.4,\n",
-    "    \"k0\": 1.6,\n",
-    "    \"k1\": 1.2,\n",
+    "true_params = {\n",
+    "    \"r1\": 1.0,\n",
+    "    \"r2\": 5.0,\n",
+    "    \"k1\": 2.0,\n",
+    "    \"k2\": 2.0,\n",
     "    \"t\": 0.25,\n",
     "}\n",
-    "true_params = {\n",
-    "    \"r1\": ssms_params[\"r0\"],\n",
-    "    \"r2\": ssms_params[\"r1\"],\n",
-    "    \"k1\": ssms_params[\"k0\"],\n",
-    "    \"k2\": ssms_params[\"k1\"],\n",
-    "    \"t\": ssms_params[\"t\"],\n",
-    "}\n",
-    "n_trials = 400\n",
     "\n",
     "data = hssm.simulate_data(\n",
     "    model=\"poisson_race\",\n",
     "    theta=true_params,\n",
-    "    size=n_trials,\n",
+    "    size=500,\n",
     "    random_state=123,\n",
     ")\n",
-    "data.head()\n",
-    "\"\"\"\n",
-    "ssms_params = {\n",
-    "    \"r0\": 1,\n",
-    "    \"r1\": 5,\n",
-    "    \"k0\": 2,\n",
-    "    \"k1\": 2,\n",
-    "    \"t\": 0.25,\n",
-    "}\n",
-    "true_params = {\n",
-    "    \"r1\": ssms_params[\"r0\"],\n",
-    "    \"r2\": ssms_params[\"r1\"],\n",
-    "    \"k1\": ssms_params[\"k0\"],\n",
-    "    \"k2\": ssms_params[\"k1\"],\n",
-    "    \"t\": ssms_params[\"t\"],\n",
-    "}\n",
-    "n_trials = 500\n",
-    "\n",
-    "data = hssm.simulate_data(\n",
-    "    model=\"poisson_race\",\n",
-    "    theta=true_params,\n",
-    "    size=n_trials,\n",
-    "    random_state=123,\n",
-    ")\n",
-    "data.head()"
+    "mo.md(data.head().to_markdown(index=False))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "80e67e87",
-   "metadata": {},
+   "id": "lEQa",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r"
+    }
+   },
    "source": [
     "## Fit the Poisson race likelihood\n",
     "\n",
-    "We pass the simulated data into an `HSSM` object that uses the analytical Poisson race likelihood. The defaults already enforce positivity for all parameters; you can override them by passing a `prior_settings` dict.\n"
+    "This model has no regression terms, so its positive simple-parameter priors\n",
+    "come from HSSM's model configuration. The model-level `prior_settings`\n",
+    "selector is not a prior dictionary: it accepts only `\"safe\"` or `None` and\n",
+    "controls generated **regression-term** priors. To replace a prior here,\n",
+    "provide it through a parameter specification such as `include=[...]` or a\n",
+    "parameter keyword.\n",
+    "\n",
+    "Because this is a synthetic recovery check, we start NUTS adaptation at the\n",
+    "known generating point. Initial values choose where adaptation begins; they\n",
+    "do not change the posterior target. With real data, use scientifically\n",
+    "plausible starts and diagnose multiple chains."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "78c7b8db",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-29T18:29:59.434086Z",
-     "iopub.status.busy": "2026-06-29T18:29:59.434027Z",
-     "iopub.status.idle": "2026-06-29T18:30:16.060863Z",
-     "shell.execute_reply": "2026-06-29T18:30:16.060212Z"
-    }
-   },
+   "execution_count": null,
+   "id": "PKri",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -224,286 +161,76 @@
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using default initvals. \n",
-      "\n"
-     ]
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Initializing NUTS using adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Multiprocess sampling (2 chains in 2 jobs)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "NUTS: [k1, r2, t, k2, r1]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<python-install>/lib/python3.13/multiprocessing/popen_fork.py:67: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
-      "  self.pid = os.fork()\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "570059d09f2140c6a4ef2f7f912fc4c8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<python-install>/lib/python3.13/multiprocessing/popen_fork.py:67: RuntimeWarning: os.fork() was called. os.fork() is incompatible with multithreaded code, and JAX is multithreaded, so this will likely lead to a deadlock.\n",
-      "  self.pid = os.fork()\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sampling 2 chains for 3_000 tune and 3_000 draw iterations (6_000 + 6_000 draws total) took 15 seconds.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "There were 10 divergences after tuning. Increase `target_accept` or reparameterize.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "Initializing NUTS using adapt_diag...\n",
+      "Sequential sampling (2 chains in 1 job)\n",
+      "NUTS: [k1, r2, t, k2, r1]\n",
+      "Sampling 2 chains for 3_000 tune and 3_000 draw iterations (6_000 + 6_000 draws total) took 47 seconds.\n",
       "We recommend running at least 4 chains for robust computation of convergence diagnostics\n"
      ]
     }
    ],
    "source": [
-    "poisson_model = hssm.HSSM(\n",
+    "_draws = 3_000 if FULL_RUN else 250\n",
+    "_tune = 3_000 if FULL_RUN else 250\n",
+    "\n",
+    "_poisson_model = hssm.HSSM(\n",
     "    data=data,\n",
     "    model=\"poisson_race\",\n",
     "    loglik_kind=\"analytical\",\n",
-    "    prior_settings=None,\n",
     ")\n",
     "\n",
-    "idata = poisson_model.sample(\n",
-    "    draws=3000,\n",
-    "    tune=3000,\n",
+    "idata = _poisson_model.sample(\n",
+    "    draws=_draws,\n",
+    "    tune=_tune,\n",
     "    chains=2,\n",
-    "    cores=2,\n",
-    "    target_accept=0.9,\n",
+    "    cores=1,\n",
+    "    target_accept=0.95,\n",
+    "    initvals=true_params,\n",
     "    random_seed=123,\n",
+    "    progressbar=False,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c54ec3d6",
-   "metadata": {},
+   "id": "Xref",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r"
+    }
+   },
    "source": [
     "## Compare posteriors against the ground truth\n",
     "\n",
-    "ArviZ summarises the marginal distributions and allows us to verify that the posterior means/credible intervals overlap the parameters used to simulate the data.\n"
+    "ArviZ summarizes the marginal posterior distributions. Adding the\n",
+    "generating values to the table and plot makes it easy to check whether the\n",
+    "fitted uncertainty covers the parameters used to simulate the data. In the\n",
+    "plot, solid red lines mark the generating values and dashed blue lines mark\n",
+    "posterior means."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "0e93d241",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-29T18:30:16.176324Z",
-     "iopub.status.busy": "2026-06-29T18:30:16.176253Z",
-     "iopub.status.idle": "2026-06-29T18:30:16.252255Z",
-     "shell.execute_reply": "2026-06-29T18:30:16.251888Z"
-    }
-   },
+   "execution_count": null,
+   "id": "SFPL",
+   "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>mean</th>\n",
-       "      <th>sd</th>\n",
-       "      <th>eti89_lb</th>\n",
-       "      <th>eti89_ub</th>\n",
-       "      <th>ess_bulk</th>\n",
-       "      <th>ess_tail</th>\n",
-       "      <th>r_hat</th>\n",
-       "      <th>mcse_mean</th>\n",
-       "      <th>mcse_sd</th>\n",
-       "      <th>true_value</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>r1</th>\n",
-       "      <td>1.43</td>\n",
-       "      <td>0.42</td>\n",
-       "      <td>0.84</td>\n",
-       "      <td>2.2</td>\n",
-       "      <td>1637</td>\n",
-       "      <td>1834</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>0.01</td>\n",
-       "      <td>0.0084</td>\n",
-       "      <td>1.00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>r2</th>\n",
-       "      <td>5.31</td>\n",
-       "      <td>0.55</td>\n",
-       "      <td>4.5</td>\n",
-       "      <td>6.3</td>\n",
-       "      <td>1755</td>\n",
-       "      <td>1867</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>0.014</td>\n",
-       "      <td>0.011</td>\n",
-       "      <td>5.00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>k1</th>\n",
-       "      <td>2.34</td>\n",
-       "      <td>0.39</td>\n",
-       "      <td>1.8</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1573</td>\n",
-       "      <td>1838</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>0.0099</td>\n",
-       "      <td>0.0079</td>\n",
-       "      <td>2.00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>k2</th>\n",
-       "      <td>2.23</td>\n",
-       "      <td>0.29</td>\n",
-       "      <td>1.9</td>\n",
-       "      <td>2.7</td>\n",
-       "      <td>1581</td>\n",
-       "      <td>1668</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>0.0076</td>\n",
-       "      <td>0.0074</td>\n",
-       "      <td>2.00</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>t</th>\n",
-       "      <td>0.2431</td>\n",
-       "      <td>0.0151</td>\n",
-       "      <td>0.22</td>\n",
-       "      <td>0.26</td>\n",
-       "      <td>1691</td>\n",
-       "      <td>1647</td>\n",
-       "      <td>1.00</td>\n",
-       "      <td>0.0004</td>\n",
-       "      <td>0.00043</td>\n",
-       "      <td>0.25</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      mean      sd eti89_lb eti89_ub  ess_bulk  ess_tail r_hat mcse_mean  \\\n",
-       "r1    1.43    0.42     0.84      2.2      1637      1834  1.00      0.01   \n",
-       "r2    5.31    0.55      4.5      6.3      1755      1867  1.00     0.014   \n",
-       "k1    2.34    0.39      1.8        3      1573      1838  1.00    0.0099   \n",
-       "k2    2.23    0.29      1.9      2.7      1581      1668  1.00    0.0076   \n",
-       "t   0.2431  0.0151     0.22     0.26      1691      1647  1.00    0.0004   \n",
-       "\n",
-       "    mcse_sd  true_value  \n",
-       "r1   0.0084        1.00  \n",
-       "r2    0.011        5.00  \n",
-       "k1   0.0079        2.00  \n",
-       "k2   0.0074        2.00  \n",
-       "t   0.00043        0.25  "
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "var_names = list(true_params.keys())\n",
-    "summary = az.summary(idata, var_names=var_names)\n",
-    "summary[\"true_value\"] = [true_params[name] for name in summary.index]\n",
-    "summary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "a742a5bf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-29T18:30:16.253932Z",
-     "iopub.status.busy": "2026-06-29T18:30:16.253825Z",
-     "iopub.status.idle": "2026-06-29T18:30:16.391926Z",
-     "shell.execute_reply": "2026-06-29T18:30:16.391378Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLoAAAF0CAYAAAAkQlADAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAni9JREFUeJzt3QV4lWUbB/D/uruDGjHGGIzukJYQRVAUBUQQMFER7PgMbLEbASUVEFtEQLprxBgwxmCw7q7zXfczNkFqg7OdeP+/6zqes5A95znbc973fu/nvi10Op0OREREREREREREJs7S0AMgIiIiIiIiIiLSBwa6iIiIiIiIiIjILDDQRUREREREREREZoGBLiIiIiIiIiIiMgsMdBERERERERERkVlgoIuIiIiIiIiIiMwCA11ERERERERERGQWGOgiIiIiIiIiIiKzwEAXERERERERERGZBQa6qMY+/PBDNGzYkDNHRCYvMTERkyZNQoMGDeDs7Ix27dphyZIlhh4WEdFVybHY+PHjqzVTI0eOrPb3EhEZ67q2e/duDB48GD4+PvDy8sKAAQPU54j+i4EuqpHFixfjscce46wRkckrKirCoEGD8Ndff+F///sfVqxYgfbt22P06NH49ttvDT08IqLrVl5ejmnTpmHZsmWcTSIyaceOHUOvXr2Qn5+Pr7/+GnPnzlXHct27d8eRI0cMPTwyMtaGHgCZhuTkZDz33HP44osv4OnpaejhEBFdt19//RX79u3D9u3b0aFDB/W5/v37Iz4+Hm+88QbuvvtuzjIRmaz9+/fjoYcewo4dO+Dg4GDo4RARXZcPPvgAjo6O6vjNyclJfa5Pnz4qC0x2HH300UecYarCjC66iCwWjz76KPr27asOjCZOnIjXXnsNf/75p7oiOGzYMM4aEZn82jZjxgxMnjxZZXGdr3nz5jh+/LjBxklEdC3mzJkDS0tLvPzyy+rjsWPHoqysDFu3boWvry8nlYhMel0LCwvD9OnTq4JcQh4HBwfzuI0uwowuuiSJiD/++OOYOXMmXFxc4OHhgbfeegs2Njb46aefOGtEZBZrW5cuXS74eklJibpSGB4ebrAxEhHVlNQWlHqDkn0vNyFbsCMiIjiZRGQ269qltjMeOHBAXcQkOh8DXXRJUpj59ddf5+wQkabWNsnyOnr0KOvZEJHJ+OWXX9RW66eeegovvfRS1ecZ5CIic1vXzldQUIBx48bB3t5ebdMmOh+3LtIlRUZGcmaISDNrm06nU0Gu2bNn44knnsCIESPqfGxERDW1a9cujBo1CkFBQaqpBhGRFta1nJwcDB06VNVZ/e6779SFTKLzMdBFl+Ts7MyZISJNrG3SsefOO+9U27MlyPXmm28aZGxERDVVuWUnLi4OH3/8MSeQiMx+XTt16pTqtLhp0ya1vXH48OEGGScZNwa6iIhIs7KystTB1NKlS1U2F4NcRGRKBg0apLb43H777Xj66afVCSARkbmua1FRUejUqZPqkL1q1Spm4NNlMdBFRESaVFpaqrrIStq7XBF85JFHDD0kIqIa8fPzU/fvvfcerKysMHXqVM4gEZnluiYBr379+sHCwkJlc/Xs2dPAIyVjxmL0RESkSZIOv2HDBkyePFm1pt66desFX+/cubPBxkZEVBMBAQF47bXX8MADD2DRokW44447OIFEZFbrmmTfJycn47PPPkN2dvYFx22urq5o0aKFQcdLxoWBLiIi0qRly5ap+88//1zdLlWgnojIVEyZMgXz5s1T2akDBgyAl5eXoYdERKSXdU2CXVKAvvJz/9WrVy+sW7eOs01VLHQ8kiciIiIiIiIiIjPAGl1ERERERERERGQWGOgiIiIiIiIiIiKzwEAXERERERERERGZBQa6iIiIiIiIiIjILDDQRUREREREREREZoGBLiIiIiIiIiIiMgsMdBERERERERERkVnQVKBLFxYGWFhU3JuJrzbE4r2/YtT95ZSXl2P//v3qXiv4nMkYmdrvZV2vmdVZz8xpfk1xzBwvGRtTOba73vXN1P8W9YXPW1uvtzkx9rVK32tUXdDqelCbys1oTq2hJTk5F96bga82nEBidiH8Xe0xsUfIJb9Hp9OhpKRE3WsFnzMZI5P7vazjNbM665lZza8JjpnjJaNjIsd217u+mfrfor7weWvr9TYrRr5W6XuNqgtaXQ9qk86M5lRTGV1ERERERERERGS+GOgiIiIiIiIiIiKzwEBXHSspK0d+cSmKS01/3ysR0ZWUlpUjp7AE5eWmn/5MRNolWzjyikrV8Zusa0REdU3WnoLiMk48UTVpq0aXgQ6ONhxNxc/7zmB7XDpOpeej8pzPz9UOLQPd0LGRJ3o280FzfxdYWFgYeshERNckI68YfxxMxN+HkxGVkImk7CL1eVsrSzTwclTr3M2RQYgIduMME5HRkpPJPw6exbojKdh/OguJWYUoKPn3BNPTyRYBbvYI9nBAWIArwgPdEB7oqj7H4zgi0pf9pzOxeMcprI1OVvWzpGySi721Wnd6NPHGzW2CUM/TkRNOdAkMdNWibbFpeOXXw4hKyLrk1+UkMCk7GX9HJ2PW79Fo4uuMm1oHqhPB+l5ctIjINJzNKsAna49j6c5TKLpEtmpxWTmOJueq29cbT6B3qA+eHRKGJr4uBhkvEdGlSNaWFGSWrmM5RaWXnaT0vGJ1O3gmG38eTKr6fJC7A7o18UL3pj64IdQHLvY2nGgiqrGsghK8/Msh/LDr9EVfyyksxfYT6er2zl8x6N7EG+O6NkS/MF8G2onOw0BXLaWWvrXqCL5YH6si7062VhjRNhj9W/iprC1ne2vkF5fhZFo+9sRnYGtsGtYfTcWx5Fy8+1cM3lsdgxtCfTG2SwP0bOoDS0tmeRGR8Skr1+HrjbGYvfqoWtOErHHDWgeic4gnGnk7w8HGCml5RYg6nYXfDiTit6iKLInNx9Mwc1BzTOjWkAdmRGRwO+PS8ejSvTiVXqA+ru/pqC4+dgrxVI+9ne3U5yWYn5RdqAL8J1LzcfBMFg6dyVaB/ITMAizdeVrd7Kwt1XHfXZ0boFMjTwM/OyIyFacz8nHPNzvUmiKGRwaq80jJGrW1tsTZzELsiEvHHwcSsfFYatVNjr/uv6EJhkQEwIrnjkQMdOmb1G94YMFurD2Soj6+vX09zBgUCq9zB0iVHG2t1UFTuwYeqoVrdmEJVh1Mwsq9CWqr45roZHVr6OWIe3uE4Lb2wbCztrro5219ui9/jYmozslWnkcW78G2E+nqY1nLHh/QDF1CvC4KXAXbOiLYwxE3RgRg+oBmeH7lQfwTk6KuVsoJ4msjWqr1jesZERnCou3xePbHAyp4L1lZT97YXJ0sXupCo5NdxdZF2Tr03+M/ybDYeO4YLjY1D7/sP6turYPdMOvWCHURk4jociSAPuqzLTibVQh/V3t8PKatOr46n6u/DUL9XVQQXUrifLf1pLpFJ+bg4UV78N5fMZjaqzFuaRsEG6vql+PmMRiZG2Z06bmmw7g527EjLgP2NpZ497ZIDI4IqNb/62pvg5HtgtXtRGqeWrBkG1BcWj6e+/EAPll7DFN7N8btHepdMuBFRFRXDiRk4Z65O5CSU6QyVp8f1gKj2tWrVvZpAy8nzL2nA+ZtjsPLvx7Gst2nkZJbhC/ubgd7G65tRFS3Pl57DG/9eUQ9lmzU125peU1bDuUCZu9QX3V7ZkiYKlshtXWW7TqNfaezVIaGbGd88aZwtQ4SEZ1Pkh5knZAgl5Sz+fbejghwc7jiJEl9rqcGh+H+3k0wd3Mcvtl8Qp1Hzli2Hx+uPYqH+jTFiDZBsK5BwIvIXPC3Xo/dFB9YuFsFuVztrbFwUudqB7n+q5G3E54b2gLbnu6Ll24KVxF9WfQkC2LAe+uxJvrfehBERHVp87FU3Pb5FhXkCvVzwS8P98DtHerXaIu1ZHyN79YIc8Z3UFsb18ekqExYdqMlorr05frYqiDXw32b4oPRkXqpqyVrXKtgd7x2SwQ2P9kHk3o0go2Vhcr2H/z+BlV3R5oVEREJWQ+eXLZfZWX5uNipC4JXC3Kdz83RBo/0a4qNM/vg6cHN4e1sq7Zhz/hhP/q++49ac9gxlrSGgS49LU4zl+1XqeqSySUnb23rX5hmei3k6qAUF1z3RG+8PDwcvi52qq7XhLk7MXHeDpWuSkRUV7YcT8OEeTtUPS4puPz91C4qMH+tejXzwdfj2qtaNtKUQ1LuZesQEVFt++PAWbz622H1+PH+zfBY/2a1Ui9QSlc8M6QF/pzWU9Xqyisuw/Tv92H69/sZ3CciRXbx/BaVqALiX41tr8o9XAtnO2vc17MxNszog2cGh8HLyVadO8qa0/+99Vi++zSPs0gzGOjSA+kitnx3gir898mYtmjfUL9FR2U7z91dGmLN9N64r2cIrC0tsPpwsroqOOW7XarOzezVMXr9mURE55OCy/fO24HCknK1/UYC+rLl+np1beKNL8e2VwVW/ziYiJs+2sj1jIhqffv1o0v2qcfjuzbEQ32b1vqM/7TvjCom3bWxlzpelG3bY+dsQ1Z+Sa3/bCIy7uLzL/18SD1+fEAoWtdzv+5/08HWCpN6hmDDzBtUzUEPRxu1pfGxpfsw4pNNOHw2+6L/R84leU5J5oSBruu0LTYNs36PVo+fH9oCfZr7obZIlP7pwWH4/ZEeqjChtL6WjhsSaFu4Lb7Wfi4RaVt5uQ4T5+1UmVxSbP7Tu9rptVZgz2Y+mH17pHp88Ew25mw8obd/m4jofBJYmvztLhSUlKm159khYXUyQYu3n8KcTXGITclTFwrkmG5rbDpu/2IL0nKL+CIRaXRX0AsrD6rjq46NPHFfjxC9/vuyO2hKr8bYMLMPnhgYChd7a1UzcNiHFRcVz8+ilzVKzinlnsgcMNB1HZJzCvHAwoqtNre0CcLYLg1QF5r6uWDJfZ0xrd+/VyDT8ooRm1LRhpaISJ8y8ktUncAQHyd8dlftFI2XmoZy4ieyC0uxNjpZ7z+DiLRN1cFZvh8JmQVo4OWIj+5sY5AizbJt+/spXVRJCqnJM+arbUjPK67zcRCRYf15MEmVbpAti9IIoyb1TmtCjq8euKEJVj/WCwPD/VBarsPs1UcxYe4OZpWS2WKg6zoOlqTAX2puEZr7u6iCo7VR2+Fy5MBsWr9mqsW1kGDbzR9vwoajKXU2BiLSTrMNSXv/ZnwHVfC0tlQGusSDC3fj0JmLU+uJiK7Vou2n8PuBRFUC4sM72uhl+/W1CgtwVY2LfM4Fu+7+ehtyi0oNNh4iqltFpWV49beKLYtSmqaJr0ut/0w/V3t8fnd7lUUvdaX/iUlRWaXSYIjI3DDQdY0WbIvHuiMpqq6MHCzJXmhDsD13JVKuBEgWxLg52zF/S5xBxkJE5kW29igWwMdj2qKB17UXnq/puiYFm6XpRnJ2YZ38TCIyb9LAR+rPiBmDQlVXRENr4uuMRZM6q4LRsm37/gW71YUFIjJ/C7bGq86IEuyWbKu6dHObICyb2rUq0H7751tQzk6wZGYY6LoGskXw1V8rOvU8Oai52kpoaJLZNbJdMGSr9fMrD+KdVUfYupqIrtnxlFxkF5RUZVp1bexdZ7Pp7mijtkmeySrEpPk7UVB8LuBGRHSNWfjP/HhABe+lDs7E7vqtg3O9wS6p2eVgY4X1MSl4enkUj9+IzFxWQQk+WHNUPZaOr1JLq66FB7rh+8ldEOTugNjUPG6fJrPDQFcNlZaV49Gl+9TBUrcmXqpbjzGwgAXeGtlKtcgWH645hqdXRKnxEhHVhGQUPLxoDyov7p2/pbAuWFpYYM64DirgJUVTH/9+ryqIT0R0LVbuPaOCSJKF//qIiFqrg3OtpMua1AuTYX2/6zQ++PuYoYdERLXo03XHkZlfgqa+zhjVLthgc93Q2wnf3ttRJUxI3S4ic8JAVw19vPY49p3KhKu9Nd4e1dqoDpakRpi0yJ4lB3EWFbUoJA2+sHL7ERFRNQ/AZBuNBJwMefD1+V3t1Lbs36IS8e5fMQYbCxGZLiny/r9zWxYf7tMEIT7OMEZ9w/zw8s0t1eP3Vsdg5d4EQw+JiGqBXLj7ZlNFd+knb2xukIYY55M1UbJKK7FWIJkLBrpqQAJclWmmcjAS4OYAY3RHx/r4ZEw7deVy1aEkTJy/C4WlzOwioquLTszGh+fWOVeHuk+lP1+nEC+8PqKVevzR2mNYtuu0QcdDRKbnlV8OqWBXqJ8L7uvZGMZsTKcGmNyzYlvlE9/vx66T6YYeEhHpWV5xKYpKy9GugQf6NPc1ivmNrOdedcwnga6dcVx7yPQx0FVNUiPm0SV7VXfDYa0DMTwyCMZsUEt/zJ/QEU62VtgSm46X12cgp7Ci3g4R0eW2LE7/fh9KynToF+YHexvDNNk4363tgvHADRUnp08u34/tJ3jwRUTVI9sVl+9JgCSnvn5rhLoAaOxmDmqOAS38UFxWjvvm70J8Wr6hh0REepR/ru7oo/2aqd04xsLR5t+Lm3IsmF/MLrBk2oz/Hd9IzPr9sCrU5+9qj5eHh8NYdArxRI+m3ur+vzqHeOG7iZ3UNsvotBLcPWcHMvOLDTJOIjJ+X6yPxYGEbLVmvHZLxRYaY1jPHu8fisER/ioAN/nbnTiRmlfnYyMi0yInac/8GKUej+vSEG3qexjt8dr5pCTG7NGRaBnkirS8YkyYt0MVriYi8yD1T9s38FC1no2JrE1dG3vB3sYScWn5ePOPI4YeEtF1Mey+FBOx7kgy5m85qR6/NaoV3B1tYSzeH93mil+XA7sF93bEmC+3ICohG6O/2KqCX97OdnU2RiIyfjFJOXh/dcWWxRdvCoevqz10RrKeyYnfO6MikZC5VW0hnzB3B5ZP7QoPJ+NZi4nIuMxefRSn0gsQ6GaP6QNDjf547XzSge3rcR0w/KNNOJaciwcW7MY393SAjYFr+RDR9dXmqsyTn2Zk2Vznr1GSCTt2znbM3RyHgeH+6NLYuAJyRNXFd8yrSMstwvTv96vH0mGxR1MfmJoWga743w1e8HG2Q3RiDm77fAsSswoNPSwiMhLSnfWJ7/eprTJSL+KWNsa3NdvB1gpfjW2v2mBLRtd93+5EUSkbbRDRxQ4kZOGrDbHq8Su3tKzzzrH64Odqj6/Ht4ejrRU2HkvF8ysPQlfZCpeITLI2l5At1MaWzXW+ns18cGen+urxsz9GoZh1nslEMdB1BXJAMXNZFFJzi9DMz1l1xjBV9VytsWhSR3VlMzYlTwW7TqWz7gMRAV9tPIF9p7PgorYsRhjdVcZKPi52mHtPBzXOHXEZmPHDfp74EdFFgfuZy/ajXAcMbRWAPs39THaGwgPd8MHoNqrG2KLt8fh8fUXwjohMS3JOYVVtLgm8G+tx1vm1AmX3z/GUPHy9saJDJJGpYaDrChZtP4XVh5Nga2WJ2be3MYrCzNejkbcTlk7pggZejohPz1fBLta6IdI22Rbz7l8x6vHzQ1vA380exqypnws+HdMO1pYWWLn3DN47t92SiEjISdnBM9lwc7DBC8OMp6bqterXwg/PDmmhHr/+ezS+2cSTTiJTXJcqEzJNoSmGrJ9PD65I8Pjg76M4k1lg6CER1Zjx/6UZSGxKLl7+5ZB6/MTAULX9zxjd8cVW9H/3H3VfHcEejlg6uQsa+zjhbFahCnYdT8mt9XESkfGRLrJP/LBPpaX3DvXByHbBJrGedW/qjVfPFcuXA7Afdp2uoxESkTGTDoXvra4I3D8zJExlgZrq8dr5JnRrWNV99qWfD2H+lrhaGCER1QZpJrFga7zRT+5/1ygpY9GhoQcKSsrwyq8V58REpoSBrksoKSvHtCV71R+27KG+t3sjGCvJyDqanFujzCyp+7Bkchc093dBSk4R7vxyK+LYxYxIc+ZsPIE98ZlwsTOOLYs1Wc9u71Af9/euOPF7avl+bD6eWgcjJCJj9vSKKBSWlKvOYaMMHLjXx/FaJVmbpw8IxdRza57U6/pyg2SIsGYXkbH7dksccotKYW1l3NsV/7tGybrz8s0tYWVpgd+iEnmcRSaHga5LkM5j+09nqbTNt0e1Vh2/zI3su14wsZOqPZaUXYQ7vtyqroQSkXayVt9edaQq8yHQ3QGmRk78hrQKQEmZDlO+3cXsVCINk4uTUrTdztrSKAL3+ibPZ8bAUEzpVRHsev2PI/hqT46qSUZExqmguAxzNlVkYJpiU4zm/q6461xh+pd+OsT1hkwKA13/sSMuHZ+sO6YezxoRgQA30zv5qy4vFezqXLWNUYJdLFBPpI0ti1LIvai0HD2aeuP2DvVgiuQixDujWqNtfXdkF5Zi4vxdyC3mSR+RFuUUVnQ0e6RfUzT0doI5kmDXzEGheHZImCpQ/8fxfEyYt0s1TSIi47NkRzzS84pRz9PBZGs9P9q/GTwcbXAkKQcLthn/FkyiSgx0nSe7sATTFu9VnXpubRuMwREBMHdSv2LRpM4I8XZCQmaBCnax4CCReZu3OQ47T2aoq4uv39rKpDMf5MDxy7HtEezhgPj0Any0I4vbeYg0qLxch7AAV0zqEQJzJuv1xB4h+Gh0JOysLLDpeBqGfLAB20+kG3poRPSfUjiyxVjc17MiE9MUuTva4rEBoeqxNC/KyCs29JCIqoWBrvO8sPKgCvZI1P3Fmyo63GiBr6s9Fk7qjIZejjidUYCxc7YjM5+LGJE5knp8b/4ZrR4/Nbg5gkxwy+KlslOlE6OtlQV2nCnClxtZqJlIKyQzVbEA3rg1AjZW2ji0HdTSH6/39UQTH6eqEhSyI0ECfkRkeNIZWs4rpVyMsdUMrKk7O9ZXtZ2lsP47f1WUvSAydto4GqiGn/adwYo9CZByXLNvj4SLvQ20xN/NHgsmdYa/qz2OJefi3nk71b5yIjIfcgI0Y9n+qmLNcuBiLiKC3fDc0DD1+O1VMdgWm2boIRFRLcsrKkV2QYl67GRrhVbB7pqa8/puNlg+tQtujgxUW9Lf/OMI7pm7A2ncykhk8OOtz/45rh5P7NHIZLctVpKC9C/eFK4eL9wWj0Nnsg09JKKrYqALUNH2Z1ZEqQl5sE9TtGvgCS2SzI7593aEq701dp3MwEOL9rDoIJEZ+XbrSbW9xdHWCm+Y+JbFS7mjQz30rG+vTvgeXLSHJ3tEZk620cjfu3C209YFykpOdtZ47/ZIlc0mhfj/iUnB4A82MNhPZECrDiWpxAE5pxpzrpi7qesc4qUaAMmS+9LPB1kmgoye5gNdEnGfvnSfKmIaWc8dD/dpAi1r5ueCr8Z1gK21JVYfTsL/fjlk6CERkR5IV9XXfz+3ZfHG5qjn6Wh28yqBu8ntXNHU1xkpOUV4cnkUD8SIzNS+U5n4ZlNF/RthZnH7Gq99t3eoj5UPdlMNhiq3Mn605ijXQKI6ptPp8Om5xmZjuzQ0q11CTw8Og72NJbadSMdvUYmGHg7RFWk+0PX1xhPYEpumMhxky6K1Rmo7XEnHRp74YHSkejx/y0l8t/WkoYdERNd50PXk8v0oKClD5xBPjOnUwGzn097aEu+OagUbKwv8dSgJ3+88beghEVEtFHmWQLZkFjjYmvaWIH1q7u+Knx7sjhFtg9TcyDbu6d/vV/NFRHVj8/E07DudpQJC93RraHa7f6b0qiis/9pvh1nmhoyaNTTs8NlsvPVnRUG954a2MMl21A/3bYr84lI42ur3pRzUMgBPDAxV8/PCTwdVV8auTbz1+jOIqG58v+u0OvCSgy7ZsmgpxQjNeD1rEeiKx/qH4o0/olV6vaTb1/cyvww2Iq36asMJdQwnLe9d7K01fbx2qa2M794WifYNPPHcygNYtvs00vOK8Old7Uy+ThCRKaiszXV7+3qqWY6pqO4aNblnY3URUUr/yHN9tH+zOhsjUU2YxtFBLSgqLcOjS/aiuKwcfZv7YnSHejBFd9bivu/7ezfG0aQc/Lj3DKYu2I2VD3QzyWAgkZbJFr5Xfz2sHj/arxkaeDlpYj27r2cI1kYnY3tcOh5duhdLJ3dRxVSJyPQ7x85eHaMePzukBSy/MI2/69o8Xrvcz/NztcMDC3dj7ZEUPLhwtwp2aaUrJZEhRCdmY8PRVNXcbGKPEJN6Eaq7RkkWrWxhlLVFAl2j2gcj2IMXE8n4aPbd7p1VMYhOzIGXky1eN8OizPogcyJzI7XLpJ3svfN2ILuworsREZkGqbMnf7/hga64t3sjaIUEtd65rTWc7Sqaa3y9MdbQQyIiPWzDfnpFFIpKy9GjqbfaokeX1zfMD3Pv6aiK1K8+nIzp3+9TtWmJqPayTcWNLQPMshZqpcER/ujUyFOtxbN+q6j/SmRsNBnoKi4tx5cbKk56JJDj42I6aaV1TdLcvxjbDgFu9jiekodHF+/lQRKRiZCMpp/3nVFXFl8f0UpzNQjlIPPZIWFV3dlOpuUZekhEpKdt2K/eHMGLlNUgW7c/vastrC0tsHLvGcz++yh/B4lqQXJ2IVbuTVCPJ/ZoZPbJEC/eFK6OL3+NOostx9MMPSSii2jrrOccyUrS6YDb2gejfws/mPqiejarQN3XFl8Xe3xxd3t1RfDv6GR1wkhExi2vqBTP/nhAPZZMrohgN2hxPbu9Qz10CfFCYUm5ygSRjBAiMj3pecWq+LF4rH8zk6u7VxfHa5fTp7mfurArPvj7qGrUQUT6NXdzHErKdGjfwANt6nuY3PTWdI0KC3Ct2u4o9VBL2fSCjIwmA12lZTr4utjhmSEtYOpu+mgTusxao+5rk5wkSxFr8dHaY/gt6myt/jwiuv7t2VIoNNjDwWQKhdbGeiZXHWeNiFCB+k3H0lRGCBGZHglyZeaXqJOrCd1ML1uiro7XLmdku2CM71rRAU5q1EqtMyLSDynivmBbvHpsarW5rmeNerx/KNwcbFQ5oHlbTtbq+IhqSlOBrvPbK79yc0v1h0nVd3ObIEw6l4r7+NJ9quMRERmfI+qAI049fvWWiFrv8mXspIlGZbBPCvMn59R9RgURXbutsWn4YddpSDnVV29pqblt2PryzJAwdGzoidyiUtWkgxkYRPohXQilHmpDL0eT3y1UEx5OtpgxKFQ9fuvPaJxgAJ2MiKWWglzZBaVVdacGhPsbekgmaeag5qoAbEFJGe77dicy8ooNPSQiOo9szfvfLwdRVq7DwHA/9Grmw/mRK6zdG6mC/HIg+tJPhzgnRCZUV7VyG/YdHeujrQluCTIW0nHxvdGRcLGzxp74TNUxjYiujxxvfb3xRFWpCK11eL6zY310b+KtSkQ88f0+NR9ExkAzga55at90RUaXq4O2sxuuh1xF/fCONqjv6YhT6QWqtSyvCBIZjz8PJqoterbWlnjWDLZn63Ptku3XcgAqhVNZo4bINEjzoGPJufB2tsXMgc0NPRyTF+TugJeGh6vHs1cfxcEzWYYeEpFJ++tQIuLT8+HuaIOR7epBa6RExOu3Rqgu1zvZ5ZqMiCYCXbJNRd7MK1lK7jtdM3dHW3w5tj0cba1U96PX2FaWyCgUlpTh5V8qijVP6Rli1q2tr0XLILeqTkjP/XgAOYUlhh4SEV1BfFq+Kp4uJHDv5siSE/pwS5sg3NjSH6XlOjyz4gC7aRNdZxF6MaZTfTjYWmlyLoM9HNXWaPHWn0ew/3SmoYdEpI1A1+u/R6t6BJKyTfoR6u+Cd2+LVI/nbDqBZSzwTGRwn/8TqwrQB7rZY2rvJoYejlGa1reZykhNzC5UB2NEZLzbsJ9beQBFpeXo2tgLwyMDDT0ks8rAePGmcJWBsfdUJhbtqCiiTUQ1r4m6NTZdZYuP6dRA09M3ukM9DAr3V50nH1y4B9m8mEgGZvaRn51x6Vi+O0E95pZF/RrU0h+P9G2qHj+1IkodLBGRYUg76E//OaYePz0kTLNXFa9G5kWKWYtvt57ErpMZhh4SEV3C7wcS8U9MCmytLPHyzS1VcIb0x8/VHo8PqGjS8cbv0UjNLeL0EtXQ/HONfwa08EOgu4Om50/W6DdGtlLdvmUr55PL9qsLFkSGYtaBLimG9/zKg+rx7e3rMaOrFkigSxZ3KRY7+dud6mSbiOre+38fVYVA29Z3x5CIAL4EV9CjqQ9GtA2CHH89tXy/Wr+IyHgUFJfhlV8qmkZM6RWCxj7Ohh6SWbq7cwO0CHBFdmEpZrEMBVGNSHObymSKsV0acvYAuDnY4KM728La0gK/RSXik3VseEGGY9aBrh92ncKhs9lwtbeuan1K+mVpaYF3b49EU19nJGUXYcp3u1BUWsZpJqpD0s558Y5TVZ1RmflwdVLvx9PJFjFJuficnceIjIp0AzyTVcht2HXQpEMyXCVZbtnu08xwJaoBKdsiXeib+Tmjc4gn5+6cyHruamu0kBIRfxxI5NyQQZhtoCu/uBTv/hWjHj/ctym8nO0MPSSzJTUepDi9BBR3x2fihZUHmapKVIfeWXVEZbDeEOqDTiFenPtqkCDX80MrulJ+uOYYjqfkct6IjMDpjHwV6BLchl372tT3wKh2werxK78e4vEbUTWUl+tU+YPKbC5eYLzQXZ0bYFyXippljy7Zi6jT7O5Kdc8aZmrOxhMqw0j2Cd997g/NHC2Y1Emd4EoRRENq6O2ED+9si3u+2a4yS8IDXXE303iJap0cPPyy/6y6Ij9jUHOTnvG6Xs+kuPXyPQlYH5OCp5ZHYfGkzipLlYgMR7bQSQH6To08zWobtrEcr13K4wNC1fvInvhMdT+sNQv/E13JhmOpKpvexc5adTE1B/peo54b2gKxqXnYcDQV477ZjqWTO6OJr4te/m0izWZ0SUHNz/6JVY+fGBgKO2vzLcosdSua+bkYRf2KXs181LYp8eLPh7D5WKqhh0Rk9t78M1rdD28diLAAV5iyul7P5Arsqze3hIONFbafSMeSnRXbP4nIMLYcT8OvUWch51kvDAs3qywJYzpeu1Rh+sk9G6vHb/wRjcISlqAgupL5myuK0I9sHwwnO/PIG9H3GiVboz8Z0xatg92QnleMMV9tw6n0fL3820SaDXR9+PdR5BaVIiLIDcNa8apUXbqvZwhGtAlSVwSmLtitrnYQUe2Q4IxcKbOxssBj/VmH8FrU83Ss6jz26q+HeRBGZCClZeV46eeKBkJ3dqqPFoGmHbg3NZN6NoK/qz1OZxRg7rmTeCK6WHxaPtYcSa5q6ECX52Jvg7n3dFR1zGSnlQS7kti4jOqI2QW64lLzsGBbvHr81ODm3IZSx+Tq62sjItCmvrvqRnLvvB3qnoj078M1R9X9qPb1UN/LkVN8jcZ3bYh2DTzUBRKpJSEn3ERUt6TsQXRijura9TgD93XO0dYa0wdWXDD5eM0xpOUW1f0giEzAd9tOqq7NPZv5IMQIMzSNjYeTLb67txPqezoiPj0fd3y5Fck5hYYeFmmA2QW6PlhzFKXlOvQO9UHXxt4wdyv3JmDx9nh1byzsbazw+d3tEOBmj9iUPDy0aA9PHIn0bHd8hsrmkhbOU3tVbDkxdYZazyS9fvbtkaqxxs6TGWyHTVTHJMj83rkGQo/2a6pOjMyNMR6v/Zdk5LcMckVOUSlmr664kEJE/yooLsOSc12uK4utm4vaXKN8Xe2xYGIn1UlXzg3HfLlNlRoiqk1mFeiKTcnFj3sq/jgf7VexFUULRVufXB6l7o2Jr4u96sQotW+k0PNrRjY+InPYoi1GtA1S2+/MgSHXM5nDl2+uaIf9/t9HsS02rc7HQKRVX6yPRVpeMRp5O2GMmW4FMtbjtfNJM45nBld0o124PR5Hk3IMPSQio/LL/jNqp4o0O+sd6gtzUttrlBxnLbqvs9oifTQ5F3d9tU3V7iKqLWYV6JIW8eU6oG9zX7Su527o4WheyyA3vHtbazUPczadUFcJiOj67T+dibVHUlTB5vt7N+GU6sktbYJV9ySpMXj/gt1IyCzg3BLVsuTsQny5vqKB0IyBobCxMqtDU5PTpbEX+rfwU+vgq78dNvRwiIzKd+fK44zp1MAoO6gauwZeTlg4qRN8XezUVnUJdmXmM9hFtcNsjiaOp+RWpVpO00g2lym4MSIAj/WveD2eW3mAWRJEegrqi5sjg9DQ24lzqkev3RKB8EBXlV1y3/ydapsCEdWe2X8fRUFJmartOailP6faCDw9OEw1OVl3JAXrzhXdJtK6AwlZ2HcqU/1tjGofbOjhmCypa7ZwUmd4O9vh0Nls3P31dtZzplphaU7beCSbq1+YLyKC3Qw9HDrPQ32aYGirAJSU6fDAwj3q6i0RXZtDZ7Lx16EkWEg21w3M5tI3B1srfDG2PbycbHHwTDYeWcwag0S15VhyblW9m6duDFMNbcjwZAvpuC4N1eNXfj3MOqtEABZsO6nm4caWASpIQ9euia8EuzqpY62ohCyMnbMd2YVsXkb6ZWkuB0o/7TujHjOby/jIgetbI1ujub+LKjzI4vRE1+6jtRW1uYa2ClQHCqR/Qe4O+PSudrC1tsSqQ0mYsWw/yuVKChHp1Zt/RKstcv3C/NCxkSdn14g81LcpPBxt1DG21Osi0jIJwvy4p+Jcc0yn+oYejllo5ueC7yZ2UuuMZMqNn7NdNSYh0hezCHR9uKYim0tqCkhdKDLOLImPx7SFk60Vtp1Ix7vnuisRUfXFJOXg9wOJ6vGDzOaqVXLS/fGdbVUNjuW7E/DCTwcZ7CLSo51x6SqQLGVuZg4K5dwaGTcHm6rSE9IRMyuf2RakXdLsTLZYN/V1ZlBej8ICXFWwS9ab3fGZeGDBbmaQkt6YfKDrWHJOVTbXI32bGno4dAWNfZzxxshW6vEn645jTXQS54uoBj5acww6naTN+yPU34VzV8vk4ok01JDdVN9uPYknftiPkrJyzjvRddLpdHjtXKHz2zvUQ1M/rmfG6I6O9dWJfUZ+CT5YU5FNTKTF9eq7rSersrm4xVq/wgPdMH9CRzjYWOGfmBS1XZpIH0w+0PX+3xUnfgOYzWUSZLvVuC4VrcMfXbIPpzPyDT0kIpNpuCFtrcWDfVibq64MjwzCO6Naq8yuZbtPY8q3u1ignug6/XkwSV29t7exZMkJI2ZtZYlnh7ZQj+dtjkNsSq6hh0RU53bEZSAmKVcFYka0YxH62tC6njveuz1SPZ67OQ7zt8TVys8hbbE09W08lSd+rM1lOp4eEobWwW6qw8ZjS/ap+hxEdGUfrz12ruGGn7r6RXVnRNtgfH5XO9hZW+Lv6GSMnbON23iIrpFkRUptLjGpRwj8XO05l0asVzMf3BDqg9JyycKreN2ItFiEfnhkIFztbQw9HLMlXXdnDmquHv/v50NqezuRZgNdH/x9VGVzDQr3R4tAV2iRj4sd/F3t1b2psLO2wod3tIWznTW2x6Xjs3+OG3pIREbtZFoeVu6tCOo/3Nd8s7mMeT3r18IP397bCS721urq7q2fbWZGKtE1kC6Lsal58HSyxX09QzQzh8a8vl3NM0NaqKzW1YeTWHaCNCUttwi/R1XURh3TqWJHirkyhjVqSq8QDGsdqALrDyzcrZqYEV0ra5hwNtevUWfV40f6abc2188PdYcpqu/liBdvCsf07/epIqfdm3irtFUiunQ2l2Q+ylX1VsHm+3di7OuZFKj/fkoXjJ+zQ3UiG/HJZnxzTwdm2BFVU15RKWavPlpVV9VFQ9kRxr6+XYl0+J3YvRE+Xx+L5348iM6PecHR1mRPIYiqbenO0yguK1c7USKCzTub3hjWKKl/9vqICBw+m62Osx5etEddZJRAO5FmMrreX320qiizdGwg03Nr2yAMiQhQUftpS/aqA2AiutCp9HzV9a+y3TsZVnN/V6x4oCtC/VyQnFOE2z7bgvUxKXxZiKrhyw2x6gp9Ay9HVeicTIdcVA5yd0BCZgHe/5uF6cn8lZfrsHD7SU1kcxkTJztrfHZXWzjaWmHz8TS8+9cRQw+JTJRJBrqOJDKbyxxI1P7VW1oiwM0eJ1Lz8Mqvhww9JCKjIx1KJRjco6k32tb3MPRwCECAmwOWTumCLiFeyCsuw4S5O/DDrtOcG6IrSM4pxBfrY9XjGQObw9baJA9BNUsyuP43PFw9/mrDCZVxQWTO1h9Nwan0AlWyQLbTUd1p4uuC129tpR5/vPY41kYnc/qpxkzyKOP9v2PU/eAIf3V1nUyXu6Mt3rmtNSwsgEXbT+HPgxX74IkI6sr5D7tOVW3zIePh5mCDuRM6qOK0EoiUbdgfrZFMYzbXILpcXdX84jJVpkCO38j09A3zU3VxZSv90yuiVMYLkblasC1e3d/aNhgOtlaGHo7m3NQ6EOO6VGTSPbp0rzomJjLrQJdcQfotKlEFRh7p2wxa99TyKNy/YJe6N1VdG3vjvh4VBWmfXLYfydmFhh4SkVH4bN1xlJTp0LWxF9o39IS5M7X1TBprvHdbJKb2bqw+fntVDF76+RCDXUT/cTwlV13MEk/d2FxldGuNqa1vl/PCTS3gZGuFPfGZ+O5cNzoic3MmswB/H05Sj+/qrI1t1sa4Rj09JEzVR8vML8H9C3ajuLTc0EMiE2JpirW5xOCIAIT6u0DrJJVTAn+mntL5+IBQtAhwRUZ+CWYs288TRdK8xKxC1Z1MPKyRbC5TXM8sLS1UO+yXh4erCzBzN8fh2R8PMNOB6Dxv/XFEZQH1be6LziFempwbU1zfLrd1e8ag5urxrN+iEZeaZ+ghEendd1tPQhIWOzXyVNvotMAY1yi5oPjRnW1VFv2+U5l47bfDhh4SmRCTCnQdOpONPw5WZnNp48RPK6RWx+zRkep+3ZEU9QZDpGWfrjumOv1Ipz+tnhiakru7NMRbIyu2Yct2B27rIaqw62SGOnaTplkzb6wIkJBpu7tzA1WjsKCkTG3bliAmkbkoLCnDou0V2xbv6dbQ0MPRvHqejnj3ttZqHuRi4q/7z2p+TsgMA12zV1fU5pJOfc38tBFd1xJ5TWVLg3j1t8OqrSyRFsWn5WPhuYOsaf0Y1DcVI9sFq4MxOaFfvOOUSv9nzS7SMvn9n3XuCvyodvV47GYmJJP1zZGt4GxnjZ0nM/DVhoomA0TmYOXeBLXDRLqM9m/BeoLGUh9wSq+KMhEzl+1HbArPEcmMAl1Rp7Ow6lCSOoGY1o+1uczVuC4NVXe5wpJyPLpkL/dikyZJK2WpzSV/C1LDjkzHLW2CMXt0G/VetWTnKZVmz2AXadVfh5JUIMTexhKP9uexm7llWTw3NEw9fmdVDGKScgw9JKLrJu/X32yKU4/HdW0AK3kzJ6MwfUAztcsht6gUk+bvRFZBiaGHREbOZAJd753L5hoeGYQmvs6GHg7V4lVC2f4je7GjErJUlyYiLZEt2iv3nVGPpfYTmWanoDfOtcX+csMJfLz2mKGHRFTnSsvK8cYf0erxvd0bwd/Nnq+CmbmtfT3cEOqjttlPW7wXRaVlhh4S0XXZGpuO6MQcONhY4fb22ihCbyqsrSzx0R1tEOBmj+MpeXhgwW6UlLE4PZl4oGtPfAbWRCerqLpWijJrmRwMzxoRoR5/su4YdsalG3pIRHXmzT+jodMBQ1sFoGWQG2feRI1qXw/PDW1R1Y1x/paKK8REWrF052l1MuLhaIPJ57ackHmR7pmv39pKvcaHzmbj9d8rAptEpuqbTSfU/Yi2QXBztDH0cOg/fF3t8dW49nC0tcLGY6l4kZ2uydQDXe+d67R4S5sgNPJ2MvRwqA5IV015k5H6po8u3YucQqankvnbGpummjFYW1pg+oBQQw+HrpNksTzcp4l6/PzKg6ruB5EW5BeXVmXiywVKV3ueMJorP1d7vD2qolC0bPmS7apEpuhUej7+Olzx+8si9MYrPNAN749uo5r/LN5xGosOsl4XmWigS7J51sekVGRz9WE2l5a8eFO4KgR5Kr0A//v5kKGHQ1Sryst1mHXuavjojvXQkEF9syB1icZ1aaAeS3eybbFphh4SUa37asMJpOQUob6nI8Z0qvj9J/MuFD2hWyP1+Ikf9uFMZoGhh0RUY19vPKEy6qU+ahNfNj0zZv1b+OHl4S3V42WH8/DFhopMPCKTCnS9+1fFFcFR7YJR38vR0MOhOiRXgN+7PVJF7L/fdRp/HGA7WTJfy3afxr5TmXCyteIWbTPb2vPCsHAMjvBXDQYmf7eL3YLIrKXmFuHzf46rx08MDIWttdEfapIezLwxFBFBbsjML8Eji/eoGm1EpiI9rxiLd1R0u57ck1utTcFdnRtgxsCKJidv/HGE3V/pIkZ99LHleBo2H0+DjZUFHrihYvsHXeimyEDc3r6eujdH0l2jsp3sEz/sR3xavqGHRKR32YUlVUWbZZuPr4s2izab63omTTbevS0SkfXc1UnghLk71EE1kTmSJjJ5xWVoFeyGIREBhh6O0TDX9a2SnbUVPryjjbpYsyMuA2+tOmLoIRFV29xNJ1THdwnWdmvipcmZM8U1anLPENwaVlHW6JVfD6v3H3a6pkrWMFLyS/rOuTdJ6eoibYzpYk8PrmjtbM4e699MbffZHZ+J+xfuwg9TusLexsrQwyLSm/dXH0VqbjFCfJxwz7ntH1pkzuuZrFlfjm2PWz7ZhLi0fEz+die+m9gJ1uxcTmbkRGoeFm6ryIp48sbmKshL5r++VZIt92+MbIUHF+7B5//EqqDB0Famc9JM2pRbVIp5W06qx/f3bqwysbXIVNeoO8KdUT8oUNX0lp1g+cVlmDkoVLOvI5lARpcUs9x5MgN21pZ48FwxX9ImG2kne2db1dXnQEI2Xv6F9brIfEQnZmPe5oqOfLLFjdt8zJePix2+Gd8BLvbWKuPhqWVRvPJIZuWtP6NRWq7DDaE+6NrY29DDIQOQwJZkWYgnvt+v3uOIjNmibfHIKihBiLcTBoT7G3o4VEMS0HrwhsZ4dkhFoO6zf47j6RVR3D5Nxhnokn39ldt4JnRvhAA3B0MPiQws0N2hql7Xgm3xWLHntKGHRKSXtW7mD/vVieHAcD/0aubDWTVzTf1c8OmYdqrByvI9CVVXkYlM3Z74DPwWlajep2fe2NzQwyEDktpssv2roKQMk7/dhax8ds4m41RUWoavNsaqx5N7haj3ZjJNE3uE4LVbIiAv4aLtpzDlu90oKC4z9LDIgIwy0CWFx4+n5MHd0aaqPhNR71BfPHiuVtvMZVHqoJrIlEkr9n2ns1SGz//OdY8h89e9qXfVFoHXfj+Cgyms10WmTcpNzPqt4gLlyLbBaO7vaughkQFZW1niwzvaqs7ZJ9PyMW3JHtVZmMjYrNidgKTsIvi72uPmNkGGHg5dpzs71ccnY9qq3RGrDyfhrq+3ITOfx1haZXSBrvziUrx3rtOiBDXcHGwMPSSj1ueddWj5wp/qXgum9WuGvs19UVxajknzd7GFNZmsuNQ8vPNXRR1CSbf2c9VmAXqtrmcTujXEzZGBKCvX4e0tmVzLyKT9fTgZ2+PSVbmJxwZUdMEi7a5vwtPJFp/f3U79Tqw9koI3/qwIhBIZCzmX+HDNMfV4Yo9GqqGClpnLGjWoZQC+u7cTXO2tsetkBkZ+tgUJmQWGHhYZgNEFuuZsPIHknCIEezjg7i4NDD0co5dfVKaKKMq9FkhK8ft3tEFzfxfVwvzeeTuRV1Rq6GER1XjL4vTv96kOP10be6mGG6St9UxqSswa0QotAlyQXVSO+xfuQWGJ+T9vMj8sN1E9WlrfKrUMcsObI1upx1KcvrJRAZExWLLzlAqA+LrYYUwnnnOa0xrVsZEnvp/SVWXqHUvOxYhPNrFeoAYZVaArLbcIn/1TsU96+oBQzUfW6dKc7azx1bj28Ha2xeGz2Xhg4W51VYbIVHyyLlY123Cxs8Ybt7ZiZxiNcrC1wqdj2sDZ1gJRCdl47scDLE5PJueHXadxNDmX5SbokoZHBmFav6bq8XMrD2DdkWTOFBmcXFj6+Fw21wM3NFHvx2ReQv1dsPz+rmjq66y2p476bAu2xqYZelik1UDX7NVHVSQ5PNAVN7VmO2K6vGAPR3x+d3vY21hi3ZEUPLpkL7trkEmITi3Gh2srDq5evrkl6nk6GnpIZOC17LHO7qp4qtSnXLidGQ9kOlS5idUV5SYe6tOU5Sbokh7p2xQj2gaprdoPLtyjLlISGZJkFyZmFyLQzR6jOzKr3pybmX0/pQs6NPRATmEpxs7Zjt+jzhp6WKS1QJe86S3YVtF96pkhYbBk1wu6inYNPFSwy8bKAr9GncWTy6NY7JSMWkZ+Md7flgWpySv1mVj4lERrPztMP1fX6MWfDmI3G22QiZByE3KlXMpN3NW5vqGHQ0a8Vfv1Ea3QOcRTXdAe/812nErPN/SwSKOkE98n646rxw/2acodRGbO3dEW397bCQNa+KkdQPcv3I35W+IMPSzSSqBLuvXIwb2c/A2O8EfXxt6GHhKZiF7NfPDhHW1UNoRsn3jmxwPqiiGRsZHfy2lL9iE5vwz1PR3wv5vZZZH+dV+PRrixpT9KynSY+t0uJOcUcnrIqJ1fbuKJgSw3QVcmXdA+v6t91TYi6YbGdY4MQYIcUue3nqcDRrUP5ougAfY2Vvj0rnYY06k+dDrg+ZUH8daf0SwXYeaMItD1W1Qitp2o6NZT2XKdqCbdNd4a2RoWFsCi7fF4aNFuFLFmFxmZt/48go3H0mBnZYFPx7SFqz07ytKFGQ9vjWpddRL44II9KClj7UEyXtKtTLJzIoLcMKwVy03Q1bk52qjMCskAPJmWj7Ffb0dWfgmnjupMZn4xPj5XPuKRvs1gY2UUp8JURw3NXrm5JR7vX5FB//Ha45jxw34ea5kxS2NIH33110Pq8dTejVW9EqKaurVdsMrskm2MEjidOH8XCkp4kkjG4Zf9Z/DZPxVp8g90cFVdQ4ku1Wjjs7vbqSYF2+PS8dpvhzlJZJROpuVVlZt48sbmLDdB1ebvZo8FEzvBx8UO0Yk5uGfudnbPpjrz0ZpjyC4sVcdht7QJ4sxr8KLiQ32b4vUREVW1USfN36nqTZL5MXigS6LqZ7IKEeTugCm9Ght6OGTChrYKxDfjO8LR1gqbj6fh6bXp6oohkSFFnc5SV4zEpB6N0K2eA18QuqzGPs5457bW6vE3m+Lw454EzhYZnTf+iFbbbKV8QLcmLDdBNdPAywnf3ttRNS/YHZ+Je77ZobIDiWqT1IWbv6UiQP/U4DCV4UPaNLpjfXxxXlOzO77cprbjk3kxaKArJimnKsvhuaFhav8s0fXo3tQbiyZ1hrezLeKzSnHzJ5vZypoMmvUgV6vzi8vQo6k3pvevaLFOdCUDwv3xUJ8m6vGTy/dj/+lMThgZjV0nM1TmtJwjstwEXavm/q6YP6EjXOwrMljHz9mOnEJuY6Ta8+afR1BcVq6OxyRIT9rWr4UfFkzsDHdHG+w7lYmRn21hkwwzY22oH1xersNTy6NQWq5DvzA/DAz3N9RQTNqrt7REYUm5ikhThdb13LHy/q6456tNiEkvwT1zd+DhPk3ViaM19+JTHZFCp+PmbEdqbjFaBLjikzFt+ft3FVzP/jWtXzNEJWSpK40T5u7A8qndUN+LW/vJ8M2DKstNjGpXD6Hchl1tXN8ufbwm2xjv+mobdp7MUO+Zcyd0ZA1L0jsJZPy874yq5/vUjawHzTWqQrsGHvhhSle19pxIzcOITzdj3j0d0SLQlX+FZsBg0ZGF2+PVVUEnWyv8b3i42jNLNdc3zA9DWgWoe7qwBsT/entidIdg1V3j/b+PYtTnW1SGDVFtyysqxb1zdyAuLV8V3Z17Twe4sPj8VXE9+5dsqZC6gxIklWDp+G+2IyOvuDZ/bYmu6vcDiWqrmYONFR4bUFHQl6qH69ultQp2x8JJnau2MaoC9QXM7CI9B+jP1bwc0SaYQQyuURdo4uuM5fd3VXXbUnKKcPvnW7D5eCr/BM2AQQJdydmFqr6DeHxAKALdWbOG9E8K0796c0u8PzpSpcbvic/E4Pc3YOmOU2wnS7VGOuU9sHA39p3Ogoejjdqa4etqzxmnGpPg6Df3dFA1LGNT8zBx/k4UlpRxJskgikvLq47dJvUMgR/XNdKTlkFuKrNLthDtPZWpTjTlXIFIH1YfTsb2E+mws7bE4wzQ0yXI+9mSyV3QqZEncopKMX7ODtVIikybQQJdL/18CDmFpWgV7IZxXRsaYgikIcMjg/D7Iz3QsZEn8orLMGPZfkyctxOJWTyIIv1fNZQt2bLdTLYTzxnfASE+zpxmuq6DL8kIdLW3VlnQ0h2IwS4yhO+2nlQNXryd7TC5ZwhfBNJ7sEtqrFZ2Y5QtRLKViOh6lJaV4/XfK7K5JnRvxOQKuizJKp03oSMGR/irWm4PLdqDuZtOcMZMWJ0Huv48mIhfo86qbRmzRkSw44UeOrrJyY/c0+UFeziqA6iZg5rD1soSf0cno/97/zC7i/TqnVUx+GHXabWufXxnW7Sp78EZrgGuZ5fW1M8FX43roLaLbTiaymAX1bms/BJ8sOaoeiwZEU52BivxarK4vl1dWIArlk3pioZejjidUYCRn27GgQQe39L1lco5npIHTydbTO3dmFPJNeqKpDHeh3e0xdguDVTpmxd/PoS3/zzCnUAmqk4DXdK285kVUerxpB4hCA90q8sfb5bk6v6tn25W93RlEnyQN7lfHu6uCqBKVqFkd42dsx0JmQWcProu3249iY/WHlOPZcss6+bVHNezy5OMVMnsqgx2SYF6diijujL77xhk5pegqa8zRrUL5sRfA65v1SNNN76f0hXhga5IyytW2xjXx6Twd45qTOpaygVI8Wi/pmxywDWq2ueLL90UjicGhqqP5dheOnbKrg0yLXUW6JJfjmdWHFBFdZv5OePR/k3r6kcTXaCZnwuWTemCpwc3V/v15aRxwLv/qG0Z0g2UqKb+OJCI51ceUI8f7dcMozvW5ySS3nUK8VLBLkdbK2w+nobbPt+KJNaxoVp2JDEH87ecVI+fH9aC3WOp1sn2xcX3dUbXxl6q5IR0z5YtRDzRpJp4968Y1dhAiozfweMyqgFpkvfADU1Uwzzx6brjDHaZoDoLdP207wz+OJgIa0sLvHtbJOysrerqRxNdxNrKEvf1bKxqd7Vv4KEOpJ798QDGfLUN8Wn5nDGqtp1x6Xhk8R6V4nxnp/p4uG8Tzh7VarBryX1dVJ2kw2ezccvHm7i1h2qNBBZe/Okgysp1GBjuhx5NfTjbVKfNOEa2C1a/f7KF6OkVB1TDF6KrkffHBdsqAvQvDAtngJ6uydguDVV2l2Cwy/TUSaBLrjg/92NFtsPDfZuqgpNExkAKhS+d3AUvDGuhtgRtiU3DwNnr8c2mE8zuoqs6lpyLe+ftRFFpOfqF+eHl4S3VVSCi2hQR7IYV93dFiLcTzmQVqqLNS3ee4qST3v0WlajeFyX7+dkhLTjDVKfkovhbI1upDHx5a120PR5j5+xAWgG7z9KVA/T/+/kQZJOGFBbv0tiL00XXTBrnnR/smr26ol4lGT/LulhsZi7bj+xzXRZZCJCMjaWlBe7p1gh/TOuBziGeKCgpU51Bb/t8C2JTcg09PDJS0vp83JztKi2+TX13fHhHGzbXoDpTz9MRK+7vhr7NfVFcWo4ZP+zHU8v3syMj6U1eUSle/fWQejylV2P1O0dU1+TikWTgfz2uPZztrLE9LgPTV6Wq7sZElysnURmgf+rGME4S6SXY9fzQios97/99FJ+sq6jJSxoPdM3ZFKfejGytLfHOqNawsarzRo9E1dLAywkLJ3bGKze3hJOtFXaezMCN72/AF+uPq7R5okq5RaWqZog0MWjk7YSvpSOeLbdjU91yc7TBl2Pb4/H+zc5lO5zCkA82YN+pTL4UdN3e+vOIyhgM9nDgRUoyuD7N/fDTg90QHuCK7GId7p2/SwVii0qZ3UX/Kiwpwyu/HlaPJ/cMYYCe9GZC90aYOai5evzmH0fw9cYTnF0jZ1nbrZRf/71isXluaAvVIp3I2LO77urcAKse64UeTb3VlrTXfotWW4MOnck29PDICEh9kKnf7cLBM9nwdrbFvHs6qrbVRIZasx7q2xRz7+moCjhLG3VZr95ddURlehFdi10n0zFvS5x6PGtEhGq5TmQM5Sa+n9IZg5tUZBd+ueEEhnywUf2+Eokv1seqi5ABbvaY0rsxJ4X0SnamTetX0VDv5V8OqY7rpMFAl7Q9f3DRbpSU6TAo3B93dWIXMjIdQe4OmD+hI968tRVc7K1VhsSwjzZi1m+HkV9caujhkYHIVuwnl0WpTp1S000yuaQVOpGh9Wrmg1XTemJY60CVgfrBmmMYNHs91kYnG3poZIIZEbIVVhpsjGoXzAL0ZFRkO9q9bVzx+V1tVVMOqZU58rMtqvOxnHuQdp1Kz6/aUvbU4DA42lobekhkhh7p27Qqy1lqkC/dwRqpmgp0ycmgdLA7mZavAgZv3NqKBZrJJOtC3NahHlY/1gtDIgLUyePn62PR/12ePGrVe3/FYNnu06oW1ydj2qJ1PXdDD4moioeTraoV9/GdFSeAsal5aovt+G+240hiDmeKquWjNcdUZqD8DrEAPRmrfmG+WP1YT9zWPlgFZedvOYk+7/yDxdvjWW5Cg+TcU4KdhSXl6NTIE8NaBRh6SGTG54czBobinm4N1cczl+/Hyr0Jhh4W1VWg6/tdp7Fy7xl1MvjBHZGqjgiRqfJztcfHY9qqQqgSuJWUaDl5vH/BLvWYtEG62kmWjJA6bjc09zX0kIguaUirAKyd3kvVJ7GxslB1MqWb7MR5O7E7PoOzRpe1/UR6VUbEy8PDefxGRs3d0RZvjmyNBRM7oaGXI1JyivDk8ihVq3DDURar11oB+rVHUtR73qu3RDDBgmo92CXF6cd0qq8C7Y8t3Yffos5y1o2MdW3U5ZI0PvFY/2Zo18BT3z+CzrP68V7qKob8wVHt6hvmp1oUS1tZKUAobdf/PpyM+3qGqI5UTnZMkTZXG4+m4unlUerxgzc0wR0duRW7NnA90x8Xexu1dWN0x/p4689o/H4gEasPJ6lb+wYeuLNTfQyOCGDtJaqSlV+CaYv3QHqvjGgbhBsjmBGhT1zfak+3Jt5Y9WgvVS/n/dUxiE7Mwd1fb1dbuqcPCEVEsFst/nQyNNmy+uLPB9Xjqb0ao4mvs6GHZJK4RtWMnHu/PLylquf8w67TeHjRHlhaWGBQS/9aeoXIoBldablFmPLdLvWCS8tzWWyodkmrZTmhkXuqfbLf/+nBYarzT8eGnup3/cM1x3DD2+tUxg+7M5of2fIlxedLy3UYHhmIxwc0M/SQzBbXM/2TrqCfjGmHvx7tpeotWVtaqI6ycvWx46ur8cLKA4hOZKMNrZMLZjOX7VddFiUz5n/DWxp6SGaH61vtku7u93ZvhH+euEFtKZK17p+YFFVfdcq3u7h924y9syoGSdlFaODliPtvaGLo4ZgsrlHX1hBISjTd1DpQnSdMXbALn647rt5TyYwCXaVl5Xhg4W61lSvE2wnvjY5ULz6ROQoPdMOSyZ3x2V1tUd/TEck5Rap4r6TLrzqYyAXOTCRlF+Keb7Yjp6hUBTbfHMl6g2Sa5Ar3W6NaY+PMPni8fzO1DTu7sBTztpzEoNkbcMsnm1Swns02tOmTdcfxx8FEte3n/dFtePGMTLpW4QvDwlV91VvaBEE2PMjv9qD31+ORxXtwIjXP0EMkPdp1MgPzz3WIlbIS7BBLdU1KNb17W+uqbYxv/BGNRxbvRTabY5hHoEuilq/8ehhbY9PhZGuFz+9uB1d71uUi809ZHdQyAH891hPPDA5T3RklXf6+b3dh+MebsPZIMgNeJiyvqBT3ztuhMhxCfJzwxdh2sLO2MvSwiK6Lv5s9HurbFBtm3KA6y97Y0l9lPuyJz1TB+k6v/o0XfzqI0xn5nGmNWBOdhLdXHVGPX7qpJZtskFloKBfdb4/En9N6YnCEvzoBlfrB/d79BzN/2M81zkw6xD7x/b6K7dZtgtghlgzG2spS1YZ7+eaW6pjqp31nMPC99Ux+MDC97HeTekVzN1dE09+5rTWa+rno4581eSUlJXjmmWcwfvx4tGjR4qrfn5KSghkzZuCJJ56o1veLrzbEIqewVAVZJvYI0cOoqaYk+DGpZwhGtQ/Glxti8c2mOOw/nYV7vtmBdg08VK26ro29WEfNhEiG6kOL9uBAQja8nGwxd3xHVfRWi3YEB+O9Hj2AO++s+lzHjh0xbdq0S37/r7/+ij/++AM5OTkIDQ1V619AQPVq/XA9qzuScd2zmY+6SQFnqS+xaHs84tPz1fu51LoZ3joQU3o3RjO+p5stqav60MI9KghwV+f6qnablqSnp2P+/Pk4ePAgbG1t0blzZ9x+++3q8aVs3LgRy5cvR1paGho2bIi7774bTZpUb6sU1zfDkPVLtm8fSMjCu3/FYE10MpbsPIXle06reptSYzXQ3cFAo6Pr8dafR1R3YT9XO5XFZ45qukbt2bMHS5cuRWJiInx9fXHbbbehXbt21fpZXKOu392dG6BFgIsqD3EyLV8lP3Rs5KmaA90Q6svdbqYW6Pp53xmVzSWeHtxcZbgQUFxcjI8//hinT5+u9nTMmTMHRUVFNZq+rzacQGJ2Ifxd7RnoMjAJhDwxsDnu6dYIn607rk4UJaV6zFfbEFnPHVN7N0b/MD8uckZOMlRf+vmQOhi2s7bEl+Pao76XI7QqwdUVbdPSMHHJkqrP2djYXPYkcMWKFXjggQfg7++PZcuW4e2331a36jTM4HpmGD4udmp9kgOxDcdS8cX649h0LA3L9yRgxd4E3BIZhEf7N0M9T+3+HZij2JRcjP9mO/KKy9TFmOeHmueJ4pXW+tmzZ8PJyQkvvPACcnNz8fnnn8PS0hJjxoy56Pujo6Px5ZdfYtKkSWjatClWr16NN998Ex988AHs7e2v+vO4vhlWyyA3zBnfAbtOpquaTpuPp2H+lpMqwD+yXTCm9mqi6fd6U7M1Ng1zNp1Qj18f0cosO8TWdI2Kj4/He++9hzvvvBORkZHYv3+/+v9feeUVNGjQ4Ko/j2uUfkgjvt8f6YGP1hzDVxtPqG7GcpMaclLLa2C4P8IDXZkAYexbF2WReXzpPvV4fNeGmMSMIkWCW7IgJSUlVXsu5QSxoKDgel4OMhLeznZ4dmgLrJ9xA8Z1aaCCJXtPZWLyt7swcPZ6LNt1GiVl5YYeJl3GB38fU0FKicvMvj0Sbet7aHquEtzcEJyXB3d396qbHHRdiqxhd9xxB9q0aaOyuG666SacPXsW2dksdm4qWV7SpWzBxM6q4cag8IrtPhLw6vPOOrWlMTW3ZhdjyDhJnaK7vtqGtLxiRAS54Yux7VUxby05c+YMjh07hilTpiA4OBjNmzfHqFGjsHnz5kt+f2ZmJm655RZ0794dfn5+6rGceNbkgiYZx0nowkmdsXBSJ3QO8URJmQ6Ltp/CDe+sw2NL9+JYcq6hh0jVaH4m9dbk/em29sG4obmvWc5ZTdeoTZs2ITw8HIMGDVIXGwcMGKB2CG3durXOx6510rxsxqDmWDe9N+7rGQJXe2uV4SUNzIZ+uBHtX1mNSfN34vN/jqvgu2zDJSPK6NoZl4575+5AcVm5Ohh+bmgLRibPOXz4sFpYJF30nnvuuepcyhafRYsW4amnnlJbF69EovQPP/wwfvjhB6SmpsLXIRgZThEIOLEG48d/i0aNGuGhhx6Cp6en+v4dO3ZgyZIlSE5ORv369dUVgLCwMPW1/Px8fPvttyrNNS8vT6W4jh49Gh06dKj6Wffffz9++uknlQLbuHFjTJ06VX0fXZ2fqz1eGt4SD/Zpqq46fbflJI4m5+Lx7/ep9PmJPRqpq4jSNZOMw9xNJ/De6hj1+IWhLXBjBDNUJaMrPCWlWvPXv3//qseyvqxatUodnLm6uuptPZOUfNnmLf/uf9czSe+X75GMWq5n16dVsDs+u7ud2tr25p/R2HA0VW1plIL1gxvbIyS0BB7OrFlnimKSclSmsWxZlfqDc+/poMni8xK0nzlzJtzc3C74vKwllyJbhirJGvP777+rtU3WokuRtW3EiBEq8+vUqVPwt/VBhlsH+MVvUuubXAyQ7NfK/18yxuSYTAJncpJ66623qm3iorS0VB0nygmrXDjw8PDAsGHDqtZG+Vny8YYNG3Dy5EkEBgaqzLOQEJa0uJyujb3VbUdcusq8kA6Ny3cnYMWeBJV9P75bQ3QJYdkJY1NersOjS/epLouNfZzMdsvitaxRPXv2VGvFf13u+2t7jRo+fDj69u2r6TVKtkU/PTgM0/o1xZ8HE/HngSS11shFpr8OJambkLpezQNc1LFX62A3dd/U11nV/qJrd02zJ9uxxs2pSHfv1sQLs0dHqo4D9O/JntRtsLOzq9aUfPfdd+jRo8dlD5b+S04KJbovtbycsuMQkfgnsj3D8OKLL6orjj///LP6PllIPvvsM7XQjB07Fl27dsUbb7yhglZCTgol2+LJJ59U6fdypUDS8s9fJOVnjRs3Dq+++qoKyMlJJtV8W9DMQc2x6ak+mDEoFN7Otqo7qWyP6/Ta33hmRRSiE5nxYmgr9pzGiz8fUo/lDWl8t0bQOmmOfNbVFVEeHnjsscdUXS45kLnUgdT51q1bh4kTJ6oDGgn2X2nbYk3Xs5tvvhmvv/66yqq41Ho2cuRI9XWuZ/oREeyGb+/thIUTO6ki5fnFZfjhcB56vv0PPvz7KHKLrvy7QMZl8/FU3Pb5FhXkau7vgiX3dYGXc/WOVcyNZKa2bt266uPy8nIVnG/ZsuUV/78DBw6odU1qdcmx1ZW2Lcoxk9TTkSx/u8J0tEr8HfnOgWorkdTYkQuRQta6t956S52oyromJ4Sy3smJpVi5ciX27t2r1mDZCi7fJ2ueXKQ8fy2V/0/WPwcHB/V1uroODT0xb0JHrHygG/q38FNZQqsOJeHOL7epjrSytbGgmNkWxuKTdcewPiYF9jaWqvaakxkH6Wu6RgUFBV2wRVECUlLb60prWm2uUXPnzkVWVlbVz9LyGiUZXre0CVYXEPe+0B/LpnZVJZ8GtPBT54Wl5TpVF3jhtnjMXBaFG9/fgIgXV2HUZ5vx8i+HsHJvAuJS89jkrIZqvDpIFHLqd7vUwa7UdPhqbAe2cr0OUVFROHLkiAo0VdeNN95YVfy0yN4L2RbOyHNrpAqjSmQ9Li6uqij0DTfcoAJcsvjIfm35WRK5v+uuu1QmxJAhQ1CvXj31/fJ47dq1alHy8vJSnxs8eLBKgxX9+vVTCyxdG+lEen/vJpjQrRG+33Ua8zbHqRT5Bdvi1U3qeMne7aGtAuDrevV6H6Q/v+4/i+nf76/ahv1I36acXgCpdnYosraGdXm5uhonmVTz5s1T2QwSAL8cOah67bXXVMDrnXfeUY8vlwla0/WsW7du6mNJzZfs2fPXM/mcFImWK41cz/SraxNv/NjYC79HncWsX6JwKrsU7/wVo7JVZU27o1N9tW2bjLfWi7zPyPZTOaCW9xvJ5NJqk41LkSD+iRMn1Anelcgxk1z8k2x4OdHz8fFRNbsuRU72IiIi1OMCpwCUFeUixzNMXdiUYL007hCVJ68DBw5UH8saJmufZI1J0F4y8uVYrPLnyAVMCbRlZGRc8LMqM/Jl/ZPaPFR9Esj/cmx7HE3KwbwtcVi2KwFHknLw1PIovP57NG5tG4w7OtZjwy0De3tVRdb9SzeFI9RfW83PqrtGCcmqknpdzZo1u2Ix+tpeo+QCZGVGGteof5uYSbMyud3Xs+L9WRIgpJHZvtOZ2HcqUwW95ELijrgMdavk7mijyg20DnZHq2A3tW7JDiLSQ6BLujI9uWy/Okjq3sRbvSE42HLrwrWSk8Wvv/5aXRm8XPeMSzn/hFFnYYUia6cLikRXZlskJCSoFNK///5bXQWQ4oXytVatWqmvSxbZzp07sWbNGrUPXBZPId9bSRayShJ9LyvjVa3rZW9jpbpy3NWpPrbGpuPbrXH482CSquMlt1d+PYTOIV7qymLvUF808r50PSTSjx/3JKi6HNKeWg5kn+c27Co+RUX4YtkyOPr4wLJhQxV8kjdkabQhWauyplyKt7e3ukkwTIJR69evV5lW+lrPKv13Pdu+fbvKIvvzzz+rAmRcz/RHMvMGhvvBu/gMEiz98OGa46rjlQS8VN2J1gEY06kB2tZ3ZykDI5KZX4ynV0Tht6iK7MfhkYF449ZWvEj5nxNIOWGTgH7lxb/LkZM2ucl6KPVzZE26XKBLanlV0llao8jKuepjOe6T7txCjsF27959QbkLOd6q7FgrASy5MCo7AOR7K9c3WY8r8XhNP6Rz/Cs3R6jmQt/vPKWCXqfSC1RQX24dGnqobo2DIwL4N2QgckHy9g7a6hBbkzVKEhbkAqOsD5JhdbljtbpYo3gMVr1jq2APR3WTdaVi3nSITc3FvlNZ2H86E3tPZ+HwmWxk5peoUhJyqyQN6SqDXnLfKsjdLJsz1GqgS9Lmvt5YEQi5OTIQb45srbnCpfp2/PhxVTvrv1fdJCVUot733nvvJf8/K6v/BhcvvS1IFhdJEZUMiEOHDqm6YbLYVQbVPv30U8TExKgTRMnWkr3gkrp6PmvrC39Fzj+ooutf2Lo09lK35JxClVX0074z2BOfqboByU22N0qXjt7NfNCzmQ86NPJUmWGkP48u3VtV0HTWiFbsivkfzsXFagtjJamrIAc+UoT5v7W3JEVe6jLI91T+jstj2fZ8OTVdz2S9Ot9/1zOpJSjrp9Su4XpWO6wsLFT26bDWQfh5/xnM3RSHfaezVH0buQW5O2BwhL/qwiy1JlhjwnBki8+MH/ar7sxSA+SJgaGqMG51uqBqhWyvkcxQqUlaWW/mcsdscgwltQPP3yokQfjLuegE8zLzLieMkj0hWRCXWh9le5FclOzVq5daA+Vk85FHHrni8RpdHzcHG9XNXDppy9/Rwu3xqhtzZYaFZEeOUFle9TWXWWRI/cJ8VV1oLanuGiXS09NVxql47rnnLlsjtRLXKONtDtTE10Xdbm1XUdqouLQcRxJzqrK+JAPsaHKOen9PPFSotlxXkvqb7Rt4oH0DT7Rv6KGSJrT4vl/td8XKINf9vRtj+oBQngzqgZyQvfvuuxd8TurgSHG+yjTS6yFRdtlqJNF6SR2Ve9lrLZ/v1KmT6trxv//9T41DSBq+YDCr7vm62KuDKbmdSs/Hb1Fnse5ICnaeTFddOuZtOaluUgpPWmRLgVTJ+pLAlxaLCOuTBLnGdKqPl4e35Lr2H/s9PPBxp074YMcOVCZGS60sZ2fnSx48ST0tyeSS+lyVwSn5ftlSqK/17PyshYULF16wnkldL0nXr2yrXfH6MjhfWySAJTUn5LYnPgPzt5xUxVYlBf/LDSfUzcXeWq1X3Zp4q5sUD9biwVZdk9fglV8O4fcDFVlcId5OeH90G1Vzjf61bNkylZElTS9kHbkS2YotFyelcVAlyYSXzK7rJRcEJFB//vom27XlooLUJZST3AkTJlQVxK/s9Mj1rfZJDWLp6ie3xKxCleW1eMcp9TcmDTrkJluQJOA1JCKAO11qmaxjWqoLXZM1qrCwUCVLyHvss88+qxIY9IVrlOFJgpG8h8vtrs4Vtdjyikpx8Ex2RdbXueBXfHo+YlPy1G3pzor3Ci8nW7Rt4KEyUqXzbMsgV7WF0txV+wxZDlbfHtUaA8P/fROmayMF/RwdHVUmwvkHNZUkE+G/HTauhdS+kUCWHIRJYXzZZ/3bb7/hmWeeUT9bPidbfeSEVdJM5YqBqExTJcOo5+mIyb0aq5vsz958LBXrYlKw5Xiaagkvi5jcPl8fq97sKwNfHRu6w7bk322nVD1SeF5qcvHk+2JNs7NhW1aGL5s1w61nzqiTPAkuSWZVZSBLAksS+JJsAmnE8f7776t6WZL1ICdqskVbMqz0tZ5Jh542bdqoFPr/rmfScVHWVAlycT2rW23qe6ibtMhedyQZv+w/q2p65hSWqquMlVca/VztznU7qwh+SUci0r9+7/yDgpIydXFkbJeGqhGKFMOlf0km1ooVK3DTTTchNDRUHZtVqjxBPP94rU+fPnj++efV9iEJpm/atElleUk36ut+vfr1U8dokrklGVuxsbHqwuR9992nvu7i4qLWPFlXpS5XZRFnlpOoW/5u9niob1Pcf0MTbDiaogrVrz6crJp0ye2lnw9iRJsgVbOwuf+VM2no2phz8fnrXaOkIHxSUpIKclV+TcjX5HsMsUZdrXkRXf/fQ8dGnupWKSOvGLvjM7BT1qW4DOw9nXlRl0cJmrUKqgiatQysuG/s42x2QeRqrxa/PNQdDbxYK0gfJPV08uTJKgVdH7/g1s72cAu6+A1VakbIAZhcDZATVMnoevDBB9VJaOU4FixYoOrZSDHVW265RS1gkoEh6fhkeJKtNSDcX93E2awCbItNV0GvrSfSVLaXpK/K7bN/oE5qWu3agsh6HioAJhH7Jj5sT3sl0/o1q6NX0/Q4lJXhybVrMb9rV3XgJN3FpFX00KFD1del8Ltsn5GvydZoKXgqWQey5sjXZA2S7IcrdSW7lvVMgm2XWs+kNoSk7cvXuJ4ZrgahbFmUW5nqIpSFjcdSselYqjrokpbwK/YkqJuQdHoJesnWbLl34dZsvZAgV8eGnnhpeDjCAnjCfSm7du1Swfoff/xR3c4na8x/j9fkBO7RRx9VJ3eLFy9WdXKka7VcnKwOKSLsUGqFhpdY3+QYbPr06aoOzy+//KK2gI8ZM0ZtZxRyMjlnzhzMmDFD/TxpzCFbjuTYjuqenAxKDVW5JWcXqgZDi3fEq1pelRn4beq7qywvaTDEIDPVxRolyQtycVEC8ueTi43S3bqu1yjZei21us7vHEm1z8PJFn3D/NRNFJWWqeL2u06mY2dcRQAsPa9Y3cutknQybRHgivAAVziW5qPcMwPNA9xM+rjMQqehvGddcDAsEhKgCwqCxbm0by2QK36VXRcvrodjnrTynM9kFmBrbJq6SfDrVEbBRd9ja2WJYA8H1PdyRH1PKXbogAA3BwS626t7Xxc71tCpI6b2e2lqa6apza8pjvl6xivZXpL1IEGvTcfTEHU6UzWBqCQ1pKSWRK9mvujVzAdhAS7XnWlpavOrL38cSFSNA7SQqWpq65S+aPV321iftxSP3nQ8VWV5rTqYpBp3CRc7awxvE6iCXuGBbmb3vKn6tLpW1Sb+XdScTqdTO4Rkq2NUQpa6ICnbH/OLL91wTuquNvd3QTN/l4p7PxeV/WUKtdq1k/9JZIZk248UQ5WbLParNu1CvlMADp7JwYEzWTh0pqI9rXRGk9vlrkxKsCvAzR4B7g4IlHs3BzT2dUZ4oCu8ne3q/HkRkXlme1XW6hLZhSUqQ3Xj0RS1zTEuLV91opXbG39Eq3VJAl69Qn1Up2d3x+p3J9a6QS1ZZoKorotH92jqo24pOUWqU70EvaRezndb49VNahT2a+GH/mF+aqu3uW0TIiLjZ2FhgRAfZ3WT80chGfgS/JKgV1RCJnYePYPEfAsk5RSpeoRy+zs6+YILk1LwXoJelcEv2a4tyRSyFhoLBrqIzIivkxUiIwNxazurqiuMsjhJgfuTckvLVx+flVtWoerUIYubPJYb4v/d/39+21oJeIUHSctaN3WQRkR0vaSDbH856Tu3psSl5mG9BL2OpKius8k5RWpLkNyEdKCVWhItAl3VY2nFXc/DAR6OtkZ1YEVE2ubjYoepvRtjcs8QbIlNUx0bVx1MxPGUPBz/Jxaf/xOrah9LsKtdfQ+VvSrbuCXzXgsFoonIuFipLo/O6jaslT/2BhSq7NHswjLEJOXgiNwSz92SclT91ZikXHWTmqyVHG2t0FSCXn7/ZoA19HaCj7OdQTLAGOgyYbJvOzo6WhUblKKEzZs3v7hNLGmanPxJcXu5db3E1yXIlZpbpLZASqCr8j4ho0AtbJIFptrWZhdWRfLjXh9S58+DzB/XM5KDIblJ8XSpKbHjRAb+iUlW2V5yMCWBern9GvXvQZWQGJdke0l9EQl6VdxsVJ0KN3tr5KTlI8kmEZ7O9hd8jymk3ZN54Pqm3WOwyixWyWCVIP7qw0lYG52M7MJSrI9JUbeq77eQhh328HKuWKM8nSruJSjmYGOJzJR8nMQZuDrYqpqW8nmp5Vr52M7aUhPblUn/uEbRpchxVKcQL3U7f+ujnCtWBr9iEnMQnZiDYym5avtjZe3o/5L1TDL1ZY2TxkRyLx/7nruXj+UigY2V/o7NGOgyUVJwUDpabLKMQImVHWzKitCt/BOMHTsWHTt2NPTwyIQi+BULjj3aXOLrsu3x8NlsHFSprNkqnZVI37ie0X9JVkP3pt7q9swQIDO/WNWQkLR6OaCSLNVTGfmquL2UwpHCqnIDLr1FG7v2XvQpOUH0cLKBp6MtVj5YUVCXSN+4vlFlBuuw1oHqVlpWrtYxqVko3dGOp+QiLjVfHXNVZdhfzu79Vzymk3Wt6mZvjWVTL3WZk4hrFF0bCaZL6Ry53RDqW/V5WdekBIUkSsj6diQxW12klOSJ4rLyquM0+dqVeElArCr4ZQdfF3v4nncv56xSN6w6GOgy0YOm2bNnq8d5gZ4otnaEbWk+0s+kq89PmzaNwS7SCzlQ6tDQU92IagPXM6oOydg6v75XpeLSchUEy8gvUQdQ8jg9X+5LKh7nFePk2VSU2zggs6Ck6vMSHJOTSrlJpzSi2sD1jS7F2sryXGdsN4zr2rAqSyI1t1iVl8g4d0Iot4z8YuQVlSKnsAQJyWmwsndGXnEZcgtLkFdUptawvOJSSGsxydLPKihRNyKuUVTX61rl9sfBEQFVn5e1TY69knIK1cXJpCy5L1TlKeRe6oClnPtYmnik5RWr2+ELk/cvUN3dRUYf6JLJKSoq0su/ZavTwaLy3yy8wtUSI08tnTdv3hW/RzK9WrZsWbWNUYqUl5SUoLCwUDOdWvT9nO3s7JgOTnoh64+p/C3W9pp5LevZlZjiWlfbYzb3tUu2H6orf6721e7IJLULpb5ExrmgWHquZIKRsR2zmfqxnb7XN3NY7/Sh8nmbW9N4Wadl247catpdTta0/BIJflUE71XwSwXHSuto9KavLtYuY1uranuNqgumsg6a+7HYlcjzli2Qcmt+hT45so7JcZkKhuUUIiW7CMnngmNyL4Gw5HOPq8uoA12yELz00kuIiYnRy7/3YUYGZIdpRkYGHpowAeYqPT0dEydONPQwzEqzZs3wwgsvaHaRIv2taYsXL8aZM2dMYkqNYc3kenZ9uHZdum6Om6ONujWE03XOMNXWMZsprVPXiuvbtePaduGaVrldkYx37TLFtYprlH5wvareOublbKduLeB62e+ryUUO4wzPEhERERERERERoSJDrLqsjf2JSBaN3rYu/vMPUFAADw8PzJkzB6ZIuiy++eabV/2+GTNmqC6MlWmdUVFRiIiIMOq0Tn3S93PWcsop6Y/8Do0ePRphYWEm8bdY22vmtaxnV2KKa11tj5lrF5nqMZupH9vpe30zh/VOHyqfd/v27XlcRia1dhnbWlXba1RdMJV1kMdihmHUga7Kxcfe/tK1N2pKdy5Qoc9/s661atUKnp6eKpX0cry8vNT3nV+jy8bGRj1nY14E9EmLz5lMQ+X6Ywq/l7W9Zl7LemZuf/emOGaiyzHE8ZWxHtvpe337L62uHZXPmxcfSZ/qYv0wtrWqtteouqDVdZCqxzh/a+myZKEZO3bsFWfo7rvvNtoFiYioEtczIjJXXN+IyJhxjSJzx2iICerYsSOmTZumovD/jbrL5+XrRESmgOsZEZkrrm9EZMy4RhG0vnVR2o9K205TpwsJgYWzM3S+vrDIz4cpk1avr7/+OhK+2orMwjK423tg1sRZKjqf/5/nJmmdQj6vlbROPufafZ0lRdgcsgbrem0ztd/Luloza7KemdP8muKYzXm8XNdMk7Ef2+lrfTP1v0V94fOu+evNtc04GOtaVVtrVF3Q6npQm8pMZE6rs65Z6KrRo1Ge6OHDh/U5NiIyYVJM3dHREaaOaxsRVeK6RkTmiGsbEWlxXatWoMtcMrqOHz+O6dOn4+2330bjxo2hFVp83nzOtfs68+qgNn4vOV7OsZZ+J7iumSZT+53UFz5vvt7VxbXNOGj1b7Y2cU61O6f21cjoqtbWRflHzCF7Q55HXFyc2Tyf6tLi8+Zz1sbrfL3q+m/C1H4vOV7OMX8nTI+prC9aXaf0hc+br7fWmPrfuFb/ZmsT55RzeiWmX2SHiIiIiIiIiIhIa4EuHx8fPPjgg+peS7T4vPmcyRiZ2u8lx8s55u8EGTtTW6f0hc+brzeZFq3+zdYmzinn9LprdBERERERERERERk7TWV0ERERERERERGR+WKgi4iIiIiIiIiIzAIDXVRt3OVKRERERERERMaMgS6qlp9++gnjxo3jbBERERERERGR0TLbQFdxcTGGDh2Kbdu2XfZ7Dh06hFGjRqF169a49dZbceDAAWjheU+dOhWhoaEX3NauXXvFf/fdd99FfHw8jElSUhIefvhhdOzYET169MCsWbNQVFRk1q91TZ7ztbzOpD/33Xcfnnzyyct+/aabbrro9YmJianzl+Cvv/66aBzyO3YpmzdvVuuL/B2NHTsWp06dMurxGsMcy5r80ksvoUOHDujatataSy+XHWsM81vTMRt6jpcvX37Rz5db8+bNjXqOqWa0+H6v5ff8kydP4t5770WbNm3Qu3dvfPXVV5f9XnN6vWvyvM3p9TYnWl2rapNW18HadFIra6zODBUWFuoeeOABXbNmzXRbt2695Pfk5eXpunXrpnv99dd1x44d07388su6rl27qs+b8/MW/fv3161cuVKXnJxcdSsqKrriv92rVy91Mxbl5eW62267TTdx4kRdTEyMbseOHep5yetprq91TZ7ztb7OpB+//PKL+jucOXPmJb9eWlqqi4iI0G3fvv2C16ekpKTOX4JPPvlEN3ny5AvGkZWVddH3JSQk6CIjI3Vff/21+v175JFHdEOHDlW/l8Y4XmOZ4+eee043YMAA3b59+3SbN2/WderUSbdo0SKjnd+ajNkY5rigoOCCn33mzBm19r366qtGPcdUfVp8v9fye35ZWZlafx5//HHdiRMndOvWrdO1bdtW99NPP5n1612T521Or7c50epaVZu0ug7WpjINrbFmF+g6evSo7qabbtINGzbsigGf77//XtenT5+qA1y5lz+OZcuW6cz5ecsfe1hYmC42Nrba/7YEuCQmWnlbu3atztDkj02eZ0pKStXnfv75Z1337t3N9rWuyXO+lteZ9CMjI0PXs2dP3a233nrZQFdcXJyuefPmKjhtaPJG984771z1+2bPnq276667qj7Oz8/XtWnT5opBdUOO1xjmWH4XWrRoodu2bVvV5z7//HPdk08+abTzW5MxG8Mc/9dnn32m69ev3yUPbI1ljqlmtPh+r+X3/KSkJBWEzsnJqfqcXMR94YUXzPr1rsnzNqfX25xoda2qTVpdB2tTkobWWLPburh9+3Z06tQJS5YsueL37du3D+3atYOFhYX6WO7btm2LvXv3wpyfd2xsrHqu9erVq/a//cknn6jURrlt2bJFzZOh+fj4qDRLb2/vCz6fm5trtq91TZ7ztbzOpB9vvPEGhg8fjiZNmlz2e44dO4aAgADY2dkZfNqPHz+Ohg0bXvX75O+offv2VR87ODggPDy8zv+OqjteY5jjXbt2wdnZWaXbn7+lVdLujXV+azJmY5jj82VmZuLLL7/E448/DltbW6OdY6oZLb7fa/k939fXF7Nnz1brkFyQlzVpx44dF6xJ5vh61+R5m9PrbU60ulbVJq2ug7XJV0NrrNkFuu688048/fTT6gD2SlJSUtQLfT4vLy8kJibCnJ+3LALyiz1jxgx0794dI0eOxD///HPF/6dFixZwdXVVt86dO6t7Q5MxyD7tSuXl5fjuu+/U+Mz1ta7Jc76W15munwSCd+7cifvvv/+qwRobGxtMnjwZ3bp1w1133YX9+/fX+Usgb3AnTpzAxo0bMXDgQPTr1w9vv/22qtFkjH9HNRmvMcyx1H8KCgrCjz/+iEGDBqFv3774+OOP1d+uMc5vTcdsDHN8vkWLFqk5lHFfirHMMdWMFt/vBd/zgT59+qjjW7nQKmu+Ob/eNXnePMYzTlpdq2oT18Ha1cfM11izC3RVV0FBwUVXfOXjS50wmRN5cywsLFTBD4mQ9+rVSxXui4qKgil76623VLG8Rx99VDOv9ZWes7m+zsZMCmO+8MILeP7552Fvb3/F75VgTVZWliru+MUXX6Bx48aqq+nZs2dRl86cOVP19yFXd2bOnImff/4Zb775plH+HdVkvMYwx/n5+arg5+LFi1VGlIz322+/xdy5c41yfms6ZmOY4/ODoN9//70Ktl2OscwxXR8tvt9r9T3/gw8+wGeffYbDhw9fMqvUXF/vqz1vc329zY1W16rapMV1sDZ9YOZrrDU0SrZa/PdFko+vdoJq6iTT5O6774abm5v6WDpTHTx4EEuXLkVERARMddGbN28e3nvvPTRr1kwTr/XVnrM5vs7G7qOPPkLLli0vuJp3OS+//LJ6M5asO/Hiiy9i9+7dWLlyJaZMmYK6Ipk70qFVfk8kHTksLExdgXziiSfw1FNPwcrK6qp/R3WZ4VmT8RrDHFtbW6v0+nfeeUeNvTJYJ5lHEyZMuOB7jWF+azpmY5jjSnIgK52ZhgwZctnvMZY5pmunxfd7Lb/nV45dLiRNnz5dZamff9Jlrq/31Z63ub7e5kSra1Vt0uo6WJsizHyN1WxGl5+fH1JTUy/4nHz83/Q8c2NpaVm1AFQKCQlRJwimSE60vvnmG7X4XSrl0hxf6+o8Z3N7nU3Br7/+itWrV1fVs5NMI7nJ40sFEyqDA0KCNoZ6fdzd3av23gvJypE3PMnUqc7fkdRPMMbxGsMcy9zIQUJlwEg0atTokhlPxjK/NRmzMcxxpQ0bNqj6W/9d94xxjunaaPH9Xovv+fJ6yXvp+aTmZUlJyUV1eczp9a7J8zan19scaXWtqk1aWwdrU6qG1ljNBrpat26NPXv2qO0OQu7lSrR83pw9+eSTKvPhfNHR0WohuJLzMyWMKYNGtte8++67V7yKb06vdXWf87W+znTtZHuXBLaktpHcZN+73OTxf8kVJ3ktK0lW0pEjR+r89ZHggDSxkNTkSpK+LMEkT0/PC75X/l6kYGUl+X8kfbwu/45qMl5jmGOZGwnCyRa/81Przw8iGdP81nTMxjDHlaQ22NUapRjLHFPNafH9Xqvv+adPn8aDDz54wcnpgQMH1Bp/qfclc3m9a/K8zen1NjdaXatqkxbXwdp0WktrrM6MSTvS89uGJycn6woKCtRjaanZuXNn3csvv6w7evSouu/WrZsuLy9PZ87P+88//9SFh4frVqxYoVrDf/jhh7pWrVrpTp06dcV/c8SIEbqAgADd33//rUtPT9cZQ7tZaSH73nvvqed3/s1cX+uaPOdrfZ1Jf2bOnKluorS0VL0+0vpYzJkzR9euXTvd6tWrdcePH1ctfbt27XpBq9+6ID+vR48euscee0yNY926dapl8xdffHHRmOV3JyIiQvf555/rYmJiVGviYcOGVbUcNrbxGssc33fffbrbb79dd/jwYd369evVWjRv3jyjnN+ajtlY5ljccMMNul9++eWCzxnzHFP1afH9Xsvv+fJ3K8ecEyZMUK+hrPOyrsydO9esX++aPG9zer3NiVbXqtqk1XWwNpVqaI3VVKBLPl62bFnVx/v27dPdfPPN6sB35MiRuoMHD+q08LyXLl2qGzBggK5ly5a6W265Rbd9+/ar/ptr1qzR1a9fX2dra6tbsGCBztDkREWe16Vu5vpa1/Q5X8vrTLUT6JI32fP/LuXE+tNPP9X17t1bvT5jxozRHTlyxCDTLyf848eP10VGRqo3LzkwkPH9d8xC3gzld0oOHMaNG6eLj4832vEayxxnZ2frnnjiCTXeLl26GP381mTMxjLHQtZ2Ccqdz5jnmKpPi+/3Wn/PT0xM1D3wwAO6tm3bqnVe1pnKgLS5vt41fd7m9HqbC62uVbVJy+tgbUrUyBprIf8xdFYZERERERERERHR9dJsjS4iIiIiIiIiIjIvDHQREREREREREZFZYKCLiIiIiIiIiIjMAgNdRERERERERERkFhjoIiIiIiIiIiIis8BAFxERERERERERmQWzDXSVl5dj//796l6rOAfVn4OvNsTivb9i1L1ehYUBFhYV9wbC3wMiIiIiIiLSCmuYKZ1Oh5KSEnWvVZyD6s/BVxtOIDG7EP6u9pjYI0R/L0JOzoX3BsDfAyIiIiIiItIKs83oIiIiIiIiIiIibWGgi4iIiIiIiIiIzAIDXUREREREREREZBbMtkYXkbEpKi3DmcxCnM0sQGFpGSwtLODtbId6no5wc7Ax9PCIiIiIiIiITB4DXUS1pLSsHKWl5bAHkJpbjA7P/YHL1cRv5O2EXs18cFNkINrW9+BrQkRERERERHQNGOgi0rOEzALM3XQCK/acwc95xQgAUFJWroJcDjZWCHS3h5OdNUrKdEjNLUJKThFOpOap29zNcejQ0APTB4SiU4gXXxsiIiIiIiKiGmCgi0hPkrIL8dGaY1iy4xSKy8rV5ywtLdS9u6Mttj/dFz4udrCwqPhcpYy8YuyIS8fvBxLx6/6z2BGXgdu/2IoxnerjmSFhcLTlnykRERERERFRdfAMmgjA1qf7XvM8lJfr8N22k3jzjyPILSpVn+sc4okJ3RrB9zs7IFsyuSzh4CqbGC/m4WSLAeH+6jZzUHO8/3cMFm0/hQXb4rH/dBa+Gtcefpf5f4mIiIiIiIjoXwx0EV2H9LxiPLpkL/6JSVEfR9Zzx4xBoeja2Pua/j1/N3vMGtEKQ1sF4qFFexCVkIURn2zG0ildEOTuwNeKiIiIiIiI6Aosr/RFIrq8Y8k5GPbhRhXksrexxEs3hWP51K7XHOQ6X7cm3vjx/m6qSL3U/Lr7q22qnhcRERERERERXR4DXUTXYO+pTIz8bIsKQjX0csSK+7thXNeGVTW59KG+lyMWTOykMrliU/Mw5dtdqqg9EREREREREV0aA11EAGavjsHLvxxS91dz6Ew2xn69DZn5JWhdzx3L7++GsADXWpnHQHcHfHtvR7jYWWPnyQy88Xs0Xy8iIiIiIiKiy2CgiwjA4u2n8PXGE+r+SuLT8jF2zjZkF5aifQMPLJzYCZ5OtrU6hyE+znhrVGv1+KuNJ7DuSDJfMyIiIiIiIqJLYKCLqJqko+LE+TuQmluMFgGumHNPBzjZ1U0/h0Et/TG+a0P1+JkVB6q6OxIRERERERHRvxjoIqoGnU6H6Uv3ISYpF74udpgzvgNc7W3qdO6km2Owh4OqC/b2n0fq9GcTERERERERmQIGuoiqYdnuBPxxMBG2Vpb4Ymx7+LvZ1/m8OdpaY9aICPV4/pY4HE3KqfMxEBERERERERkzBrqIruJMZgFe+umgevxo/2aIrOdusDnr0dQHA1r4oVwHzGJheiIiIiIiIqILMNBFdJUtizOX7UdOUSna1HfHfT1DDD5fT97YHNaWFlgTnYzNx1INPRwiIiIiIiIio8FAF9EVLNwejw1HU2FnbYm3R7WGlaWFwedLujCO6VRfPZ69+qihh0NERERERERkNBjoIrqM+LR8vPrrYfV4xqDmaOzjbDRzNbV3E1UvbHtcOrbGphl6OERERERERERGgYEuoksoL9fhiR/2Ib+4DJ0aeeKerg2Nap6kGP6o9sHq8YdrmNVFREREREREJBjoIgLQKcQTPZp6q3sxd3Mctp1Ih6OtFd4a2RqWRrBl8b+m9m6sanVtOpaGAwlZhh4OERERERERkcFZG3oARMbg/dFtqh4fT8nFG39Eq8dPDw5DfS9HGKNgD0fcGBGAn/edwTeb4vDOba0NPSQiIiIiIiIig2JGF9F5ysp1mP79PhSVlqsMr8qi78ZqQreKLZUS7ErJKTL0cIiIiIiIiIgMioEuovN8sT4We+Iz4WJnjTdubQULC+Pbsni+NvU9EFnPHcVl5Viw7aShh0NERERERERkUAx0EZ1zJDEH7/0Vox4/P6wFAt0dTGJu7jmX1bV0xymVkUZERERERESkVazRRQRg9OdbsOdUpsqM6tvcFyPbVXQ0NAUDw/3h5mCDM1mF2HgsFb2a+Rh6SEREREREREQGwYwuIgBRCVmqLpfsVJw1IsLotyyez97GCjdHBlZldRERERERERFpFQNdpHnbT6Qjr7hMzYNkRvm62pvcnIxqX0/drzqUiPS8YkMPh4iIiIiIiMggGOgiTcsqKMGjS/ZWfWxvbQVT1DLIDeGBrigp0+HHPQmGHg4RERERERGRQTDQRZpVXq7DY0v2IiGzAFYmtFXxcm7vUJHVtXTnKeh0LEpPRERERERE2sNAF2nW7NUx+Ds6GXbWlnB3tIGpG946CLbWlohOzMGhs9mGHg4RERERERFRnWOgizTpjwOJ+GDNMfVYis/bWJn+n4Kbow36hPqqxz/tO2Po4RARERERERHVOdM/uyeqoc3HU/Hw4j3q8fiuDTGibbDZzOFN57ov/rLvrNqaSURERERERKQlDHSRpuyJz8CkeTtRXFqO/i388MyQMJiTPs194WxnreqO7Y7PMPRwiIiIiIiIiOoUA12kGRL4Gf/NDuQVl6FbEy98eEcbs9iyeD57GysMaOGnHnP7IhEREREREWmNtaEHQFQX/olJwQML96KgpAztGnjgi7vbq6BQpYf7NkV+cSkcbU3/T2JYZCCW70nAr/vP4vmhLWD6/SSJiIiIiIiIqsf0z+qJrmJDfAE+2rEbpeU69Grmg0/vantRQOvOTvXNZh67N/GGh6MN0vKKsel4Gro39jT0kIiIiIiIiIjqhHnt2yL6j282x2H2tiwV5BrWOhBfjm1vFllbVyLbMQdHBKjHv0edNfRwiIiIiIiIiOoMA11klnQ6Hd78Ixqv/BqtPh7bpT7evz0Sttba+JWvDHStOpSE0rJyQw+HiIiIiIiIqE6Yd2oLaTbI9dzKA/hua7z6+M6Wznh+SBgsLS9frSo5uxBlOh2sLCzg62oPU9exkSfcHW2QnleMnSczYPrPiIiIiIiIiOjqtJHeQpoKcr3222EV5LKwAF69ORy3hjnDQj64gps+2oQus9aoe3PZvtg/rKL74h8Hkww9HCIiIiIiIqI6wUAXmZU5m+Lw5YYT6vEbI1phdId60KpBLf3V/V+HklCu0xl6OERERERERES1joEuMhvrY1Lw6q+H1ONnBofhNg0HuUS3Jt5wtrNGYnYRjqWXGHo4RERERERERLWOgS4yC4lZhXh48R6U64BR7YIxsUcjaJ29jRVuaO6rHm9NKDL0cIiIiIiIiIhqHQNdZPLKy3V4bOleZOaXICLIDa/c0vKqNbm04sZz2xe3ni5U9cuIiIiIiIiIzBkDXWTy5m6Ow+bjaXCwscL7oyNhZ21l6CEZjd6hPrCztkRSXhkOn80x9HCIiIiIiIiIahUDXWTSkrML8e5fMerxM0PCEOLjbOghGRVHW2v0bOqtHrP7IhEREREREZk7BrrIpL3222HkFpWidT133NmxvqGHY5QGhvup+7+jkw09FCIiIiIiIqJaxUAXmaytsWn4ce8ZSDmul4eHw9KSdbkut31R/tCjE3NwOiO/zl8nIiIiIiIiorrCQBeZpJKycryw8qB6LJlcrYLdDT0ko+XhaIvm3jbq8d+HmdVFRERERERE5sva0AMguhbzNsfhSFIOPBxt8MTA0OuexAWTOqGsXAcrM80Kax9oj0OpJVh9OAnjujY09HCIiIiIiIiIagUzusgkC9DPXn1UPZ4xqDncHW2v+99s7OOMZn4u6t4cdQi0q9rumVNYYujhEBEREREREdUKBrrI5Mz6PbqqAP3t7esZejgmIdDFGiHeTigp02F9TKqhh0NERERERERUKxjoIpOyLTYNK/YksAD9NejT3Efdy/ZFIiIiIiIiInPEQBeZVgH6nyoK0I/uoN8C9Cv3JmDx9nh1b676hfmq+zXRySgtKzf0cIiIiIiIiIj0jsXoyWTM2XgC0Yk5cHe0wQw9FKA/36zfopGYXQh/V3sMjwyCOWpTz13NXWZ+CXadzECnEC9DD4mIiIiIiIhIr5jRRSbhVHo+3lsdox4/PTgMHk7XX4Bea6ytLNEntCKri9sXiYiIiIiIyBwx0EVGT6fT4dkfD6CwpBydQzwxql2woYdksvqG+an7vw8nG3ooRERERERERHrHQBcZvZ/2ncE/MSmwtbLEq7dEwMLCwtBDMlk9m3nDxsoCsal5OJ6Sa+jhEBEREREREekVA11k1E5n5KtsLvFgnyZo7ONs6CGZNBd7G3Q+V5tr9SF2XyQiIiIiIiLzwkAXGS3pDPjYkn3IKSxFZD13TO3d2NBDMgv9KrcvRnP7IhEREREREZkXBrrIaM36PRrb49LhZGuF90dHwsaKv676cMO5gvTSeTG7sEQv/yYRERERERGRMWDkgIzS9ztP4euNJ9Tjt0e1RgMvJ0MPyWzU93JEiLcTysp12HQ01dDDISIiIiIiItIbBrrI6Kw6mIgnl0epxw/3aYIbIwIMPSSz0yvUR92vO5Ji6KEQERERERER6Q0DXWRUNh5NxYML96hsoxFtgjCtX7M6+bk+Lnbwd7VX91rQ+9z2xXUxydDpdIYeDhEREREREZFeWOvnnyG6fuuOJGPqd7tRXFaOgeF+eHNkK1haWtTJ1P78UHdoSadGnrC3sURSdhEOn81Bi0BXQw+JiIiIiIiI6Loxo4uMwvLdpzFx3k4UlJShVzMffHBHG1iz+HytsbexQtfG3lVZXURERERERETmgIEuMijZNvf5P8fx2NJ9KC3XYXhkIL4c2x521lZ8ZWpZb9bpIiIiIiIiIjPDQBcZTHm5Di//chizfo9WH0/q0Qjv3RYJW2v+WtaF3s0q6nTtOpmB7MKSOvmZRERERERERLWJNbrIIIpKyzD9+/34ed8Z9fEzg8MwqWeIwV6Np5ZHIaugGG4Otpg1IgJaUN/LESHeTohNzVNNAAazuyURERERERGZOAa6qM7lFJZgyne7sOlYGqwtLfD2qNa4uU2QQV+JtdHJSMwuVJ0XtUS6L8amnlCNABjoIiIiIiIiIlPHPWJUp5JzCjH6i60qyOVoa4U54zsYPMilZZV1uv6JSVH10oiIiIiIiIhMGQNdVGdOpObh1k834+CZbHg52WLxfZ3Rs1lFoIUMo2MjTzjYWCEpuwiHz+bwZSAiIiIiIiKTxkAX1Yn9pzMx8tPNOJVegPqejlg2tStaBbtz9g3M3sYKXRp7qcfrYpINPRwiIiIiIiKi68JAF9U62RYn2xXT8orRMshVBbkaejtx5o1s++K66BRDD4WIiIiIiIjoujDQRbVq5d4E3Dt3B/KLy9C9iTcW39cFPi52nHUj0ruZr7rfHZ+B7MISQw+HiIiIiIiI6Jox0EW15ptNJ/DI4r0oLdfhptaBqvC8sx0bfRqb+l6OaOTtpF6nzcfSDD0cIiIiIiIiomvGQBfpnXTve/vPI3jp50Pq4/FdG2L27ZGwteavm7Hqda4pgGwzJSIiIiIiIjJVjDyQXpWV6/D0igP4aO0x9fH0Ac3wwrAWsLS04EwbsV7n6nStj0lRgUoiIiIiIiIiU8R9ZKTXINcT3+/D8j0JsLAAXrm5JcZ0amASM3xTZCCy8kvg5mgDLercyEtl3CVkFuBYci6a+rkYekhERERERERENcZAF+lFebkOM5ftV0EuK0sLvD86EkNbBZrM7D49OAxa5mBrhU6NPLHhaKravshAFxEREREREZkibl2k6yZb3Z5deQA/7DqtglwfjG5jUkEuqsA6XURERERERGTqGOii6/bJuuNYuC0eUobrvdsjMaRVAGfVBPU+V6drW2w68otLDT0cIiIiIiIiohpjoIuuy8q9CXjrzyPq8Ys3heOm1szkMlWNfZwR5O6A4rJyFewiIiIiIiIiMjUMdNE1izqdhSe+368eT+zeCGO7NDTZ2ezzzjq0fOFPda9VFhYWVd0XpU4XERERERERkalhoIuuSV5RKR5evEdl//QL8zP5Yu75RWXILSpV91rGOl1ERERERERkyhjoomvywk8HcSI1DwFu9nh7VCtYSoEuMnldG3vB2tJCvbYn0/IMPRwiIiIiIiKiGmGgi66pLpd0WJTY1uzbI+HuaMtZNBMu9jZo18BDPeb2RSIiIiIiIjI1DHRRjZxKz8ezKw6oxw/2aYpOIV6cQTNTVafrCOt0ERERERERkWlhoIuqraSsXNXlyikqRfsGHni4TxPOnhnX6dp8PA1FpdquWUZERERERESmhYEuqrb3Vx/FnvhMuNhbY/boSFhb8dfHHLUIcIWPix0KSsqwMy7D0MMhIiIiIiIiqjZGKqhathxPw8frjqnHs0ZEINjDkTNnpiwsLNh9kYiIiIiIiEwSA110VRl5xXh0yV7odMBt7YMxtFUgZ00j2xdZp4uIiIiIiIhMCQNddEU6nQ4zlu1HYnYhQryd8OJN4ZwxDejexFt11TySlIMzmQWGHg4RERERERFRtVhX79tIq77bFo+/DiXB1soSH9zRBo625vkr8+otLVFYUg57G8Z+hYeTLVrXc1c12dbHpGB0x/qGfomIiIiIiIiIrso8oxakF4fPZuOVXw6pxzMGhaJlkJvZzmzfMD9DD8Eoty9KoOsfBrqIiIiIiIjIRDB9hS4pu7AEU7/bhaLScvQO9cGEbo04UxrTO9RX3W88moqSsnJDD4eIiIiIiIjoqhjookvW5Zr5w37EpeUj0M0e790WCUsp2ESaEhHkBg9HG+QUlWLvqUxDD4eIiIiIiIjoqhjooot8sT4Wvx9IhI2VBT4e01bVazJ3UaezsOtkhrqnClaWFujRlN0XiYiIiIiIyHQw0EUX+GX/Gcz6PVo9fm5oC7Sp76GJGZo0fydu/XSzuqcL63SJtUeSOS1ERERERERk9Bjooipro5Px2JJ96vH4rg1xd+cGnB2N6xXqAwsL4OCZbCRkFhh6OERERERERERXxEAXKb9HncV93+5EcVk5bmzpr7K5LCTCQZrm7WyHDg081eNVBxMNPRwiIiIiIiKiK2KgS+NKy8rx1p/RmLpgN0rKdBjSKgAf3NFG1WciEgNb+qv7Pw4w0EVERERERETGjYEuDXdW3HQsFUM/3IiP1x6v2q74/u2RsLHirwX9a0ALP3W/Iy4dablFnBoiIiIiIiIyWtaGHgDVXWArJbcIJ9PysfV4Gn6NOovoxBz1NXdHG/xveEvc1DqQLwddpJ6nI1oGueJAQjZWH07C7R3qc5aIiIiIiIjIKDHQZWYk4+bw2RxEJ2YjNiUXh06mI3vtBlVIvKi0/ILvdbCxwm3tgzGtXzN4ONkabMxk/AaF+6tAl2xfZKCLiIiIiIiIjBUDXWYgLjUPP+5NwJroZOw/nXWJ7yhW/5WyW/6u9ogIdkOvZr6qHpebg02dj5dMz8Bwf7y9KgabjqUZeihEREREREREl8VAlwnbcDQFX288gXVHUi74fCNvJ4T6uSDExxHITUWXVqFo4OUMfzd72Fqz/hbVXBNfZ4T4OCE2JY/TR0REREREREaLgS4TFJOUg1d+PYz1MRUBLgsLoFczHwxuGYDeoT7wdbVXny8rK8PevfmIbOwFKysrA4+aTJmFhQWGtQrE+38fNfRQiIiIiIiIiC6LgS4Tkp5XjPf+isHC7fEoK9fBxsoCYzo1UN0SG3o7GXp4Jm31471UwX4J6NCl3dwmiIEuIiIiIiIiMmoMdJmA4tJyzN8Sp4IMOYWl6nMDw/3w1I1hDHDpibMd/xSuRrbEtq7nrq8pJyIiIiIiItI7nt0bMckw+utQEl777TDi0vLV51oEuOK5oS3QpbGXoYdHGnRLZKChh0BERERERER0WQx0GaldJ9Px+u/R2BGXoT72cbHDEwNCcWu7YFhJ+0QiAxjWmoEuIiIiIiIiMl4MdBmZAwlZ+ODvo1h1KEl9bG9jiXu7N8LU3k3MfntdcXEx5s6di+3bt8PW1hZDhgxRt8vZs2cPli5disTERPj6+uK2225Du3btLvq+I0eO4J133sHChQsv+299tSFWbQt1sbfGxB4hentO5sbL2c7QQyAiIiIiIiK6LPOOnJjQFsV1MSn44p9YbIlNU5+TpK3b2tfDtH7N4O9W0UXR3EkgKjY2Fs888wxSU1Px2WefwdvbG506dbroe+Pj4/Hee+/hzjvvRGRkJPbv34/Zs2fjlVdeQYMGDaq+Ly8vD2vXrr3qz/5qwwkkZhfC39WegS4iIiIiIiIiE8VAlwEVlZZh5d4zKpsoJilXfU62JQ5rFYAHbmiCpn4u0IrCwkIVkJo5cyYaNWqkbqdPn8aqVasuGejatGkTwsPDMWjQIPWxv78/du3aha1bt14Q6Fq8eDHc3NxUwIuIiIiIiIiIzBsDXQaQkVeMBdtOYt6Wk0jJKVKfk22Jd3Ssh/HdGiHI3QFaIxlaZWVlaNasWdXnQkND8eOPP6K8vByWlpYXfH/Pnj1RWlrRgfJ8+fkVRfvF4cOH1a1bt25Yvnz5ZX/2oUOHUO/IEpS7tET9M/swceIiDB8+HE2aNMFXX32FjIwMtG/fHlOmTFHjkAy8FStWYPXq1Wq7pYzznnvuUdlnQgJ03377LY4ePYqy7t0RkpqKiSdPIujcz5JMtWHDhqnnJuPt0KEDJk2aBBsbGz3NJhEREREREZE2MdBVh2JTcjFn0wn8sOs0CkvK1edkq9z4bg1xZ6f6cLXXbqAjMzMTLi4usLb+91dSMrFKSkqQm5sLV1fXC74/KEjCRv+S4NLBgwfRr18/9bH8fxKkGjduHOLi4q76861L8+GZfwpnGw3G2A52WLRokcoMk+BWTk6O2hYpASm5SZaZZJQ9+OCDaoy//vorZs2ahTfeeEMFwt5++21ERERgwoQJyO/VC9/Ur49FISGYfu5nSeBM6pBJ9po8li2YzZs3R58+ffQyl0RERERERERaxUBXLZPsn50nM/DF+lisPpwEna7i8+GBrpjUIwRDWgXAxurCbCUtKioquiijqTLoJUGrK8nOzlbBIskGqyxGLxlXDRs2VAGn6gS6LHTliPNoC3c7dwwY0EPVCxswYACaNm2qvi5BrzNnzqjHP//8s8rgatGihfp44sSJuP/++7Fv3z61nbJv377o378/7O3tgdxc9IqNxc8REVU/SzLXJAAXHByM+vXro3Xr1jh+/DgDXURERERERETXiYGuWlJWrsOfBxNVgGvvqcyqz/cL88W93UPQOcQTFhYWtfXjTY4Euf4b0Krcmmhnd/lOf1lZWXjttddUQHHatGkqo+rUqVNYs2aNyrCqiUJrZ3UvHR+Fj49P1dfkczI+qSWWnp6ODz/88ILXT7YwSvdHCbRJkGvDhg04ceIEzrRujRNOTnD7zzZLqSlWycHBQQW/iIiIiIiIiOj6MNClZydS87Bs12ks330aZ7IK1edsrS1xa9tg3Nu9EZr4VgRT6EKenp5qi6AEfKysrKq2M0qAydHR8ZLTJQGnV199VT1+7rnnqrY3yrZA2e4ogS9RGUSSLKx7770X3bt3v/T0W1yYWXepQGTlv/XII48gICDggq85OzurQNizzz6rtmG2bdsWXU6exJniYvzasuUF33v+Fk0iIiIiIiIi0g+ebV8nySSKTszBmuhktTVxT/y/2Vsejja4u0tDjO3SAN7Ol89KooqtgRLgkgLuUq9KHDlyBCEhIRcVohcSUJKMLQlGSWDJ3d296msDBw5UBeiFFLKX7K7ffvtN1dGSmlrXw8nJSQXUJAjXpk2bqswzyfAaMmSICrBJ3S0ZmwrYTZ2KqPMyw4iIiIiIiIio9jDQVUPl5TocTc7Fjrh0ddsWm47E7IrMLWFpAfRs5oNR7eqhb5gv7G0qspPoymR7onRSnDNnDiZPnqyytaTIuzyuJMElye6SLK+VK1ciKSlJBbkqvybka5JZJbfKDKzKx+dvF7wegwcPxtKlS1XAKzAwUNUDk6CcdE6UOl4ShNu5c6cK0h3w98eqkBA4lFc0HyAiIiIiIiKi2sNA11Wk5xXjQEIWohKysCc+QxWWz8y/sJaUvY0lujX2xg3NfdG/hR/8XO1r8SUzX3fddZcKdL3yyisqoDVy5Eh07Nix6utS8F0CX7169VLbE6Uu1vPPP3/BvyHBMumUeC3a1HeHl1NFfa4rGTp0qApmff311ygoKECjRo3w5JNPqoCaFMQfMWIEvvnmG1XTq56fH8bv3IkvO3VSwTsiIiIiIiIiqj0WOtl7Z0JkuFL76mBCFg6cycaRxGyk5RYjq6AExWXlqoOhtaUFbK0soSspQIC3B1zsbeBib61uznbWcD53Lx872VqjtFyH3KJS5BeXIim7CKfS83E6owBHk3Kq6mydz8HGSgVFOjT0RMdGnmjXwMMoM7ckm2nv3r2IjIysqnulNQafg+BgICEBCAoCTp/W5hwQERERERER1RFrY98mGJeWh4NnsnHgTBYOyX1CFjL+k1F1JVHJSdc9jhBvJ4QHuaFVkBs6NPJEeKCrCqgREREREREREZHxMJpAV1puEY4k5SAmMQcxybnq/vDZbOQVV3S5O59kbEn3wpZBbmgR4IoAN3u4OdjAzsYSJWU6lJSVo6CoFIeOHoeXXxByi8uRW1SC3MJS5BSVqnvJ4FK3wlLVFdHR1gpOdtaqaHywh4O6NfRyQotAV5URRkRERERERERExq1OA10ZecUqQ0vdUvPPPc5HXGqe2np4KXbWlmge4IqWga4ID3RDyyBXNPNzuepWQdmu5VV0BpGR9bldi65IOjNGR0ergvbSvVG6Pl6q0yMRERERERERmUmga92RZJSV61Q9q8r78qqPy6s+X3nLKypT3QiTsguRmFWIhMyCywazhIUFUM/DUQWxQv2d1X1zf1c09nGCNbcJUi2Rovbz58/HJssIlFjZwaasCN3KP8HYsWMvKIRPRERERERERGYU6Br/zQ69/EA/Vzu1JVDdvOXeUd038HKEo63R7KQkjQS5Zs+erR7nBXqi2NoRtqX5SD+Trj4/bdo0BruIiIiIiIiITEi1I0tSgF1qY1lZWsDa0rLi3soClhYW/37eSu4ruh7KlkM/V3v4u9nD39UeAe72qO/JYNa1dposKiqq8f8n2zdLSkpQWFio2e2bl5sD2a44b968K/6/kunVsmXL69rGaKfTwaLyNSy8uIOnoebAzs4OFpJGSURERERERKTFQNevD/eo3ZHQJUmA5KWXXkJMTAxnqI6lp6dj4sSJ1/VvfJiRAS/5tzIy8NCECTAWzZo1wwsvvMBgFxEREREREZkVVtwmIiIiIiIiIiKzwKJYRk62l0nmzbVuXYyKikJERISmty5eag6ky+Kbb7551f9/xowZqgvjtbL75x+goACeHh6YM2cOjGUOuHWRiIiIiIiIzBEDXSYS7LK3t7+mAIeNjY36f7Uc6LrUHLRq1Qqenp5qe+LleHl5qe+7nhpdqp3odbyG+sDfAyIiIiIiItIKbl0kTZLg1dixY6/4PXfffff1BbmIiIiIiIiIqE7xLJ40q2PHjpg2bZrK7PpvJpd8Xr5ORERERERERGa2dbG8vByFhYUwJbJdS+Tn52t6257gHFx+Dlq2bInXX38dCV9tRWZhGdztPTBr4iyVySX/z3ULCQGcnQFfXxkEzOX3QLZhMtuNiIiIiIiIjI2FTqfTXe2b5AT58OHDdTMiIjJ6YWFhcHR0NPQwiIiIiIiIiGoe6DLFjK7jx49j+vTpePvtt9G4cWNoEeeAc1BbvwfM6CIiIiIiIiKT3booW5RMLXtDxhwXF2eSY9cXzgHngL8HREREREREpCUsRk9ERERERERERGbBbANdPj4+ePDBB9W9VnEOOAf8PSAiIiIiIiItqVaNLiIiIiIiIiIiImNnthldRERERERERESkLQx0ERERERERERGRWWCgi4iIiIiIiIiIzAIDXUREREREREREZBZMKtBVVFSEp59+Gu3bt0f37t0xZ86cy37vunXrMHz4cLRp0wbDhg3D33//fcHXf/nlF/Tr1w+tW7fGAw88gPT0dGhpDqQHwRdffIE+ffqgbdu2GDduHI4dOwat/R5U+v333xEaGgpToc85+OOPPzBw4EBERkZiwoQJSEhIqINnQERERERERKTxQNebb76JAwcOYN68eXjhhRfw0UcfqZP0/4qOjsaDDz6IW2+9FT/++CNGjx6NRx55RH1e7N+/H88884z6niVLliA7OxtPPfUUtDQHixcvVsGR5557DsuWLUNwcDAmTZqEgoICaGUOKsnr/+qrr8KU6GsOdu/ejccffxz33HMPli9fDltbWzz22GMGeEZERERERERE188aJiI/Px/ff/89vvzyS4SHh6vb0aNHsWDBAgwaNOiibK3OnTtj7Nix6uMGDRpgzZo1KmunefPm+O6773DjjTfi5ptvrgoa3HDDDTh16hTq1asHLczBihUrVPaOPG/x4osvomPHjirw0a1bN2hhDirJ6y+ve0pKCkyBPudAgp033XSTCoAJCQBLdp9kOHp6ehrk+RERERERERGZfaBLMlBKS0vV9qtK7dq1w2effYby8nJYWv6bnHbLLbegpKTkon8jJydH3e/bt09lL1UKCAhAYGCg+rwxB7r0OQczZsxQWVyVLCws1HbGyq9rYQ7E9u3b1U0CPPfddx9MgT7nQJ7766+/XvV5+f2XQBgRERERERGRKTKZrYuSbePh4aG2VlXy9vZWtYoyMzMv+N7GjRtfkLEj2S5btmxBly5d1MfJycnw9fW94P/x8vJCYmIitDIHUtvJ39+/6uuSISTBEwmYaGUOiouL1dbN559/Hvb29jAV+poD2bKZlZWFsrIy3HvvvSqTb+rUqUhKSqrT50NERERERESkuUCX1I46/8ReVH4sAYvLkS1YDz30kCq43rdvX/W5wsLCS/5bV/p3zG0OzieZbG+88YYKdvj4+EArc/Dxxx+rbX9SzN2U6GsOZAukeOWVV1SR+k8//VT9/5MnT1aZYURERERERESmxmS2LtrZ2V10El/58eWycVJTU1WRbdmS98EHH1Rt6brcv+Xg4ACtzEGlPXv2qG2cPXv2VEXKjZ2+5iAmJgZLly7Fzz//DFOjrzmwsrJSXxs1alRVvbq3335bZXbt3btXBcSIiIiIiIiITInJBLr8/PyQkZGhttdZW1tXbeGSE3tXV9eLvl+2X1UW4J4/f/4FhbXl35IT//PJx8aezaTPORDbtm3DlClTVGDjnXfeuSgIZs5zsGrVKrVtr3///upj2b4npO7VSy+9pAq0m/scyPZHGxsbhISEVH2vfM7d3d3ot/ESERERERERXYrxRzbOCQsLUyf1kmlSadeuXYiIiLgoQCNbsiZOnKg+Lx0WJTBwvtatW6v/t9LZs2fVTT6vlTmQjCapx9SjRw/Mnj1bBTxMgb7m4K677lKdB3/88Ud1k+17Qh736dMHWpgD+Tdk66YUtz9/e6ME0YKCguro2RARERERERFpMKNLthXK9qoXX3wRr732miooP2fOHMyaNasqo8XFxUVltXz++eeIj4/Ht99+W/U1IV+T77njjjtw9913IzIyUgUHXn31VfTu3duoOy7qew6kALt0m3zqqadUYKNS5f9v7nMgWUtyq1SZwdSgQQMYO33+Hsh2RvkdkOBZs2bN8NZbb6nHrVq1MuhzJCIiIiIiIroWFjop2mNCRbjl5F62nTk7O6vi6ePHj1dfCw0NVSf6I0aMwKBBg3DixImL/v9bbrkFr7/+unq8fPlyVatItq/J1r2XX35ZbdvSwhw8/vjjly3AXvn/a+X34PxtnLK978iRIzAF+pwDqVX22WefIS0tDR07dlR/C+d35CQiIiIiIiIyFSYV6CIiIiIiIiIiIjL5Gl1ERERERERERERXwkAXERERERERERGZBQa6iIiIiIiIiIjILDDQRUREREREREREZoGBLiIiIiIiIiIiMgsMdBERERERERERkVlgoIuIiIiIiIiIiMwCA11ERERERERERGQWGOgiIiIiIiIiIiKzwEAXERERERERERGZBQa6iIiIiIiIiIgI5uD/x4ayvGwLU0IAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1536x401.804 with 8 Axes>"
+      "text/markdown": [
+       "|    |     mean |       sd |   eti89_lb |   eti89_ub |   ess_bulk |   ess_tail |   r_hat |   mcse_mean |     mcse_sd |   true_value |\n",
+       "|:---|---------:|---------:|-----------:|-----------:|-----------:|-----------:|--------:|------------:|------------:|-------------:|\n",
+       "| r1 | 1.41982  | 0.411784 |   0.834143 |   2.12525  |    1927.56 |    2252.93 | 1.00205 | 0.00930975  | 0.00769077  |         1    |\n",
+       "| r2 | 5.2836   | 0.531954 |   4.50744  |   6.19299  |    1414.92 |    1904.43 | 1.00105 | 0.0142903   | 0.0109482   |         5    |\n",
+       "| k1 | 2.32912  | 0.390063 |   1.76538  |   2.98161  |    1800.45 |    2194.27 | 1.00188 | 0.00914875  | 0.00749123  |         2    |\n",
+       "| k2 | 2.21355  | 0.268641 |   1.84602  |   2.68826  |    1265.31 |    1574.02 | 1.00131 | 0.00772825  | 0.00656554  |         2    |\n",
+       "| t  | 0.244213 | 0.014064 |   0.218543 |   0.261764 |    1393.78 |    1734.46 | 1.00139 | 0.000398223 | 0.000369556 |         0.25 |"
       ]
      },
      "metadata": {},
@@ -511,47 +238,83 @@
     }
    ],
    "source": [
-    "# ArviZ 1.0 — plot_dist returns a PlotCollection, not axes\n",
-    "pc = az.plot_dist(\n",
-    "    idata,  # xarray.DataTree (was InferenceData)\n",
-    "    var_names=var_names,\n",
-    "    ci_prob=None,  # was hdi_prob=None\n",
-    "    point_estimate=None,\n",
-    ")\n",
-    "\n",
-    "for var in var_names:\n",
-    "    ax = pc.get_viz(\"plot\", var)  # was: iterating np.ravel(axes)\n",
-    "\n",
-    "    # posterior group is now a DataTree node; .dataset gives the xr.Dataset\n",
-    "    post_vals = idata[\"posterior\"].dataset[var].values.ravel()\n",
-    "\n",
-    "    lo, hi = np.quantile(post_vals, [0.005, 0.995])\n",
-    "    post_mean = np.mean(post_vals)\n",
-    "\n",
-    "    ax.axvline(\n",
-    "        post_mean, color=\"C0\", linestyle=\"--\", linewidth=2, label=\"posterior mean\"\n",
-    "    )\n",
-    "    ax.axvline(\n",
-    "        true_params[var], color=\"red\", linestyle=\"-\", linewidth=2, label=\"true value\"\n",
-    "    )\n",
-    "    ax.set_xlim(lo, hi)"
+    "var_names = list(true_params)\n",
+    "summary = az.summary(idata, var_names=var_names)\n",
+    "summary[\"true_value\"] = [true_params[name] for name in summary.index]\n",
+    "mo.md(summary.to_markdown())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b6e41db",
+   "id": "BYtC",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABL0AAAFzCAYAAADbm3vCAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAtoNJREFUeJzs3QdYVEcXBuCP3jsKoliwK/beu1FjNCbGqEnURKPG9N57M70ZUzRGjS3GGBNr7L1iw4YNFSyA9N75nzPr8q8EFBHYvbvf+zwbFtzA7N3duTPnnjljVVBQUAAiIiIiIiIiIiIzYm3sBhAREREREREREZU3Br2IiIiIiIiIiMjsMOhFRERERERERERmh0EvIiIiIiIiIiIyOwx6ERERERERERGR2WHQi4iIiIiIiIiIzA6DXkREREREREREZHYY9CIiIiIiIiIiIrPDoBfdtnnz5mHKlCk8kkSkeWvWrMG4cePQu3dvjBo1CnPmzEFBQYGxm0VEVKJhw4bh/fffL/URys3Nxb333otNmzbxqBKRSVq/fj06duyICxcu3PBxiYmJ+OSTT1Q/2LdvXzz++OMICwurtHaSNjDoRbdlw4YNmDhxIo4fP84jSUSa9vbbb6uJYKNGjfDGG2+gW7dueO6553D33Xcz8EVEJuvgwYM4e/ZsqR6bl5eH8ePHY+nSpYiLi6vwthERlUVsbCz27NmDjIyMEh8THx+P9u3bY8mSJRg9ejReeuklpKamokWLFli+fDkPPBWy/f9dotLLysrC559/jnfeeQf5+fk8dESkaUlJSfjoo49UtsQrr7yifibZXv7+/ioQtnr1agwaNMjYzSQiKrOTJ09iwoQJ2LlzJ48iEWnejBkzcP78eURFRcHb21v9rH///oiMjMTTTz+Nu+66y9hNJBPBTC8q0W+//aZSRRcvXqwme3Jfn2J6//3348MPP1STxJ49e/IoEpFm9OvXD7/88gueeOIJlQo/depU2NjYYNu2bZg8efJ1j+3cubP6evjwYSO1lojo1hw4cABdu3bFiy++WJilKhPD4OBgJCcnY8GCBTykRKQp0pdJnyZ9m/RxYvjw4SobTB/wMhy7nTt3DikpKUZqLZkaZnpRiS5duoQVK1bg1KlT+OKLL7Bjxw7UqFFD/ZvUuvn5559RtWpV/PvvvzyKRKQZ+/btw9atW/HCCy+o2g+Suerq6qpqRxR16NAh9VXf9xERmbKQkBCV6SABLlmybWVlpX7u6OiIhQsX4p577lHjOiIiLQW85KKkXLCcO3cuWrdurX5et27dYh8vYzdPT081tiMSDHrRTYudfvrppxgwYIC66UmmFxGRVjVs2FBlq96s/3vrrbfg5+en6noREZl6QF8CXs2bN8eqVavg4uJS+G+yVFuyIoiItBbwkvrRv/76q9o8beTIkTd8/Pbt21X/J1lh+qA/EYNedFPNmjXjUSIisyJZEDcjWWCyrFF2dHRzc6uUdhERlcXRo0fV0m1nZ+f/BLyIiLRKSlFs3LhRldS5WcBLyvCMGDECHTp0wHvvvVdpbSTTx5pedFPVqlXjUSIii+rXnn32WcyZM0ftCNSrV69KaxcRUVns378f7u7uuHLlCstOEJHZ2LJlixqzzZ8/H9nZ2SU+LiIiQm1AFBgYqDYfcnBwqNR2kmlj0ItuiqmhRGQp/ZrsRjtp0iTMmjVLZXhx5x8i0gKpcXP8+HF06dIFU6ZMQVxcnLGbRER026SO16JFi1T/JjtsF0fqFHbr1k3V+NqwYYOq50VkiEEvIiIiQF1BlE06/vnnH3VlkTvTEpGWSlFI0eYZM2YgISEBTz/9tLGbRER022SpYvfu3TF+/Hi12/bBgwev+3f5XgJeEvBfuXIli9dTsRj0IiIiiycZXlIHQrK7Nm3ahJYtW1r8MSEi7WncuDFeffVVtRRo+fLlxm4OEVG5+Oyzz+Dr64uHH34YOTk56mehoaGqBIUExaTIvZ2dHY82FYtBLyIisniLFy/G33//DXt7e4wbNw4dO3a87vbTTz9Z/DEiIm147bXXVPBr8uTJSExMNHZziIhumyxZ/Pbbb9UGQx9//LH6mSzlTkpKQlhYGDp37vyfsVt8fDyPPClWBbIPKFExLl++rIoCSqdxIydOnFDbyTZp0oTHkYhMXkhICKpWrYqaNWsW/uzixYvqVpIaNWqoGxGRqZHlPVLEXurZFB3D1atXT2VHGMrMzMShQ4fQoEEDeHt7G6HFREQ3JnUJT58+rTLvHR0drxvDWVtbqzqGcj83N7fE39GmTRtmf5HCoBcREREREREREZkdLm8kIiIiIiIiIiKzw6AXERERERERERGZHQa9iIiIiIiIiIjI7DDoRUREREREREREZodBLyIiIiIiIiIiMjsMehERERERERERkdlh0IuIiIiIiIiIiMyOxQa9Cho3BqysdF81bOa2cHy17pT6eiP5+fkIDQ1VX82dJT1XS3y+5kbrr19l96Wl7fMs6TVg+8nc3yPmOtariP7MUl9vS3zOlvy8zfmYaLnf0vqx13L7tdz2ymi/LSxVSsr1XzVq5rZziErOhL+7IyZ0CyrxcQUFBcjJyVFfzZ0lPVdLfL7mRvOvXyX3paXt8yzpNWD7ydzfI+Y61quI/sxSX29LfM6W/LzN+phouN/S+rHXcvu13PbKaL/FZnoREREREREREZH5YtCLiIiIiIiIiIjMjuUub9SA/PwCJKRnw9neFk72NsZuDhFRuZDU5ZSsXOTmFcDaCrC2toKznQ1sbXgdhojMQ05ePlIzc5FfUABPZ3vYSGdHRGTEsVd6dp4ae7k52qqxF5GlYNDLxFxNycLikEisOx6N45eTkZ2nK+bm5+6AXg2rYlyX2mjk727sZhIR3VBefgFORafgYEQizl5NxYW4NJyPS0dcahaSMnKQX2TJvpUV4OPigOqejgiu7oEWNTzRvUEV+Hs48kgTkcm7nJiBLaeuYtvpqwiLSkFEXDpyr3V0ttZWqFfVFV3q+eK+tjU4jiOiSpGbl49NJ69i2cFL2Hs+Xs0zhYu9DVoEemJE20Dc2bwa7HjRkcwcg14m4kpSBr7dcBp/HriE7Nz/7loQnZyFRfsi8XtIJEa0CcTbQ5qoDDAiIlORkpmDjWExWHM0CttOxyI1K7fU/6/UrYxNzVK3wxeTMH9PhPp521peuLtVddzbugYzXonIpGTm5GH10StYtDcSe87Fl/g4CX5JIExuv2w/h14Nq+Dtu5pWaluJyLIuPP518BK+Xn8KFxMy/vPvadl52Hk2Tt2+XHcKn9zbHJ3q+hilrUSVgVETE0h/n73jPL5af0qlnIpWNXWR9851fRDg6YSMnDwcikjE7/sisfLIFRX4OhCRgFnj2hm7+URESnJmDjp/tEENpPRcHWzRMtATDf3dUNvXBbV9nOHn7ggPJzt1s7exVkt/8mS5Y2YuopIycSEuHaEXE9UVSckSC7mQoG4yKBvTqZZ6PBGRMWVk52Hh3gj8uOUsYq5lTki2auuaXujRoIr6GlTFRfV3sqRIHiP92aojV7DmWJTKvNhxdiscbbmkm4jK14kryXjlz1B1AVF4u9hjeJsa6NvYD42rucHe1hrnYtOw7lg05uy6gIj4dIyasRtP9KqH5/o14LJHMksMehnRvvPxeOOvozgZrduStk0tL7w8oBHa1faClYyerpGUU1nmI7cx4XF4cuFBnI5Jxf0/7cLiSZ1Q08fZiM+CiCyVZGXZZeTAA0B6Vp4KeNXxdcGgZv64o6k/mgZ43LSOjTWs1InIwdUGvq4OammjpNoLCYKtCL2MObvOIzI+A1+vPw1fV3t8NKwZ7m8XWEnPkohIRwJY/x6LxnvLj+FyUqb6WTUPR4xuXxPD29ZANQ+nYg6VlbqAKTfp22Sy+eayo9h+JlZl9o/rXBtvDW7CQ0xEt515+t3G0/hpS7jKLnVzsMXjvethbKfa/8mUl1I5cpOyOR+tOoGFeyMxbdMZFQD7YkSLGy533P1aH75SpDkMehmB1LT5eHUYluy/qL73crbDqwMbqyj8zYoKdgjywfInu2L0jN04ezUNo2fuxt+Pd4GPq0MltZ6ILJ1M/GSA9PGqE1ibnaeCXg521pg3vgO61PO5Lmh/O6Se14RuQWpSKNkRX649hfDYNLz21xFV+/Dz+5qjXlW3cvlbREQ3G7u9/Gco1p+IUd9X93TCE73rqaXXkjlRWnJh4Lfx7fH9pjP4Yt0pzN55Hlm5efjw7mbMsCCiMtkdHofXlh5RYyQxoKk/3h3aVGWb3oibox0+vqc5WtX0Uv//P4cvq4z6b0a24uYbZFYY9Krk3RilLtcna8JUIWcxqn0gXrqjEbxc7Ev9e6QDWzixI+77cZdaCvTYvAOYN6HDLQ26iIjKIik9B68sDcXqo1Hqe/3VQC9ne3St71shB1V2dRzcPAD9m/hj3u4L+GrdKRyKTMSgb7fj2b4N8Gi3Otz5kYgqNDP/yQUHEZWcCTsbK0zqXheP96pX5jqDcmHgid71UcPLGc8tPqQuIsjk87VBjcu97URk3qUlPl4VppZbi6puDnhvaFMMCNZlzJeWlNWRTPpJv+3HitArcLa3wdR7mjMQT2aDUZJKsv9CPO75YafKUJCAV5Nq7vjzsc4qun4rAS+9qm6O+GVsW5W6KrVvpN4NEVFFkmU5d03brgJeMvF7bVAj+Ljeev9VVhLYf6RrHax9rrsqBC1Lg+Qiwsifd6vNQIiIyptklUofIwGvulVcsOLJbnjhjoblsrGGbNLx+X0t1P2ft4Zj/p4L5dBiIrIEm8Ji0P/LrYUBr1Hta2Ldcz1uOeCl17uRH74d2Qqy6GhxyEVMXRNWzi0mMh5melWw45eT8fnak2pHM31h5+f7N8BDHWvddmaCLOvp0bCKishLMdWeDaugYxB33iCi8ifF5R/+dR/i0rIR6O2E70e3RvManqjssvKyE5EUvW9RwxN3Ng/Au/8cU4Xu7/x2O74c0QI9G1at5BYRkbn6actZVY5CDGkRgI/vaQYXB9ty7886BflgV3gc3vnnGIIDPNAi0LPc/gYRmZfE9Gy8t+I4lh64pL6v5eOsdl8sjzngwGbV8NnwFnj+j8MqEB/k64KR7WsW22+5Odrimb4NbvtvElUGBr0qcII4beMZrD0erb6XYs4j2tZQncPN1lffipDzCYX3n198GKuf6QZ3R7ty+/1ERPsvJOChX/aoHWaDq7vj13HtUcXNOHUEF+2NVBkX/u6OqpiqbPzx+IIDOHopGeN+3YfHe9VVSx5v96ICEVm2bzecLsyin9Q9CK8MbFRu9QqL688GBvurLNonFh7Ayqc4liOi/1p3PFqtGrqakqV2jB3fpQ6e718+mad697apgciEdLV50BvLjqoN0zrX9S2232LQi7SCs4Jytic8Tk0Oh0zboQJe0iHd1SIA65/roZYylmfAy5CNlRUuJWaowtJEROUlLCoZD/+6VwW8pEj9oomdjBbwKk4tHxcsmdxZZc+K7zedxcOz9xXWTSQiulVSO1Af8JJdtV8d1LjcA15FTb23OWp4Oamdal/5M1RtGEJEJKScw3vLj+PRuSEq4FWvqqsqk/PG4CblGvDSe7pPfZXdKrtASu3o8KupfCFI0xj0Kidnr6ZizKy9uP/n3dh2OlZldt3TujrWPdsd341qpXbrqUgezrrsLimGKlkZRES3KzI+HWN+2YvkzFy0qeWFmWPaqSXapsbRzgbv3x2s+lonOxvVB98zfQfOX9vFiIiotFYfuYI3/z6q7j/Vpz4e61m3Ug6eh5Mdpo1uDVtrK6w6EqV2USMiiknOxP0/78KsHefUwZDNe1Y82RWta3pV2MGRIP+nw2VXR091EXH8nBC1rJJIqxj0uk25efn4Yu1JDPh6K7aeugp7G2uM7lATm1/oiS9HtFR1tyqD/N3hbWqo+6//dUS1i4iorNKycjFhTghiUrLQyN8Ns8a2q5CrieVJsmr/mNwJ1TwccfZqGu6evkNt401EVBrHLifh2cWHIElWD3SoiWf71q/UA9cy0FNlWIi3/zmmMjqIyHJJhtWw6TtxMCIR7o62mDGmLV6/s4m62FfR5G/8/FBbVPd0UhsZyc6OknFGpEUMet2G2NQsjJ6xB99tPIOcvAL0aVQVa5/tjo+GNUOgtzMq26sDG8HT2Q5hUSmYvfN8pf99IjIPsqzmpT9DcTI6RS1lnP1w+8JsUlMXXN0Dfz/eRRWCTkzPwYMz9+CvgxeN3SwiMnHxadmYOHc/MnPy0aNBFbw3NLjClzQWZ3LPumqHb+m/3v5Hl3FGRJYnL78AI37apcrX1PZxxvInu6JfE79KbYOMAX8Z11Zl+e85F49XloZW6t8nKi8MepWRdEAjftyFvefjVUcwbXQr/DKuHWpX8DLGG/FxdcArAxqp+1J8UNJhiYhulezYszL0CuxsrPDDA63h71ExtQgrSlV3R/w+sSMGN6+m6lE8+/th/HptWQARUXGTy6cWHlRjO9kJ7duRrVSZCmOws7HGZ/c1L1zmuOrIFaO0g4iMH4iPTc1WQfAlj3VWNUyNoZG/O75/oLXqE2XHyNSsXKO0g+h2MOhVBnEqw2s3wmPTVMrnsse7YHDzAJiCEW0DVYaDdEhT1+i22SYiKq1DkYn49N+T6v5bdzVF29remjx4kpYvE9eHu9RW37+7/Di+XHuSxaGJ6D9mbgvH9jOxcLbXLecxdmZr0wAPTLlWS+zNZUeRkMZaOkSWQr+HhQTj61ZxwW/j28PX1bgbCEn26/tDg9V9Br1Iixj0ukWZOXmYMDcEF+LS1S47Uj9GdtAwFdbWVnh3SFN1X6Lx+y/EG7tJRKQR6dm5ePb3Q2qgdWfzaniwQ01omfSHbw1uguf6NVDff7vxDN5fcYKBLyK6ro7X52t1gf6372qChv6VU4v1Zh7vXQ8N/FwRl5aND7kzN5HFlJfQ7z4tY5i54zuolTymQGpWT+oRVPh9NutHk4Yw6HWLPlp1QhUTlF12pM5NgKcTTI0UQr2/baC6/9bfx9QElojoZj5ceUIVK5VC8B/d3cwo9WzKmzwH2YHt/aG6iwGy+9EHKxn4IiLdhcxnFh1SdVn7N/FT2fKmwsHWBlPvbQ7phpfsv4htp68au0lEVMF+3xep+iXh6WSnVhSZkpfvaAQHW134QDJQT0WnGLtJRKXCoNctWHssCnN3XVD3vxnZ0iQyvDoEeaNbfV/11dCLAxrCzdEWxy4nY9G+CKO1j4i0YcOJaMzfo+srPr+vhdGX99xqn3czD3WqrTYZEb9sP6cuYMgVVSKyXFNXh+F0TKoq1qwLMFmZVH/WuqYXxnbSLdF+7a8jKhuXiMzThbg0vLfieOH39teCS6ZEss+kmL7sJCkjqLGz9uJyYoaxm0V0U7Y3fwgJSTV9fZluF51Hu9VBz4ZVTeLAfDOyVbE/l7XfsqRH6th8/u9JDGhiGu0lItOTmJ6Nl/88ou5P6FoHXer5wlSV1OeVNjU/v6AAbyw7ihnbzsHaygqvDNRt/kFElmXLqauFO11/Nrw5vF3sTbI/e+GOhlh3PBqR8Rn4at0pvH5nk0ppGxFVHrkI9/KfoUjPzjPJYJehaaNbq3Hj8B934UxMKsb9uhd/TOpsshdLiYRpf6pMiASOrqZkIcjXRQ1AtOChjrXQ0M8NCek5+Gr9GWM3h4hMeFljbGoW6ld11Uz/VlYPdqxVuNTxp63haqdbIrK8XdFe+OOwuj+2Uy2TuZBZHNkh/INhwYVZqqEXE43dJCIqZ8tDr2B3eLxaOigldEydp7M95jzSHn7uDjgVnYpHfwspXJZJZIoY9CplkdN5e3TLGmXgIXUWtMDWxhrvXCtqv2BvBM4l6gojEhHp7TgTiz/2X1R1Y2R5j+x6aO5kqeM7d+myJb7ZcBrzdnMJOJElZVS8tvSIupApZSpeGdgYpq5Xw6oY2jIAUqJVsnJzWECayGykZeXio5Un1P3He9WDjbU26qlKvTGpb+3mYIu95+Lx3GLdRkhEpohBr1L4dI1scw8Mbl4Nneua7rKf4nSq66PaLX3QLweTWcOGiAplZOepOjH6zNA2tbws5uiM61IHT/epr+6/s+I4dkSyJgWRJfgj5CLWHIuCnY0Vvr6/JZzstRHol51ovZztcOJKMmZsCzd2c4ionEzbdAZRyZmo6e2Mid3/vzuiFjSu5o6fxrSBvY01Vh2Jwgesl0omikGvm9h1Nk7VfbC1tsIL/U1v2c+on3ej35db1NeSvH5nYzjZ2eBEbA7+OXylUttHRKbr6w2ncCEuXe3W+KJGljWWps8rrWf61seDHWuqixrf7klSWW9EZN6Fot9Zfkzdf65fQwRX99BMf+bj6oA3B+syVGVZtuy0S0TaFhmfjpnXgtjy+dZCtn3RfksSQr4Y0ULdn7srAstOsm8i08Og101S4KeuCVP3R7Wvidq+LjA1MuiRnYduNPip5uGEx3vprhxMXXMSqVnc/YfI0h29lISZ286p++8PDYabo+nXkChtn1daslPbu0OCMSjYH7kFwOT5B3E4kvVyiMxRbl4+nvn9kCoU3b6Ot0lkVNxqfzasVXW122N2bj5e+TMU+VxKRKRpUmIhJ68AXev5om9j060teLN+664WAXjjTt1S8XlHUvHXwUtGbCHRfzHodQMbTsSoCZBkST3Zpx607JEudeDvaoOYlCx8t5GFm4ksmdRceHXpEfX1zmbV0LeJHyyV1M74/L7maFbVXk2GH569T2WDEJF5+X7TWRyMSISboy2+ur+lZurmFA3UfzSsmRqX7jkXj0X7Io3dJCIqo7NXU7H0wEV1XzYRks+3lk3oFoTxXWur+68sPYqtp64au0lEhRj0ukGW1/TNuh0Px3aujapujtAy2Q3kkZZu6v6s7edUR0tElmnh3ggcuZSkio++PUS3XMaSSf/4cmdPBAe4q13dJPAl23ETkXmQwu/fXrvg98HdwaoAs1YFejvj+f4N1P0PVh7HeS5zJNIkWaYsyZqS4dUy0BPm4JU7GqJroCNy8wvw2Lz9alUBkSlg0KsE+84n4EBEIuwlWHQtaq11bao5olfDKiqN9tU/dVkeRGRZ4lKz8Nm/J9V9mThpPaBfXpzsrDHjodYI8HBE+NU0TPxtP7Jyuf02kTlIzMhRY54hLQIwtGV1aN3DXeqgQx1vlZ369O+HuJsjkcaERSVjRehldf/ZfrogtjmwtrbCE+080CnIG2nZeRj3615ExKUbu1lEDHqV5MctZ9XXe1vXMKtJ4duDG8PF3gZ7z8fj563c/YfIEnejTcrIUTvuPNixlrGbY1Kqujti1sPt4Hpt+225OCBZv0SkbXl5BSqgLfULzYEszZQlmu6OtqoMxzfrWbaCSGvLrWV4MaiZP5oGGHdDjfImO+P+8EBrNc6MTc3G2F/3MnuejI6ZXiVE3zeGxUDKPUwygUKn5Z0W//aQpur+l+tOMu2UyIIciEjA7yG6GjDvD20KWxueAopq5O+O6Q+0VpPKpQcvqeUHRKRNWTnXsjWtgM9HtICHszY27CiNAE8nfHRPM3X/+81nsCc8zthNIqJS7ti46sgVdf/xXtquGV0SqZ045+F2aim5FLyfMv8AM1LJqDjjKcZPW3QZUAODq5nkjo236742NdC/iZ9a5vjUwoNIzswxdpOIqILJ0p43lx1V94e3qYG2tb15zEvQvUEVVfdHv7OSvtAsEWlHTEomkjJ1u1W72Nuic11fmJvBzQNUfy4ZI08uPIjo5ExjN4mIbmLWjnNqTCY7NppbllfR7PmZY9vC2d4GO8/G4Z1/jjF7noyGQa9iou//HNatsZ7coy7MkewOMvXe5rraNbFpeGbRIW57TWTmFuy5gGOXk9XVt1cGNjJ2c0zeqPY1C88Bryw9gkORicZuEhGVkixLfmlJaOHYxtXR1myP3btDmqKBn6vanVsKR7MWIZHpSkrPwe/Xdl2daGariYojSxy/GdkKsjHl/D0RmLvrgrGbRBaKQa8iftmui753qeeDZjXMN/ru7WKPnx5qq3Ytk6WcX647ZewmEVEFDrK+uPYZf6F/Q/i6OvBYl8JLdzRUuypl5+Zj8m/7VeYIEZm+eXsisPnkVTXREte+mCUXB1s1npMLGrIB07vLjxu7SURUgnl7LqgNKBr5u6FbffPLPi1OvyZ+eGWA7mLru8uPYeupq8ZuElkg8730VQYJadmF0XetZHk91ac+0rNz4Wx/6y+lBPWm3tsMz/5+GNM2nYGvqz3GdalTIe0kIuP5buNpJKbnoH5VVzzQoaamX4rb6fPKsguRFIu++/sdOHs1DVPmHcCCRzuqXX2JyDTJTmEfrTyh7ksgCCkw+/6sjq8Lvh3VCo/M3ocFeyLQyM8VTXltg8ikSBbm7J3nC7O8ZOWNFpWl35LnezomFUv2X8TjCw7grymdUa+qW4W2k8gQg14Gftt9ARk5eWga4K7WWWvB6NucwA5rVQMX4tJVseZ3lh9XHdiIdoHl1j4iMq4LcWmYs0s3yHr9zsaaL15/u33erXJztMOMMW0x9PsdCLmQgLf/OYaPrxWPJiLTIssZX1hyWI3lOgZ5V0pw3FT6s14Nq6pM3s/+PanGcy928kTLluX264noNv198DKupmTB391R1ePTqrL0WxLg+3BYsBqT7jufgPFzQrBsShd4udhXSBuJitL27KccZebkYY4ZRN/L4uk+9TGhqy7D6+WloYXHgYi0b+rqMLVphRRn79mwqrGbo0lBVVzx7bWaFAv3RqhMCiIyPZJFsfdcvCqc/NnwFrA0U3rWxch2gZBSZl/tTkTI+QRjN4mIrgXkf96m2yjtka61LTJj3MHWBj8+2AY1vJxUwsXkeftV+QiiymB5n7gSLD1wCXFp2Wpr1UHNqsGSSIBPMkDGdqqldgCSTIZP1oSxuD2Rxsnkb/XRKFhbAa8Pamzs5mhar0a6LArxzvJjOH452dhNIiID4VdT8em/Yer+a4MaI9Db2eKOj4znZOfZPo2qIDsfGD83BCHn443dLCKLt/lUDM7EpMLVwRYj22u7zMTt8HF1wC9j28HF3gZ7zsXj7X+OckdHqhQMel2Lvs8sjL7XgZ2Glv/EJGfiSlKG+nq7A6V3hjTFC/0bqO9/2HwWE3/bj6SMnHJqKRFV9u5lH67S1bWRAVZDf/OonVBefV5ZPNajLno30hW2l5oUqVm5ld4GIvov2YDoxSWhyMzJV+UptFK7sCL6M1nC/s39LdG0ij1Ss/IwZtZe7AmPK7ffT0S37qct4YVLA90d7TR9CG+335Lx6Hej9dnzkZi1gyuMqOJpJ7pTgdadiEZ4bBrcHW1VWriWDJm2A50+3qi+3i4JfD3Ruz4+G94c9jbWWH8iGkOmbWdGA5EGrT8Rg8ORiXCys8GzfXXBbHNQnn1eWQrbf3FfC1TzcMS52DS8tvQIr1ASmYDfdp3H/gsJKovik+HNNVOioqL6Myd7G7ze1Qtd6vqoneLG/roX20/HluvfIKLSkbGYZDXZWlthXOfamj9s5dFv9W7kV7gC4cOVx7HpZEw5tpDovxj0AvDzVl30/cGOtdTWz5buvraBWPJYJ7XUU9ZcD5u+A4uv7WpJRNrIXv1i7Ul1f1yX2qjixm28yosUXZ02uhVsrK3wz+HLWMS+kcioopIy8fnaU+r+ywMbqbELSf0cK/z8UGv0aFBFZcA9PHsv/j50iYeGqJLpa3kNaRGAAPZPhcZ3rYP72+pqED654CBORZvwVrukeRYf9MrJy1dXByWzyRyi7+WleQ1PrHyqK3o2rIKs3Hy89GcoXvjjMDKy84zdNCK6iVVHryAsKgVuDraY1D2Ix6uctanljRfv0NX3em/5cZX1RUTG8f6K42qpcctATzxgwbVyiuNoZ4Ofx7TBoGb+akOTpxcdwvTNZ5ihSlRJIuPTsfrIFXV/QjeOxwxJRu77dwejfR1v1YePn7MP8WnZfG9ShbD4oJe+JsuwVtVR1d2xYo6yRnk622PW2HZqcieFsJfsv4i7v9+hCjESkenWtvlqnS7rYXy3OupzTOVvYrcgdAryQUZOHp5bfAi5edyBiKiyyZKYlUeuqMzLj4Y1U0uQ6b87pk0b1VplVYhP15zEG8uOss8iqgS/bD+nMpm61fdFkwB3HvMiZBdL2dGxprczIuMzMPk37uhIFcPig15ZOfkqoDO5Z90KOsTaJgPIx3vVw7wJHeDr6oCT0SkYOm071hyNMnbTiKgYsnzl7NU0eDrbqY05qOL6xs9HtFDZdAcjEvHjlrM81ESVKDMnD2/9fVTdf7hzbU4ob9JfvTm4Cd4a3EQVj56/JwKTftuP9GxuxkFUURLTs/H7tRIIE5l1XyJvF3v8MratGk/tPR+P1/9ivVQqfxYf9BJDW1ZHHV+XCji85qNzXV+serorOgZ5Iy07D4/N349fd5wzdrOIqEiW17cbTqv7k7rX1fwOQaZOage9d3dTdf/r9adx5GKSsZtEZFEZFJIZIBtLPNvPfDbrqEhyIeSHB1rDwdYaG8JiMOrn3UjgciKiCjFv9wWVDd64mrvaVZZKVt9Pt6OjJKL8sf8iZm7jHJPKl7Ul1/JSrIAnetczdnM0oaqbI+aN76C2Ai8oAN5dfhwfrz7B2hBEJmLd8Wicj0tXWV5jO9cydnMswt0tq6t6Obn5BaruYXYulzkSVbS41Cz8sFmXXfnygEbchOgWDAiuhgWPdoCXsx0OX0zCiJ92ITo5s6JeKiKLzUSdvfOCuj+xex3N7ChrTD0bVsUbdzZR9z9afQIbTkQbu0lkRiw26JWWpSvI7mRng7pVXI3dHM2wtbHGB3cHq0Gm+GlLOD5eHcbAF5EJmHlthyAJTDvbcyfayiAD2Q/vbgYfF3u1/PsnLnMkqnDfbTyjarI2DXBXO6LRrW/GsXhSJ/i5O+B0TCru+3GXKrhNROVj2cFLiE3NUpmog5uzjyqth7vUxqj2uuSKpxYeRFhUMt+SVC4sMuh17HKSisALFwdODMsyyXusZ12144b4eWs4pq4JK/fXiYhK72BEAkIuJMDOxgpjO3En2srk5WKPt4c0LZyMn4nhtttEFeV8bJpaNiReG9SYxetvYznRksmdVQHpiPh0lfF1MYGBL6LyKDUhcyPxSJc6sLOxyOl2meeY7w1tWlhOZ/zsEBU8JLpdFvcpLCgowMer/h+gseVOP2X2UMdahYEvyfjSZ5kQkXHq24ghLbgTrTHc1bwaejeqiuy8fLzy5xHky3ZNRFTuPvv3pFpO3KNBFXRhnZzbEujtjCWTO6FuFRdcScrEgzP3ICaFSx2JbrfURHhsGtwdbTGqQ00ezFskQcIfHmiD2j7OuJSo29ExK1eXrEJUVhaX5rT+RAy2n4lVu9eYg/mPdlBXFGS7bmMFvtKycjF1dRg+XHUC1TyccGfzakZpC5Glkqvzq6/tqKrflt5cGbvPu9HVSbkIsOfLLSrjbv7eCNU/ElH5ZrSuPHJFjeFeHaQrs6BlptCfVXV3xPwJHTH8x52qJuSYX/Zi8eRO3AiFqIzJFfrdnB/qVAuuZriiqDL6Lcmgnzm2HYZN36HGVK/+eQRfjGjB2mhUZhaV6SVR4g9XHlf3zaXejdQja+DnZtS6ZJO6B2FMp1pq/fWziw8h9GKi0dpCZIlm7zivBiBd6vmgSYA7zJkp9Hk32s3xpWv1Dj9ZHYYrSRnGbhKRWU0mP1p1Qt0f3roGGvlrv68zlf7M30MCXx1Qxc0BYVEpqpaOnFOI6NbsORePQ5GJsLe1xrjO5nkRsrL6rXpVXTH9gdYquLb04CVVPoKorCwq6DVn53l1FUtO6uYYeTdmhsPbdzVFH1nak5uv0lC5/pqocqRk5mDRvkh1f0K3IB52I3uwYy20rumpimy/ueyYsZtDZFZLhvadT4CjnTWe69/A2M0xO7V8XDBrbDt1fDefvFoYYCSi0tNned3Xpoaab9Lt6Va/Ct4fqiul8+W6U2qDAKKysJiglwRhvtugixC/eEdDs1neaCokCv/VyJYI8nXB5aRMPD7/AHLy8o3dLCKz9/u+SBVgkStiPepXMXZzLJ70hVPvba7qRa4/EY1/j+mWnRJR2eXm5RdumCNLuKWUApW/ZjU88MV9LQvrRP6+L4KHmaiUTlxJVgFjWfU3sTsvQpaX0R1qqlVF4qUlodh7Lp7vSbplFhP0+mLtSaRk5aJZdQ+VFm8u/j50CYv2RqivxubuaIefx7SBi72NSu813DCAiCpmIvjrjvOFE0FrE6tzZe59Xkkk7X9SD90A7e2/j6mgJBGVnWSzhl9Ng7eLPSb1qGs2h9IU+zOpy/psX10m3RvLjqo6akR0cz9dy/Ia2Kyaypw0V8bot14e0AgDg/3VZkETfwvBudi0SvvbZB4sIuh17HJS4fKft+5qYlYTQwksvbL0iMkEmOpVdVOFBsWsHeewIvSysZtEZLbWHItSO9v4uNhjWKvqsASm1ueV5Mne9VHT2xlRyZnqogsRlY0Ejb9ef0rdf6p3PbMqsG6q/dlTfephUDN/5OQV4IkFB5GYnm3sJhGZtMj4dCwPvaLuT+5uPoF5U+m3ZO7+5YiWaBHoicT0HDz8614kpLFfotKztoTCp+8tP66KrA9uXg3tansbu0lmb0BwNTzWU9fhv7wkFGdiUo3dJCKz7NtmbDtXWEfK0c7G2E0iA/J6fHB3cGE9SW7wQVQ2M7aGIzY1W21fP7oDd0StrFqtsky7lo+zurDywh+H1TmHiErop7aFF24oJMuEqfw52dtg5pi2atMgqdEtGV+ySR1RaZh90GvN0Si11M7B1hqvDmps7OZYjOf7NUDHIG+kZedhyvz9SM/m8h6i8nQgIgGHr+0QJNtik+np3qAKhrYMgGyC9urSI2o5KhGVXkxyJn7eGq7uy86o0t9R5ZCMuu9Ht1bHfP2JGDWpJ6L/kp2aF+3VrSh6vFc9HqIKJJsDzH64HdwcbdXGJlLjiwF5Kg2zHj1k5uThw2u7z0gBPIkMU+WwtbHGt6Naqc7pVHQqXv/rKDslonI0Y6suy+ueVtXh68odgkzVm4ObwMPJDscuJ2P2Tl39NSIqna/Wn0ZGTh5aBnqqei5UuYKre+CtwU3U/U/WnMT+CywgTVTUj5vPqlpT7et4o1OQDw9QBavv54YfHmijNgz6+9BldZ4gsuigl+w8czEhA/7ujph8bbkdVZ6qbo6YNqqV2s3sr4OXMH8PdwEiKg8X4tLw73HdroCPdK3Dg2rCJCD56sBGhdtty1IhIrq5MzEphbsHvn5nY7XkjirfAx1q4q4WAWrpltT3Yh0dov+LSsrEwmtZXs/0qc9+qpJ0re+LD4fpSkh8u+E0/tx/kW9LssygV3RyJr7fdEbdf3lgQzjb2xq7SRapQ5APXrqjobovtdVY14bo9smOjVJepUeDKmqnQDJtI9oGol1tL6Rn5+Htv5n1SlQaU1efVEuD+zfxYz1WI5Jg48f3NEOQrwuuJGWyvheRgR82n9FledX2Rqe6zPKqTPe3q4kp15JaXlkail1n4/jeJMsLen265qSaYEhK/NAWlrGrmama2D1IDVrlpPDYvAPcBYjoNiRl5GBxiO6q4oRuzPLSAtl16KNhzWBnY6Vq4/x7LNrYTSIyaXvC47D+RLTKFJdaXmRcrg62mHatvteGsBjMvLaJChEsPctr37Usr77M8jKGF/o3xJ3NqqmdZif9FsLN08iygl5S3PnPA7o0x7fvaqImHGTcq4Sf3deicBeg5xYfRr5cviWiW7Zwb4QK6Dfyd0PXer48ghqqQTG5h+6K5Dv/HENKZo6xm0RkkqQo8UfX6rGObBeIelVdjd0kAtAkwN2gvleY2kyFyJL9uOUssnPzVSY3s7yMQ+b4X4xogVY1PZGcmYtHZu9DXGqWkVpDpszaHAdL7604ru4Pa1UdrWp6GbtJBKhCztMf0F0l3BgWgx+2nOVxIbpFOXn5mL1DVwx9fNc6rB2hMbKrU20fZ0QlZ+KLtaeM3Rwik7TyyBUcvpgEZ3sbPNO3gbGbQ0Xqe93ZvBpy8wvw5IKDSEpn8J4sk5TRWbBXV3NQ+inWHDQeRzsbzBjTFoHeToiIT8eEuSHIyM4zYovIFJld0GvN0Sjsv5AAJzsbvGwBKfGyO6IU6pevpq5pgAfeH9pU3f9i7UnsPBNr7CYRacqqI1dUwEQ+70NaBsASaanPK25g9sHdzdT9ObvOM1OCqIis3DxVnkJM6l5Xk59zc+7PZGI/9Z5mhZn7Ly45zJ25ySL9sPn/WV6dLayWlyn2W7Jp0K/j2qski4MRiXh8wQF1oZhIz6yqu8ub+7N/dYOlR7sHwd/DEeZu+ZNdobWigyHnE/DH/ot4atFBrHiym0W8TkTlkcU6Y1u4uj+2Uy042NpY5EHVWp9X3I5D97SqjqUHL+G53w9h5VPd4OJgVqdiojL7bdcFdaVeJlOWULNQi/2Zm6Mdvh/dGvdM34m1x6Mxe+d5PNzF/F8rouKyvJ7uY3lZXqbab8lS+F/GtsUDM/eoVUWvLj2Cz4Y3t7jXhywg0+v3fZEIj02Dj4s9HrWAwZJWvX93sKpHFJuajScYiScqlT3n4nH0UjIc7awxukMtHjUNe/uupgjwcMT5uHR8sFJXu4jI0iWkZaut58Xz/RowGGzCgqt74PU7G6v7Un+NO3OTJdbyalvLC13qWVaWl6lrW9tbBeVlE5Ql+y/ik2uZw0RmE/RKy8rF1+t1g6Une9dTV6LIdJf4/PhgG7g52CLkQoIq6ixZLERUMv1uWfe2rgFvF3seKg3zcLbD5yNaQC4+ysYE649zN0eir9efUoWIG1dzx31tA3lATNyYTrUwoKm/2jVNduZm8WiyBDGS5bWHtbxMWd8mfvj4nmaFAcqZ11ZJkGUzm6DXrO3nEJuahZrezsyC0IDavi748v6WatI3f0+ESo8nouKdiUnFhjBdYOSRrsxiNQed6/piwrXX8uU/Q3E1hbsNkeU6E5OCedcmkm/e2VhdpSfTJkuGPhneHHV8XVR9rycWHGQNHTJ7shFXVm4+2jDLy6SNaBuIlwY0VPclo37ZwUvGbhIZmVkEveTq0k9bdVHcF+5oqHYItBSyXnnK/P3qq9b0a+KHVwfqNht4f8VxbAqLMXaTiEySXKWSZEj5zNSt4gpLpuU+ryg5X8lS77i0bDy18CByWXSVLNSHK08gL78AfRv7oXM9X1gKrfdnUjT654fawMXeBrvC49RSRyLLyPKqb7G1orTSbz3Woy4e7lJb3X/hj8PYcuqqsZtERmQW0aFpm84gNSsXwdXdMbhZNVgSCRStOhKl2YDRo92CcH/bQOQXAE8uPIiwqGRjN4nI5AZZSw/orlBN7hEES6f1Ps+QbEYwbXSrwgnjp9c2YiGyJFtPXcWmk1dha22F1waZ/67b5taf1fdzU5n74tcd51UdHSJz9OOWcJXl1bqmJ7paUHBeq/2WBCXfvLMJhrQIQG6+LMPej0ORicZuFhmJ5oNekfHpmLf7grr/yoDGsGZKvKZIhySF7TsGeavA5fjZIVzmQ2Rg1o7zyM7TFUxtU8ubx8bM1Kvqhs/va6Hu/7w1HMsPXzZ2k4gqjWQ3frDyuLo/plNtBFl4JqtW3dHUH0/1qa/uv/bXEU4sySwvQM7fo5tvPtPX8nZs1CqJC8gYq1t9X6Rn5+GR2ftw9mqqsZtFRqD5oNcXa0+qIpryZpat4El7ZDmqFLbX14WY+FsIMnPyjN0sIqNLyczB/GtB/Uk96hq7OVRBBjarhsnXXl9JwQ85H89jTRbh95BInIpOhaezHZ6+FjQhbXqmT321PFV2tZs4NwRRSZnGbhJRuZEyOvosL5lzkrbmmT882AbNa3ggPi0bY37Zi+hk9k+WRtNBr6OXkrDskO6q+MsDLCsl3tx4Otvjl7FtVX2IgxGJeGlJKHd0JIsnO/ulZOWibhUX9GlU1eKPhzl78Y6GasIog+rxc0JUYW8ic5acmYMv155S9yXgJbuakrYzKr66vwUa+LkiJiWLFzDJbMSkZBauKnqaWV6a5Opgi1nj2hUmWIydtRdJGTnGbhZVIk0HvT5ZE6a+ylrd4Ooexm4O3SZZ1vDDg61VXY9/Dl/GtI1neEzJYmXl5mHWdt2uppO61+XSbTMnu9V9N6oVWtX0VAOxsbP2qeX7RObq+01n1CYOQVVc8GDHWsZuDpUDN0c7zBzTTmXuhV5M4gVMMgs/X6vlJefn7szy0ixfVwfMfaQ9qrg5ICwqBY/O4coiS6LZoNf207HYdjoWdjZWeKG/bktS0r7OdX1VjS/xxbpTWHP0irGbRGQUi0MuIio5E37uDhjaKoCvggVwsrfBL2PbIejalciRP+9m4IvMUkRcOn69FtR/fVBj2NlodjhKRdT0ccb0B/5/AXP65rM8RqTtLC/W8jIbgd7OmPNwe7g52GLv+XjunG1BNDnKyM8vKMzyeqBDLXWCJfMxqn1NjOus22L22d8P49jlJGM3iajSs7ymb9JlOk7pWU/t8keWwdvFHgse7Xhd4OtcbJqxm0VUrqauOaE26JAd0Hpz6bZZXsB8Z0hTdf/ztSex7ni0sZtEVOYsr8ycfLQMZJaXuWgS4I4ZY9uqWl9rj0fjzb+PsqSOBdBk0GvlkSs4cilJrc99snc9YzeHKsAbdzZWhSIzcvJU+unVlCweZ7IYv++LxJWkTPi7O+L+doHGbg5VMn8PRyyc2FEt+5LA1z3Td2Afi9uTmdh7Ll5tdy+bbb8xuDF3QTNTsmT1oY61UFAAPLPoIMKiko3dJKJbInOP/2d51WdfZUY6Bvng25Et1Xlo4d5IfLlOV1+SzJfmgl6yK4xcNRITuwfBx9XB2E2iCmBrY41po1qrbIfLSZmYPG+/yn4hMneyc+n0TbrlIFN61YWjHbO8LJGfuyN+n9gJLQI9kZCegwdm7MHyw7qNW4i0SjL1319xXN2/v11NNPJ3N3aTqAK9dVcTdAryQVp2HibMCUFcKi9gknb8vPVsYZZXjwZVjN0cKmcDgqsVltT5buMZzNmpW3JP5klzQa9F+yJwIS5dFaMb37UOLN2QlgG4v22g+mpuZCcnST91c7TF/gsJeP0vpp+S+Zu/J0LV8qrmwSwvS+vzipJiq4se7Yj+TfzUUrAnFx7EV+tOqcABkRb9dfBSYab+c/0awNKZe38mtdqkvlctH2dcTMjAY/MPqIvXRFrI8vqtcMdGZnmZa78lZZKe7as7F72z/JhaTUbmyRYakpqVi283nC7sgFwcNNX8CvHaoMYwZ3WruOL70a0x7te9WLL/Ihr6ueHR7kHGbhZRhZBd+77bqOvjnupTn7W8LLDPK664/Q8PtsGHK09g1o5z+GbDaRyKTMQ3I1vC09ne2M0jKrWM7Dx89q8uU//xXvVUUNfSWUJ/5uVij5lj2mLY9J1qaevb/xzDR8OCuVSMTNqMbbpaXpJt3ZNZXmbdbz3Vpx5iU3VBzuf/CMVrXTzR0tiNIsvO9JqxNRyxqdmo7eOMkaxzYzG6N6iCNwc3Ufc/Xn0Cm07GGLtJRBVCitcnpuegflVX3NemBo8yKTbWVmqZ0Bf3tYCDrTW2nLqKwd9tx9FL3OSDtGPmtnCVxVrDywkPd9FtVkOWob6fG74b1QpWqn5OBObu0mXQEJkiCYDM3aVb6vZMH2Z5mTsrKyu18cagZv7IySvAxzsSsO10rLGbRZYa9JI0U4m6ixfvaMTtrS2M7OYogU5Z1fPUgoM4E5Nq7CYRlatLCRn49Vo9gVcHNVJ17YgM3dumBv6a0gU1vXVLhe75YScWh0TyIJEmxnA/btHVKnxpQCPWKrRAvRpVxSsDGqn77604jh1nOKkk0/Tz1mtZXjU80LMha3lZysXFr+5vqbL6svOAib/tx7/HoozdLCpHmplVyZKf9Ow81QFJJJYsLwr/3tBgtKvthZSsXEycG4Kk9BxjN4uo3Hy29pSqddIxyBu9GlblkaUSt9pe/kRX9GlUVb1fXloSiteXHUUO63yRCftmwylVzFzGcHc1r2bs5pCRyAZU97Sqjrz8AkyZfwDnYtP4WpBJUcvcrmUiPtO3AZfhWhAHWxv88EArdKrhgOw8XR/1645zKJAtaEnzNBH0Oh+bhgV7ItT9VwZye2tDvb/YjOC3/1VfzZ29rbWqbRPg4Yjw2DQ8ueggcvNYEJW070hMFpaHXlFLP964swkHWTdgSX3eDTf5GNMWz/eTAbls8HIR72yOV4N1IlMjmdmyJby+FoxcxCLL7M/ktf/onmZoVdNT1bCcMGcfkjN5AZNMq5RORk4emjPLyyL7LZlrPtvBE/e10QXn311+HC8uCVU7q5O2aSLo9fnak8jNL1Appp3q+hi7OSYlPStPFfiXr5ZAdu2UHR2d7Gyw9dRVTF0dZuwmEd0Wydb5+UCyuv9Qx1oIru7BI3oDltbnlcTa2gpP9qmPWePaqR1uw+JycPf0XazzRSZHztMyeejb2A8dgjiGs/T+zNHOBj891EbtUHz2ahqeWnhQvT+ITGEZtr7e3NOs5WWx/ZYsdfx4WDDeuLMxrK2gNlIbOm0Hx1caZ/JBr9CLiVhxLQPipTt0tQDIsjUN8MAXI1qo+zO3n8MfrGlDGvbLjnO4nJIHX1d7PN+/obGbQxojS2GXTu6IAFcbXEnKxPAfd2JF6GVjN4tI2RMeh/UnotUk4pWBHMORTlU3R5Wt6mhnjc0n5QLmCR4aMrofNp9VWV6yY2PvRiwzYckkK3VCtyDMeaQ9fFzscTI6BUO/34HP/z2pdiIm7THpoJesodVn8gxrWV3VMiESg5pVU1dhxOt/HcX+Cwk8MKQ5Us9k2iZdcefXBjaCh5OdsZtEGhRUxRVT+/ioAqxSfPeJBQfxy/Zzxm4WWbj8/AJ8tEoXzJCNaOpVdTV2k8iESFbz5/fpLmDO2HZOZVMQGUtUUibm7dFleelKB3AZNgHd6lfB2me7q3rikpE6bdMZtazz70OXWOtLY0w66CXbhe48Gwd7G2s826+BsZtDJkaCXgOa+iM7Lx+TftuPy4kZxm4SUanJyfP5xYdUkKJ5VXsMacHizlR2LvbW+Pmh1mqnW/H+iuP4eNUJFXggMoYVR67g8MUkuNjbqILQREUNbh6Ap3rXU/dfW3oEByJ4AZOMY9qm06rchGyY1a2+L18GKuTj6oDpD7TBDw+0RnVPJ5VV//SiQ7j3h504yD5LM0w26CUDdX2W10OdaiHQ29nYTSITrGkjyxwb+bupAs4Tfwthyilpxsxt4TgQkQhXB1tMaefBq4p022QJ2dt3NcFLA3TLZH/aGo4XlhxmvRyqdFm5efh0jW4MN6lHXVRxc+CrQMWSgOgdTf0KL2BKxg1RZYqMT8fv+3SbbUiZCWZ5UXEGNquGDc/3wIt3NISzvY0aww+bvhPP/n4IV5KYeGHqTDbo9dfBSzh+JRluDrZ4vJfuKhBRUS4OtqouhLeLPY5eSlYTPGY2kKk7GZWCL9adUvffGNQIVZxtjN0kMhMyWJ/Ssx4+G95cBcGWHriEZ34/xJ1uqVL9tusCLiZkoKqbAyZ0q8OjTze8gPnliJZo6OemColP+i2EO6VRpfpu42nk5BWgSz0fdORmG3STjTgkLrHphZ4Y3qZGYcyi1+eb8fX6U+qCD5kmkwx6SYE42bFRPN67ngpoEJVEsgAl5dTW2gorQ6/go9VhXGdNJistKxdT5u9XafS9GlbB8DbVjd0kMkP3tQ3E96NbqX5x+eHLeGrRQeTk5Ru7WWQBktJz8N3GM+r+8/0bwNne1thNIo1cwPR0tlNLYl9deoTjOKoU52PT8OeBS+r+c/24mRCVjp+7o6pJuPyJrmpJrJQq+Xr9aQz+djsORSbyMJogkwx6zdpxTq2XlXWz+vokRDci26DrC6L+uvMC/j6ZxgNGJrk5x5vLjqpt2v3cHdR7lmn0VFEGBFfDDw+2gZ2NFVYdicITCw6oYCtRRdfGScrIUZk7w9sE8mBTqdT0ccb00a1VhqpkTszYFs4jRxXumw2nVQkAuQjZppYXjzjdkmY1PLB4Uid8N6qV2oX9dEwq7pm+Q9VUZdaXaTG5oJfUZpItY4WsmZU0QqLSuLtVdbxxZ2N1/7cjqYVXbohMxeKQSCw9eAnWVsB3o1qr4phEFalfEz/8/FBb2Nta499j0SrLkAMxqsjaOHN26nZAe2VQIxXAICqtzvV88dbgJuq+1PXdfDKGB48qzOnoFCw7xCwvuj1y8fquFgFY92wP3N0yALJ/kNRUlUL3kklIpsHkcs6/WX8aqVm5CK7ujiEtAozdHJP34bBglVLpaGdy8UujmNAtCNHJmWr761f/OgpvFwf0beJn7GYR4fjlZLz197HCQqnt63jzqJQB+7xb16tRVcwc0xaPzg3B+hMxmDLvAKY/2BoOtryoROXr039PqoLkUhunZ4MqPLw3wf7sv8Z0qoUTV5KxaF8knlx4EMse74K6VVz5XqJy9+W6UygogNpIQTJ2qHTYbxXPy8UeX49shTubB+DlP0NVrenB323H1HubqZ1qybhMKlJy9moqFuyNUPdfG9RYFbekG+vT2A93Nq+mvpLOS/0boGctR5WuPGX+AWw4Ec1DQ0bPYJWAQ1ZuPno2rILHetTlK1JG7PPKpnuDKvhlbDs42FpjQ1gMHpt3gBlfVK4ORyaq+nFWVsCrAxtz6XYpsD8rPmvivaHBaFvLCymZuercKctlicrT/gvxWH00SmXes5bXrWG/dfMM+1VPdUP72t4qkeeJBQfx+l9HuEGHkVmbUq2b91ccV4GKPo2qonNdX2M3iTRKgqWPtfXAoGB/dcVZJncbwxj4IuOQpWSyDfulxAzU8XXBN/e3YkCfjKJrfd/CwNdGBr6onMdwH646oe4Pa1UdwdWZNUFlJ8uxpR5hgIcjwq+mYfJvus1fiMqtv1qp66/uaxOIhv5uPLBUrvw9HLHg0Q54olc9dSFo/p4IDJu+E+FXU3mkLT3oteFEDDafvKoK7r52rS4TUVnJjmVfjmiOQc10ga/JvzHwRcYZWMkuVPsvJMDd0RYzx7aFh7MdXwoymcCXTCYzc7jFNt0eWTa791y8el+90J87oNHtq+LmgBlj28LF3ga7wuPUciE5pxLdrjVHo3AgIhFOdjZ4rn8DHlCqELY21njhjoaY83B7+LjYq2Xbd323HX9fqyNHFhj0kgH3uyt0tW7Gdw3i2v1bcORikppQy1e6np2NNb4Z2QoDg/8f+FoZeoWHiSrN9M1nsfTAJVXM+fsHWrNvKwfs88on8DVrXDtVC3LTyauYPI+BLyq7nLx8TF2ty5p4pGsdBHg68XCWEvuzG2sa4IHpD7Yp3NHx87Un+d6i2+6vPlkTpu4/2q0O/NwdeURvEfutWy8vserpbuhQxxtp2Xl4etEhvLo0lBccLTHo9dOWcETGZ8Df3RFP9q5n7OZoitQ6kN0h5CsVH/j6dlQr3Nmsmgp8PbHwAObuOs9DRRXu930R+Oxf3QD97buaoFt9FnUuD+zzykeXer6YNVYX+JIsawa+qKwW7o3A2atp8Haxx2M9Wa/wVrA/u7keDarg42HN1P3vN53Fgj262r9EZSHvn/Nx6fB1tcdE1lctE/Zbt06Cq/MndMBTvXXLHRfujcTQaTvUJldkIUEv2d56+uYz6v7rdzaGi4PJbShJZhL4erBjTbVLi+yg98Xak0yTpwqz/ni0WtYoZBI4plNtHm0yOZ2LBL4emb0PyZksGE2lJwXGv1p3St1/tl8DuDty+TaVvxHtAvFUn/rq/hvLjmDVEWbt061LTM/G1+t1/dXTfRvAlXNOquTljs/1b4jfHumggq4no1MwZNp2fLvhtMpAJDMOesna/Nf+OqJ2NOsU5IPBzasZszlkxiQ1/v2hwXiun27t/ncbz+ClJaHcvYwqZEegxxccQH4BMLxNDbx0B+vbkIkHvsa1g7O9DXaejcOIH3fhSlKGsZtFGvH9pjNISM9BvaquGNUu0NjNITP2bN/6uL9toDq3PrXwIDcoolsm2ffSXzX0c8NI9ldkxBITq5/ujjua+iE3vwBfrjuFe6bvxKnoFL4m5hr0+iPkIradjlWFTz8cFsztranCt8GWK4UfDWumtij+Y/9FjJ6xB1dTsnjkqVzICeuR2SEqkN+7UVV8fE8z9mtk8mS35MWTOqnC0WFRKRj2/U6m3NNNRcSlY/aO84WZ+nIVm6gix3Af3dMMd7UIUBPFyfMOYOeZWB5wKpWjl5KwYK9uaex7Q5uqVSBExiLjrR8fbIOv72+pNro6cikJg7/djm/Wn+ZOtRXEaJ/4qKRMvL/yuLr/fP8GCKriaqymkIUZ3aEmfn24PdwcbdUmAJJayo0A6HZdTszA2Fl71XKfVjU98f3o1hxUkWYEV/fAX1M6o35VV0QlZ+KeH3Zgyf6Lxm4WmTApBi21MrvV90XPBqxZSJWTtf/liBbo18RPTQzHzwnB1lNXeejphvLzC/Dm30dViZOhLQPQIciHR4xMIpB/d6vqWPdcD3WhXM6nX60/hTu/3YaQ8/HGbp7ZsTbmssaUzFy0CPRUOzYSVXZh1L8f74KgKi64kpSJ4T/uVIXHuR02lbVOxJhZe9V7qW4VF1UnycnehgeTNKWGlzOWPNZZ7TSUmZOPF/44jJeWHEZqVq6xm0YmRgbkK49cUVnTkuUlg3eiyiAZOtNGt0LPhlWQkZOHCXNCsOYoa3xRyRbui8DBiES42NvgtUGNeajI5Irc/zK2Lb4b1UrV+jodk4rhP+5S9QtZZ1XjQa/FIZHYGBYDextrfDa8ubpyQ1TZJLtw2eNdVHRdlqO9/OcRPLHwoMrUISqtjOw8dbX5TEyq2oF27vgO8HKx5wEkTfJwssPsce1U/UOJYywOuYg7vtqK7ae5jIh0cvPy8cayo+r+/e0C0cjfnYeGKpWDrQ1+fqgtBjXzV9kRU+YfYGYqlZiF//GqMHX/+f4NVYCByNTIhSNZur3+uR4Y0baG+tm83RHo9+UWrDkaZezmmYVKD3qdjk7B2/8cK9zpp4GfW2U3gaiQ7DQ1c0xbvDKwEWytrbAy9AoGfbNNFSMnKs3k74kFB9QyWVmTP+eR9qju6cQDR5pmba2rfyjba9fwcsKlxAw8+Mse9V6XHZfJss3eeV7VfvN0tsOLdzQydnPIQtnbWuO7Ua0Li9u/vPQo5oamIE++Ibq2suj1v46obOXWNT0xtjN30ibT5ulsj0+Ht8CCRzugto8zopOzMHnefkz6LQTRyZnGbp6mVWrQKzMnD08sOKiWTUgNiEnduayRTGOCN7lHXbWsp6a3s5rg3ffjLry/4jjSs7msh0quEfHSn6HYEBajNuP4ZVw7NPRnEJ/Mq8D9v890x9hOtVTW14rQK+jz5RZMXR2GpHRmxFpq1oTsNCVeHdgI3sxqJSOSlSJT722Gx3vVVd//fTINE+buZ/9EyrJDl7Hp5FW1suhTriwijY2/1jzTXfVtkpTx77Fo9P1iC+btvqDmH2TCQS99Ha+T0SnwdXXAlyNaqmADkaloGeiJlU91xT2tq6urhr9sP4f+X21lkVQqtj97b8VxLD1wSQ26p41ujXa1vXmkyOy4ONji3aHBWPFkV3Su66OKR/+45Sy6frIRn/0bhvi0bGM3kSrRu8uPIT07D21reeG+NoE89mQSy4Ik4/Cb+1tASmluPR2LwdO2YR8LQVu06LRcvLP8hLr/dN/6qFeVFyVJWxztbFTftvzJrqoGekpWriotMOKnXWrlHN0aW1SSmdvOFU4Qvx3ZUm3VSbdv/fM91AScRWTLh5ujnQrIDmkRgNf/OoqLCRmqQLmss5ar2gFcukYAvl5/Wi3xEZ/f11ztJEWVg32ecTQN8FDLHTeciMFn/55UF7C+33QWv+44jwc71sKEbnVQ1Y21UszZuuPR6mqzXHX+YFgwL1yWA/Zn5Wdw82rIib+Ir0PSERmfoSaGj3YLUvUJZfJIlkNKT3yzJ0kta5QAPVcWlS/2W5WrcTV3LH2sM37bdV6Nv0IuJGDQt9swpWc9TOlVV9U4JBPJ9NoUFoOPV+ui7W/e2Rid6/lWxp+1CK4OtipQI1+p/PRsWBVrn+2OR7rUUct6lh++jN5fbMY360+rwuVkuWZtP4dvNpxW998b2hTDWukKTlLlYJ9nPHJxpW8TP6x+uht+fLANmga4q6yfn7eGo9snm1QWUEwKa06Yo7jULLy6NFTdH9+tDovXlxP2Z+WrjqcdVjzRGfe1qYGCAqi+SSaHm0/GlPNfIlM2bdNZnIzLgZujLb4e2RK2NkbZt81ssd+qfJI0NK5LHax7rgf6NKqKnLwCNReROtR7z7EOdWlYV8a21o/N36+Wi41sF8gigqSpZT1v3dUEy5/oivZ1vFUtuq/Wn0LfL7dgRehllWFHluWPkEi1rFE8368BxnRiUVSyPFKaYECwv1ryOGtcW7U0XHbAlayv7p9uUhe5uOzR3IpBH0VsajYa+Lni2b4NjN0kohLJheDP7muBGWPaqnIq4VfTMO7XfZgwZx/OxabxyJk5CXBO23xW3X9/aFPU8HI2dpOIyo2sOJo5ti2+H91a9W9nr6aprNZXlx5BcgZrrRot6HXiSjIemb1PBQt6NKiC94YGW9QyvIiICISHh5f68VlZWdiwYQPy8/MrtF10a4Kre+D3iR1VByM780mhe9mQQYrdy659ZBlky+CX/9RlOkzoWgdP9K5n7CaZhPMuLlhfrx7WV6uG9evXq9vp07pMuBv1jVu3bsWJEycYPNYwOZ/3buSHv6Z0xm/j26vgl5zvf9oimV8b8cXak0jO5CBM6/48cAlrjkXBzsZKLf8396Vi2dnZOHz4MLZv344LFy7c9PG5ubk4dOgQtm3bhqtXr1ZKG+nmpOzAhud7YHzXOmpJ7voTMeqi5UtLDnMXWjN1IS4NTy08qLL8+gU54a7m1WApUlNTERISgp07dyI6OrrcH0+mNfa6s3k1bHiuh0ooEgv3RuCOb7Zj18VMjqtLUGFr4o5eSlK1kJIzdeupZSmEbC9sKeLi4vD555+je/fuCAoq3S6Vv//+O9asWYNu3brB3t6+VP/PzG3hSMnMVSm8E7pxN8yK7mB6N6qq0uV/2HJGram+94edGNDUHy8NaIigKq4V9vfJuLaeuqoGUpKxOqJtDbx+Z2OLCuDfyNrq1RFhZ4c6WVmwujZBdHd3L/Hxf/31F9atW4fg4GAVHKtSpQpeeukl2NqW7nTEPs/0yGehW/0q6FrPF5tOxuCLtadw7HIyvtt4Ru009ETv+niwY03WndAguXj5xrIj6v4zfRuoi0DmTIJW77//Pjw9PVG1alXMmTMHnTt3xsMPP1zs49PT09XjZczm4+ODWbNmYezYsejZs2ep/h77s4rl4WSHNwc3waj2gfhw5Qm1k9/ikIuqxvCIdoF4olc91mo1E7Lb+qTf9qt5Z6tAD4xvaTk1JsPCwvDll1+q+aajoyNmzJiBkSNH4o477iiXxxfFfss0eDjbYeq9zXF3q+p4bekRhMem4fNdWTiUcBDvDwtGNQ8nYzfR/INesqTx4V/3qV0GmtfwwC/j2sFJtlSxEAcPHlQdiETRS+vUqVNqIngze/fuRZ06dZCWlqauQM5dH4WIHFdUdy5AI6vL8PDwUJNJwwl5Zmamump55swZVK9eHf7+/tf9zvj4ePW7kpKS1AS0cePGsLa2vu7vpaSkqOwMPz8/9e+WSt7HsgvM/e0C8fX6U1gcEqmugK87EY3R7WviqT71uUmDGQa8Hp0bguy8fAwM9sfH9zRnwMvAeVdX3Bkaii65ubAaP/6Gx/LSpUtYtmwZPv30U9WXyITx6aefxr59+9CpU6diLx5IYKxly5aqD8vLy8Mvm5NwJS0ftW0SVJ8n/ZFMNg1FRkbi3Llz6ucNGza8LqAmmbRnz55VVzaln5N/lwmu/u9Jdm6LFi1w5MgRlfHRvHnzGwbx6L+ZXz0bVMXa41H4fO0pnIlJxfsrjuPXHefw4h0NcVfzABZA14ik9Bw1iZTsve4NqmByj7owdwsXLlR9wuOPP66+v3LligrKS//UqFGj/zxe+jPpP15++WX1/ebNmzFv3jx1wVM/jjIk/YqM0+zs7FTfNu/fCJzP80I1F2s0sYmCg4OD6u9sbGyuyyST/0/GfTIek3GcoeTkZNXfJSQkFI4B9X9b/j9vb2/1+2QMKG1t1qxZsW0zZ7Jz368Pt1fZ+V+tO4XtZ2KxYE8EloRcVDt2T+wexAuXGi9c/+SCgwiLSlFj8O9Ht8KV8DBYCgm2Dx48GEOGDFHf79+/H19//TU6duyo+oTbffyuXbtUvyh9zMWLFzF3fTQiclxQ3SkPDXFJ9TFNmza97v/JyMjA8ePH1Zirfv36/xmnxcbGqrmnzC9lPCi/X98v6f+ezE/l7wUEBKBBAy6rL0nHIB+serobvttwWu2uvT4sBru+2KKyXMd3C1LBf6qAoJcU/H7hj8OqvofUQfplbFu1vt5SSGBIAl4jRozAjh07SvX/5OTkqP9n0KBBWL58+Q0f+/fff6sJmAxy5Cpk9bN7YeXWCFWiL+PgwSZqgNOlSxd1pVE/YPvwww9VMEvqcsiATNrWr18/9e8SaPvjjz/UxE7+/cCBA6rjeuGFFwr/nr6NMtCSiWePHj0Kf7+l8vdwVNH1R7rWwSerw7AhLAa/7b6ApQcuYlKPumonM2d7bi6gddtO6wJe0p/1beyHb0a2UsUk6f+TsYvOzvBNT8eu6tXhdPAgmjRpoiZuxZHBzbBhw9QAR0h2hEzGJJhVHBnsyARy1apVqg87f/48qsenw8XGG65WWdi06ZwavH388ceFv3PRokXYuHGj6tOk/5MB1yuvvKIGcjJpfO+999TfrVGjhgqO/fDDD3j11VcLg3KS2SHtr127tsr6mD17tsrkqFbNcpZJlE/Nr2rqM/PH/otqkik74T696BBmbAvHqwMbows3tDFp2bn5eGLhAUTEpyPQ20ntum0JfZ9cFJSgk5587r28vBAVFVVs0MvV1bVw4iicnJxUf1ZSzU8pYSH9kIzhAgMD4X9+D6xdguAdfRX7PRvj5MmTqu/Rj8HkcTKGk35SJn7SH/bq1Qv333+/+ndZnvTjjz+qQJf0azJGkwmo9HNi06ZNqh+TCwx169bF0aNH1QRU//stTZtaXpg3oQP2hMfhy3WnsOdcPBbti8TvIZHqotZjPeqhWQ3zzmY0N/JZe/PvY2oc7mBrrVYW+bk74gosZxwmASLJSNWTeZz0Q/LZLxrEutXHiyVLlqg5p/Rd0h9WPxsCuDdGVTX3bITQ0FD07dtXZYsJ+T0zZ85U80bpI3/55Rc89NBD6mKAkLnuihUr1DhN/q7MPdu2bYsnnnii8O9JBpqM32RsJ+MyyULT/376Lyk78Fy/+qhnn4i5YXk4GJGIbzeewa87z6tdbB/qWAteLqVbRWauym1Wnpev20Xg22u7msnOAtNGt7aoDC8hnYJEy2XwUdqg159//qk+1HIl8WZBLyGdjkzCJCK+fspbqJZ4EpEN7sOTTw7F7t278dNPPxUGpaSjkN8rHYXUnJDO7IMPPlCDOplESqRdrmLWq1evcAAlKa8SoZfBm/6EMnXqVPX35PfLJHHUqFGlXoJpzhr4ualMxl1n41Tx5tCLSWogNWfnebXDlXQylhT0NbeA14Q5/w94TX+gtUUt0S4NCRrlWVtjRvv2qJeRgfAFC9QARoJI0r8UJZNGuUkQXWp/SX8iE7AOHTqU+DfkSt+4cePUgEj6q6eeegr5LlUQVWcg3ni1N1577TXs2bNHTTwlg0t+r/RXvr6+qu/65ptvVCBs0qRJKqjVunVrFfjXZ8O+8cYbKqNVsh+EZLzK35ArnjLgev3117FlyxYOtspAdswa1b4mhrYMULue/rglHEcvJeOBmXtUnc9XBjZSW3GTaZHx3HOLD2Hb6Vg42lnjhwfawNPZMs730jcUDbxLBqhkWBVHH/CSgLz0I1KrUJZCGmZqFSVZpp999pkKrq88nQ7/q4dwKWgInnxypOrD3nzzTRXskgucclFSgl3SJ0mfJX2gZJW1atVKZT5IYF+y0uR7IZkT0v9KX6cnfdoXX3yhJpGS7fXWW2+pNugvFFiiDkE++H1SJ+w7H48fN59VAZNVR6LUTZZpS1Zjl3o+zOrWgG83nFH1jCQm/+2oViqwWdKFNHMkmezji2TZS/Bbsknl4t7tPl5Pxm3vvvuu+kwMnfwqqqWcQmTDEXjqqcEqoUJK9OiDUjIO6927N+67777C5ZSffPKJGmdJ0CwxMVH1UxLgF1I/UeaWU6ZMKcz2kjmm9IXyvfz+uXPnqv7Z0rJUb1VNDzssfrQt1oddVZuvnYpOVfPSaZvOYHDzaniwYy20CvS0yL6tXIJeUUmZePb3Q9gVHqe+f7RbHbwysLFFXBUsSgYVt0JS0uVKnEzSZGBSGhIZ13/oc+zdkW7niTx718KrlFIQX5Y0Com+S6ciVxdl8CYdmnQkUkBaJqUSvNKTTkhu+isBehIg0/89GfhJxyeBNwa9/q9TXR8sm9IFK49cwWf/nlRXxz9dc1INpkZ3qKXqSdTycbml9wYZz4YT0Zgy/8C1gFdVBrxKIEGhARcv4t7du+FctSry165VfZkMTp5//vkSj68E1SXrSyZ1EjiTCZp+8FOUnJj1mRcqkGVljUSnANhf+ze50KDvO2WZpAyoJMCvJ8F7yW4QMknUp8hLP3b58mU1ADTs74QExoT0e7Vq1Sp130zFk6xXqeslATB9na8tp65i6+mrGNaqOp7tw00hTEV+foGq4bUi9IoqXC9ZE+Zex6skMo6SiVjXrl1VP3AjsuxHguwyLpJxl2RRlFSn0DAbVsZwOdb2yHLWXSTQB6L0QS8JpEnAX8ZwenLxUvo06cvuuuuuwp/L/yNBMWHYp8nf049N9TVmpU+z5KCXXrva3mg3zhthUclqA45/Dl9WSx/lVq+qq7pwKcsfefHSNMlSLpnYi3eGNMUdTa8v32KJpA+QhIfhw4eXak5a2sfLOEwfKJF+K9c+A/m2ToVzT/04Sb7K2Eof/DIkS7rbt2+vsr4M+07pu6T/lGClfr4pgXzDuaf0x3JzduZunKXJth/YrJr6PKw4ckXNRY9fSVa1DOUW5OuCgc38MTC4GpoGuFtMAOy2g15rj0XhpT9DkZieA2d7G7w/NBj3tik5Ukz/Jx/un3/+WUXGZaJW2olV0Q98nnXxL6N+8CMditQXk+9lkipZFfr0VQm6LV68WNUUE5JuLwxT893c3Arv6zsg7jBZfCdzV4sADAj2xz+HLmP65jNqK1k5KctNrhre3bK6Kobv41r88i8yvsX7IvHqX0dUtgMzvG5MlssEhYfDKicH0mNIdoMsf5YlgTcikzl9RsX06dPV4995551iHyuTSMPJYwGsruvz5GSt76+kj5P7hjuuyf+rz4KQfkuWbEs2hqTfy6RPJoeGVzdlMmoY0Jc+j/1d+ZB+TyYm4zrXxmdrT2Jl6BU1AJMAy4AgRwQEZaKaFy8OGHNJo5SnkIm/XLP8+v5W6NmwKiyRLAeUzYhkqeCjjz5608dLHyO3gQMH4tlnn1WZ/tIXFkefRa9YWSHP6v/Z4PrJh/RjcgFTLg7I+M2wT5OlSBLsF5KxJXXIpHaO1CCUPln//+txDHdzjfzd8dX9LfFcvwaqSLcsy5Z6hG//cwyfrgnDsNbVMaJtIJpV97CYCaKpk9dp6mpd3a4X+jfAmE7FXzizJDKu+eijj1SZG8OAeHk8/vq5p/RbN557Spa+BLP05OKBLHXUB79k7imZrTLG0tcpvFm/VdKycSp5XjqkRYDaxfRgZKK64CjjLSl4//2ms+pW3dMJvRpVUXPTznV9zXp35jIHvWJSMvHu8uNq0CqCq7vj25GtWAjyFkg9LekUJPgl0XC5LyTzS+ozFC1WqlfaE66+w5B10HKVUrIfDAukygBJauG0a9dOLXmUSL0MrGS5EJWdnY21CvxKBoMUuJdiqZLRsONMnLrJy9emphc61/VB61peaFXTi0UGTYCcTL/fdEYV3xbD29TAx/c0U68nFU/qz6R5e6O1wVIaUVL6uQTXZSKnX0oopLaE1CIsD9LnSTZY0dR9vX///VftkDt58mT1d2UQ99VXX5XL36bSq+3rgu9Ht8bEbolqWfju8Hj8cyodqz7bgjuC/TGmYy1VE5STy8ojGfuPLzigCn3bWlvhixEt1I7FlkguQMpSHMkukL7kRstpZNmN9Gf6Is0S0Jc6YBKMKklp39cSgJebZI2VtARcli1K8F6WAcmYUYJ1EydOLNXvp/8K9HbGu0OD8cIdDVVAXmq1SvBr3u4Idavt46wubg5uHoAGfq7so4zog5Un1Nen+9RXmcSWTmpKyyZBMucrTcDrVh9/q3NPqVOtT6QwJH2UrAiQ+l4TJkxQ/Zcsf9TXIaTyJ69d65pe6vbukKbYGBaDNUej1G7blxIzCvs3qYknc1MJgPVqVBU1vMwrq65MQS9ZO/3xqhNqW1hZwihFu+XqiIOt+UYHK4JcQZQ0T/0VPLmip++ISlrqcyskm0sGX1KPZsyYMepnkrGwbds2VVdHMhzkCqJ0TPoizZJKr38c3X6EXVJL5RYZn44/D1zEuuPROHY5GSEXEtRNyHmkflVXtYSk2bVbkwB3FsKvZC8uCcWS/RfV/Sk966qd5jjpvjFJYV/UoAG+PnEC+qR4qa8lQfviSDFoqa8lgSb98h4JeJVHfyekX5NlQHL1Ul9TTGrtSDtl4ij1bGS3R33ml1yFlMGWfjkjVa4WgZ5Y+GhHbJCdHlcdQVhcjrqQJje5+ihBlzubVVO7QPOzWHHBfun3Plp1AgnpOXBztFUBSdmt0RJJ/S65CCiZD7Lc52Yka1SWZz/wwAOFmfXyvWFx+9shwXn5G4ZBr507d6o6XzJuk7IV8rf1k0tZ4i04hrs9spxxbOfaGNOplirdIhcv15+Ixvm4dLVEW27SR3Vv4Ivu9auoEheWUvfOlMiO6c/0ZcBLdp2WAJYsG5S+q7wffyvkwqMEvmSuOXr0aPUzmW9KPyYXCOSigpS4kN0j9RcL2G9Vbt82tGV1dcvIzsOu8FgVBNsUdlUFwDadvKpu+PsYGvq5qeCXBMFa1/RUdVotLuj16lLdVXmZnEsmhKXWeygLCXBJZyO770jAS256+kKoUoS+vOplSQFoKZgqHYyQXdCkbpf8XSlaKCnysnOkDKhkqaOknOoDcLK1NZXf1cNn+jZQt8uJGaqejRRQlavqF+LSVaFBucmVRSFLS+pW0QXC9MEwWXft4sAdISuKTPzkuL81uAnGdSm+aDFdr1u3btjwxRf4sHdvdExKQtjnn6t0dSl2apgJIUEtucngSnZWlHR66YMk80uyxSRLoTzI75TfLxt9SBFV6cck6K8vpir1EGUXIQm8yRIjaZvUsNBfcKDKJ8EsGVR5ZfrAvmoQFuyLxN+HLqvB189bw9XN19Ve7fYoBaa71vdFNQ+D5WFU5mDX3nPxhTvYiSbV3PHDg60ttv6kHBPZyEe+yvjHsB6NbLghGfOSwSWBeslSkHGaTOokY14y5+VCpn7nWMmgLw/y+6U/laWWEgCTPlOC95IVIRcOpK7X/PnzVaBN2rZ//371c+nTGCi+fXIMZcmP3NKyclXgS3ap33oqVvVRC/dGqpuoW8VFFVFXGRW1vFCviqu6+EkV4+27muBhjtVUjWUJYEkQXOZ6hv2WXOCTwJLMOyVALv1WaR5/OyQzVsZfsjuj/C2ZZx48eFD9LRkDSkBM+krZdVYuOMq8U+afQvqtW62NTWXnZG+D3o381E3OezIPlQDYxrBoNT89GZ2iblKix8PJTl0M6y1LIRv6wcNZe5u0lWkGLbW7JLNL6nJoPepXkeTDXLRQqGQWSOHm4khH0KdPnxvu+iOTupo1axZ+n+Xki8zskn+HRNVlQCb1JSSDTHYkk05HvzZbBlMy8ZOllZKdIammS5cuLQySFf170hnJ72enVHYBnk6qoLPcxNWULByOTMSRS0k4eilJfY1JycLpmFR1++vgpcKMMCk+qA+CBV8LhDnb8TNYHryc7dSOszK5ptKRellvHz6M7fb2uFi9upqUSf0bwy2vpb+TmoVC+iXZLVF26pFJmmRmSZ9jWLvBkAy+5AKBoRSvhsi2cYY+7CF9nIuLS+EE5cUXX8SuXbvUIEr6KdmdVl+8XmrsyPIjqX8jJ3jZEU2uQOqvMhb396QINLMmKodkuH58T3O8NbgpNp+MURuDyAAsNjVbBcLkJgK9nXQFqK/dZLLJCX7ppKqJ+xUs2BuhBrVCdmiUCzLju9ax6OXcMkHTF3o3rKEl9GM5GRvJv+n7BNn5WsZYkn0ly3YefPDBGwa8DPsrkWPvgViX/2e6ysVIGWPpa9/I+EuWWkqfKeM06Y+kz9T3sbKTo5TEkH+Tx0qAX8Z0ejKuK9q/yu/X98lUenLRUZ8hkZ6dq4LFW2VDjlNXVf1W/W1xiC5jXLImWwZ6qhIWkiXRKtBLkxNFU8WAFwqzS/V9TtF+S8ZYQpId9Du6lubxRXXq1Elll+plOldBet7/axNLfyL9ip70ixKYl7GVzHtl7CW/Q5/hLxcm5YKktEXmyo899pja/VFWH0mWftG/J/2h/H7pH6liWFlZoaG/m7o91rMuEtOzVYLGprAYbD51VdVul4C/3KQEgmS3SiH8/k394KuROtVWBWWoChednAk/d21HYgtq1IDVpUsoqF4dVhd1JygtmjBnH+LSsuHjYo+ZY0seaEndsKI1vcyVOTzXmORMHL2chCMXkwuDYVHJuh05i6rj64zqTvno2rQWmgd6qmCYuyNPDLdKlqBKRl5l0/r7tbL70tL2eZb0Gphz+7Ny83AwIhE7zsRi2+lYhF5MRH6RUYu3iz3a1vJSdcDa1vZWFwMsOXhTXN+2OSway0PO4sjVXGTk5Kmf29tYY3jbGmo5t7nV7tDKWK8i+jNz6BO09pzjUrNUP3UgIkHdDkcmFX7ODEmAXhcEk3qunmjg53bbO91b4mtt7sdEy/2W1o+9lttfUW3Pyy/AocgEdRFy/fEYlf2lJ92XXHwcGOyPfk391bJvUz32Zcr00nrAy5yU5yCJTEdVd0f0lluj/2cKSkaYPhPs6LXb5aRMnItNhyQGb488WfhYKbZqmBEWHODBK4w3YYyAF9069nmWRWqFdgzyUbfn+zdESmYODkQkIuR8vFqedygyEfFp2Vh7PFrdhJOdjZpQ6jPB5L4lLw3v9umm676XjOG7W1XHyHaB6lxDxsP+zHx2pu3bxE/dRG5evpoYSl91MCJBBcTOxf4/G0xfP9TF3gbNa3iiZU1PtJCvgZ7w9+Bnkkwb+y3LYmNthTa1vNXtxTsaIfxqKtYci8LqI1FqTipZr3J7Z/lx1PR2Roc63mhXx1uVTKhX1dVkdoS03FEgkcZUcXNQtW/kphebmoXQyASs238Scfkuqki+1JmQYqtyk61p9aQj0gfBdF/dWXiViDRXhLVHgyrqJrJz89WgS2okSiBs3/kEJGXkYOfZOHXTD9gk+0sXBPNS2WBaSccvD/L8WwV6or5bDkZ2b4bmgV5cDkpUgaT0S9MAKUHhgYc61lI/k+C8ZEvoM8IORSQiTRWSjlM3PX93R7QI9EDjau6qtqtMGuv4upjMxJGILFtQFVdM6VlP3SST/F8JgB2NUhchI+LT1e2Pa4F9GX9IIobMQSWjvLqXk8oGkzGY1GuVr1IvrDLqHzLoRaRh0lnI5M8j/VJhOqgMrAwzwuTrxYSMwo5I6uTo1fByKhII81BLhYiItMDe1loVj5YbetRFfn4BzlxNVVlg+iCYXAgIvZikbr9s1xXMlUmkvi6iZMLKVy8z7fsOvNkPrvbWatmAPGfWPyOqfDK20heN1i8ZOh2TooJfhy9KRlgiTkWnqFIWUccy8e8xXeaqvqZrgIcT/Nwd1GobuVV1d1DLyzwcbREXmw33q6nwdXOCu5PdbS+ZJCIq7SqZCd2C1E1qhsq4a3d4vKpVfSIqWdUC02e4lkRqhEn/KP2ZfUEW6pwOVYkecqvqpuvr9F/dHGzLPIZh0EvDpJBqWFiYKlAoOw1JAULZNYMsm3QcssOG4ZbzCWnZKgvMMBAmATAJhslNIvR6EoEPquKiBlhSdF+i8gGejqrDkai81AvjjkRkDOzz6Gakb5I6OXJ78FqGhQS99MshQ87rdiSSpUZyk6KsegEejmjg74bZD/9/V2VzIFdRpVYGmRb2Z5ZNAlON/N3VbeS1jY2kQP6RawF6CYidiUlVt+TMXNWPya1Em7arLzIf9HSyU0F8b2f7wq+fDG9eWU+NzBj7LSqJq4Mtejasqm5CysZHJ2epYL7qv9ScM12V5pGVSnGp2SozPze/QG3gJjdxOPr/47KiZOMdmY9KRqzMTWWe+tKA4jdgKIpBL43au3cv5s6dix3WzZBj4wC7vCx0yZ+OMWPGqB0XiQzJoKdrfV9100tKz1HF8g2zwmRJ5M0GVvqI/N7X+/IgU6Vhn0dlJYH86td2XROyK5Gk4cuFgOOXk1U/eCFONxCTG1FFY39GxXG2t0WHIB9105OJo+xgKxcqr6ZkqkmkbCgmXxPSsxGfloWo+FSk5VkhJTMXsj1ZQnqOuoXj/9kVDHoR+y2qTJKRJTUKb1SnUEpUyAolCYLFJGfgwPEzcPHxVwExXSAsU329mpyFlKxcZObkF65c0mPQy8wHS19//bW6nxbgjWxbZ9jnpiP+crz6+TPPPMPAF92UbJ3dpZ6vuulJxP3ElWS1RvtyYiYuJ2bgcpIuCBabkqWuNuoj8kSVhX0elSdPZ/vrrkaK5MwcnLicfMMUfKLywP6MbnXiqF/qc7Mdz/JhpZYT6YJh2SrLPz5d95WI/RaZYokKfWAsz9/1WrmeOsXu3piRnac2dZNA2BW5SHmz7FctZ3rJ1Y6srPKZbNsXFMBK/zszMzWVVjpnzpwbPkYywIKDg69b6ignxZycHGRmZmpuC9ZbdbvP1cHBwWJrnsgyGP1OacXJys1DQlqOishT+ZF+SKufzYruS8va590KrfeP5dl+S+3/ZNl20QwLMt0xnFbHepXRn5lDn1aWfosAOxvrGwbIyPT7LK33W9JmLfc9pth3Wuq4rCgnexvUlKL4Ps4oC80EveRD9O677+LUqVPl8vu+S0iADG0TEhLw5COPwJzEx8djwoQJxm6GZjVo0ABvv/02O5hiONjawN9DbtxSuzz7tkWLFuHy5ZLXsJsyU+hL2eeVH/Z/pIUxnJb6p1vF/qxs/dYbb7xRAa8GWSpj9VmC/RYZ4risfLDqORERERERERERmR3NZHpJWp9k35Tb8sYtW4CMDHh5eWHWrFnQCtmt8dNPP73p41566SW1m6NhuuaRI0fQrFkzk0nXrCi3+1yZRkqV3beNHDkSjRs31uRns6L70rL2ebdC6/1jebaf/R9pYQyn1bFeZfRn5tCnlaXfkiVYRFrvs7Teb9WvX1/TfY8p9p0cl1lY0EvfATk6ls+yqoJra2PL83dWhubNm8Pb21ulv5fEx8dHPa5oTS87Ozv1XE3lQ1xRLOm5knnQ90NafL9WdF9a1j7PkvoMrbefLIMxxlumNtarjP5MsE8gun3G6je03G/JslAtj0fYd5ovLm/UGBkEjRkz5oaPeeihh25rsEREZCrY5xGRuWB/RkRaw36LzAEjIxrUvn17PPPMMyrqXjTKLj+XfyciMhfs84jIXLA/IyKtYb9FFre8UdbMyzaeWlcQFAQrV1cUVK0Kq/R0aI1sCzt16lRcmrkbiZl58HT0wscTPlbR+PRino+kawr5Ny2mm94KS3quxn6+kr5sDlmFxuzXtP5+ray+9Fb7PEt6Ddj+8mdufZvW3yPmNtaryP5MWOLrbYnP+Vaft7n1a+b6XtByv6X1Y6/l9mu57bfb/tL0bVYFsvj2FkhDTpw4cUsNISLzJMXXnZ2doXXs14jIEPs2IjI37NeIyFL7tlsOeplLptfZs2fxwgsv4PPPP0fdunVh7izp+VrSczX287WUq4YVSevvV6233xyeA9tf/sytb9P6e6Ss+Lwt5/Xma33z19rc+jVzfS9ouf1abrvW26/ltt9u+0vTt93y8kb5heaQ2SHP4/z582bzfG7Gkp6vJT1XS3y+FcGYx07rr5/W228Oz4Htpxu9N+Q9rfX3SFnxeVvO683X2rJe6xs9V62/F7Tcfi23Xevt13LbK6P92g/3ExERERERERERFWGxQa8qVargiSeeUF8tgSU9X0t6rpb4fM2N1l8/rbffHJ4D20/m/h4pKz5vy3m9+Vpbzmtt7u8FLbdfy23Xevu13PbKaP8t1/QiIiIiIiIiIiIydRab6UVEREREREREROaLQS8q884pRERERERERESmikEvuiUpKSkYO3Ys1qxZwyNHRERERERERCbLFhZg1apVyM7Oxt13333Dxx0/fhyLFy9WgZ2ePXvirrvugtZkZWXh9ddfx4cffggHB4cSH/fvv//i77//vu5n8pxHjBhxw99/9uxZzJ07F/fddx+Maf/+/ep1TU5ORtOmTTFq1KgbPt+TJ0/i999/R1JSErp164ahQ4fCysoKWpCRkYFFixap96eHh4d6X7Zo0aLEx2/YsAF//vnndT/r0qULHnjggUpoLd1IfHw83nnnHbz99tvw8fEp8XEvvvgi0tLSrvvZ+++/f8P/pyJNnToVERER1/3smWeeQYMGDYp9/JUrV/Dbb78hKioKzZs3x+jRo2Fvbw9j+fnnn3Ho0KHrfvbQQw+hU6dO5fL4ipaXl4elS5di9+7dcHR0RP/+/dGjR48b9hnz589XfUb16tXVhQpfX18Yk5xzNm7cqPrdjh073rAP3rp1q+rzDLVv3x7jxo2rpNZqV0WPAUxNXFwcFixYoLY59/Pzw8iRI1GzZs0SH5+amqr6ptOnT6vHyXvK09MTWiP9sYxppI+tVasWHnzwQXh7e5f4+K+++ko9Z0OPPfYYmjVrBi2RMejChQuRkJCg+pF77rkHNjY2JT7+3Llz6v0h517pQ2Tsam2tvev9ISEh+Oeff9Rcpm/fvupWkszMTDz//PMoWrJ5+vTpMAeff/45hgwZUuL44/Dhw/jpp5+K/bdXX30VgYGBCAsLw7fffnvdv9WpU0eNvSqCjInkfXvp0iXUqFFDjYmkvyqJvF+ln7pw4QLq1aunzuEuLi6l/vfytn79enVezsnJQYcOHW46h7rR42NjY/HWW29d93hXV1d8+umnFdJ2mfdJH3DmzBlVIH348OHqmJVE5k8yjzJ05513qpsxxld79+5ViSZy7pL++v777y92PC3H+umnny72d0j8o3///mqVlozdc3Nz//OZcnZ2rpCxq4zlDh48qI6RnJ9r165d4uOlXUuWLFH9nZyX5bxm+Pib/fvNaK/nv0Xbtm1TnZy82W/kyJEjKiggB7Ft27bqw/f9999DS+REJ2/m5cuX/+cNXVyHJB8aGTDobzI5vRH5sMgJV//h0t+vbPLhnzhxouq8JJizYsUK1enIh6s4cnKToJicEGTQ8/XXX6ubFshxlsn2li1b1HN1c3NT38vrV5JNmzapQZ3ha9u6detKbTcV74MPPlCTTTlplkQGBDK4HTRo0HWvYUWckEpDPvcyuZKBi2F7SjrJyyRUJs6JiYnqPSvPRQbgxvTXX3+hfv3617VfJorl9fiK9vLLL+OHH35QQTdp13PPPaeOa0mmTJmi+gEJ8MvkWF4PGTAZi0wu3nzzTTVga9mypZqA3+j8Kv2d9OeGx1/Oy2TcMYCpkYmfTKYiIyNVEFguFMhkuGhwR0/eU4888ogaMMtnQ8YGMu4z1ljmdgI/8rxlfCDPW8a38ryl7y2J9OHy2TN8vatVqwatPW+Z8Mk4vXPnzpg5c6a6gFQSCQjI4/WB9lmzZqmLR1oj/eHjjz+OoKAg1Ye+8cYb6rnc6CLvzp07r3ut5aZ1EsSTc8eMGTNU0LMk8r4u+tzlArm8H/QXDvfs2aMCxoaPkaB/RZBAl3w+Jfgin9fLly+ri9fytaR+XCbz0o9JPyUXu8aPH19YVuZm/17epk2bpj43DRs2VH2InM/lwkpZH3/06FE15zY89vqAUnmTcc+9996LEydOqGMv76Fhw4apwGhJVq9erS4gGLavUaNGRhlfyYUp+ez7+/ur8Z9c/CzptZbgf9H3vQTlduzYoQKtQi4OSUBPgmCGj7Ozs0NFjV1lPCLHSs5X8rfkc1iS9957TwVzpb+W87VcpJDze2n//aYKzFRGRkbBRx99VNCyZcuCbt26FXz22Wc3fPzEiRML3n///cLvQ0JCCpo3b16QkpJSoAXS3jvvvLOgX79+BQ0aNChITU294eMHDRpUsHr16lv6G2vXri2wt7eXS0cFdnZ2Be3bty8whqFDhxbMmjWr8PuEhISCJk2aFOzevbvYxz/55JMFb775ZuH3R44cKWjatKn6/0zdpk2b1HGW97PeJ598UjBy5MgS/59hw4YVLFu2rJJaSKW1fv169VrK5zMyMrLEx23evLmgV69eJnNgz5w5oz4vWVlZpXr8l19+WfDAAw8Ufh8XF1fQrFkz9bkzhrS0tIJGjRrd8JjfzuMr2oEDBwoaNmxYcOLEicKfHT9+vCA0NLTYx+/YsUOd9wzPXffee2/BL7/8UmAM0dHRBY0bN1bnD71z586V2F+L+++/v2Dx4sWV1ELzUBljAFPz008/qfe2oQkTJlx3vjckz7dTp04FmZmZ6vu8vLyCO+64Q3Pvtddff73gueeeK/xenseAAQMKZs6cWezjL1++rPoQrYxnS/LCCy8UvPPOO4Xfb926VfUtJZ2bXnvttYKnn3668Pvz58+rx1+6dKlAS+65556CuXPnFn4/e/bsgv79+5f4+Pnz5xc8+OCDBeYkIiKi4OGHHy7o06ePei/f6PxR1M6dO9V87uzZs4U/e+mll246LywvU6dOVf2SoeHDh6uxUnEWLFig+nH5XAt5f3fp0qVg3bp1pfr38pSdnV3QokWLgm3bthX+bP/+/eocI2O7sjx+2rRpal5WGRYuXKj6eP2xEtJ3PvPMMyX+P507dy7x/VXZ4yvp1+fNm1f4/dWrV9X7/+DBgzf9f2WOK+8LOQZ6y5cvLxgyZEhBZc0dZG4eGxt7XV/23XfflfgZl7F3eHh44c+effbZgrfeeqtU/14aZpvpJamkEkWXNMXGjRvf8LES+ZX0QYlE6klmjGTL3CgabEokcitXtL788subPlauEkjKt1zlkCw4iciHhobe9P/r16+fujoiJNqsv1/ZnnrqqeuWnrq7u6sr1iVlz0g7u3btWvh9cHCwyvo6cOAATJ1c2ZOrJLKkSU8ybEp6rhJJl6s/V69exWuvvYZ3331XE8/T3MlVRnktbnR1TE+uSAUEBKirZS+88IJaaiefWWPRp3DL1RVpj7wfJYurJEU/b3LFrEmTJupqpDFINoeTk5PK+pWlC5999lmJV1jL8viKtnnzZrRq1eq6K41yTitpWZIcf3m8LBfQk4w7Yx1/OY7yHpDzh56ko0vmYHHkCqZkKsiVfPm8SCbHvn37KrHF2lQZYwBTI/2M9KuGbnR+lM9Gu3btCpd9yhhPrp4b67NRVnKVXq7+68nz8PLyKvF5Sx8umQKyLET6cMmWuVFWmKmSLIFHH330P8+rpKXzRc9Fkq0r51YZ72uJZJYYjnnleeszN0oaQ8j7QZYsyTlMlmKVtBJCK+QzKue9ZcuW3dLyVBkTS3aIZHjKeNrwGMq5RvoPGSvfaPXE7RowYMB/lk1KxtmN+inJZNQ/T3l/S6azvp+62b+XJ8kYlveRYaa1Psu/uPaX5vHy/pQ5mJTNkEwg6ZeKLsUtLzKX/+STT657z9zo2EdHR6vVFpJVKm2TMgGnTp0y2vhKVkkMHDiw8HspcWNra3vD1SJ633zzjervZFxg+L6vWrWqWu0k54LZs2dXWKazHCOZv+izKyUzW2Izsry4ONIvS3tlmXFxx/Zm/14aZhv0koPy3XffXdfJlURqeKWnp1+3vlrSoWX5nLxAWvDSSy+pZW83qm1gOKmTE6DUxZI3jHyAJMVfUqi1oHfv3tctrZKlSPJ6SUdUXH0TmaAXXTsvH3otvLZSc8Rwciid0x9//HFdgNaQLHOQx8jyDTkpyuRdln6uW7euEltNRcnJvXv37qWqCSUnJf2gQFJ4ZTmv1H+QwZsxSHskPV9OsjKBkLX5kh4ugbzixMTEFPt5kwm2sdov/bukdcvnRp6LfklUeTy+okkquAz2t2/fjldeeUXVhLvRxRgZtJlSfyfp/7LMQYIqUsdDAlk3OtdIMEaOvwxw5P0vFzUknX/lypWV2m6tsaQxgJ4E06Wmp55MVtauXVvi+bGkz4ax+qaykgml4dhWXk/plw0DPEX7NOmXJZCsX9YpfZrWAl9y/pRJjyw/kgDYjz/+qAJ4JTGX17tPnz5qSadMUCWAsmvXLhXIKcmxY8dUTUo5Vm3atFH/n2GQVItkGZMEjgyDDaVdHib9gpxDDOcF4eHh6hwj9XHlIowEOOT9VBHkbxjWH5NzopzPy9pPVeb7WuYQUj/O8MK71MeS/kcuhpbl8dIfyRylbt26KglBLqRK4LEiyHE3rIEs830piVPSsZe2CRljyWPkvSI1wPTJA5U9vpJjaVirUeZ/UurkZqUI5EKt1CiXcgeGtdeOHz+ulpZKIErmlvL7KmpprBwnGV/I7548eTLuuOOOwnquxnrfW0Qh+5uRN7WQgZ8h+f5mdTG0SNa7S/RVJuHyYRg8eLCKgkt0/kbFkU2RTKQ++ugjNQCQCLg5v7bScciEUa5SSwHa4khHJgU85bWV11ReW1mrLdkqhpkWVHlkPb3c5ERbmowtqdUgJyr9pEZeNznxyf8vwabKJleZ5CqzTDANC3rKhhZPPPFEsZ+5op83eQ8aK2gnJ3a50i2DfyG1NSQ4IEV9P/7449t+fEWTYKNMciToJp9nGaxLeyQTUD7nxR3/ohMDY/Z3EsCSQb7001L7QiYgUpNMrmBKMLcomdxJ/TI5F+kDODKQljqbFVX3w9KY0xjA8H0m/ZFc7ClpE6Li+iYtjgUMSVb3k08+iYcffljVzynpQqHUK9Jnh8rxkWwxqYklk32tkaxXmSRLYfBnn31WTdyKbvIimSNyAdCcXm+ZMMoFBDkXScFqef7F1eKRf5PJvr5mm3wmJFgmQR6pa2tJ5syZo2r6Gp4TJeAvWTByXPS1UiUgI58FGX/damDtVshFeAlAyuevpMDLzfopY/ZjsoGYBFMkkFrWx8tnV5IU9J9Z6bcksCTZeFKztKJIfyBja/kMSUH14kiBe6mXJ8EaIedG+f8kuC6rHYw5vpKLVHKOlovoN9u0QNoqfYC8xw1NnDhRZVrps63kfC/zC9lk6EabY9wO+bxNmDBBBb2k7XJ85bU2xvueQS+gsNOTQZMh+b4iOz9jkUhp0WipTPTk5CBvztJcKTYFcqVATh4SCJKOqTgyWZJBfdFUUK29thIwkGUokgUhHUZJRc0l6i23ogMluYIlARfDqy9U8aSwshTwluwc2YSgNEGvooNSCebKIN8wxboyFb2iJINsCQiV1B55bxb9vMlxkGUoxlDcIEr6OznJl8fjK5oEuaVflkCQ/oQvgzAp5ltc0EuOvymdy6TPkUCXLImXz4CQ7C2ZuBUX9JKBsEzSix5/maRIdqH8v3R7zGUMoCfvi0mTJqns/C+++KLEXcVkoqD1sYAhyUKVyYN8XiTTrySG2XBCApyyzNNY55TyWMkhN5ksSxaUZPvLpMqQvAeKOxdp+fXWL3GXzF/JepOl40X7SlE0cC0rBuT8K6+3JQW9JKNRnnPRjavkfVF0gi/9n4yzZYxdUTuaSoBa3qcyprpRpl5J/ZQ+0HGzf68osrRULvzJfKI0m56U9Piix16Ot7wm8lpVVNBLjo9cHBAy9ijpHGcYEDJ8b0iwxpjjK7nwKQE7ed/ILow3IgF/yYwvLrDUuUgQTOaLcoFdjn1FBb1kziDZyXKTYyUBxOLadrPzc3mcv812eeOtkAMpJwTDHQXkQEoHZbh21FxIxoiscTYka23lCrtWBrtSv0Su6srV/xvtSiMfNjnhy1IlPZkwSuqnVl5b+ZBLZpfs/CLR+xttSy47A8oOgUVfW+kUGPCqfHLSl+MvV6KlLocELoUs85IlGsWdrOTKtQR0DcmylKJXsiuL1PuRJUOG5DmV1B5JWTf8vAnpW431eZNdAuWKeNH2l7T75K0+vqLJgESWqRhe4ZJBmSxXKun4F90dR14PYx1/ab/Ul9EHvPTtl6VVxdXxkL5dgsRF3/8S/NPqZNXUmMMYQE+WPMjSTMlElcBoSfWd9O/Fop8NY/ZNt0MmKRI0luxJ/XmlJDJOkh20TKVPKytZ3i3LOPWkT5T3rD6j/2avt/Q3kjGrpddbLhjJxV3D5VP6OrbFPW9ZviVjDQneGK4SkPGjscYQxiLLteU9IOfEoitEpDawYZ0z+TyIivpMSLazZJxJkFLqRN2oLtnN+ilj9GO//vqrClZIhn9pAqclPV6Wosn7U+bXhnMcuSBcUe9PGT9ImRd5bSUAJ8kQJVm0aJHKoi+przTG+EpKnEh2vBzPkhI8DEl5FDkvFl3dk52drebN+iWchsenIt73Uo+26OoIeY0luFzcckp5X8vnxHBcWPR9f6N/Lw0Gva6RN4dMdPQF3ebNm6fSXQ2LB5sLiexK8EQ+GEK2WpUrvLKM52ZMYUAsE3AZ5MnyjNIsxZDXVrbr1mfZyOssH/CKuppTnmRQI4VbZbInmR4lZXjpydV7WT+vL0oswVs5+ZTmtaXyJzVWJB1Zvy3woEGD1M8lzbe4vkWflShZPPoBmbzf5aQqyxOMRd57+gG2vLekHkVJ7yn5vMlVJsnuEXI1WoLMFbUd+M3IAEfar9/iXCY9//zzT4ntv9XHVzR53aU+i36yJ+coCZiWNPCUzAe5wq0PnMogU95D8p4zBumj5Vjqg7wyYJHjKdmCxWXkyJIcWQ6hb7/027/88kvhEjwy7hjAlMjESZYjSZ8jGbU3e3/I42SJl/55y4BZBubG+mzcTsBLljjLBRLDWkU3GrdJdoM+Q0H6ByncrbXXWyZL0jfrJ0w7d+5UdUxLWiYmGRGymZW8v/UXoaTPkSw3LV2Ul4CXjOP0ZAwrr6lhsXA9ubgg5yzD5WTy2ZYLwCUdJ3MldZmKG2fJJgBbt25V5yEh7ycJhsj7Qr8ktDzJRF0C1BJ4kaWnNyPv202bNhUGV/Q1sPQZPjf79/ImJVPkfCHvO1kaeDuPl2zco0ePqhISevKZlgt7UnS+vEmwd8yYMSorVC70FLcc2JBcoJPxhrxm+oCXPA99X1nZ4ysZS8tmPtKmollaN3rfS2C8aM01e3t79Xzkd+kDR7KJgGRKy/Mqb/Kayuusn4/KHELmp9IPFXeuluxVmfdIPy2k35YVAvpje7N/Lw0r2cIRZk7S3iVlUnYqMLwCIC+2FLvXr7OWmgjyAZEPpUwypRMsrji6KZPBnKwVl6J7hqmuEiSSCbi+JopcEZUToaScyqBB1jFLhsPN0mMlnV5OGJLqKfWFDIszVgb5cMrkWa7uFT2ZyeBXOgUZCEnQUqL18sGSK1+SSikDZMnokytg8rprIc1bnoO0VV47/Y5T+iVv+gi6DPZlAimvu/4EIgFBKd4oO5DIjkXyM8NMCzIOeQ/KaynZLPrdl2QSJgNUuYojr7F8xqToowQ35KqIfKblpKd/fSubfH6kD5XAlWToyIBFMg+lNoCQ95gsKXrjjTfUSU5OSjKwk0GB9CvSfnmPGqv9MlGSq2TSHn1BdWmLtEkmQPpdAuU5SSD8Zo83Bhk4yK580j4ZjEm2pwRGZYAmJG1famLoLwLIEmjpN6RIrEyQpS5b0eypyiQTbKnjIecLGXTJMZb2SwFhISn7smRHihULGZRJ3yfnJ+mv5X0l52Pp98m4YwBTItka0pcWvfglYwP5NxlkS2Bo3Lhxhed7ed7S38pnQyYvsrOV4dhQC+T1vXjx4n/GMDKZkGwSCXrI+EAKf8tVcH22uPTV8r0UMpYJuCyX0RK5kCLnHcl+knG6TPbltdMvk5YLA9KvSGabXCiUgLlcNJQ+RDL+pS+Ui1DGugBTVtJuef1kIivZbfL6yhhc/zzkgoIEQeR5Czkukh0mj5dJvpwz5PxR0kYHWiNZnRIENNzkSca4wrDerfR1cu4rrvao1JqSc7qcd/RZR/LekfdJeZMAtXzmigYtJGgpcxPJepa2SDv1tVNlV0kJysn38nrKmNBw59Kb/Xt5nk9kridz6KLL/vT9i6xkkMfJCobSPF52Y5a+RwKMUo9Jjr+ce0qqSXg7ZFwqc335rBgGWmRepK9nWHT8JKsbZAMEOUfI85F+Vsa4+iziyhpfyVipV69eqq8rOtfWn9OKxjKE9A1yoVSy1oo6e/as+oxIvyBzwtOnT6vHV1TNZwl+yjlXjpXEVWQsJxsX6DPLio79pC+TsaKcw+UcJ0vz5fH6Y3+zf78Ziwh6yYsvJ0AZ1OnJSUPerIbRTZmsSYRUBkoyudDiUgqZoMqWqvJBMczKkqsaEvU1TPOV9Ed5w8ub71Yy2mRCKINlOaEaplBXVtCrpO2m5YMjz1GCBtJRyWurn6TKlRx5bWUQJB8+rQSApM2GacB68gHX1/ORrBsJ5hm+v+W1lYmMTIr1J1EyPglkyWdRimTqU6zlSpEEkgw/szIQkPewBOHl/Wrsyb6cJk6ePKmW1EkgyLAekFwwkACR1I4z7DOl/TKYk77FFJbRyMle+gYZdBkOxqS/l2w0GXAZtrOkxxtzwieDW/lMy3vCMAAnE38ZFBm2U4KU0r/LIN4UlvPIuUkCiBLYlWNtuFxT6lVIIM/wqrD0e3KOlgC/DGyMFXDUmsoYA5gKucBVtL6KkPeSZA3ImE6CAfJ5MawpKEEA/ZIUU/hslyWIXBy5kCKvo/49IJkrhhv8yOdJzjcyIa2IjJbKIK+pBCvlOcpzNTw3yvtZggsyNtJPguTcJT+Tx0s/YuxzaVnJeUr6fxnLyvM2DE7LOFze04bBX3m87OIoXyWwraVg9s3I+U4SEgxLfcg8TxgGTuS8Lv2dTLSLI+MrGafIe0WOUdEi2eVFskmLK7Yt4yiZa0pQWjY7MizubjgGkbF9cc/hZv9eHmQcUXQ5nJ6+f5GxoQRoJBOnNI8X0m/L4+S4yGtWUeVXZL5Y3E7jMn/VXzQobvwkARX5XEk/aTi3qszxlX5sXRz9Oa24WIa8p+XCYkl117Kzs9VjJFNKHlPR82EZu8qxkve2nHsMx3LFjf1k3iB9lwT7ZF5f1M3+HZYe9CIiIiIiIiIiIsvCAhlERERERERERGR2GPQiIiIiIiIiIiKzw6AXERERERERERGZHQa9iIiIiIiIiIjI7DDoRUREREREREREZodBLyIiIiIiIiIiMjsMehERERERERERkdmp0KBXfn4+QkND1VfisTKF99XMbeH4at0p9bVcNW4MWFnpvpoQfgaJiIiIiIjIUtlW5C8vKChATk6O+ko8Vqbwvpq57RyikjPh7+6ICd2Cyu9tmZJy/VcTwc8gERERERERWSoubyQiIiIiIiIiIrPDoBcREREREREREZkdBr2IiIiIiIiIiMjsVGhNLyJLlZ6di5NRKYhLzUZWbj48ne1Qw8sJNb2dYSUF74mIiIiIiIioQjHoRVSOUrNz8cD3OxB6MRHF1dmv4uaAbvV9MbxNDXQK8mEAjIiIiIiIiKiCMOhFdJuSM3OAzFy4y+aNGbk4HJlYGOAK8HSCg4014tKyEJmQgaspWVh64JK6NfBzxTN9G2BAU39YWzP7i4iIiIiIiKg8MehFdBvWH4/G68uOYFmWLuhlZ2ON9+8ORr/GfvD3cLzusZk5eTgQkYAVoVfwz6HLOBWdiinzD6BNLS98NKwZGvq78bUgIiIiIiIiKicMepFF2f1an3L5PXn5Bfjs35P4cctZ9b2tjS5Ty8fVHg91rFXs/+NoZ4POdX3V7eUBjTBr+znM3BaO/RcScOe32zC5R1081ac+7G25vwQRERERERHR7eLsmugWScbWxLkhhQGv8V3rwNfVQd0v7SJFDyc7PNuvAdY91wP9mvghN78A0zadwX0/7UJkfDpfEyIiIiIiIqLbxKAX0S3uyjhhTgg2hMXAwdYa341qhTcHNyl1sKsoqfk1Y0xb/PBAaxUIk3pgg77dhnXHo/m6EBEREREREd0GBr2ISiktKxfjft2H7Wdi4WxvgzmPtMddLQLK5fgNbFYNK5/qilY1PZGSmYuJv4Xg1x3n+NoQERERERERlRGDXmRRvl5/Cu+vOK6+3moNr6cWHsTec/Fwc7DFb+Pbo2OQT7m2rYaXMxZP6oQHOtREQQHw7vLj+GjVCeTnF5Tr3yEiIiIiIiKyBAx6kUVZtDcSv2w/p77eiqmrTxQuaZwzvj3a1PKukPbJ7o8f3B2MlwY0VN//vDUcry87igKJghERERERERFRqTHoRXQTi/ZGYMY23VLDz+9rgdY1vSr0mFlZWWFKz3r44r4WsLYCFu6NwAcrTzDwRURERERERHQLGPQiuoGdZ2PxxrKj6v6zfRuUWw2v0ri3TQ1Mvbe5ui/Zab/uOF9pf5uIiIiIiIhI6xj0IipB+NVUPDbvAHLzCzCkRQCe6lOv0o/ViLaBeH1QY3X/w1UnsP10bKW3gYiIiIiIiEiLGPQiKkZiejbGzwlBUkaO2lHx0+HN1bJDY5jQrQ7uaV1dFdN/YuEBRCdnGqUdRERERERERFrCoBdRETl5+SrD61xsGqp7OuHnh9rC0c7GaMdJgm0fDWuGpgHuSEzPwYtLQlnfi4iIiIiIiOgmGPQiMiC7JL7191HsCo+Di70NZo5tiypuDkY/RhJ0+/r+lmr3yK2nrmLe7gvGbhIRERERERGRSWPQi8iAFIxfuDdS7Zr43ehWaFzN3WSOT30/N7wysJG6/+mak4jhMkciIiIiIiKiEjHoRXTN+uPRqli8eG1QY/Ru5Gdyx2ZMp9poUcMDKVm5+Hh1mLGbQ0RERERERGSyGPQii9IhyBvd6vuqr4ZOXEnG04sOoqAAGNW+JsZ3rQNTZGNthfeGBkNq6v918BL2nos3dpOIiIiIiIiITJKtsRtAVJm+GdnqPz+LScnEhDkhSMvOQ+e6PnhvaFOj7dRYGi0CPTGyXU0s3BuBqatP4M/HOpt0e4mIiIiIiIiMgZleZNEyc/Iwce5+XErMQJCvC354oA3sbEz/Y/Fs3/pwtLPGgYhEbDgRY+zmEBEREREREZkc05/dE1XgTo0vLgnFochEeDjZ4Zdx7eDhbKeJ413V3RHjOuuWYH6+9iTy8wuM3SQiIiIiIiIik8KgF1ms7zaewfLDl2FrbYUfHmyNOr4u0JLJPYLg5miLsKgUrD0eZezmEBEREREREZkU1vQiizLq592ITc2CtbUVTkalqJ+9f3cwOtf1hdZ4OttjXOfaKng3ffNZ3NHUn7W9iIiIiIiIiK5hphdZlHOxaTgdk4pT1wJeYzrVUrs1apUEvaS2V+jFJOw8G2fs5hARERERERGZDAa9yKLkF+hqX8l/O9TxxpuDm0DLfFwd1E6OYvrmM8ZuDhEREREREZHJYNCLLIYUe0/MyFH3ra2A6Q+01sROjTczoVsd2FhbYceZOJyK1mWwEREREREREVk67c/4iUrpx61nkZ2br+57OdurLClzUMPLGf0a+6n7c3edN3ZziIiIiIiIiEwCg15kEULOx+OLtacKvzeHDC9DYzrXUl+XHriE5ExdNhsRERERERGRJTOvmT9RMRLTs/HUwoPIyy9QRd/NUacgH9Sv6or07Dz8uf+isZtDREREREREZHTmGQEgMvD6sqO4nJSJ2j7OcHe0M8tjY2VlpXaiFL/tuqDqlxERERERERFZMga9yKz9eywKK0OvqELv345qBWsrK5irYa1rwNXBFuGxadh+JtbYzSEiIiIiIiIyKga9yGwlZeTgzWVH1f2J3YPQvIYnzJkEvO5tXV3dX7QvwtjNISIiIiIiIjIqW+P+eaKK89HKE4hJyUKQrwue7lNf/eypPvWRnp0LZ3vzfOvf364m5uy6gHXHoxGflg0PRxtjN4mIiIiIiIjIKMxz5k8Wb8eZWPweEqmOwyfDm8PRThf8Gd2hplkfmyYB7giu7o6jl5Kx7OAljO1k3s+XiIiIiIiIqCRc3khmRzK5Xlkaqu5Lcfd2tb1hSUa0DVRfF4dEoqCABe2JiIiIiIjIMjHoRWbni7WnEBmfgQAPR7w0oBEszZAWAbC3tUZYVAqOXU42dnOIiIiIiIiIjIJBLzIrByISMGvHOXX/w3uaqeLuhmKSM3ElKUN9NVeezvbo38RP3V+y/5Kxm0NERERERERkFAx6kdnIys3Dy0tCISv67mlVHb0aVv3PY4ZM24FOH29UXy1hieM/oVeQnccljkRERERERGR5GPQis/H9prM4HZMKX1d7vDm4CSxZl3q+qObhiKSMHBy4kmXs5hARERERERFVOga9yCyERSVj+qYz6v67Q4Lh5WIPS2ZjbaVqe4ltERnGbg4RERERERFRpWPQizQvJy8fL/xxGLn5BaqW1aBm/sZukkkY0lIX9Np/JQspmTnGbg4RERERERFRpWLQizRv+qazOHopGR5Odvjg7mBYWVkZu0kmoUk1d9Sr4oKcfODf49HGbg4RERERERFRpWLQizTt6KUkfLfxtLr/3tCmqOruaOwmmQwJ/umXOP5z6Iqxm0NERERERERUqRj0Is3Kyv3/ssYBTf0LAzz0f3e1qKa+7gqPQ0xyJg8NERERERERWQwGvUizPloVhrCoFHi72OODYVzWWJya3s5o4G2H/AJgRSizvYiIiIiIiMhyMOhFmrQ9IgPz9kSo+1+MaAFfVwdjN8lkdaupW/L59+HLxm4KERERERERUaVh0Is053BkIr4PSVL3n+hVD70aVjV2k0xa50BHWFvpjtv52DRjN4eIiIiIiIioUthWzp8hKh8StJnw2wFk5wE9Gvji2X4Nbun/n/9oB+TlF8BGokAWwtPRBl3q+mDbmTj8fegynu5b39hNIiIiIiIiIqpwzPQizQi/mopRM3YjPi0bQZ62+G5ky1sOXtWt4ooGfm7qqyUZfK2g/cojXOJIREREREREloFBL9KE0IuJGPHTblxJykS9Ki54rZsXXByYqFha/Rr7wc7GCqeiU3EmJqVCXysiIiIiIiIiU8CgF5m0goIC/BESieE/7kJsahaaVHPHgkc7wMvRxthN0xQPJzt0qeer7q86EmXs5hARERERERFVOAa9yGTFpGRi8rz9eHFJKLJz89GnUVUsmtQRPi72Zf6dfx+6hEV7I9RXSzOomW6J46ojV4zdFCIiIiIiIqIKx/VhZJLZXUsPXMJ7K44jKSMHttZWeLpPfTzeqx6sra2Ql5dX5t/98aowRCVnwt/dEUNbVocl6d/ED69ZWyEsKgVnr6ZaXF0zIiIiIiIisizM9CKTcjEhHQ/P3ofn/zisAl7B1d3xzxNd8WSf+irgRWXn6Wz//yWOocz2IiIiIiIiIvPGoBeZhLz8Avy64xz6f7UVm09ehb2NNV68oyGWTemCJgHuxm6e2bhTv8TxKOt6ERERERERkXnj8kYyusj4dDy96CAORCSq79vX9sbH9zbj8rsK0L+pH177ywonriTjXGwa6vi6VMSfISIiIiIiIjI6ZnqRUf17LAp3frtNBbzcHGzx4bBgLJrYkQGvClzi2LlwF0cucSQiIiIiIiLzxaAXGUV+fgE+Xn0Ck37bj+TMXLSq6YnVz3TDAx1qsXZXBRsU7K++rmRdLyIiIiIiIjJjDHpRpcvMycMTCw/gpy3h6vuJ3YOweFIn1PBy5qtRCfo39YeNtRWOX0nG+dg0HnMiIiIiIiIySwx6UaVKTM/GAzP3YNWRKNjZWOHr+1vitUGNYWfDt2Jl8XaxR+e6Pur+Si5xJCIiIiIiIjPFSANVmvi0bIyesQf7LyTA3dEWcx/pgLtbVecrYASD9Ls4MuhFREREREREZopBL6oUsalZGD1jt1pS5+vqgD8md0ana9lGlamKmwP83R3VV0t2x7UljscuJyMiLt3YzSEiIiIiIiIqd7bl/yuJrheTkokHZuzB6ZhUVHVzwIJHO6JeVVejHKblT3bly3NtiWPHIG/sOBOH1UevYFKPujwuREREREREZFaY6UUVKjo5EyN/3q0CXpJh9fukTkYLeNH1BgZfW+J4NIqHhoiIiIiIiMwOg15UYa4kZaiAV/jVNAR4SMCrI+r4uvCIm9ASRysr4HBkIi4lZhi7OURERERERETlikEvqhASRLn/p904F5uGGl5OKsOrlg8DXqZE6pq1q+2t7q9hthcRERERERGZGQa9qNxFxqfj/p92ISI+HTW9nVXAK9Db2SSO9KtLj2DK/P3qKwGDgv3VYVjNXRyJiIiIiIjIzDDoReXqQlyaCnhdTMhQSxllSWN1TyeTOcqbwmKw6kiU+krAgGt1vUIuJCAqKZOHhIiIiIiIiMwGg15Ubo5eSsKIn3bhclImgqq4YNHEjqjmYToBL/ovfw9HtKnlpe7/e4wF7YmIiIiIiMh8MOhF5WLtsSjc9+MuRCdnoYGfqwp4+bk78uhqwMBrSxxXcYkjERERERERmREGvei2FBQUYOa2cEyatx8ZOXnoVt8XSx7rjKpuDHhpxYBrQa995+NxNSXL2M0hIiIiIiIiKhcMelGZ5eTl4/VlR/HByhMoKABGd6iJWePawd3RjkdVQ2p4OaNFDQ/kFwBrj3OJIxEREREREZkHBr2oTJIzc/DI7H1YsCcCVlbAG3c2xod3B8POhm8pLRrYTFfQfvURBr2IiIiIiIjIPDBCQbcsMj4d907fiW2nY+FkZ4OfH2qLCd2CYCXRL9J0Xa9d4XGIT8s2dnOIiIiIiIiIbhuDXnRL9l9IwN3f78DpmFT4uTvgj8md0K+JH4+ixtXycUHTAHfk5RdgHZc4EhERERERkRlg0ItKbfnhyxg1Yzfi0rJVgOTvx7siuLoHj6CZZXutPsoljkRERERERKR9tsZuAGljh8ZpG8/gi3Wn1Pd9G/vhm5Et4eKgvbfPkJYBSErPgYczi+0XV9fr87WnsONMLI8RERERERERaZ72ohZUqWS52xvLjmDh3kj1/YSudfDqoMawsdZm/a7XBjU2dhNMVt0qrmjo54aT0SlYfyIa97apYewmEREREREREZUZlzdSiTJz8vD4/AMq4CUxrvfvDsYbg5toNuBFNzewmX6J4xUeLiIiIiIiItI0Br2oWKlZuXhk9j6sORYFextrfD+6NR7qWItHy8wNDK6mvm49FYuUzBxjN4eIiIiIiIiozBj0ov+IS83C6Bm7sfNsHFzsbTD74Xaq3hOZvwZ+rgiq4oLsvHxsDIsxdnOIiIiIiIiIyoxBL7rOpcQM3PfTLoReTIK3iz0WTuyIzvV8zeYo9f5iM4Lf/ld9pf+ysrLCoGvZXquPcBdHIiIiIiIi0i4GvajQmZgUDP9hJ8KvpiHAwxGLJ3VC8xqeZnWE0rPy1NJN+Uo3ruu16WQM0rJyeZiIiIiIiIhIkxj0IuVQZCLu+3EXriRlom4VFyx5rDPqVXXl0bFATaq5o5aPM7Jy87H55FVjN4eIiIiIiIioTBj0Imw/HatqeCWk56BFDQ/8MbkzAjydeGQseInjgGBdttcq7uJIREREREREGsWgl4VbdeQKHp69F+nZeehazxfzH+2oanmRZdPX9doUFoPMHC4FJSIiIiIiIu1h0MuCzd9zAY8vOICcvAIMauaPX8a1hauDrbGbRSageQ0PVPd0UsHQLae4xJGIiIiIiIi0h0EvC1RQUIAv1p7E638dRUEBMLpDTXw3qjUcbG2M3TQyoSWOA68tcVx95Iqxm0NERERERER0yxj0sjA5efl44Y9QfLfxjPr+qT718eHdwbCxtjJ208hEd3FcfyIGWblc4khERERERETawqCXBUnOzMEjs/fhzwMXVZBr6j3N8Fy/Biqrh6ioVoFe8HN3QGpWrtrsgIiIiIiIiEhLGPSyEKejU3D3tB3YdjoWTnY2mDmmLUa2r2nsZpEJs7aWJY66gvYrQrnEkYiIiIiIiLSFVcstZIfGF/84jLTsPAR4OOKnh9qiWQ0PWKIPhwUjMycfjnaM95bGXS0CMHvnefx7LAoZ2XlwsmfdNyIiIiIiItIGBr3MWFpWLt5dfgyLQy6q7zvX9cF3o1rBx9UBlqpPYz9jN0FTWtf0RKC3EyLjM7D+RLQKghERERERERFpAdNdzNS+8/G489ttKuAlJbse61kXcx9pb9EBL7p1Uu9taIvq6v7fhy7xEBIREREREZFmMNPLzCSkZWPq6jD8HhKpvpfljF/e3xIdg3yM3TTSqKEtAzBt0xlsPnlVvb+8XOyN3SQiIiIiIiKim2LQy0zk5OVj6YGL+GTNScSnZaufjWofiFcGNoaHk52xm2cyjlxMQnZePuxtrC22rtmtqu/nhsbV3HHiSjJWH43C6A7cAIGIiIiIiIhMH4NeGpedm48/D1zE9M1nVN0l0dDPDR/dE4w2tbyN3TyT8+jcEEQlZ8Lf3RG7X+tj7OZoxt0tA1TQa9mhSwx6ERERERERkSYw6KVRmTl5+CMkEj9sPovLSZnqZz4u9qp219jOtWFnw3JtVH6kgP3UNWHYey4elxMzEODpxMNLREREREREJo1BL43JyM7Dwr0R+GnrWUQnZ6mfVXVzwKQedTG6fU042dsYu4lkhiTI1b62N/aci8fyw5fV+42IiIiIiIjIlDHopRFpWbmYt/sCZmwLR2yqrmZXNQ9Hldk1om0gHO0Y7KKKNbRldRX0WnaIQS8iIiIiIiIyfQx6mbiUzBzM3XUBM7eFIyE9R/2shpcTpvSsh3vbVIeDLYNdVDkGNfPHO/8cU7W9jl1OQtMAbgRAREREREREpotBLxOVlJ6DWTvO4dcd55Ccmat+VsfXBVN61sXdraqzZhdVOk9ne/Rr6oeVoVeweF8k3h3KoBcRERERERGZLga9TExKZi7m7ApXmV0pWbpgV72qrniydz3c2awabFmgnozo/raBKuj118FLeHdoMF8LIiIiIiIiMlkMepnQbozLTqZhxcothcsYG/m74cne9TEw2B/W1lbGbiIRutbzRXVPJ1xKzODRICIiIiIiIpPGoJeRFRQUYO3xaLy/4jguJugCCUFVXPBcvwYYFFyNwS4yKRJ8Hd6mBr7ZcNrYTSEiIiIiIiK6IQa9jOjs1VS8u/w4tp66qr73cbLGS4Oa4N7WgVzGSCbrvrY18O1GBr2IiIiIiIjItDHoZQRpWbn4buMZ/LI9HDl5BbC3scb4rrXR1TsVHVvXgA3rdlWY9c/3UNl1VlZcLlpWNbyc1TJHIiIiIiIiIlPGoFclkmDLP4cv4+NVYYhKzlQ/69WwCt6+qykCvRxx6NChymyORXJ14Fu+PIxqX7Ncfg8RERERERFRRWEEoJIcvZSEd5cfw77zCer7mt7OePuuJujT2E99n5eXV1lNIbpt/Zvo3rdEREREREREpopBrwp2JSkD3244jUX7IlFQADjZ2WBKz7p4tHsQHO1sYIkSEhKwYcMG9bV+/fro3r07rK2tS3x8dHQ0tm3bhsTERFSvXl09vjg5OTmYPXs2hgwZAj8/BmUqki2X4BIREREREZGJKznSQLflcmIG3vnnGHp8uhkL9+oCXne1CMCG53vgyT71LTbglZSUhDfffFMFsgIDA7F8+XLMnDmzxMefP38er7zyCtLS0lC7dm3s27cP77zzjgpwFfXnn39i06ZNSE5OLvH3zdwWjq/WnVJfiYiIiIiIiMh8MdOrHOXk5WPHmVjM3xOBDSeikV+g+3n7Ot54oX9D9dXSrVq1Cv7+/nj88cfV9+3atcMzzzyDwYMHIyAg4D+PX7ZsGbp27YqxY8eq7yXL66mnnsKpU6fU/6t37tw5FfC6md//XoO4bCt4OtmjIGwDvL29MXDgQMTGxmLz5s0q46xfv37XZYrFxcVh48aNKphWq1Yt9OzZE7a2///oHDt2DCdq1UJ89epws7dHl4gI1Kypq3klbXJxcUF2djZOnDgBNzc39OnTB1WqVLnNI0lEREREREREN8JMr3LYifHfY1F4bvEhtP1gPcb9ug/rjusCXp2CfLBgQgf8PrEjA14GAaIWLVoUHj8fHx/UqFEDR48eLfb4SpBr0KBBhd/b29urwJEEkfRyc3Px888/Y9SoUTd9vRwyYlA74SDcEk+jTp062LFjBz766CP8+OOPKtB16dIlfPDBB+p3CslIe+2119TSSglk7dmzB++++25hDbZ169bh+++/h1NuLurGxSHc1VVloumzzU6fPq0y2eTvSMBMgnXy/+t/PxERERERERFVDGZ6lSHIFXIhAbvD49TtyMUk5OpTugB4u9hjSIsAPNixJupVdSvv10vz4uPjVaDLkGRbSTZVcVq3bn3d9xI0unz5ssrG0vvnn3/g7u6uMrAk+HUzBVZAdM2+6Nu3L2xsbDBjxgx89tlnql5Y586dMWnSJFy5ckUtv/zjjz9URtmECRPU/ytZWi+88AK2bt2KXr16qay1V199FYGdOgGXLqFzTg4meHvj4sWLaNKkifp/nJyc1P8jf6tLly6YOHGiCoY1bty4TMeQiIiIiIiIiG6OQa9bDHKFXkxCnkGQSwR6O6FfY3/c0dQPbWp5scj3DUiGluHSQPUmtLUtVeaTBMamTZuGoUOHFgbOJLi0Zs0afPjhh6V/Te29ASsrdd/DwwN2dnYq4CUki0w9Ji1NfQ0LC4Ovr6/K5tKTtoaHh6ugV7NmzVBQUIArTk64HBCA89d+j+FunFKLTAJeQpY6Ojo6IjMzs9TtJSIiIiIiIqJbx6BXEQlp2TgUmYi95+NLDHLV8HJCxyAfdetQxxuB3s5lOPSWSQI+hksThQSA5Oc3IssMP/74Y3Tq1An33nsvDh06hPz8fPz0008YPnz4LdXIyre6/m0vQa8bFd7v2LGjClzpyfJMCYTpg2I//PADUlu1Qu24ONTPyvrPTpSS6WXIyspKBcqIiIiIiIiIqOJYdNArKzcPJ66k4FBEggp0HYxMxIW49P88jkGu8iPLASWAZSgmJgbdunW74Q6OsvzwrrvuwoABAwqzqA4cOKAK2EstLlkuaLiLoyxTlHpgt0uWXnp5eali+sWRWmAtW7bE2D//hPWlS8gKDMQ/14rYExEREREREZHx2FrSzopnr6bi+OVklb0lQS65n52X/5/HBvm6oHUtL2ZyVYC2bdti7dq1asdEZ2dnhIaGIiEhAc2bNy/28RLUkgyvhx9+WGV5GZLC8pMnT77uZ1Iwvn79+oXLFW9X+/btsX79evTo0QOurq5qaeOiRYtUPS6pNyYF7iULTJ/btTwwUH1loXoiIiIiIiIi47I1x+DW5cQMRMZnqCDXsctJOH4lGaeiUosNcHk526FloCdaBnqhZU1PtKjhAU9ne6O03RJI8fiQkBC8/PLLatdGKUw/btw4VYheX6Pr77//xoMPPqh+9s0336h6WJLVJTchSwOlppdkWFWrVu263z99+nQVQKtbt265tHfYsGE4efKkam9QUBAuXLig2iV1xWSZomSezZ07FwebNEF806awsbVVSx9jY2PL5e8TERERERERkYUEvSTgEZ/2v/buBDaqao/j+L8t7XSDbrK0lOVZ5FEoi8RXTAiuiDsE1FgXikLdWExVRIIiVCMQg6IhPjcUihqUREMkihEUMaJPQLT0mWIRHhTKY3m0pdDplNL25X9kynQ6XaaltPf2+0maduaeXuae3iGZX/7nf87If/5XJgeLnSbcOljklIIipxwqLpf/niwXrxZctbo6ukhyQjcZktDtXNAVLX1jw014gYtDm9bPmzfPhF2lpaUybdq02v5YSquptGeWw+Ew1VLar8ub9vJyN5r3Nn36dLPcsSGnYv4uJ8oqJPLcY63Scu/M6HmOhIQE87NWo2VlZZnXqxVp48ePlwEDBtTeM2lpaabn17EJE6RnQYH0i4iQ3a+8UtusX5vde/fv0n/Ps0cYAAAAAAC48AJq2rCjtvZe0objWpHj3r3OH67KKvl34Un5taBE8o6Uyr7jZbLv+GkpdTW+05+jS6Dpw/W3SyJkcHw3GZzQTQbHR5ldFjtqwNXauepMWjNXGdnb5UTZGYmLCJEVU/5x4V5UYqJIYaGILqs8dEg6Cu4rAAAAAEBn1WEqvTR700otbSa/80Cx/FpQbJYlVlbVz+Q0t0qICjNVWhpk9YnR7+d/viTSIYGBHTPcQvu6oEEXAAAAAADosNot9DrprJRdhSWSc7BEcs41lj9+qqLeuEsiQ+TyvjEyrHeUJPWIlEu7R0j/uAgJDaYaCgAAAAAAABc59DpztloOFTkl91iF7NlxSA6XVsih4r/6bhXqV0l5/RcTGGCWIo7sGyOX940233WZYkddkggAAAAAAACbhV4VZ6vkcInLNJE3QVbJ+UBLvx895ZLz3cKKfZ6jX1y4DEv8a8fE4X2iJSUhSsJCqOBC29AG+Lt375aSkhKJjo6WQYMGSWBgINMNAAAAAIANtSj0GrVokxwtrb8U0VtocKDEhQZIUq8YSYwNN1VbvaPDJDEmXJK6R0h0eEhL/nnAb9u2bZPVq1fL1sChUhnkkOCqChld/U9JT0+X1NRUZhQAAAAAAJtpUejlDrzCgoNM83gNsrSRvDvQ6h2j38MkOjRIcnJy2JEQ7R54vfbaa+bnsoRYOdMlXELOOqXocJF5PjMzk+ALAAAAAACbaVHotW7GaOkTEyaxESGN9tuqqqpqzWuzJd2lsqKiwudcVVZWisvlkqAglng2xp+50iWN2dnZjY7RCrCUlJRWLXV01NRIgPvv63KJFebK4XDQLw8AAAAAYFstCr1G9Im+8K+kE9BAJCsrS/Lz89v7pcBDUVGRZGRktGpOlhcXS5yeq7hYZk2daon5HThwoCxYsIDgCwAAAABgS3TxBgAAAAAAgO20ePdG+E+XgmplTUPLG3Nzc2Xo0KEsb2yCP3OluzW+/PLLTf5t5syZY3ZzbCnHli0i5eUSGxMj77//vlhhrljeCAAAAACwM0Kvdgi+QkNDfYYTwcHB5hg9vRrnz1wNGzZMYmNjzRLGhsTFxZlxrenpJed62zX0920v3FcAAAAAgM6K5Y2wNQ2y0tPTGx0zefLk1gVeAAAAAACgw+GTPmwvNTVVMjMzTcWXd4WXPq/HAQAAAABAJ1/eWF1dLS6Xq9lLq5TT6WTJHnN1wbTkvkpJSZElS5ZI4Yp/SYmrSqJDY2RxxmJT4aXnabVLLxWJjBTp0UNfmHQUbf0e1KWcVMkBAAAAADqigJqamhp/fkE/POfl5bXdKwJgGcnJyRIeHt7eLwMAAAAAgNaHXv5Ueu3du1dmz54tS5culaSkJH/+mU6HuWKurHhfUekFAAAAALDN8kZdytTcyg4du3//fr9+p7Nirpgr7isAAAAAAC4cGtkDAAAAAADAdto09OrevbvMnDnTfAdzxX118fEeBAAAAAB0Vn739AIAAAAAAAA6OpY3AgAAAAAAwHYIvQAAAAAAAGA7hF4AAAAAAADo3KGX0+mUhQsXyvXXXy+33XabfPLJJ42OP3r0qMydO1fGjRsnt99+uyxbtkxcLleLz2clx44dkyeeeEKuvfZaufPOO2Xz5s2Njs/Pz5fp06fLddddJ5MmTZLVq1eLZ7u1po5b2d69e+Whhx6Sq6++WiZPniy7du1qdPz27dvlwQcfNHN79913yxdffOFz3NmzZ+Xee++Vjz76SOxCr12vSefq0UcflYMHDzY6fsOGDZKWlmbmasqUKbJt27Y6x/W+evjhh+Wqq66SiRMnytq1a9v4CgAAAAAA6ICh1/z58+XPP/+Ut99+W55++ml59dVX5csvv/Q5tqqqynyY1uDhnXfekRdffFE2btwoL730UovOZyUaRmkgERQUJCtXrjQhxZNPPim///67z/ElJSUmxLnssstMmJWZmSlvvvmmrFq1qlnHrUyDzwceeEAGDRokH3zwgYwZM0amTp1qQsPGArKxY8fKhx9+aEIyDVY3bdpUb+yKFSvkl19+qRO0WllBQYF5T2lArPdBr169ZNq0aXLmzBmf47///nuZN2+euXd0rjQo0/F//PGHOX78+HEzf/Hx8fLxxx+b+2rRokWyZcuWi3xlAAAAAAC0Y+ilVVtaUaOVWQMGDDAfoPUDeHZ2ts/xGvDs2bPHhF39+/eXESNGmMonPYeGQv6ez0q0mkbDmRdeeMFcu1Zm3XLLLSZ48OW7776T0NBQMz+JiYmm6kaDoPXr1zfruJXpPeBwOEwo2LdvX3MPJCcny6efftrg+JEjR8p9990nvXv3NgGQVhF6V3vp/GvgqGPsYs2aNXLFFVeYELVfv34mNNZAr6Eqws8++0zuuOMOufHGG808aJg4ZMgQ+frrr81xvR/j4uJkwYIFkpCQYN6DP/zwg6Smpl7kKwMAAAAAoB1Dr9zcXImIiDABldvw4cNNuFVZWVlvvFbu/PjjjxIWFlb73OnTpyU8PFwCAgL8Pp+V5OTkyMCBA821umno99tvv/kcf9NNN8m6devqPKdzpfPTnONWnyv9u+s94aaP9XlftFJp+fLljc5FdXW1PPvss2Y5aM+ePcUudE70PnLTSsKUlJQG7ysNnGfPnl3nubKystq50nBWA7HAwPP/DURGRtZ5zwIAAAAAYPvQq7i4WGJjY+s8FxMTYwKqU6dO1RsfEhIi0dHRtY+1IuXdd981VTktOZ+V+Lo2nYuioiKf47WKq2vXrrWPdWmf9jcbP358s45bmc6Jr7k6ceKEz/Ea2HgGXHl5efLtt9+aii83XfqndOmenTQ0Vw3dV3rP6L3j9tVXX8mBAwfkhhtuMI+PHDlizqdLIK+55hrTH03nEgAAAACAThV6aY8uz2ocf2jPIe0XpB+w9Xtrz9fR+bq25l6r9u/SJX7asP6uu+7y+7jVaFVWS+dKm7hr77THHntMrrzyytrntN+Z9o7zrGCyg9bM1c6dO0312+LFi6VPnz6170vtpzdq1CjT7F83XHj88cdlx44dbfL6AQAAAAC4mJqdCkRFRUlpaWmd57QiSz9065KohuhyKg0m3A3ttX9Ta85nBb6uTR9369at0d/TPmdanaTL+7ShuL/HrTpX3pV9zZkrbcaufb30a8aMGeY57RWnwY4ugUxKShK7aeg909RcaZ8uDQZ1ueOtt95a+7y+z7Tqa8KECabnl4aoGqZ+/vnnbXYNAAAAAAB0uNBLm4vrsj0NXjyDB+3JpUsZfdHxU6ZMMbvMvfXWW3V6XLXkfFah16a7UmrFl+e16fMN2b9/v9xzzz2m4X1WVla9KqWmjluVzol7N8HmzpVWLemOhE899ZSpenM7fPiw/Pzzz2bXRq1e0q9du3aZHmB2WOrYkrnS3VDnzJlj5kDvHU+DBw+udx/pe8/qPfUAAAAAAFDNTk50F0LdNU+XR5WXl5tlZNqjq6Eldk6n0wQT+oFcq5K6dOnSqvNZyejRo00vpddff91UuGkDct1JT5eP+aK9le6//37zpRU5/h63sptvvln27dsna9euNcv3vvnmG7MBwsSJE32O140OMjIyzM6YWqHkKT4+Xn766SfTu2rDhg3mS3cr1PFvvPGGWJ3OycaNG03lls7VqlWrzHLXcePG+RyvY5977jkTAvrakTEtLc3cl1u3bjWPdVmj/o7+TQAAAAAAsLqAGl0T1kyFhYVmNzjdeVF3jtPKo2eeeaa2r9CsWbPMkikNslauXClLliwxS6+8q0k2b95sqr6aOp+VaYXR3LlzpaCgwARg2ispPT299rg29Nfm64888ojMnz/fhD6ejf9Vjx49ZP369U0etzq9HxYuXGia1+s1alCjO1a6+06NGTNGnn/+ebM0T+dw+/bt9Zb0aYCqvby86T01duxYs+TRDtasWSPLli0zoXJiYqIJlPXaVX5+vqloe++998yujjpvWk3pvcvnpEmTzPtM6a6gS5cuNTtg6q6NM2fONEtGAQAAAADoVKGXm37g1iDHO8zSD85Kgy8dozs2+uK9A11D57MD7WmmAZ93kHfy5EmzlEyDBp03DXe8aRCofZyaOm4Xep2++rnp7oT6vM6XzpvnslG34ODgOjtceva80mOeuxhanVZ56XvLc7mw0nnR+dFAUCsrG9st1PN39b8AvU+t3ksPAAAAAIBWh14AAAAAAABAR2a/0ioAAAAAAAB0eoReAAAAAAAAsB1CLwAAAAAAANgOoRcAAAAAAABsh9ALAAAAAAAAtkPoBQAAAAAAANsh9AIAAAAAAIDtEHoBAAAAAADAdgi9AAAAAAAAYDuEXgAAAAAAALAdQi8AAAAAAACI3fwfOT82is6iTl8AAAAASUVORK5CYII='/>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_plot_collection = az.plot_dist(\n",
+    "    idata,\n",
+    "    var_names=var_names,\n",
+    "    ci_prob=None,\n",
+    "    point_estimate=None,\n",
+    ")\n",
+    "\n",
+    "for _var in var_names:\n",
+    "    _axis = _plot_collection.get_viz(\"plot\", _var)\n",
+    "    _posterior_values = idata[\"posterior\"].dataset[_var].values.ravel()\n",
+    "    _lower, _upper = np.quantile(_posterior_values, [0.005, 0.995])\n",
+    "\n",
+    "    _axis.axvline(\n",
+    "        np.mean(_posterior_values),\n",
+    "        color=\"C0\",\n",
+    "        linestyle=\"--\",\n",
+    "        linewidth=2,\n",
+    "        label=\"posterior mean\",\n",
+    "    )\n",
+    "    _axis.axvline(\n",
+    "        true_params[_var],\n",
+    "        color=\"red\",\n",
+    "        linestyle=\"-\",\n",
+    "        linewidth=2,\n",
+    "        label=\"true value\",\n",
+    "    )\n",
+    "    _axis.set_xlim(_lower, _upper)\n",
+    "\n",
+    "_plot_collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "RGSE",
+   "metadata": {
+    "marimo": {
+     "config": {
+      "hide_code": true
+     },
+     "md_prefix": "r"
+    }
+   },
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "HSSM's analytical Poisson race likelihood can recover the generating\n",
+    "accumulator rates, thresholds, and non-decision time in this synthetic\n",
+    "example. Model-level prior presets are relevant when those parameters are\n",
+    "regression targets; explicit parameter priors remain the appropriate tool\n",
+    "for changing this intercept-only model."
+   ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -561,98 +324,14 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "pygments_lexer": "ipython3"
   },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {
-     "26ff45f651b845018ca53d5e6773ae52": {
-      "model_module": "@jupyter-widgets/base",
-      "model_module_version": "2.0.0",
-      "model_name": "LayoutModel",
-      "state": {
-       "_model_module": "@jupyter-widgets/base",
-       "_model_module_version": "2.0.0",
-       "_model_name": "LayoutModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/base",
-       "_view_module_version": "2.0.0",
-       "_view_name": "LayoutView",
-       "align_content": null,
-       "align_items": null,
-       "align_self": null,
-       "border_bottom": null,
-       "border_left": null,
-       "border_right": null,
-       "border_top": null,
-       "bottom": null,
-       "display": null,
-       "flex": null,
-       "flex_flow": null,
-       "grid_area": null,
-       "grid_auto_columns": null,
-       "grid_auto_flow": null,
-       "grid_auto_rows": null,
-       "grid_column": null,
-       "grid_gap": null,
-       "grid_row": null,
-       "grid_template_areas": null,
-       "grid_template_columns": null,
-       "grid_template_rows": null,
-       "height": null,
-       "justify_content": null,
-       "justify_items": null,
-       "left": null,
-       "margin": null,
-       "max_height": null,
-       "max_width": null,
-       "min_height": null,
-       "min_width": null,
-       "object_fit": null,
-       "object_position": null,
-       "order": null,
-       "overflow": null,
-       "padding": null,
-       "right": null,
-       "top": null,
-       "visibility": null,
-       "width": null
-      }
-     },
-     "570059d09f2140c6a4ef2f7f912fc4c8": {
-      "model_module": "@jupyter-widgets/output",
-      "model_module_version": "1.0.0",
-      "model_name": "OutputModel",
-      "state": {
-       "_dom_classes": [],
-       "_model_module": "@jupyter-widgets/output",
-       "_model_module_version": "1.0.0",
-       "_model_name": "OutputModel",
-       "_view_count": null,
-       "_view_module": "@jupyter-widgets/output",
-       "_view_module_version": "1.0.0",
-       "_view_name": "OutputView",
-       "layout": "IPY_MODEL_26ff45f651b845018ca53d5e6773ae52",
-       "msg_id": "",
-       "outputs": [
-        {
-         "data": {
-          "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">                                                                                                                   \n <span style=\"font-weight: bold\">                      </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\">           </span> <span style=\"font-weight: bold\"> Grad      </span> <span style=\"font-weight: bold\">                    </span> <span style=\"font-weight: bold\">          </span> <span style=\"font-weight: bold\">          </span> \n <span style=\"font-weight: bold\"> Progress             </span> <span style=\"font-weight: bold\"> Draw      </span> <span style=\"font-weight: bold\"> Divergen… </span> <span style=\"font-weight: bold\"> Step size </span> <span style=\"font-weight: bold\"> evals     </span> <span style=\"font-weight: bold\"> Speed              </span> <span style=\"font-weight: bold\"> Elapsed  </span> <span style=\"font-weight: bold\"> Remaini… </span> \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━</span>   6000        8           0.163       19          446.48 draws/s       0:00:13    0:00:00   \n  <span style=\"color: #d62728; text-decoration-color: #d62728\">━━━━━━━━━━━━━━━━━━━━</span>   6000        2           0.147       23          417.20 draws/s       0:00:14    0:00:00   \n                                                                                                                   \n</pre>\n",
-          "text/plain": "                                                                                                                   \n \u001b[1m                      \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m           \u001b[0m \u001b[1m \u001b[0m\u001b[1mGrad     \u001b[0m\u001b[1m \u001b[0m \u001b[1m                    \u001b[0m \u001b[1m          \u001b[0m \u001b[1m          \u001b[0m \n \u001b[1m \u001b[0m\u001b[1mProgress            \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDraw     \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mDivergen…\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mStep size\u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mevals    \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mSpeed             \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mElapsed \u001b[0m\u001b[1m \u001b[0m \u001b[1m \u001b[0m\u001b[1mRemaini…\u001b[0m\u001b[1m \u001b[0m \n ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━\u001b[0m   6000        8           0.163       19          446.48 draws/s       0:00:13    0:00:00   \n  \u001b[38;2;214;39;40m━━━━━━━━━━━━━━━━━━━━\u001b[0m   6000        2           0.147       23          417.20 draws/s       0:00:14    0:00:00   \n                                                                                                                   \n"
-         },
-         "metadata": {},
-         "output_type": "display_data"
-        }
-       ],
-       "tabbable": null,
-       "tooltip": null
-      }
-     }
-    },
-    "version_major": 2,
-    "version_minor": 0
-   }
+  "marimo": {
+   "app_config": {
+    "width": "medium"
+   },
+   "header": "\"\"\"Simulate and fit an analytical Poisson race model with HSSM.\n\nThis marimo notebook is the source of truth for the output-bearing Jupyter\nartifact published by MkDocs. Run a quick local check with::\n\n    uv run --group notebook --group docs marimo check --strict \\\n        docs/tutorials/poisson_race.py\n    uv run --group notebook --group docs marimo export html --no-sandbox \\\n        docs/tutorials/poisson_race.py \\\n        --output /tmp/poisson-race.html --force\n\nRegenerate the committed full-run artifact with::\n\n    FULL_RUN=1 uv run --group notebook --group docs marimo export ipynb \\\n        --no-sandbox docs/tutorials/poisson_race.py \\\n        --output docs/tutorials/poisson_race.ipynb \\\n        --include-outputs --force\n    uv run ruff format docs/tutorials/poisson_race.ipynb\n\"\"\"\n\n# ruff: noqa: B018, D401, E501, PLR1711  (generated marimo notebook: prose, display expressions, and bare returns)\n",
+   "marimo_version": "0.24.0"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/poisson_race.py
+++ b/docs/tutorials/poisson_race.py
@@ -1,0 +1,217 @@
+"""Simulate and fit an analytical Poisson race model with HSSM.
+
+This marimo notebook is the source of truth for the output-bearing Jupyter
+artifact published by MkDocs. Run a quick local check with::
+
+    uv run --group notebook --group docs marimo check --strict \
+        docs/tutorials/poisson_race.py
+    uv run --group notebook --group docs marimo export html --no-sandbox \
+        docs/tutorials/poisson_race.py \
+        --output /tmp/poisson-race.html --force
+
+Regenerate the committed full-run artifact with::
+
+    FULL_RUN=1 uv run --group notebook --group docs marimo export ipynb \
+        --no-sandbox docs/tutorials/poisson_race.py \
+        --output docs/tutorials/poisson_race.ipynb \
+        --include-outputs --force
+    uv run ruff format docs/tutorials/poisson_race.ipynb
+"""
+
+# ruff: noqa: B018, D401, E501, PLR1711  (generated marimo notebook: prose, display expressions, and bare returns)
+import marimo
+
+__generated_with = "0.24.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import logging
+    import os
+    import warnings
+
+    # This tutorial does not need a GPU. Keep Molab and headless documentation
+    # builds away from host CUDA plugins before importing HSSM/JAX.
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    os.environ["JAX_SKIP_CUDA_CONSTRAINTS_CHECK"] = "1"
+    warnings.filterwarnings("ignore")
+    logging.getLogger("jax._src.xla_bridge").setLevel(logging.CRITICAL)
+
+    import arviz as az
+    import marimo as mo
+    import numpy as np
+
+    import hssm
+
+    hssm.set_floatX("float32")
+    az.style.use("seaborn-v0_8-whitegrid")
+
+    FULL_RUN = os.environ.get("FULL_RUN") == "1"
+    return FULL_RUN, az, hssm, mo, np
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    # Poisson race models
+
+    This short tutorial shows how to:
+
+    1. simulate synthetic reaction times with the Poisson race simulator from
+       `ssm-simulators`;
+    2. fit HSSM's analytical Poisson race likelihood; and
+    3. compare the recovered posterior with the generating parameters.
+    """)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Simulate with ssm-simulators
+
+    `hssm.simulate_data` wraps the `ssm-simulators` Poisson race generator.
+    The simulator and HSSM likelihood share the same accumulator-specific
+    parameter names: `r1`, `r2`, `k1`, `k2`, and the non-decision time `t`.
+    """)
+    return
+
+
+@app.cell
+def _(hssm, mo):
+    true_params = {
+        "r1": 1.0,
+        "r2": 5.0,
+        "k1": 2.0,
+        "k2": 2.0,
+        "t": 0.25,
+    }
+
+    data = hssm.simulate_data(
+        model="poisson_race",
+        theta=true_params,
+        size=500,
+        random_state=123,
+    )
+    mo.md(data.head().to_markdown(index=False))
+    return data, true_params
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Fit the Poisson race likelihood
+
+    This model has no regression terms, so its positive simple-parameter priors
+    come from HSSM's model configuration. The model-level `prior_settings`
+    selector is not a prior dictionary: it accepts only `"safe"` or `None` and
+    controls generated **regression-term** priors. To replace a prior here,
+    provide it through a parameter specification such as `include=[...]` or a
+    parameter keyword.
+
+    Because this is a synthetic recovery check, we start NUTS adaptation at the
+    known generating point. Initial values choose where adaptation begins; they
+    do not change the posterior target. With real data, use scientifically
+    plausible starts and diagnose multiple chains.
+    """)
+    return
+
+
+@app.cell
+def _(FULL_RUN, data, hssm, true_params):
+    _draws = 3_000 if FULL_RUN else 250
+    _tune = 3_000 if FULL_RUN else 250
+
+    _poisson_model = hssm.HSSM(
+        data=data,
+        model="poisson_race",
+        loglik_kind="analytical",
+    )
+
+    idata = _poisson_model.sample(
+        draws=_draws,
+        tune=_tune,
+        chains=2,
+        cores=1,
+        target_accept=0.95,
+        initvals=true_params,
+        random_seed=123,
+        progressbar=False,
+    )
+    return (idata,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Compare posteriors against the ground truth
+
+    ArviZ summarizes the marginal posterior distributions. Adding the
+    generating values to the table and plot makes it easy to check whether the
+    fitted uncertainty covers the parameters used to simulate the data. In the
+    plot, solid red lines mark the generating values and dashed blue lines mark
+    posterior means.
+    """)
+    return
+
+
+@app.cell
+def _(az, idata, mo, true_params):
+    var_names = list(true_params)
+    summary = az.summary(idata, var_names=var_names)
+    summary["true_value"] = [true_params[name] for name in summary.index]
+    mo.md(summary.to_markdown())
+    return (var_names,)
+
+
+@app.cell
+def _(az, idata, np, true_params, var_names):
+    _plot_collection = az.plot_dist(
+        idata,
+        var_names=var_names,
+        ci_prob=None,
+        point_estimate=None,
+    )
+
+    for _var in var_names:
+        _axis = _plot_collection.get_viz("plot", _var)
+        _posterior_values = idata["posterior"].dataset[_var].values.ravel()
+        _lower, _upper = np.quantile(_posterior_values, [0.005, 0.995])
+
+        _axis.axvline(
+            np.mean(_posterior_values),
+            color="C0",
+            linestyle="--",
+            linewidth=2,
+            label="posterior mean",
+        )
+        _axis.axvline(
+            true_params[_var],
+            color="red",
+            linestyle="-",
+            linewidth=2,
+            label="true value",
+        )
+        _axis.set_xlim(_lower, _upper)
+
+    _plot_collection
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Takeaway
+
+    HSSM's analytical Poisson race likelihood can recover the generating
+    accumulator rates, thresholds, and non-decision time in this synthetic
+    example. Model-level prior presets are relevant when those parameters are
+    regression targets; explicit parameter priors remain the appropriate tool
+    for changing this intercept-only model.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ validation:
 not_in_nav: |
   tutorials/attentional_ddm.py
   tutorials/link_functions.py
+  tutorials/poisson_race.py
   tutorials/random_slope_safe_priors.py
 
 exclude_docs: |
@@ -121,6 +122,7 @@ plugins:
   - mkdocs-jupyter:
       ignore:
         - tutorials/link_functions.py
+        - tutorials/poisson_race.py
         - tutorials/random_slope_safe_priors.py
       execute: true
       execute_ignore:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ notebook = [
     "ipython>=8.31.0",
     "ipywidgets>=8.1.2",
     "jupyterlab>=4.2.4",
+    "marimo==0.24.0",
     "mistune>=3.0.2",
     "nbconvert>=7.16.5",
     "nb-clean>=4.0.1",

--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -43,7 +43,16 @@ class aDDM(HSSMBase):
     include
         Optional list of regression/parameter specifications (HSSM's standard
         ``include=[...]`` machinery), e.g. a hierarchical regression on ``eta``.
-    p_outlier, lapse, prior_settings, missing_data, deadline, **kwargs
+    link_settings
+        Link-function preset for regression parameters without an explicit link.
+        Accepts ``"log_logit"`` or ``None`` and is forwarded through ``**kwargs``.
+        Defaults to ``None``.
+    prior_settings
+        Generated regression-term prior preset. ``"safe"`` uses HSSM defaults;
+        ``None`` delegates missing regression-term priors to Bambi. Parameters without
+        regressions retain their explicit, model-config, or bounds-derived priors.
+        Defaults to ``"safe"``.
+    p_outlier, lapse, missing_data, deadline, **kwargs
         Forwarded to :class:`hssm.base.HSSMBase`.
     """
 

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -78,6 +78,14 @@ _new_sampler_mapping: dict[str, Literal["pymc", "numpyro", "blackjax"]] = {
 }
 
 
+def _validate_setting_preset(name: str, value: object, preset: str) -> None:
+    """Validate a model-level preset selector at the public boundary."""
+    if value is not None and (not isinstance(value, str) or value != preset):
+        raise ValueError(
+            f"`{name}` must be either {preset!r} or None, but got {value!r}."
+        )
+
+
 class classproperty:
     """A decorator that combines the behavior of @property and @classmethod.
 
@@ -257,6 +265,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         initval_jitter: float = INITVAL_JITTER_SETTINGS["jitter_epsilon"],
         **kwargs,
     ):
+        _validate_setting_preset("link_settings", link_settings, "log_logit")
+        _validate_setting_preset("prior_settings", prior_settings, "safe")
+
         # ===== Input Data & Configuration =====
         self.data = data.copy()
         self.global_formula = global_formula

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -157,25 +157,30 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         parameters. If you specify parameter-wise regressions in addition, these will
         override the global regression for the respective parameter.
     link_settings : optional
-        An optional string literal that indicates the link functions to use for each
-        parameter. Helpful for hierarchical models where sampling might get stuck/
-        very slow. Can be one of the following:
+        A preset for regression parameters whose link is not specified explicitly.
+        Helpful for hierarchical models where sampling might get stuck or become very
+        slow. Can be one of the following:
 
-        - `"log_logit"`: applies log link functions to positive parameters and
-        generalized logit link functions to parameters that have explicit bounds.
-        - `None`: unless otherwise specified, the `"identity"` link functions will be
-        used.
-        The default value is `None`.
+        - `"log_logit"`: uses identity for bounds `(-inf, inf)`, log for
+        `(0, inf)`, and generalized logit when both bounds are finite.
+        - `None`: uses the `"identity"` link unless a regression parameter specifies
+        another link.
+
+        Explicit per-parameter links take precedence. Parameters without a regression
+        formula have no linear predictor and are unaffected. Defaults to `None`.
     prior_settings : optional
-        An optional string literal that indicates the prior distributions to use for
-        each parameter. Helpful for hierarchical models where sampling might get stuck/
-        very slow. Can be one of the following:
+        A preset for generated regression-term priors. Helpful for hierarchical models
+        where sampling might get stuck or become very slow. Can be one of the
+        following:
 
-        - `"safe"`: HSSM will scan all parameters in the model and apply safe priors to
-        all parameters that do not have explicit bounds.
-        - None: HSSM will use bambi to provide default priors for all parameters. Not
-        recommended when you are using hierarchical models.
-        The default value is `"safe"`.
+        - `"safe"`: fills eligible missing common and group-specific regression-term
+        priors with HSSM's weakly informative defaults.
+        - `None`: leaves missing regression-term priors to Bambi. This is not
+        recommended for hierarchical models.
+
+        Explicit regression-term priors take precedence. This setting does not alter
+        explicit, model-configuration, or bounds-derived priors for parameters without
+        a regression formula. Defaults to `"safe"`.
     extra_namespace : optional
         Additional user supplied variables with transformations or data to include in
         the environment where the formula is evaluated. Defaults to `None`.

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -158,25 +158,30 @@ class HSSM(HSSMBase):
         parameters. If you specify parameter-wise regressions in addition, these will
         override the global regression for the respective parameter.
     link_settings : optional
-        An optional string literal that indicates the link functions to use for each
-        parameter. Helpful for hierarchical models where sampling might get stuck/
-        very slow. Can be one of the following:
+        A preset for regression parameters whose link is not specified explicitly.
+        Helpful for hierarchical models where sampling might get stuck or become very
+        slow. Can be one of the following:
 
-        - `"log_logit"`: applies log link functions to positive parameters and
-        generalized logit link functions to parameters that have explicit bounds.
-        - `None`: unless otherwise specified, the `"identity"` link functions will be
-        used.
-        The default value is `None`.
+        - `"log_logit"`: uses identity for bounds `(-inf, inf)`, log for
+        `(0, inf)`, and generalized logit when both bounds are finite.
+        - `None`: uses the `"identity"` link unless a regression parameter specifies
+        another link.
+
+        Explicit per-parameter links take precedence. Parameters without a regression
+        formula have no linear predictor and are unaffected. Defaults to `None`.
     prior_settings : optional
-        An optional string literal that indicates the prior distributions to use for
-        each parameter. Helpful for hierarchical models where sampling might get stuck/
-        very slow. Can be one of the following:
+        A preset for generated regression-term priors. Helpful for hierarchical models
+        where sampling might get stuck or become very slow. Can be one of the
+        following:
 
-        - `"safe"`: HSSM will scan all parameters in the model and apply safe priors to
-        all parameters that do not have explicit bounds.
-        - None: HSSM will use bambi to provide default priors for all parameters. Not
-        recommended when you are using hierarchical models.
-        The default value is `"safe"`.
+        - `"safe"`: fills eligible missing common and group-specific regression-term
+        priors with HSSM's weakly informative defaults.
+        - `None`: leaves missing regression-term priors to Bambi. This is not
+        recommended for hierarchical models.
+
+        Explicit regression-term priors take precedence. This setting does not alter
+        explicit, model-configuration, or bounds-derived priors for parameters without
+        a regression formula. Defaults to `"safe"`.
     extra_namespace : optional
         Additional user supplied variables with transformations or data to include in
         the environment where the formula is evaluated. Defaults to `None`.

--- a/src/hssm/rl/rlssm.py
+++ b/src/hssm/rl/rlssm.py
@@ -91,9 +91,13 @@ class _RLSSM(HSSMBase):
     lapse : dict | bmb.Prior | None, optional
         Lapse distribution. Defaults to ``None``.
     link_settings : Literal["log_logit"] | None, optional
-        Link-function preset. Defaults to ``None``.
+        Link-function preset for regression parameters without an explicit link.
+        Accepts ``"log_logit"`` or ``None``. Defaults to ``None``.
     prior_settings : Literal["safe"] | None, optional
-        Prior preset. Defaults to ``"safe"``.
+        Generated regression-term prior preset. ``"safe"`` uses HSSM defaults;
+        ``None`` delegates missing regression-term priors to Bambi. Parameters without
+        regressions retain their explicit, model-config, or bounds-derived priors.
+        Defaults to ``"safe"``.
     extra_namespace : dict | None, optional
         Extra variables for formula evaluation. Defaults to ``None``.
     missing_data : bool | float, optional
@@ -447,9 +451,13 @@ class RLSSM(_RLSSM):
     lapse : dict | bmb.Prior | None, optional
         Lapse distribution. Defaults to ``None``.
     link_settings : Literal["log_logit"] | None, optional
-        Link-function preset. Defaults to ``None``.
+        Link-function preset for regression parameters without an explicit link.
+        Accepts ``"log_logit"`` or ``None``. Defaults to ``None``.
     prior_settings : Literal["safe"] | None, optional
-        Prior preset. Defaults to ``"safe"``.
+        Generated regression-term prior preset. ``"safe"`` uses HSSM defaults;
+        ``None`` delegates missing regression-term priors to Bambi. Parameters without
+        regressions retain their explicit, model-config, or bounds-derived priors.
+        Defaults to ``"safe"``.
     extra_namespace : dict | None, optional
         Extra variables for formula evaluation. Defaults to ``None``.
     process_initvals : bool, optional

--- a/tests/addm/test_addm_subclass.py
+++ b/tests/addm/test_addm_subclass.py
@@ -11,6 +11,8 @@ The synthetic data is built directly with numpy (no efficient_fpt dependency).
 collapses near t≈a/b=0.5), so the init log-likelihood is finite.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -84,6 +86,29 @@ def test_construct_explicit_config():
     df = make_addm_dataframe(20)
     model = hssm.aDDM(data=df, model_config=aDDMConfig())
     assert isinstance(model, aDDM)
+
+
+@pytest.mark.parametrize(
+    ("setting_name", "invalid_value", "preset"),
+    [
+        ("prior_settings", "SAFE", "safe"),
+        ("link_settings", "LOG_LOGIT", "log_logit"),
+    ],
+)
+def test_addm_rejects_invalid_setting_presets(setting_name, invalid_value, preset):
+    """The aDDM constructor reaches the guard before parameter construction."""
+    with patch("hssm.base.Params.from_user_specs") as make_params:
+        with pytest.raises(
+            ValueError,
+            match=rf"`{setting_name}` must be either '{preset}' or None",
+        ):
+            hssm.aDDM(
+                data=make_addm_dataframe(4),
+                process_initvals=False,
+                **{setting_name: invalid_value},
+            )
+
+    make_params.assert_not_called()
 
 
 def test_is_hssmbase_subclass():

--- a/tests/rl/test_choice_only_rl.py
+++ b/tests/rl/test_choice_only_rl.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import bambi as bmb
 import jax.numpy as jnp
 import numpy as np
@@ -230,6 +232,33 @@ def test_choice_only_rlssm_warns_for_missing_declared_choices():
             p_outlier=None,
             prior_settings=None,
         )
+
+
+@pytest.mark.parametrize(
+    ("setting_name", "invalid_value", "preset"),
+    [
+        ("prior_settings", "SAFE", "safe"),
+        ("link_settings", "LOG_LOGIT", "log_logit"),
+    ],
+)
+def test_choice_only_rlssm_rejects_invalid_setting_presets(
+    setting_name, invalid_value, preset
+):
+    """Choice-only RLSSM uses the shared preset validation path."""
+    with patch("hssm.base.Params.from_user_specs") as make_params:
+        with pytest.raises(
+            ValueError,
+            match=rf"`{setting_name}` must be either '{preset}' or None",
+        ):
+            hssm.RLSSM(
+                data=_fake_choice_only_data([0, 1, 0, 1]),
+                model_config=_fake_choice_only_config(),
+                p_outlier=None,
+                process_initvals=False,
+                **{setting_name: invalid_value},
+            )
+
+    make_params.assert_not_called()
 
 
 def _make_shell_rlssm(config, lapse):

--- a/tests/rl/test_rlssm.py
+++ b/tests/rl/test_rlssm.py
@@ -124,6 +124,36 @@ def _register_custom_rldm(
 class TestRLSSMInit:
     """Basic construction and invalid-input guards at construction time."""
 
+    @pytest.mark.parametrize(
+        ("setting_name", "invalid_value", "preset"),
+        [
+            ("prior_settings", "SAFE", "safe"),
+            ("link_settings", "LOG_LOGIT", "log_logit"),
+        ],
+    )
+    def test_invalid_setting_presets(
+        self,
+        rldm_data,
+        rlssm_config,
+        setting_name,
+        invalid_value,
+        preset,
+    ) -> None:
+        """RLSSM reaches the shared preset guard before parameter construction."""
+        with patch("hssm.base.Params.from_user_specs") as make_params:
+            with pytest.raises(
+                ValueError,
+                match=rf"`{setting_name}` must be either '{preset}' or None",
+            ):
+                RLSSM(
+                    data=rldm_data,
+                    model_config=rlssm_config,
+                    process_initvals=False,
+                    **{setting_name: invalid_value},
+                )
+
+        make_params.assert_not_called()
+
     def test_rlssm_init(self, rldm_data, rlssm_config) -> None:
         """Basic RLSSM initialisation should succeed and return an RLSSM instance."""
         model = RLSSM(data=rldm_data, model_config=rlssm_config)

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -449,6 +449,68 @@ def test_invalid_setting_presets_fail_before_model_preparation(
     make_params.assert_not_called()
 
 
+def test_valid_prior_settings_preserve_regression_and_simple_prior_scope(
+    cavanagh_test,
+):
+    """None delegates regression terms while simple HSSM defaults remain."""
+    model_kwargs = {
+        "data": cavanagh_test.iloc[:12],
+        "include": [{"name": "v", "formula": "v ~ 1 + theta"}],
+        "p_outlier": 0.0,
+        "process_initvals": False,
+        "initval_jitter": 0.0,
+    }
+
+    delegated_model = HSSM(**model_kwargs, prior_settings=None)
+    safe_model = HSSM(**model_kwargs, prior_settings="safe")
+
+    assert delegated_model.params["v"].prior is None
+    assert delegated_model.model.components["v"].intercept_term.prior is not None
+    assert isinstance(safe_model.params["v"].prior, dict)
+
+    for name in ("a", "z", "t"):
+        delegated_prior = delegated_model.params[name].prior
+        safe_prior = safe_model.params[name].prior
+        assert delegated_prior is not None
+        assert safe_prior is not None
+        assert delegated_prior == safe_prior
+
+
+def test_valid_link_settings_preserve_links_precedence_and_repr(cavanagh_test):
+    """Valid link presets retain assignment, explicit precedence, and repr behavior."""
+    model_kwargs = {
+        "data": cavanagh_test.iloc[:12],
+        "include": [{"name": "a", "formula": "a ~ 1 + theta"}],
+        "v": 0.0,
+        "z": 0.5,
+        "t": 0.2,
+        "p_outlier": 0.0,
+        "prior_settings": None,
+        "process_initvals": False,
+        "initval_jitter": 0.0,
+    }
+
+    identity_model = HSSM(**model_kwargs, link_settings=None)
+    transformed_model = HSSM(**model_kwargs, link_settings="log_logit")
+    explicit_model = HSSM(
+        **(
+            model_kwargs
+            | {
+                "include": [
+                    {"name": "a", "formula": "a ~ 1 + theta", "link": "identity"}
+                ]
+            }
+        ),
+        link_settings="log_logit",
+    )
+
+    assert identity_model.params["a"].link == "identity"
+    assert transformed_model.params["a"].link == "log"
+    assert explicit_model.params["a"].link == "identity"
+    assert "(ignored due to link function)" not in repr(identity_model)
+    assert "(ignored due to link function)" in repr(transformed_model)
+
+
 @pytest.mark.slow
 def test_prior_settings_basic(cavanagh_test):
     """Apply requested prior-setting modes."""

--- a/tests/test_hssm.py
+++ b/tests/test_hssm.py
@@ -1,7 +1,7 @@
 """Tests for the HSSM public model interface."""
 
 from copy import deepcopy
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pymc as pm
@@ -26,6 +26,13 @@ param_v = {
 }
 
 param_a = param_v | dict(name="a", formula="a ~ 1 + x + y")
+
+
+class _EqualitySpoof:
+    """Object that compares equal to every preset string."""
+
+    def __eq__(self, other):
+        return True
 
 
 @pytest.mark.slow
@@ -400,6 +407,48 @@ def test_model_creation_all_parameters_constant(data_ddm):
 
 
 # Prior settings
+@pytest.mark.parametrize(
+    ("setting_name", "preset"),
+    [("prior_settings", "safe"), ("link_settings", "log_logit")],
+)
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        pytest.param("SAFE", id="wrong-case-safe"),
+        pytest.param("LOG_LOGIT", id="wrong-case-log-logit"),
+        pytest.param("banana", id="arbitrary-string"),
+        pytest.param(False, id="false"),
+        pytest.param(True, id="true"),
+        pytest.param(0, id="zero"),
+        pytest.param(1, id="one"),
+        pytest.param(1.5, id="float"),
+        pytest.param({}, id="mapping"),
+        pytest.param([], id="sequence"),
+        pytest.param((), id="tuple"),
+        pytest.param(np.array(["safe"]), id="array"),
+        pytest.param(_EqualitySpoof(), id="equality-spoof"),
+        pytest.param(object(), id="object"),
+    ],
+)
+def test_invalid_setting_presets_fail_before_model_preparation(
+    cavanagh_test, setting_name, preset, invalid_value
+):
+    """Reject invalid presets before parameter or Bambi model construction."""
+    with patch("hssm.base.Params.from_user_specs") as make_params:
+        with pytest.raises(
+            ValueError,
+            match=rf"`{setting_name}` must be either '{preset}' or None",
+        ):
+            HSSM(
+                data=cavanagh_test,
+                p_outlier=0.0,
+                process_initvals=False,
+                **{setting_name: invalid_value},
+            )
+
+    make_params.assert_not_called()
+
+
 @pytest.mark.slow
 def test_prior_settings_basic(cavanagh_test):
     """Apply requested prior-setting modes."""

--- a/tests/test_initvals.py
+++ b/tests/test_initvals.py
@@ -137,6 +137,31 @@ def _check_initval_defaults_correctness(model) -> None:
             pass
 
 
+@pytest.mark.parametrize(
+    ("link_settings", "expected_link", "expected_initval"),
+    [(None, "identity", 1.5), ("log_logit", "log", 0.0)],
+)
+def test_valid_link_settings_preserve_regression_initvals(
+    cavanagh_test, link_settings, expected_link, expected_initval
+):
+    """Both valid presets retain their documented deterministic starts."""
+    model = hssm.HSSM(
+        data=cavanagh_test.iloc[:12],
+        include=[{"name": "a", "formula": "a ~ 1 + theta"}],
+        v=0.0,
+        z=0.5,
+        t=0.2,
+        p_outlier=0.0,
+        prior_settings=None,
+        link_settings=link_settings,
+        process_initvals=True,
+        initval_jitter=0.0,
+    )
+
+    assert model.params["a"].link == expected_link
+    np.testing.assert_allclose(model._initvals["a_Intercept"], expected_initval)
+
+
 @pytest.mark.slow
 def test_basic_model(caplog):
     """Test basic model with p_outlier distribution defined."""


### PR DESCRIPTION
Closes #1233

## Summary

- Reject unsupported `prior_settings` and `link_settings` values at the shared base boundary, before Formulae or Bambi model construction.
- Lock existing behavior for valid presets across HSSM, aDDM, RT-and-choice RLSSM, and choice-only RLSSM, including prior ownership, explicit-link precedence, representation, and initial values.
- Correct the public documentation and migrate the Poisson-race tutorial to a marimo source plus an output-bearing Jupyter artifact; make marimo available to notebook-only CI.

## Compatibility

- Valid preset behavior and public signatures are unchanged.
- Values that previously entered silent fallback paths now raise an actionable `ValueError`.

## Validation

- Full non-slow suite: 864 passed, 371 deselected.
- Post-rebase affected modules: 112 passed, 49 deselected.
- Ruff, Ruff format, Pyrefly, mypy, and all configured hooks passed.
- Fresh notebook-only execution: 10 cells, zero errors/path leaks, one rendered plot.
- Strict marimo check, full-run artifact review, documentation weight check, and `mkdocs build --strict` passed.
- Independent ecosystem review found no issues.
