### PR TITLE
Restore the aDDM API reference build

### DIFF
--- a/src/hssm/addm/addm.py
+++ b/src/hssm/addm/addm.py
@@ -43,17 +43,17 @@ class aDDM(HSSMBase):
     include
         Optional list of regression/parameter specifications (HSSM's standard
         ``include=[...]`` machinery), e.g. a hierarchical regression on ``eta``.
-    link_settings
-        Link-function preset for regression parameters without an explicit link.
-        Accepts ``"log_logit"`` or ``None`` and is forwarded through ``**kwargs``.
-        Defaults to ``None``.
     prior_settings
         Generated regression-term prior preset. ``"safe"`` uses HSSM defaults;
         ``None`` delegates missing regression-term priors to Bambi. Parameters without
         regressions retain their explicit, model-config, or bounds-derived priors.
         Defaults to ``"safe"``.
-    p_outlier, lapse, missing_data, deadline, **kwargs
+    p_outlier, lapse, missing_data, deadline
         Forwarded to :class:`hssm.base.HSSMBase`.
+    **kwargs
+        Additional keyword arguments forwarded to :class:`hssm.base.HSSMBase`,
+        including ``link_settings``. That link-function preset accepts
+        ``"log_logit"`` or ``None`` and defaults to ``None``.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

- keep `link_settings` documented under `hssm.aDDM`'s existing `**kwargs`
- preserve the public constructor signature and runtime behavior unchanged
- restore the strict MkDocs/Griffe API-reference build

## Why

HSSM main's documentation workflow began failing after #1249 documented
`link_settings` as a standalone `hssm.aDDM` parameter even though the existing
constructor intentionally accepts and forwards it through `**kwargs`. Griffe
reports the mismatch and the strict MkDocs build aborts. This moves the detail
under the documented `**kwargs` contract, retaining #1249's setting guidance
without changing positional compatibility.

## Verification

- `./scripts/docs.sh build` (strict; 180-file weight guard and 45-notebook path guard passed)
- existing aDDM setting-validation tests: 2 passed
- Ruff check/format on the changed source file
- `bash -n scripts/docs.sh`
- `git diff --check`

The mismatch first failed main Docs run
[`32785380739`](https://github.com/lnccbrown/HSSM/actions/runs/32785380739)
after #1249 and repeated in
[`32790776119`](https://github.com/lnccbrown/HSSM/actions/runs/32790776119)
after #1252.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `aDDM` constructor documentation for the `link_settings` option, including its accepted values and default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->