### PR TITLE
Capture Bayesian recovery stages

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/benchmark_jeam_recovery_evidence.py"
       - "scripts/benchmark_jeam_repeated_recovery.py"
       - "tests/test_jeam_recovery_evidence_io.py"
+      - "tests/integration/test_jeam_bayesian_evidence_capture.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
       - "tests/integration/test_jeam.py"
       - "tests/integration/test_jeam_model.py"
@@ -56,6 +57,7 @@ jobs:
       - name: Run the Bayesian recovery preflight and gate
         run: >-
           uv run --group jeam-prototype pytest
+          tests/integration/test_jeam_bayesian_evidence_capture.py
           tests/integration/test_jeam_bayesian_recovery.py
 
       - name: Verify the repeated-recovery protocol contract

--- a/scripts/benchmark_jeam_bayesian_recovery.py
+++ b/scripts/benchmark_jeam_bayesian_recovery.py
@@ -37,6 +37,8 @@ from scripts.benchmark_jeam_objective_parity import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from scripts.benchmark_jeam_recovery_evidence import ScenarioEvidenceWriter
+
 DEFAULT_CHAINS = 4
 DEFAULT_TUNE = 1_500
 DEFAULT_DRAWS = 1_500
@@ -149,6 +151,29 @@ def _circular_summary(angles: np.ndarray) -> tuple[float, float]:
 def _circular_distance(first: float, second: float) -> float:
     """Return the absolute shortest angular distance in radians."""
     return float(abs(np.angle(np.exp(1j * (first - second)))))
+
+
+def _validated_dataset(data: object, *, trials: int) -> np.ndarray:
+    """Return an immutable float64 copy of one supported circular dataset."""
+    if not isinstance(data, np.ndarray):
+        raise TypeError("data must be a numpy.ndarray.")
+    if data.dtype != np.dtype(np.float64):
+        raise TypeError("data must use the concrete float64 dtype.")
+    expected_shape = (trials, 2)
+    if data.shape != expected_shape:
+        raise ValueError(
+            f"data must have shape {expected_shape}; received {data.shape}."
+        )
+    if not np.all(np.isfinite(data)):
+        raise ValueError("data must contain only finite values.")
+    if np.any(data[:, 0] <= 0.0):
+        raise ValueError("data response times must be strictly positive.")
+    if np.any(data[:, 1] < -np.pi) or np.any(data[:, 1] >= np.pi):
+        raise ValueError("data angles must lie in [-pi, pi).")
+
+    validated = np.array(data, dtype=np.float64, order="C", copy=True)
+    validated.flags.writeable = False
+    return validated
 
 
 def _summary_interval_columns(summary: pd.DataFrame) -> tuple[str, str]:
