### PR TITLE
fix(docs): update the bioRxiv paper link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -142,7 +142,7 @@ Widely Applicable Toolbox for Hierarchical Bayesian Neurocognitive Modeling.
 bioRxiv 2026.06.05.730398.
 
 - DOI: [https://doi.org/10.64898/2026.06.05.730398](https://doi.org/10.64898/2026.06.05.730398)
-- bioRxiv: [https://www.biorxiv.org/content/10.1101/2026.06.05.730398v1](https://www.biorxiv.org/content/10.1101/2026.06.05.730398v1)
+- bioRxiv: [https://www.biorxiv.org/content/10.64898/2026.06.05.730398v1](https://www.biorxiv.org/content/10.64898/2026.06.05.730398v1)
 
 ## Community
 


### PR DESCRIPTION
## Summary

- replace the stale `10.1101` bioRxiv content URL with the canonical `10.64898` record
- keep the visible citation aligned with the paper DOI already used by HSSM
- fix the sole rendered-link failure from manual Docs run 32783959111 without broadening Lychee exclusions

## Verification

- exact uv 0.12.2 / Python 3.12 docs environment synced offline
- documentation weight guard: 179 files passed
- notebook path guard: 45 notebooks passed
- `mkdocs build --strict` passed
- `bash -n scripts/docs.sh`
- `git diff --check`

After PR CI passes, a manual feature-branch Docs run will exercise the hosted rendered-link gate; deployment must remain skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the bioRxiv citation link to use the matching DOI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->