### PR TITLE
Orchestrate durable JEAM recovery evidence

### DIFF
--- a/.github/workflows/jeam_prototype.yml
+++ b/.github/workflows/jeam_prototype.yml
@@ -25,6 +25,7 @@ on:
       - "tests/integration/test_jeam_objective_parity.py"
       - "tests/integration/test_jeam_predictive.py"
       - "tests/integration/test_jeam_repeated_recovery.py"
+      - "tests/integration/test_jeam_repeated_recovery_evidence.py"
       - "tests/integration/test_jeam_simulator.py"
   workflow_dispatch:
 
@@ -66,6 +67,7 @@ jobs:
         run: >-
           uv run --group jeam-prototype pytest
           tests/integration/test_jeam_repeated_recovery.py
+          tests/integration/test_jeam_repeated_recovery_evidence.py
 
       - name: Verify durable recovery checkpoints
         run: >-

--- a/scripts/benchmark_jeam_repeated_recovery.py
+++ b/scripts/benchmark_jeam_repeated_recovery.py
@@ -16,12 +16,12 @@ import argparse
 import json
 import math
 from collections.abc import Iterator, Mapping, Sequence
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass, replace
 from datetime import UTC, datetime
 from numbers import Real
 from pathlib import Path
 from time import perf_counter
-from typing import Literal, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 import pytensor
@@ -29,6 +29,14 @@ import pytensor
 import hssm
 from scripts import benchmark_jeam_bayesian_recovery as bayesian
 from scripts import benchmark_jeam_objective_parity as objective
+from scripts.benchmark_jeam_recovery_bundle import (
+    finalize_evidence_bundle,
+    prepare_evidence_bundle,
+)
+from scripts.benchmark_jeam_recovery_evidence import ScenarioEvidenceWriter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DEFAULT_TRIALS = objective.DEFAULT_TRIALS
 DEFAULT_MAXITER = objective.DEFAULT_MAXITER
@@ -40,6 +48,15 @@ DEFAULT_REPEATED_TUNE = 1_000
 DEFAULT_REPEATED_DRAWS = 1_000
 DEFAULT_REPEATED_PRIOR_DRAWS = bayesian.DEFAULT_PRIOR_DRAWS
 DEFAULT_REPEATED_PREDICTIVE_DRAWS = 40
+PROTOCOL_BASE_REVISION = "cd3fe0a1decc963a9db160a72597e6715b895a5c"
+EVIDENCE_SOURCE_PATHS = (
+    "pyproject.toml",
+    "scripts/benchmark_jeam_bayesian_recovery.py",
+    "scripts/benchmark_jeam_objective_parity.py",
+    "scripts/benchmark_jeam_recovery_bundle.py",
+    "scripts/benchmark_jeam_recovery_evidence.py",
+    "scripts/benchmark_jeam_repeated_recovery.py",
+)
 
 
 @dataclass(frozen=True)
@@ -309,12 +326,15 @@ def run_scenario(
     predictive_draws: int,
     optimizer_maxiter: int,
     optimizer_popsize: int,
+    evidence_writer: ScenarioEvidenceWriter | None = None,
 ) -> ScenarioResult:
     """Run fixed-budget objective parity and HSSM posterior recovery."""
     truth = np.asarray(scenario.truth, dtype=np.float64)
     data = objective.simulate_dataset(
         truth=truth, trials=trials, seed=scenario.data_seed
     )
+    if evidence_writer is not None:
+        evidence_writer.record_dataset(data)
     direct_objective = objective.make_direct_objective(data)
     compiled_objective = objective.make_compiled_hssm_objective(data)
     bounds = objective.optimization_bounds(data)
@@ -363,6 +383,8 @@ def run_scenario(
         prior_seed=scenario.prior_seed,
         predictive_draws=predictive_draws,
         predictive_seed=scenario.predictive_seed,
+        data=data,
+        evidence_writer=evidence_writer,
     )
     if recovery.sampler != "pymc.Slice[a,t,v_x,v_y]":
         raise RuntimeError(f"Unexpected sampler: {recovery.sampler}")
