### PR TITLE
Bind durable JEAM recovery bundles

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -13,8 +13,10 @@ on:
       - "src/hssm/modelconfig/circular_diffusion_config.py"
       - "scripts/benchmark_jeam_bayesian_recovery.py"
       - "scripts/benchmark_jeam_objective_parity.py"
+      - "scripts/benchmark_jeam_recovery_bundle.py"
       - "scripts/benchmark_jeam_recovery_evidence.py"
       - "scripts/benchmark_jeam_repeated_recovery.py"
+      - "tests/test_jeam_recovery_evidence_bundle.py"
       - "tests/test_jeam_recovery_evidence_io.py"
       - "tests/integration/test_jeam_bayesian_evidence_capture.py"
       - "tests/integration/test_jeam_bayesian_recovery.py"
@@ -68,4 +70,5 @@ jobs:
       - name: Verify durable recovery checkpoints
         run: >-
           uv run --group jeam-prototype pytest
+          tests/test_jeam_recovery_evidence_bundle.py
           tests/test_jeam_recovery_evidence_io.py

--- a/scripts/benchmark_jeam_recovery_bundle.py
+++ b/scripts/benchmark_jeam_recovery_bundle.py
@@ -7,6 +7,7 @@ import importlib.metadata as importlib_metadata
 import platform
 import re
 import subprocess
+import tomllib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,8 @@ from scripts.benchmark_jeam_recovery_evidence import (
     _RAW_GROUPS,
     _atomic_bytes,
     _canonical_json_bytes,
+    _fsync_directory,
+    _require_posix_durability,
     _sha256_file,
 )
 
@@ -59,6 +62,38 @@ def _environment_snapshot(*, hssm_revision: str, jeam_revision: str) -> bytes:
     ).encode()
 
 