@@ -276,6 +301,7 @@ def run_recovery(
     truth: Sequence[float] = tuple(DEFAULT_TRUTH),
     trials: int = DEFAULT_TRIALS,
     data_seed: int = DEFAULT_DATA_SEED,
+    data: np.ndarray | None = None,
     chains: int = DEFAULT_CHAINS,
     tune: int = DEFAULT_TUNE,
     draws: int = DEFAULT_DRAWS,
@@ -284,6 +310,7 @@ def run_recovery(
     prior_seed: int = DEFAULT_PRIOR_SEED,
     predictive_draws: int = DEFAULT_PREDICTIVE_DRAWS,
     predictive_seed: int = DEFAULT_PREDICTIVE_SEED,
+    evidence_writer: ScenarioEvidenceWriter | None = None,
 ) -> RecoveryResult:
     """Fit the fixed circular model and collect recovery diagnostics."""
     if len(chain_seeds) != chains:
@@ -295,13 +322,17 @@ def run_recovery(
             f"({len(PARAMETER_ORDER)},)."
         )
 
-    data = simulate_dataset(truth=truth_values, trials=trials, seed=data_seed)
+    if data is None:
+        data = simulate_dataset(truth=truth_values, trials=trials, seed=data_seed)
+    dataset = _validated_dataset(data, trials=trials)
+    if evidence_writer is not None:
+        evidence_writer.record_dataset(dataset)
     model = hssm.HSSM(
-        data=pd.DataFrame(data, columns=["rt", "response"]),
+        data=pd.DataFrame(dataset, columns=["rt", "response"], copy=False),
         model="circular_diffusion",
         p_outlier=None,
     )
-    minimum_observed_rt = float(np.min(data[:, 0]))
+    minimum_observed_rt = float(np.min(dataset[:, 0]))
     initial_point = _resolved_initial_point(minimum_observed_rt)
     initial_values = dict(zip(PARAMETER_ORDER, initial_point, strict=True))
     initial_logp = float(model.compile_logp()(initial_values))
@@ -311,6 +342,8 @@ def run_recovery(
         random_seed=prior_seed,
     )
     prior_predictive_seconds = perf_counter() - started
+    if evidence_writer is not None:
+        evidence_writer.record_prior(prior)
     prior_values = np.asarray(
         prior["prior_predictive"].to_dataset()["rt,response"].values
     )
@@ -320,7 +353,7 @@ def run_recovery(
             f"Expected prior-predictive shape {expected_prior_shape}, "
             f"received {prior_values.shape}."
         )
-    observed_rt = np.quantile(data[:, 0], PRIOR_RT_QUANTILES)
+    observed_rt = np.quantile(dataset[:, 0], PRIOR_RT_QUANTILES)
     prior_rt = np.quantile(prior_values[..., 0], PRIOR_RT_QUANTILES)
     prior_predictive = PriorPredictiveCheck(
         shape=prior_values.shape,
@@ -357,6 +390,8 @@ def run_recovery(
     sampling_seconds = perf_counter() - started
     if not isinstance(traces, xr.DataTree):
         raise RuntimeError("Expected PyMC sampling to return an xarray DataTree.")
+    if evidence_writer is not None:
+        evidence_writer.record_posterior(traces)
 
     summary = az.summary(
         traces,
@@ -405,11 +440,13 @@ def run_recovery(
     predictive_seconds = perf_counter() - started
     if predictive is None:
         raise RuntimeError("Expected non-inplace posterior predictive output.")
+    if evidence_writer is not None:
+        evidence_writer.record_predictive(predictive)
     predictive_dataset = predictive["posterior_predictive"].to_dataset()
     values = predictive_dataset["rt,response"].values
-    observed_angle, observed_resultant = _circular_summary(data[:, 1])
+    observed_angle, observed_resultant = _circular_summary(dataset[:, 1])
     predictive_angle, predictive_resultant = _circular_summary(values[..., 1])
-    observed_rt = np.quantile(data[:, 0], RT_QUANTILES)
+    observed_rt = np.quantile(dataset[:, 0], RT_QUANTILES)
     predictive_rt = np.quantile(values[..., 0], RT_QUANTILES)
     predictive_recovery = PredictiveRecovery(
         rt_probabilities=tuple(float(value) for value in RT_QUANTILES),

--- a/tests/integration/test_jeam_bayesian_evidence_capture.py
+++ b/tests/integration/test_jeam_bayesian_evidence_capture.py
@@ -1,0 +1,171 @@
+"""Fast contracts for durable JEAM Bayesian recovery capture."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+pytest.importorskip("jeam")
+
+from scripts import benchmark_jeam_bayesian_recovery as recovery
+
+DATA = np.array([[0.8, -0.4], [1.2, 0.7]], dtype=np.float64)
+RESPONSE_DIMS = ("chain", "draw", "observation", "response_dim")
+
+
+class _ModelReached(Exception):
+    pass
+
+
+def _stop_model(events):
+    def constructor(*, data, **_):
+        events.append(("model", data))
+        raise _ModelReached
+
+    return constructor
+
+
+def _response_tree(group: str) -> xr.DataTree:
+    return xr.DataTree.from_dict(
+        {group: xr.Dataset({"rt,response": (RESPONSE_DIMS, DATA.reshape(1, 1, 2, 2))})}
+    )
+
+
+def test_supplied_data_is_copied_without_simulation_and_default_path_still_simulates(
+    monkeypatch,
+):
+    """Use a frozen supplied copy or the unchanged simulation default."""
+    supplied = DATA.copy()
+    events = []
+    writer = Mock()
+    writer.record_dataset.side_effect = lambda value: events.append(("dataset", value))
+    simulator = Mock(side_effect=AssertionError)
+    monkeypatch.setattr(recovery, "simulate_dataset", simulator)
+    monkeypatch.setattr(recovery.hssm, "HSSM", _stop_model(events))
+
+    with pytest.raises(_ModelReached):
+        recovery.run_recovery(data=supplied, trials=2, evidence_writer=writer)
+
+    assert [name for name, _ in events] == ["dataset", "model"]
+    recorded, modeled = events[0][1], events[1][1]
+    assert recorded is not supplied
+    assert (recorded.dtype, recorded.flags.c_contiguous, recorded.flags.writeable) == (
+        np.dtype("float64"),
+        True,
+        False,
+    )
+    assert isinstance(modeled, pd.DataFrame)
+    np.testing.assert_array_equal(modeled.to_numpy(), recorded)
+    supplied[0, 0] = 99
+    assert recorded[0, 0] == DATA[0, 0]
+
+    simulator.side_effect = None
+    simulator.return_value = DATA
+    with pytest.raises(_ModelReached):
+        recovery.run_recovery(trials=2)
+    simulator.assert_called_once()
+    assert [name for name, _ in events] == ["dataset", "model", "model"]
+
+
+@pytest.mark.parametrize(
+    ("data", "trials", "message"),
+    [
+        ([[0.8, 0.0]], 1, "numpy.ndarray"),
+        (np.array([[0.8, 0.0]], dtype=np.float32), 1, "float64"),
+        (np.array([0.8, 0.0]), 1, "shape"),
+        (np.array([[0.8, 0.0]]), 2, "shape"),
+        (np.array([[np.nan, 0.0]]), 1, "finite"),
+        (np.array([[0.0, 0.0]]), 1, "strictly positive"),
+        (np.array([[0.8, -np.pi - 0.01]]), 1, "angle"),
+        (np.array([[0.8, np.pi]]), 1, "angle"),
+    ],
+)
+def test_invalid_supplied_data_has_no_side_effects(data, trials, message, monkeypatch):
+    """Fail every invalid data class before simulation, recording, or modeling."""
+    simulator, model, writer = Mock(), Mock(), Mock()
+    monkeypatch.setattr(recovery, "simulate_dataset", simulator)
+    monkeypatch.setattr(recovery.hssm, "HSSM", model)
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        recovery.run_recovery(data=data, trials=trials, evidence_writer=writer)
+
+    simulator.assert_not_called()
+    model.assert_not_called()
+    assert not writer.method_calls
+
+
+def test_writer_records_raw_stages_with_posterior_before_summary(monkeypatch):
+    """Record each raw object immediately, with posterior before reduction."""
+    prior = _response_tree("prior_predictive")
+    traces = xr.DataTree.from_dict(
+        {
+            "sample_stats": xr.Dataset(
+                {
+                    name: (("chain", "draw"), [[1.0, 1.0]])
+                    for name in ("nstep_in", "nstep_out")
+                }
+            )
+        }
+    )
+    predictive = _response_tree("posterior_predictive")
+    model = Mock(pymc_model={name: object() for name in recovery.PARAMETER_ORDER})
+    model.compile_logp.return_value = lambda _: -12.0
+    model.sample_prior_predictive.return_value = prior
+    model.sample_posterior_predictive.return_value = predictive
+    events = []
+    writer = Mock()
+    for method, name in (
+        (writer.record_dataset, "dataset"),
+        (writer.record_prior, "prior"),
+        (writer.record_posterior, "posterior"),
+        (writer.record_predictive, "predictive"),
+    ):
+        method.side_effect = lambda value, name=name: events.append((name, value))
+
+    def summarize(value, **_):
+        events.append(("summary", value))
+        return pd.DataFrame(
+            {
+                "mean": [1.0, 0.1, 0.0, 0.0],
+                "sd": [0.1] * 4,
+                "hdi_3%_lb": [0.8, 0.08, -0.2, -0.2],
+                "hdi_97%_ub": [1.2, 0.12, 0.2, 0.2],
+                "r_hat": [1.0] * 4,
+                "ess_bulk": [100.0] * 4,
+                "ess_tail": [100.0] * 4,
+                "mcse_mean": [0.001] * 4,
+            },
+            index=recovery.PARAMETER_ORDER,
+        )
+
+    monkeypatch.setattr(recovery, "simulate_dataset", Mock(side_effect=AssertionError))
+    monkeypatch.setattr(recovery.hssm, "HSSM", Mock(return_value=model))
+    monkeypatch.setattr(recovery.pm, "Slice", lambda **_: object())
+    monkeypatch.setattr(recovery, "_sample_with_resolved_init", lambda *_, **__: traces)
+    monkeypatch.setattr(recovery.az, "summary", summarize)
+    monkeypatch.setattr(recovery, "_installed_jeam_revision", lambda: "revision")
+
+    recovery.run_recovery(
+        data=DATA,
+        trials=2,
+        chains=1,
+        tune=2,
+        draws=2,
+        chain_seeds=(1,),
+        prior_draws=1,
+        predictive_draws=1,
+        evidence_writer=writer,
+    )
+
+    assert [name for name, _ in events] == [
+        "dataset",
+        "prior",
+        "posterior",
+        "summary",
+        "predictive",
+    ]
+    assert [value for _, value in events[1:]] == [prior, traces, traces, predictive]


### PR DESCRIPTION
## Base

- #1203 is merged into `dev` at `8c1614a3`.
- This branch now contains only the three Bayesian capture commits, replayed patch-identically onto that accepted base.

## Purpose

Attach the checkpoint interface to the existing one-dataset Bayesian recovery runner without changing its default scientific behavior or return type.

## Scope

- accept an optional caller-supplied exact `float64` dataset and validate its shape, finiteness, positive response times, and half-open circular support
- defensively copy and freeze supplied data, then pass that same array to HSSM without another data copy
- add an optional `ScenarioEvidenceWriter` seam
- checkpoint the dataset and prior predictive output before inference
- checkpoint posterior and sample-stat draws before summary calculations
- checkpoint posterior predictive output immediately after generation
- keep the existing simulation path, sampler, diagnostics, `RecoveryResult`, and CLI behavior unchanged when no writer or dataset is supplied
- run the focused capture contract in the optional JEAM workflow

## Review boundary

This PR does not define bundle provenance, manifests, repeated-scenario orchestration, or commit scientific evidence. Those are separate stacked units. The canonical four-scenario run remains intentionally deferred until the complete capture path is reviewed and merged.

## Verification

- replay range-diff: all three commits patch-identical
- focused Bayesian capture, recovery, and checkpoint tests: `28 passed`, `5 slow deselected`
- optional JEAM fast lane on the assembled stack: `66 passed`, `5 deselected`
- focused Ruff check and format check
- focused mypy
- `git diff --check`