@@ -379,7 +401,7 @@ def run_scenario(
             )
         )
     )
-    return ScenarioResult(
+    result = ScenarioResult(
         name=scenario.name,
         truth=scenario.truth,
         data_seed=scenario.data_seed,
@@ -412,6 +434,43 @@ def run_scenario(
             hssm_predictive_seconds=recovery.predictive_seconds,
         ),
     )
+    if evidence_writer is not None:
+        evidence_writer.write_measurements(
+            {
+                "schema_version": 1,
+                "parameter_order": list(objective.PARAMETER_ORDER),
+                "scenario": {
+                    "name": scenario.name,
+                    "truth": list(scenario.truth),
+                    "trials": trials,
+                    "data_seed": scenario.data_seed,
+                    "optimizer_seed": scenario.optimizer_seed,
+                    "chain_seeds": list(scenario.chain_seeds),
+                    "prior_seed": scenario.prior_seed,
+                    "predictive_seed": scenario.predictive_seed,
+                    "tune": tune,
+                    "draws": draws,
+                    "prior_draws": prior_draws,
+                    "predictive_draws": predictive_draws,
+                    "optimizer_maxiter": optimizer_maxiter,
+                    "optimizer_popsize": optimizer_popsize,
+                },
+                "objective": {
+                    "candidates": [list(values) for values in candidates],
+                    "direct_values": list(direct_objectives),
+                    "compiled_values": list(compiled_objectives),
+                    "direct_fixed_budget_optimizer": asdict(direct_optimizer),
+                    "compiled_hssm_fixed_budget_optimizer": asdict(compiled_optimizer),
+                },
+                "initialization": {
+                    "minimum_observed_rt": recovery.minimum_observed_rt,
+                    "point": list(recovery.initial_point),
+                    "logp": recovery.initial_logp,
+                },
+                "runtime_seconds": asdict(result.runtime),
+            }
+        )
+    return result
 
 
 def aggregate_results(
@@ -622,31 +681,37 @@ def evaluate_gate(
     return GateResult(passed=not failures, failures=tuple(failures))
 
 
-def run_benchmark() -> MultiScenarioRecoveryResult:
-    """Run the frozen four-scenario protocol under float64."""
+def _run_benchmark(
+    evidence_writer: Callable[[Scenario], ScenarioEvidenceWriter] | None = None,
+) -> MultiScenarioRecoveryResult:
+    """Run the frozen protocol, optionally retaining each scenario's raw stages."""
     started = perf_counter()
     original_floatx = cast("Literal['float32', 'float64']", pytensor.config.floatX)
     hssm.set_floatX("float64")
     try:
-        results = tuple(
-            run_scenario(
-                scenario,
-                trials=DEFAULT_TRIALS,
-                tune=DEFAULT_REPEATED_TUNE,
-                draws=DEFAULT_REPEATED_DRAWS,
-                prior_draws=DEFAULT_REPEATED_PRIOR_DRAWS,
-                predictive_draws=DEFAULT_REPEATED_PREDICTIVE_DRAWS,
-                optimizer_maxiter=DEFAULT_MAXITER,
-                optimizer_popsize=DEFAULT_POPSIZE,
+        results = []
+        for scenario in DEFAULT_SCENARIOS:
+            writer = evidence_writer(scenario) if evidence_writer is not None else None
+            results.append(
+                run_scenario(
+                    scenario,
+                    trials=DEFAULT_TRIALS,
+                    tune=DEFAULT_REPEATED_TUNE,
+                    draws=DEFAULT_REPEATED_DRAWS,
+                    prior_draws=DEFAULT_REPEATED_PRIOR_DRAWS,
+                    predictive_draws=DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+                    optimizer_maxiter=DEFAULT_MAXITER,
+                    optimizer_popsize=DEFAULT_POPSIZE,
+                    evidence_writer=writer,
+                )
             )
-            for scenario in DEFAULT_SCENARIOS
-        )
+        scenario_results = tuple(results)
     finally:
         hssm.set_floatX(original_floatx)
-    aggregate = aggregate_results(results)
+    aggregate = aggregate_results(scenario_results)
     total_runtime_seconds = perf_counter() - started
     gate = evaluate_gate(
-        results,
+        scenario_results,
         aggregate,
         DEFAULT_THRESHOLDS,
         total_runtime_seconds=total_runtime_seconds,
@@ -680,18 +745,89 @@ def run_benchmark() -> MultiScenarioRecoveryResult:
         optimizer_maxiter=DEFAULT_MAXITER,
         optimizer_popsize=DEFAULT_POPSIZE,
         thresholds=DEFAULT_THRESHOLDS,
-        scenarios=results,
+        scenarios=scenario_results,
         aggregate=aggregate,
         total_runtime_seconds=total_runtime_seconds,
         gate=gate,
     )
 
 
+def run_benchmark() -> MultiScenarioRecoveryResult:
+    """Run the frozen four-scenario protocol under float64."""
+    return _run_benchmark()
+
+
+def _evidence_protocol() -> dict[str, object]:
+    """Return the fully resolved protocol recorded by a durable bundle."""
+    return {
+        "schema_version": 1,
+        "result_schema_version": 2,
+        "parameter_order": list(objective.PARAMETER_ORDER),
+        "sampler": "pymc.Slice[a,t,v_x,v_y]",
+        "pytensor_floatx": "float64",
+        "trials_per_scenario": DEFAULT_TRIALS,
+        "chains": len(DEFAULT_SCENARIOS[0].chain_seeds),
+        "tune": DEFAULT_REPEATED_TUNE,
+        "draws": DEFAULT_REPEATED_DRAWS,
+        "hdi_probability": HDI_PROBABILITY,
+        "prior_draws": DEFAULT_REPEATED_PRIOR_DRAWS,
+        "predictive_draws": DEFAULT_REPEATED_PREDICTIVE_DRAWS,
+        "optimizer_maxiter": DEFAULT_MAXITER,
+        "optimizer_popsize": DEFAULT_POPSIZE,
+        "thresholds": asdict(DEFAULT_THRESHOLDS),
+        "scenarios": [asdict(scenario) for scenario in DEFAULT_SCENARIOS],
+    }
+
+
+def run_evidence_benchmark(directory: str | Path) -> MultiScenarioRecoveryResult:
+    """Run once from clean source and retain a hash-bound raw evidence bundle."""
+    root = Path(directory)
+    repository = Path(__file__).resolve().parents[1]
+    if hssm.__file__ is None:
+        raise RuntimeError("Cannot locate the imported hssm package.")
+    jeam_revision = objective._installed_jeam_revision()
+    provenance = prepare_evidence_bundle(
+        root,
+        repository=repository,
+        imported_hssm_file=hssm.__file__,
+        protocol_base_revision=PROTOCOL_BASE_REVISION,
+        jeam_revision=jeam_revision,
+        source_paths=EVIDENCE_SOURCE_PATHS,
+    )
+    result = _run_benchmark(
+        lambda scenario: ScenarioEvidenceWriter(root / "scenarios" / scenario.name)
+    )
+    result = replace(
+        result,
+        interpretation=(
+            "This deterministic smoke is not a calibration study; its derived "
+            "report is accompanied by hash-bound datasets and raw draws."
+        ),
+        reproduction_command=(
+            "uv run --group jeam-prototype python "
+            "-m scripts.benchmark_jeam_repeated_recovery "
+            "--evidence-dir benchmarks/evidence/jeam_repeated_recovery_v2"
+        ),
+    )
+    finalize_evidence_bundle(
+        root,
+        result=asdict(result),
+        protocol=_evidence_protocol(),
+        provenance=provenance,
+    )
+    return result
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--output", type=Path)
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--output", type=Path)
+    output.add_argument("--evidence-dir", type=Path)
     parser.add_argument("--compact", action="store_true")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.evidence_dir is not None and args.compact:
+        parser.error("--compact cannot be used with --evidence-dir")
+    return args
 
 
 def _json_payload(result: MultiScenarioRecoveryResult, *, compact: bool) -> str:
@@ -702,14 +838,18 @@ def _json_payload(result: MultiScenarioRecoveryResult, *, compact: bool) -> str:
 def main() -> None:
     """Run the protocol, write optional JSON, and enforce its gate."""
     args = _parse_args()
-    result = run_benchmark()
-    payload = _json_payload(result, compact=args.compact)
-    if args.output is None:
-        print(payload)
+    if args.evidence_dir is not None:
+        result = run_evidence_benchmark(args.evidence_dir)
+        print(args.evidence_dir / "manifest.json")
     else:
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(f"{payload}\n", encoding="utf-8")
-        print(args.output)
+        result = run_benchmark()
+        payload = _json_payload(result, compact=args.compact)
+        if args.output is None:
+            print(payload)
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(f"{payload}\n", encoding="utf-8")
+            print(args.output)
     if not result.gate.passed:
         raise SystemExit(
             "Multi-scenario recovery gate failed: " + "; ".join(result.gate.failures)

--- a/tests/integration/test_jeam_repeated_recovery.py
+++ b/tests/integration/test_jeam_repeated_recovery.py
@@ -369,12 +369,28 @@ def test_schema_v2_serialization_is_canonical_and_finite(
         "predictive_draws": DEFAULT_REPEATED_PREDICTIVE_DRAWS,
         "optimizer_maxiter": DEFAULT_MAXITER,
         "optimizer_popsize": DEFAULT_POPSIZE,
+        "evidence_writer": None,
     }
     assert all(kwargs == expected_kwargs for _, kwargs in calls)
 
     monkeypatch.setattr("sys.argv", ["benchmark"])
-    assert vars(repeated._parse_args()) == {"output": None, "compact": False}
+    assert vars(repeated._parse_args()) == {
+        "output": None,
+        "evidence_dir": None,
+        "compact": False,
+    }
     monkeypatch.setattr("sys.argv", ["benchmark", "--scenario", "baseline"])
+    with pytest.raises(SystemExit):
+        repeated._parse_args()
+    monkeypatch.setattr(
+        "sys.argv", ["benchmark", "--evidence-dir", "bundle", "--compact"]
+    )
+    with pytest.raises(SystemExit):
+        repeated._parse_args()
+    monkeypatch.setattr(
+        "sys.argv",
+        ["benchmark", "--output", "result.json", "--evidence-dir", "bundle"],
+    )
     with pytest.raises(SystemExit):
         repeated._parse_args()
 
@@ -440,3 +456,10 @@ def test_cli_writes_compact_output_and_enforces_the_gate(
         "passed": False,
         "failures": ["forced failure"],
     }
+    capsys.readouterr()
+
+    evidence_dir = tmp_path / "evidence"
+    monkeypatch.setattr(repeated, "run_evidence_benchmark", lambda _: result)
+    monkeypatch.setattr("sys.argv", ["benchmark", "--evidence-dir", str(evidence_dir)])
+    repeated.main()
+    assert capsys.readouterr().out.strip() == str(evidence_dir / "manifest.json")

--- a/tests/integration/test_jeam_repeated_recovery_evidence.py
+++ b/tests/integration/test_jeam_repeated_recovery_evidence.py
@@ -1,0 +1,176 @@
+"""Fast contracts for durable repeated-recovery evidence capture."""
+
+from dataclasses import asdict
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+pytest.importorskip("jeam")
+
+import scripts.benchmark_jeam_repeated_recovery as repeated
+from scripts.benchmark_jeam_objective_parity import FitSummary
+
+DATA = np.array([[0.2, -0.5], [0.3, 0.75]], dtype=np.float64)
+
+
+def _recovery_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        sampler="pymc.Slice[a,t,v_x,v_y]",
+        hdi_probability=0.94,
+        minimum_observed_rt=0.2,
+        initial_point=(1.0, 0.05, 0.0, 0.0),
+        initial_logp=-10.0,
+        slice_diagnostics=SimpleNamespace(),
+        prior_predictive=SimpleNamespace(),
+        predictive=SimpleNamespace(),
+        prior_predictive_seconds=0.25,
+        sampling_seconds=2.0,
+        predictive_seconds=0.5,
+    )
+
+
+def _stub_scenario(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    scenario = repeated.DEFAULT_SCENARIOS[0]
+    monkeypatch.setattr(repeated.objective, "simulate_dataset", lambda **_: DATA)
+
+    def objective(received):
+        assert received is DATA
+        return lambda _: 4.0
+
+    monkeypatch.setattr(repeated.objective, "make_direct_objective", objective)
+    monkeypatch.setattr(repeated.objective, "make_compiled_hssm_objective", objective)
+    monkeypatch.setattr(
+        repeated.objective, "optimization_bounds", lambda data: ((0.1, 2.0),) * 4
+    )
+    monkeypatch.setattr(
+        repeated.objective,
+        "_fit",
+        lambda *_, **__: FitSummary(scenario.truth, 4.0, 10, 2),
+    )
+    recovery = Mock(return_value=_recovery_result())
+    monkeypatch.setattr(repeated.bayesian, "run_recovery", recovery)
+    monkeypatch.setattr(repeated, "_scenario_parameters", lambda *_: ())
+    return recovery
+
+
+def _run_scenario(writer=None):
+    return repeated.run_scenario(
+        repeated.DEFAULT_SCENARIOS[0],
+        trials=2,
+        tune=3,
+        draws=4,
+        prior_draws=2,
+        predictive_draws=2,
+        optimizer_maxiter=2,
+        optimizer_popsize=3,
+        evidence_writer=writer,
+    )
+
+
+def test_scenario_reuses_one_raw_dataset_and_records_only_raw_measurements(
+    monkeypatch,
+):
+    """Reuse one dataset and exclude derived gate values from measurements."""
+    scenario = repeated.DEFAULT_SCENARIOS[0]
+    recovery = _stub_scenario(monkeypatch)
+    writer = Mock()
+    result = _run_scenario(writer)
+
+    recorded = writer.record_dataset.call_args.args[0]
+    assert recorded is DATA
+    assert recovery.call_args.kwargs["data"] is recorded
+    assert recovery.call_args.kwargs["evidence_writer"] is writer
+    measurements = writer.write_measurements.call_args.args[0]
+    expected_scenario = asdict(scenario) | {
+        "truth": list(scenario.truth),
+        "chain_seeds": list(scenario.chain_seeds),
+        "trials": 2,
+        "tune": 3,
+        "draws": 4,
+        "prior_draws": 2,
+        "predictive_draws": 2,
+        "optimizer_maxiter": 2,
+        "optimizer_popsize": 3,
+    }
+    assert measurements["scenario"] == expected_scenario
+    assert measurements["objective"]["candidates"] == [
+        list(candidate) for candidate in result.objective_candidates
+    ]
+    assert measurements["objective"]["direct_values"] == [4.0] * 3
+    assert measurements["initialization"] == {
+        "minimum_observed_rt": 0.2,
+        "point": [1.0, 0.05, 0.0, 0.0],
+        "logp": -10.0,
+    }
+    assert {"gate", "aggregate"}.isdisjoint(measurements)
+
+    _run_scenario()
+    assert recovery.call_args.kwargs["data"] is DATA
+    assert recovery.call_args.kwargs["evidence_writer"] is None
+
+
+def test_evidence_run_preflights_scenarios_then_finalizes_protocol(
+    tmp_path, monkeypatch
+):
+    """Preflight first, finalize last, and freeze the resolved protocol."""
+    root, events, finalized = tmp_path / "evidence", [], {}
+
+    def prepare(directory, **kwargs):
+        events.append("prepare")
+        assert (directory, kwargs["protocol_base_revision"]) == (
+            root,
+            repeated.PROTOCOL_BASE_REVISION,
+        )
+        assert kwargs["source_paths"] == repeated.EVIDENCE_SOURCE_PATHS
+        return {"producer_revision": "revision"}
+
+    class Writer:
+        def __init__(self, directory):
+            events.append(f"writer:{directory.name}")
+
+    def scenario(item, **kwargs):
+        assert isinstance(kwargs["evidence_writer"], Writer)
+        events.append(f"scenario:{item.name}")
+        return item.name
+
+    def finalize(directory, **kwargs):
+        events.append("finalize")
+        assert directory == root
+        finalized.update(kwargs)
+
+    monkeypatch.setattr(repeated, "prepare_evidence_bundle", prepare)
+    monkeypatch.setattr(repeated, "ScenarioEvidenceWriter", Writer)
+    monkeypatch.setattr(repeated, "run_scenario", scenario)
+    monkeypatch.setattr(repeated, "aggregate_results", lambda _: ())
+    monkeypatch.setattr(
+        repeated, "evaluate_gate", lambda *_, **__: repeated.GateResult(True, ())
+    )
+    monkeypatch.setattr(repeated, "finalize_evidence_bundle", finalize)
+    monkeypatch.setattr(repeated.objective, "_installed_jeam_revision", lambda: "jeam")
+
+    result = repeated.run_evidence_benchmark(root)
+
+    names = [item.name for item in repeated.DEFAULT_SCENARIOS]
+    assert events == [
+        "prepare",
+        *(event for name in names for event in (f"writer:{name}", f"scenario:{name}")),
+        "finalize",
+    ]
+    assert result.scenarios == tuple(names)
+    assert finalized["provenance"] == {"producer_revision": "revision"}
+    protocol = finalized["protocol"]
+    assert (
+        protocol
+        | {
+            "schema_version": 1,
+            "result_schema_version": 2,
+            "trials_per_scenario": repeated.DEFAULT_TRIALS,
+        }
+        == protocol
+    )
+    assert protocol["scenarios"] == [
+        asdict(item) for item in repeated.DEFAULT_SCENARIOS
+    ]
+    assert finalized["result"]["schema_version"] == 2


### PR DESCRIPTION
## Base

- #1203, #1250, and #1251 are merged into `dev`; the accepted base is `d11e15bf`.
- This branch contains only the three repeated-orchestration commits, replayed patch-identically onto that base.

## Purpose

Connect the frozen four-scenario recovery protocol to the reviewed capture components while preserving the ordinary transient benchmark path.

## Scope

- simulate each scenario once, checkpoint that exact array before objective evaluation, and reuse it for both objective paths and the Bayesian recovery run
- retain only primary raw measurements: declared seeds and budgets, objective candidates and values, fixed-budget optimizer results, supported initialization/log-density, and stage runtimes
- keep aggregate errors, summaries, and pass/fail gates derived in `result.json`, not duplicated as primary measurements
- add a separate `--evidence-dir` mode with clean-source preflight, four frozen scenarios, and final hash-bound manifest creation
- bind the evidence protocol to the merged schema-v2 executor base revision and every source file that can affect capture
- finalize a failed scientific gate before returning a nonzero exit, so failures remain inspectable
- preserve the zero-argument `run_benchmark()` API and existing `--output`/`--compact` behavior
- run the focused evidence-flow contract in the optional JEAM workflow

## Review boundary

No canonical draws or binary artifacts are included here. After this code is merged, the next PR will perform the one canonical run from a clean checkout and commit only its immutable bundle plus a network-free verifier that recomputes the report from raw evidence.

## Verification

- replay range-diff: all three commits patch-identical and the endpoint tree unchanged
- focused repeated-protocol, execution, and evidence-flow tests: `10 passed`
- complete optional JEAM fast lane: `66 passed`, `5 deselected`
- focused Ruff check and format check
- focused source mypy
- workflow YAML parse
- `git diff --check`