+def _durable_mkdir(directory: Path) -> None:
+    """Create a directory chain and flush every new parent entry."""
+    missing: list[Path] = []
+    cursor = directory
+    while not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    if not cursor.is_dir():
+        raise NotADirectoryError(cursor)
+    for path in reversed(missing):
+        path.mkdir()
+        _fsync_directory(path.parent)
+
+
+def _declared_jeam_revision(repository: Path) -> str:
+    """Return the exact JEAM commit declared by the HSSM source tree."""
+    with (repository / "pyproject.toml").open("rb") as source_file:
+        configuration = tomllib.load(source_file)
+    try:
+        source = configuration["tool"]["uv"]["sources"]["jeam"]
+    except (KeyError, TypeError) as error:
+        raise RuntimeError("HSSM must declare an exact JEAM source pin.") from error
+    if (
+        not isinstance(source, dict)
+        or source.get("git") != _JEAM_REPOSITORY_URL
+        or not isinstance(revision := source.get("rev"), str)
+        or re.fullmatch(r"[0-9a-f]{40}", revision) is None
+    ):
+        raise RuntimeError("HSSM must declare an exact JEAM Git revision.")
+    return revision
+
+
 def prepare_evidence_bundle(
     directory: str | Path,
     *,
@@ -69,6 +104,7 @@ def prepare_evidence_bundle(
     source_paths: Sequence[str | Path],
 ) -> dict[str, object]:
     """Preflight a clean source tree and create a provenance-bound bundle root."""
+    _require_posix_durability()
     target, repo = Path(directory), Path(repository).resolve()
     imported = Path(imported_hssm_file).resolve()
     if target.exists():
@@ -80,6 +116,12 @@ def prepare_evidence_bundle(
     if status := _git_output(repo, "status", "--porcelain", "--untracked-files=all"):
         raise RuntimeError(f"Evidence capture requires a clean worktree: {status}")
     _git_output(repo, "merge-base", "--is-ancestor", protocol_base_revision, "HEAD")
+    declared_jeam_revision = _declared_jeam_revision(repo)
+    if jeam_revision != declared_jeam_revision:
+        raise RuntimeError(
+            "Installed JEAM revision does not match HSSM's declared pin: "
+            f"{jeam_revision!r} != {declared_jeam_revision!r}."
+        )
     revision = _git_output(repo, "rev-parse", "HEAD")
     tree = _git_output(repo, "rev-parse", "HEAD^{tree}")
 
@@ -93,8 +135,8 @@ def prepare_evidence_bundle(
         hssm_revision=revision, jeam_revision=jeam_revision
     )
 
-    target.mkdir(parents=True)
-    (target / "scenarios").mkdir()
+    _durable_mkdir(target)
+    _durable_mkdir(target / "scenarios")
     _atomic_bytes(target / "environment.txt", environment)
     return {
         "producer_revision": revision,
@@ -155,6 +197,15 @@ def _artifact_record(root: Path, path: Path, role: str) -> dict[str, object]:
     return record
 
 
+def _write_or_attest(target: Path, payload: bytes) -> None:
+    """Create a final document, or accept an identical retry checkpoint."""
+    if target.exists():
+        if not target.is_file() or target.read_bytes() != payload:
+            raise FileExistsError(f"{target} already records different content.")
+        return
+    _atomic_bytes(target, payload)
+
+
 def finalize_evidence_bundle(
     directory: str | Path,
     *,
@@ -168,11 +219,8 @@ def finalize_evidence_bundle(
     result_payload = _canonical_json_bytes(result)
     protocol_sha256 = hashlib.sha256(_canonical_json_bytes(protocol)).hexdigest()
     result_path = root / "result.json"
-    _atomic_bytes(result_path, result_payload)
-
     expected: dict[Path, str] = {
         root / "environment.txt": "environment",
-        result_path: "derived_result",
         **{
             root / "scenarios" / name / filename: role
             for name in names
@@ -187,10 +235,13 @@ def finalize_evidence_bundle(
     if missing:
         relative = ", ".join(path.relative_to(root).as_posix() for path in missing)
         raise RuntimeError(f"Evidence bundle is incomplete: {relative}")
+    environment_hash = _sha256_file(root / "environment.txt")
+    if provenance.get("environment_sha256") != environment_hash:
+        raise RuntimeError("Evidence environment no longer matches its provenance.")
     actual = {
         path
         for path in root.rglob("*")
-        if path.is_file() and path.name != "manifest.json"
+        if path.is_file() and path not in {root / "manifest.json", result_path}
     }
     if unexpected := actual - expected.keys():
         relative = ", ".join(
@@ -198,9 +249,13 @@ def finalize_evidence_bundle(
         )
         raise RuntimeError(f"Evidence bundle has unexpected files: {relative}")
 
-    artifacts = [
-        _artifact_record(root, path, role) for path, role in sorted(expected.items())
-    ]
+    records = {
+        path: _artifact_record(root, path, role) for path, role in expected.items()
+    }
+    _write_or_attest(result_path, result_payload)
+    expected[result_path] = "derived_result"
+    records[result_path] = _artifact_record(root, result_path, "derived_result")
+    artifacts = [records[path] for path in sorted(expected)]
     manifest = {
         "schema_version": 1,
         "bundle": "JEAM repeated-recovery durable evidence",
@@ -210,5 +265,5 @@ def finalize_evidence_bundle(
         "artifacts": artifacts,
     }
     manifest_path = root / "manifest.json"
-    _atomic_bytes(manifest_path, _canonical_json_bytes(manifest))
+    _write_or_attest(manifest_path, _canonical_json_bytes(manifest))
     return manifest_path

--- a/scripts/benchmark_jeam_recovery_bundle.py
+++ b/scripts/benchmark_jeam_recovery_bundle.py
@@ -1,0 +1,214 @@
+"""Provenance and manifest handling for durable JEAM recovery evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata as importlib_metadata
+import platform
+import re
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import xarray as xr
+
+from scripts.benchmark_jeam_recovery_evidence import (
+    _RAW_GROUPS,
+    _atomic_bytes,
+    _canonical_json_bytes,
+    _sha256_file,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_HSSM_REPOSITORY_URL = "https://github.com/lnccbrown/HSSM.git"
+_JEAM_REPOSITORY_URL = "https://github.com/AlexanderFengler/JEAM.git"
+
+
+def _git_output(repository: Path, *arguments: str) -> str:
+    """Run one read-only Git query and return stripped standard output."""
+    return subprocess.check_output(
+        ("git", *arguments), cwd=repository, text=True
+    ).strip()
+
+
+def _environment_snapshot(*, hssm_revision: str, jeam_revision: str) -> bytes:
+    """Return a path-free, normalized installed-distribution snapshot."""
+    packages: dict[str, str] = {}
+    for distribution in importlib_metadata.distributions():
+        raw_name = distribution.metadata.get("Name")
+        if not raw_name:
+            continue
+        name = re.sub(r"[-_.]+", "-", raw_name).lower()
+        version = distribution.version
+        previous = packages.setdefault(name, version)
+        if previous != version:
+            raise RuntimeError(
+                f"Conflicting installed versions for {name!r}: "
+                f"{previous!r} and {version!r}."
+            )
+    packages.update(
+        hssm=f"git+{_HSSM_REPOSITORY_URL}@{hssm_revision}",
+        jeam=f"git+{_JEAM_REPOSITORY_URL}@{jeam_revision}",
+    )
+    return "".join(
+        f"{name} @ {value}\n" if value.startswith("git+") else f"{name}=={value}\n"
+        for name, value in sorted(packages.items())
+    ).encode()
+
+
+def prepare_evidence_bundle(
+    directory: str | Path,
+    *,
+    repository: str | Path,
+    imported_hssm_file: str | Path,
+    protocol_base_revision: str,
+    jeam_revision: str,
+    source_paths: Sequence[str | Path],
+) -> dict[str, object]:
+    """Preflight a clean source tree and create a provenance-bound bundle root."""
+    target, repo = Path(directory), Path(repository).resolve()
+    imported = Path(imported_hssm_file).resolve()
+    if target.exists():
+        raise FileExistsError(target)
+    if Path(_git_output(repo, "rev-parse", "--show-toplevel")).resolve() != repo:
+        raise RuntimeError("repository is not the resolved Git worktree root.")
+    if not imported.is_file() or not imported.is_relative_to(repo / "src" / "hssm"):
+        raise RuntimeError("Imported hssm does not resolve from the capture worktree.")
+    if status := _git_output(repo, "status", "--porcelain", "--untracked-files=all"):
+        raise RuntimeError(f"Evidence capture requires a clean worktree: {status}")
+    _git_output(repo, "merge-base", "--is-ancestor", protocol_base_revision, "HEAD")
+    revision = _git_output(repo, "rev-parse", "HEAD")
+    tree = _git_output(repo, "rev-parse", "HEAD^{tree}")
+
+    source_sha256: dict[str, str] = {}
+    for source_path in source_paths:
+        source = (repo / source_path).resolve()
+        if not source.is_relative_to(repo) or not source.is_file():
+            raise ValueError(f"Invalid evidence source path: {source_path!s}")
+        source_sha256[source.relative_to(repo).as_posix()] = _sha256_file(source)
+    environment = _environment_snapshot(
+        hssm_revision=revision, jeam_revision=jeam_revision
+    )
+
+    target.mkdir(parents=True)
+    (target / "scenarios").mkdir()
+    _atomic_bytes(target / "environment.txt", environment)
+    return {
+        "producer_revision": revision,
+        "producer_tree": tree,
+        "protocol_base_revision": protocol_base_revision,
+        "clean_worktree": True,
+        "jeam_revision": jeam_revision,
+        "source_sha256": dict(sorted(source_sha256.items())),
+        "environment_sha256": hashlib.sha256(environment).hexdigest(),
+        "python": {
+            "implementation": platform.python_implementation(),
+            "version": platform.python_version(),
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+    }
+
+
+def _scenario_names(protocol: Mapping[str, object]) -> list[str]:
+    scenarios = protocol.get("scenarios")
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("protocol must declare a non-empty scenario list.")
+    names: list[str] = []
+    for scenario in scenarios:
+        if not isinstance(scenario, dict) or not isinstance(scenario.get("name"), str):
+            raise TypeError("Each protocol scenario must be a mapping with a name.")
+        name = scenario["name"]
+        if name in names or name in {"", ".", ".."} or re.search(r"[/\\\0]", name):
+            raise ValueError(f"Invalid or duplicate scenario name: {name!r}.")
+        names.append(name)
+    return names
+
+
+def _artifact_record(root: Path, path: Path, role: str) -> dict[str, object]:
+    """Describe one hash-bound bundle artifact without absolute paths."""
+    record: dict[str, object] = {
+        "path": path.relative_to(root).as_posix(),
+        "role": role,
+        "bytes": path.stat().st_size,
+        "sha256": _sha256_file(path),
+    }
+    if role == "dataset":
+        dataset = np.load(path, allow_pickle=False)
+        record.update(shape=list(dataset.shape), dtype=dataset.dtype.str)
+    elif role == "raw_datatree":
+        with xr.open_datatree(path, engine="h5netcdf") as tree:
+            groups = tuple(
+                node.path.removeprefix("/") for node in tree.subtree if node.path != "/"
+            )
+        if groups != _RAW_GROUPS:
+            raise RuntimeError(
+                f"Unexpected raw evidence groups in {path.name}: {groups}."
+            )
+        record["groups"] = list(groups)
+    return record
+
+
+def finalize_evidence_bundle(
+    directory: str | Path,
+    *,
+    result: Mapping[str, object],
+    protocol: Mapping[str, object],
+    provenance: Mapping[str, object],
+) -> Path:
+    """Write the derived result and final hash manifest after all scenarios finish."""
+    root = Path(directory)
+    names = _scenario_names(protocol)
+    result_payload = _canonical_json_bytes(result)
+    protocol_sha256 = hashlib.sha256(_canonical_json_bytes(protocol)).hexdigest()
+    result_path = root / "result.json"
+    _atomic_bytes(result_path, result_payload)
+
+    expected: dict[Path, str] = {
+        root / "environment.txt": "environment",
+        result_path: "derived_result",
+        **{
+            root / "scenarios" / name / filename: role
+            for name in names
+            for filename, role in (
+                ("dataset.npy", "dataset"),
+                ("measurements.json", "measurements"),
+                ("raw.nc", "raw_datatree"),
+            )
+        },
+    }
+    missing = [path for path in expected if not path.is_file()]
+    if missing:
+        relative = ", ".join(path.relative_to(root).as_posix() for path in missing)
+        raise RuntimeError(f"Evidence bundle is incomplete: {relative}")
+    actual = {
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.name != "manifest.json"
+    }
+    if unexpected := actual - expected.keys():
+        relative = ", ".join(
+            path.relative_to(root).as_posix() for path in sorted(unexpected)
+        )
+        raise RuntimeError(f"Evidence bundle has unexpected files: {relative}")
+
+    artifacts = [
+        _artifact_record(root, path, role) for path, role in sorted(expected.items())
+    ]
+    manifest = {
+        "schema_version": 1,
+        "bundle": "JEAM repeated-recovery durable evidence",
+        "protocol": protocol,
+        "protocol_sha256": protocol_sha256,
+        "provenance": provenance,
+        "artifacts": artifacts,
+    }
+    manifest_path = root / "manifest.json"
+    _atomic_bytes(manifest_path, _canonical_json_bytes(manifest))
+    return manifest_path

--- a/tests/test_jeam_recovery_evidence_bundle.py
+++ b/tests/test_jeam_recovery_evidence_bundle.py
@@ -1,0 +1,204 @@
+"""Provenance and manifest contracts for JEAM recovery evidence bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import scripts.benchmark_jeam_recovery_bundle as bundle
+import scripts.benchmark_jeam_recovery_evidence as evidence
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _repository(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repository = tmp_path / "repository"
+    package = repository / "src" / "hssm" / "__init__.py"
+    package.parent.mkdir(parents=True)
+    package.write_text("", encoding="utf-8")
+    source = repository / "pyproject.toml"
+    source.write_text("[project]\nname='hssm'\n", encoding="utf-8")
+    return repository, package, source
+
+
+def _clean_environment(
+    monkeypatch: pytest.MonkeyPatch, repository: Path, status: str = ""
+) -> None:
+    """Install deterministic source and environment answers."""
+    answers = {
+        ("rev-parse", "--show-toplevel"): str(repository),
+        ("status", "--porcelain", "--untracked-files=all"): status,
+        ("merge-base", "--is-ancestor", "base", "HEAD"): "",
+        ("rev-parse", "HEAD"): "producer",
+        ("rev-parse", "HEAD^{tree}"): "tree",
+    }
+    monkeypatch.setattr(
+        bundle,
+        "_git_output",
+        lambda received, *args: (
+            answers[args] if received == repository else pytest.fail("wrong repository")
+        ),
+    )
+    monkeypatch.setattr(
+        bundle.importlib_metadata,
+        "distributions",
+        lambda: (
+            SimpleNamespace(metadata={"Name": "NumPy"}, version="2.4.0"),
+            SimpleNamespace(metadata={"Name": "hssm"}, version="0.3.0"),
+            SimpleNamespace(metadata={"Name": "JEAM"}, version="0.1.0"),
+        ),
+    )
+
+
+def _prepare(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, dict]:
+    repository, package, _ = _repository(tmp_path)
+    _clean_environment(monkeypatch, repository)
+    root = tmp_path / "bundle"
+    provenance = bundle.prepare_evidence_bundle(
+        root,
+        repository=repository,
+        imported_hssm_file=package,
+        protocol_base_revision="base",
+        jeam_revision="jeam-revision",
+        source_paths=("pyproject.toml",),
+    )
+    return root, provenance
+
+
+def _complete_scenario(root: Path, name: str) -> None:
+    scenario = root / "scenarios" / name
+    scenario.mkdir()
+    with (scenario / "dataset.npy").open("wb") as target:
+        np.save(target, np.ones((2, 2)), allow_pickle=False)
+    xr.DataTree.from_dict(
+        {
+            group: xr.Dataset({"value": ("draw", [1.0, 2.0])})
+            for group in evidence._RAW_GROUPS
+        }
+    ).to_netcdf(scenario / "raw.nc", engine="h5netcdf")
+    (scenario / "measurements.json").write_text('{"schema_version":1}\n')
+
+
+def test_prepare_attests_clean_source_and_path_free_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bind clean source, source hashes, and a path-free environment."""
+    root, provenance = _prepare(tmp_path, monkeypatch)
+    environment = (root / "environment.txt").read_bytes()
+
+    assert environment.splitlines() == [
+        b"hssm @ git+https://github.com/lnccbrown/HSSM.git@producer",
+        b"jeam @ git+https://github.com/AlexanderFengler/JEAM.git@jeam-revision",
+        b"numpy==2.4.0",
+    ]
+    assert str(tmp_path).encode() not in environment
+    assert tuple(
+        provenance[key]
+        for key in ("producer_revision", "producer_tree", "clean_worktree")
+    ) == ("producer", "tree", True)
+    source = tmp_path / "repository" / "pyproject.toml"
+    assert provenance["source_sha256"] == {
+        "pyproject.toml": hashlib.sha256(source.read_bytes()).hexdigest()
+    }
+    assert provenance["environment_sha256"] == hashlib.sha256(environment).hexdigest()
+
+
+@pytest.mark.parametrize(
+    ("inside", "status", "message"),
+    [
+        (False, "", "Imported hssm"),
+        (True, " M tracked.py", "clean worktree"),
+    ],
+)
+def test_prepare_rejects_wrong_or_dirty_source_before_writing(
+    inside: bool,
+    status: str,
+    message: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject wrong imports and dirty source before creating the bundle."""
+    repository, package, _ = _repository(tmp_path)
+    _clean_environment(monkeypatch, repository, status)
+    root = tmp_path / "bundle"
+    with pytest.raises(RuntimeError, match=message):
+        bundle.prepare_evidence_bundle(
+            root,
+            repository=repository,
+            imported_hssm_file=package if inside else tmp_path / "elsewhere.py",
+            protocol_base_revision="base",
+            jeam_revision="jeam",
+            source_paths=(),
+        )
+    assert not root.exists()
+
+
+def test_manifest_binds_exact_inventory_hashes_and_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bind every exact artifact, schema descriptor, size, and hash."""
+    root, provenance = _prepare(tmp_path, monkeypatch)
+    _complete_scenario(root, "first")
+    protocol = {"trials": 2, "scenarios": [{"name": "first", "seed": 7}]}
+    result = {"schema_version": 2, "gate": {"passed": True, "failures": []}}
+
+    manifest_path = bundle.finalize_evidence_bundle(
+        root, result=result, protocol=protocol, provenance=provenance
+    )
+    manifest = json.loads(manifest_path.read_bytes())
+
+    assert manifest["schema_version"] == 1
+    assert manifest["protocol"] == protocol
+    assert (
+        manifest["protocol_sha256"]
+        == hashlib.sha256(evidence._canonical_json_bytes(protocol)).hexdigest()
+    )
+    assert [(item["path"], item["role"]) for item in manifest["artifacts"]] == [
+        ("environment.txt", "environment"),
+        ("result.json", "derived_result"),
+        ("scenarios/first/dataset.npy", "dataset"),
+        ("scenarios/first/measurements.json", "measurements"),
+        ("scenarios/first/raw.nc", "raw_datatree"),
+    ]
+    for item in manifest["artifacts"]:
+        path = root / item["path"]
+        assert (item["bytes"], item["sha256"]) == (
+            path.stat().st_size,
+            evidence._sha256_file(path),
+        )
+        assert str(tmp_path) not in item["path"]
+    assert (
+        manifest["artifacts"][2] | {"shape": [2, 2], "dtype": "<f8"}
+        == manifest["artifacts"][2]
+    )
+    assert manifest["artifacts"][-1]["groups"] == list(evidence._RAW_GROUPS)
+    assert json.loads((root / "result.json").read_bytes()) == result
+
+
+@pytest.mark.parametrize("fault", ["missing", "extra"])
+def test_manifest_rejects_missing_or_extra_files(fault: str, tmp_path: Path) -> None:
+    """Never finalize an incomplete or contaminated inventory."""
+    root = tmp_path / fault
+    (root / "scenarios").mkdir(parents=True)
+    (root / "environment.txt").write_text("numpy==2\n")
+    name = "missing"
+    if fault == "extra":
+        name = "first"
+        _complete_scenario(root, name)
+        (root / "undeclared.txt").write_text("unexpected")
+
+    with pytest.raises(RuntimeError, match="incomplete|unexpected"):
+        bundle.finalize_evidence_bundle(
+            root,
+            result={"schema_version": 2},
+            protocol={"scenarios": [{"name": name}]},
+            provenance={},
+        )
+    assert not (root / "manifest.json").exists()

--- a/tests/test_jeam_recovery_evidence_bundle.py
+++ b/tests/test_jeam_recovery_evidence_bundle.py
@@ -18,13 +18,24 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+JEAM_REVISION = "a9f547b3630ae8ff31ccec1b904e0c02fdba6d99"
+
+
 def _repository(tmp_path: Path) -> tuple[Path, Path, Path]:
     repository = tmp_path / "repository"
     package = repository / "src" / "hssm" / "__init__.py"
     package.parent.mkdir(parents=True)
     package.write_text("", encoding="utf-8")
     source = repository / "pyproject.toml"
-    source.write_text("[project]\nname='hssm'\n", encoding="utf-8")
+    source.write_text(
+        "[project]\n"
+        "name='hssm'\n"
+        "[tool.uv.sources]\n"
+        "jeam = { git = "
+        "'https://github.com/AlexanderFengler/JEAM.git', "
+        f"rev = '{JEAM_REVISION}' }}\n",
+        encoding="utf-8",
+    )
     return repository, package, source
 
 
@@ -66,7 +77,7 @@ def _prepare(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, dic
         repository=repository,
         imported_hssm_file=package,
         protocol_base_revision="base",
-        jeam_revision="jeam-revision",
+        jeam_revision=JEAM_REVISION,
         source_paths=("pyproject.toml",),
     )
     return root, provenance
@@ -90,12 +101,17 @@ def test_prepare_attests_clean_source_and_path_free_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Bind clean source, source hashes, and a path-free environment."""
+    synced = []
+    monkeypatch.setattr(bundle, "_fsync_directory", synced.append)
     root, provenance = _prepare(tmp_path, monkeypatch)
     environment = (root / "environment.txt").read_bytes()
 
     assert environment.splitlines() == [
         b"hssm @ git+https://github.com/lnccbrown/HSSM.git@producer",
-        b"jeam @ git+https://github.com/AlexanderFengler/JEAM.git@jeam-revision",
+        (
+            b"jeam @ git+https://github.com/AlexanderFengler/JEAM.git@"
+            + JEAM_REVISION.encode()
+        ),
         b"numpy==2.4.0",
     ]
     assert str(tmp_path).encode() not in environment
@@ -108,6 +124,52 @@ def test_prepare_attests_clean_source_and_path_free_environment(
         "pyproject.toml": hashlib.sha256(source.read_bytes()).hexdigest()
     }
     assert provenance["environment_sha256"] == hashlib.sha256(environment).hexdigest()
+    assert synced == [tmp_path, root]
+
+
+def test_prepare_rejects_drifted_jeam_before_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never start canonical capture with a JEAM revision other than the source pin."""
+    repository, package, _ = _repository(tmp_path)
+    _clean_environment(monkeypatch, repository)
+    root = tmp_path / "bundle"
+
+    with pytest.raises(RuntimeError, match="Installed JEAM revision"):
+        bundle.prepare_evidence_bundle(
+            root,
+            repository=repository,
+            imported_hssm_file=package,
+            protocol_base_revision="base",
+            jeam_revision="deadbeef",
+            source_paths=("pyproject.toml",),
+        )
+
+    assert not root.exists()
+
+
+def test_prepare_rejects_unsupported_platform_without_side_effects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject unsupported durability before creating any bundle parent."""
+    target = tmp_path / "absent" / "bundle"
+
+    def reject() -> None:
+        raise RuntimeError("POSIX durability required")
+
+    monkeypatch.setattr(bundle, "_require_posix_durability", reject)
+
+    with pytest.raises(RuntimeError, match="POSIX durability"):
+        bundle.prepare_evidence_bundle(
+            target,
+            repository=tmp_path,
+            imported_hssm_file=tmp_path / "hssm.py",
+            protocol_base_revision="base",
+            jeam_revision=JEAM_REVISION,
+            source_paths=(),
+        )
+
+    assert not target.parent.exists()
 
 
 @pytest.mark.parametrize(
@@ -199,6 +261,60 @@ def test_manifest_rejects_missing_or_extra_files(fault: str, tmp_path: Path) -> 
             root,
             result={"schema_version": 2},
             protocol={"scenarios": [{"name": name}]},
-            provenance={},
+            provenance={
+                "environment_sha256": hashlib.sha256(b"numpy==2\n").hexdigest()
+            },
         )
+    assert not (root / "result.json").exists()
     assert not (root / "manifest.json").exists()
+
+
+def test_manifest_retry_attests_the_completed_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resume finalization after a manifest-write fault without replacing output."""
+    root, provenance = _prepare(tmp_path, monkeypatch)
+    _complete_scenario(root, "first")
+    protocol = {"scenarios": [{"name": "first"}]}
+    result = {"schema_version": 2, "gate": {"passed": True}}
+    atomic_bytes = bundle._atomic_bytes
+    failed = False
+
+    def fail_manifest(path: Path, payload: bytes) -> None:
+        nonlocal failed
+        if path.name == "manifest.json" and not failed:
+            failed = True
+            raise OSError("injected manifest failure")
+        atomic_bytes(path, payload)
+
+    monkeypatch.setattr(bundle, "_atomic_bytes", fail_manifest)
+    with pytest.raises(OSError, match="injected manifest failure"):
+        bundle.finalize_evidence_bundle(
+            root, result=result, protocol=protocol, provenance=provenance
+        )
+    assert (root / "result.json").is_file()
+    assert not (root / "manifest.json").exists()
+
+    manifest = bundle.finalize_evidence_bundle(
+        root, result=result, protocol=protocol, provenance=provenance
+    )
+    assert manifest.is_file()
+
+
+def test_manifest_rejects_environment_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject a changed environment record instead of authenticating two hashes."""
+    root, provenance = _prepare(tmp_path, monkeypatch)
+    _complete_scenario(root, "first")
+    (root / "environment.txt").write_text("changed\n")
+
+    with pytest.raises(RuntimeError, match="environment"):
+        bundle.finalize_evidence_bundle(
+            root,
+            result={"schema_version": 2},
+            protocol={"scenarios": [{"name": "first"}]},
+            provenance=provenance,
+        )
+
+    assert not (root / "result.json").exists()


### PR DESCRIPTION
## Base

- #1203 and #1250 are merged into `dev`; the accepted base is `a4fcfbf8`.
- This branch now contains only the three bundle-provenance commits, replayed patch-identically onto that base.

## Purpose

Define the bundle-level provenance and manifest contract around the already isolated scenario checkpoints.

## Scope

- require a clean HSSM worktree and verify that the imported HSSM package resolves from that exact checkout
- require the installed JEAM revision to equal the exact Git revision declared in HSSM's `pyproject.toml` before creating the bundle
- bind the capture revision, Git tree, frozen protocol base, pinned JEAM revision, and hashes of every evidence-producing source file
- record a normalized, path-free installed-distribution snapshot and hash it into provenance
- create the bundle directory tree durably on POSIX
- reject unsupported platforms before creating the bundle or any missing parent
- require the exact scenario inventory: `dataset.npy`, `measurements.json`, and six-group `raw.nc`
- hash every artifact and record byte size plus dataset shape/dtype or DataTree group schema
- write strict finite `result.json` and `manifest.json`, accepting only byte-identical finalization retries
- reject incomplete, extra, conflicting, or environment-drifted bundles
- run the focused manifest contract in the optional JEAM workflow

## Review boundary

This PR is filesystem/provenance infrastructure only. It does not run HSSM, alter recovery defaults, orchestrate scenarios, or contain generated evidence. The repeated runner adopts it in the next stacked unit.

## Verification

- replay range-diff: all three commits patch-identical
- focused checkpoint and bundle tests: `19 passed`
- combined checkpoint, bundle, Bayesian capture, and recovery tests: `38 passed`, `5 slow deselected`
- direct drifted-JEAM preflight probe: rejected before bundle creation (`target_exists=False`)
- optional JEAM fast lane on the assembled stack: `66 passed`, `5 deselected`
- focused Ruff check and format check
- focused source mypy
- `git diff --check`
