### PR TITLE
CI: retain targeted notebook execution artifacts

### DIFF
--- a/.github/notebook-skip-list.txt
+++ b/.github/notebook-skip-list.txt
@@ -1,0 +1,1 @@
+docs/tutorials/tutorial_bayeux.ipynb

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -2,12 +2,27 @@ name: Check notebooks
 
 on:
   workflow_dispatch:
+    inputs:
+      notebook_path:
+        description: "Run one tracked non-archive docs notebook instead of all shards"
+        type: string
+        required: false
+        default: ""
   workflow_call:  # Called by drift.yml (monthly notebook drift run)
+    inputs:
+      notebook_path:
+        description: "Run one tracked non-archive docs notebook instead of all shards"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
 
 jobs:
   check_notebooks:
     runs-on: ubuntu-latest
-    if: ${{ ! contains(github.event.head_commit.message, '[skip fast tests]') }}
+    if: ${{ inputs.notebook_path == '' && ! contains(github.event.head_commit.message, '[skip fast tests]') }}
 
     name: Check notebooks (shard ${{ matrix.shard }})
     strategy:
@@ -75,3 +90,73 @@ jobs:
             fi
           done
           exit $EXIT_CODE
+
+  check_target_notebook:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.notebook_path != '' && ! contains(github.event.head_commit.message, '[skip fast tests]') }}
+    name: Check targeted notebook
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Validate notebook target
+        env:
+          TARGET_NOTEBOOK: ${{ inputs.notebook_path }}
+        run: python3 scripts/validate_notebook_target.py "$TARGET_NOTEBOOK"
+
+      - name: Setup environment
+        uses: ./.github/setup-env-notebooks
+        with:
+          python-version: "3.13"
+
+      - name: Execute and inspect target notebook
+        shell: bash
+        env:
+          TARGET_NOTEBOOK: ${{ inputs.notebook_path }}
+        run: |
+          set -uo pipefail
+          artifact_dir="$RUNNER_TEMP/executed-notebook"
+          mkdir -p -- "$artifact_dir"
+          printf '%s\n' "$TARGET_NOTEBOOK" > "$artifact_dir/target.txt"
+
+          echo "Cleaning $TARGET_NOTEBOOK"
+          uv run nb-clean clean -o "$TARGET_NOTEBOOK"
+
+          uv run --group notebook jupyter nbconvert \
+            --ExecutePreprocessor.timeout=10000 \
+            --ExecutePreprocessor.allow_errors=True \
+            --to notebook --execute "$TARGET_NOTEBOOK" \
+            2>&1 | tee "$artifact_dir/execution.log"
+          execution_status=${PIPESTATUS[0]}
+
+          executed_notebook="${TARGET_NOTEBOOK%.ipynb}.nbconvert.ipynb"
+          validation_status=1
+          privacy_status=1
+          if [[ -f "$executed_notebook" ]]; then
+            cp -- "$executed_notebook" "$artifact_dir/"
+
+            uv run python scripts/check_executed_notebook.py "$executed_notebook" \
+              2>&1 | tee "$artifact_dir/validation.log"
+            validation_status=${PIPESTATUS[0]}
+
+            uv run python scripts/check_docs_notebook_paths.py \
+              2>&1 | tee "$artifact_dir/privacy.log"
+            privacy_status=${PIPESTATUS[0]}
+          else
+            echo "Executed notebook was not produced: $executed_notebook" \
+              | tee "$artifact_dir/validation.log"
+          fi
+
+          if (( execution_status != 0 || validation_status != 0 || privacy_status != 0 )); then
+            exit 1
+          fi
+
+      - name: Upload executed notebook diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: executed-notebook-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/executed-notebook/
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -55,9 +55,7 @@ jobs:
           # against. The page says so in its own text. Everything else runs —
           # this workflow is dispatch/drift-only, so "too heavy for the PR
           # check" no longer applies: there is no PR check.
-          SKIP_NOTEBOOKS=(
-            "docs/tutorials/tutorial_bayeux.ipynb"
-          )
+          mapfile -t SKIP_NOTEBOOKS < .github/notebook-skip-list.txt
 
           EXIT_CODE=0
           INDEX=0

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -22,6 +22,11 @@ on:
         description: "Also run the (expensive) notebook suite"
         type: boolean
         default: false
+      notebook_path:
+        description: "Run one tracked non-archive docs notebook instead of the suite"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -46,8 +51,13 @@ jobs:
     uses: ./.github/workflows/run_slow_tests.yml
 
   notebooks:
-    if: (github.event_name == 'workflow_dispatch' && inputs.run_notebooks) || github.event.schedule == '0 3 * * 2'
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.run_notebooks || inputs.notebook_path != '')) ||
+      github.event.schedule == '0 3 * * 2'
     uses: ./.github/workflows/check_notebooks.yml
+    with:
+      notebook_path: ${{ inputs.notebook_path || '' }}
 
   report:
     needs: [lint, fast, slow, notebooks]

--- a/scripts/check_executed_notebook.py
+++ b/scripts/check_executed_notebook.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Fail when a retained executed notebook contains error outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any
+
+
+class ExecutedNotebookError(ValueError):
+    """Raised when a retained artifact is not a readable notebook."""
+
+
+def execution_errors(notebook: pathlib.Path) -> list[str]:
+    """Return ordered summaries for all code-cell error outputs."""
+    try:
+        content: dict[str, Any] = json.loads(notebook.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ExecutedNotebookError(f"cannot read {notebook}: {error}") from error
+
+    cells = content.get("cells")
+    if not isinstance(cells, list):
+        raise ExecutedNotebookError(f"{notebook} has no notebook cell list")
+
+    errors: list[str] = []
+    for index, cell in enumerate(cells, start=1):
+        if not isinstance(cell, dict) or cell.get("cell_type") != "code":
+            continue
+        outputs = cell.get("outputs", [])
+        if not isinstance(outputs, list):
+            raise ExecutedNotebookError(
+                f"{notebook} code cell {index} has an invalid output list"
+            )
+        for output in outputs:
+            if not isinstance(output, dict) or output.get("output_type") != "error":
+                continue
+            error_name = output.get("ename", "Error")
+            error_value = output.get("evalue", "")
+            summary = f"cell {index}: {error_name}"
+            if error_value:
+                summary += f": {error_value}"
+            errors.append(summary)
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Report retained execution errors for one notebook."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("notebook", type=pathlib.Path)
+    args = parser.parse_args(argv)
+
+    try:
+        errors = execution_errors(args.notebook)
+    except ExecutedNotebookError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    if errors:
+        for error in errors:
+            print(f"EXECUTION ERROR: {error}")
+        return 1
+
+    print(f"ok: no execution errors in {args.notebook}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_executed_notebook.py
+++ b/scripts/check_executed_notebook.py
@@ -17,9 +17,11 @@ class ExecutedNotebookError(ValueError):
 def execution_errors(notebook: pathlib.Path) -> list[str]:
     """Return ordered summaries for all code-cell error outputs."""
     try:
-        content: dict[str, Any] = json.loads(notebook.read_text())
+        content: Any = json.loads(notebook.read_text())
     except (OSError, json.JSONDecodeError) as error:
         raise ExecutedNotebookError(f"cannot read {notebook}: {error}") from error
+    if not isinstance(content, dict):
+        raise ExecutedNotebookError(f"{notebook} notebook root is not a JSON object")
 
     cells = content.get("cells")
     if not isinstance(cells, list):

--- a/scripts/validate_notebook_target.py
+++ b/scripts/validate_notebook_target.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKIP_LIST = pathlib.Path(".github/notebook-skip-list.txt")
 
 
 class NotebookTargetError(ValueError):
@@ -57,6 +58,18 @@ def validate_notebook_target(
         raise NotebookTargetError("the resolved path escapes docs/")
     if not candidate.is_file():
         raise NotebookTargetError("the requested notebook does not exist")
+
+    skip_list = root / SKIP_LIST
+    try:
+        skipped_notebooks = set(skip_list.read_text().splitlines())
+    except OSError as error:
+        raise NotebookTargetError(
+            f"cannot read the notebook skip policy at {SKIP_LIST}"
+        ) from error
+    if target in skipped_notebooks:
+        raise NotebookTargetError(
+            "the requested notebook is disabled by the notebook CI skip policy"
+        )
 
     tracked = subprocess.run(
         ["git", "-C", str(root), "ls-files", "--error-unmatch", "--", target],

--- a/scripts/validate_notebook_target.py
+++ b/scripts/validate_notebook_target.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate a repository-relative notebook selected for hosted execution."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+class NotebookTargetError(ValueError):
+    """Raised when a requested notebook is not a safe tracked docs target."""
+
+
+def _validate_target_shape(target: str) -> pathlib.PurePosixPath:
+    """Return a canonical docs path or raise ``NotebookTargetError``."""
+    if not target:
+        raise NotebookTargetError("the notebook path cannot be empty")
+    if any(ord(character) < 32 or ord(character) == 127 for character in target):
+        raise NotebookTargetError("control characters are not allowed")
+    if target != target.strip():
+        raise NotebookTargetError("leading or trailing whitespace is not allowed")
+    if "\\" in target:
+        raise NotebookTargetError("use repository-relative POSIX separators")
+
+    path = pathlib.PurePosixPath(target)
+    if path.is_absolute():
+        raise NotebookTargetError("absolute paths are not allowed")
+    if str(path) != target:
+        raise NotebookTargetError("the path must be in canonical POSIX form")
+    if len(path.parts) < 2 or path.parts[0] != "docs":
+        raise NotebookTargetError("the path must be below docs/")
+    if any(part in {".", ".."} for part in path.parts):
+        raise NotebookTargetError("path traversal is not allowed")
+    if path.parts[:2] == ("docs", "archive"):
+        raise NotebookTargetError("archived notebooks are frozen and cannot be run")
+    if ".ipynb_checkpoints" in path.parts:
+        raise NotebookTargetError("notebook checkpoints cannot be run")
+    if path.suffix != ".ipynb":
+        raise NotebookTargetError("the target must be an .ipynb notebook")
+    return path
+
+
+def validate_notebook_target(
+    target: str, repo_root: pathlib.Path = REPO_ROOT
+) -> pathlib.Path:
+    """Validate and return one tracked, non-archive documentation notebook."""
+    path = _validate_target_shape(target)
+    root = repo_root.resolve()
+    docs_root = (root / "docs").resolve()
+    candidate = (root / pathlib.Path(*path.parts)).resolve()
+
+    if not candidate.is_relative_to(docs_root):
+        raise NotebookTargetError("the resolved path escapes docs/")
+    if not candidate.is_file():
+        raise NotebookTargetError("the requested notebook does not exist")
+
+    tracked = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--error-unmatch", "--", target],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if tracked.returncode != 0:
+        raise NotebookTargetError("the requested notebook is not tracked by git")
+    return candidate
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate one command-line target and report a concise failure."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("notebook", help="tracked repository-relative docs notebook")
+    args = parser.parse_args(argv)
+
+    try:
+        validate_notebook_target(args.notebook)
+    except NotebookTargetError as error:
+        print(f"Invalid notebook target {args.notebook!r}: {error}", file=sys.stderr)
+        return 2
+
+    print(args.notebook)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_notebook_workflow_support.py
+++ b/tests/test_notebook_workflow_support.py
@@ -1,0 +1,185 @@
+"""Tests for safe targeted notebook execution support."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+from scripts.check_executed_notebook import (
+    ExecutedNotebookError,
+    execution_errors,
+)
+from scripts.validate_notebook_target import (
+    NotebookTargetError,
+    validate_notebook_target,
+)
+
+
+def _write_notebook(path: pathlib.Path, outputs: list[dict] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "execution_count": 1,
+                        "metadata": {},
+                        "outputs": outputs or [],
+                        "source": ["print('ok')"],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+
+
+class NotebookTargetTests(unittest.TestCase):
+    """Validate the target boundary before a workflow executes code."""
+
+    def setUp(self) -> None:
+        """Create a temporary repository with one tracked notebook."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp_dir.name)
+        subprocess.run(
+            ["git", "init", "--quiet", str(self.root)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.good = self.root / "docs" / "tutorials" / "good.ipynb"
+        _write_notebook(self.good)
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "docs/tutorials/good.ipynb"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def tearDown(self) -> None:
+        """Remove the temporary repository."""
+        self.temp_dir.cleanup()
+
+    def test_accepts_one_tracked_non_archive_notebook(self) -> None:
+        """Accept a canonical tracked tutorial path."""
+        target = validate_notebook_target(
+            "docs/tutorials/good.ipynb", repo_root=self.root
+        )
+
+        self.assertEqual(target, self.good.resolve())
+
+    def test_rejects_an_untracked_notebook(self) -> None:
+        """Do not execute files that are absent from the git index."""
+        _write_notebook(self.root / "docs" / "tutorials" / "untracked.ipynb")
+
+        with self.assertRaisesRegex(NotebookTargetError, "not tracked"):
+            validate_notebook_target(
+                "docs/tutorials/untracked.ipynb", repo_root=self.root
+            )
+
+    def test_rejects_a_missing_notebook(self) -> None:
+        """Reject a tracked path when its working-tree file is absent."""
+        self.good.unlink()
+
+        with self.assertRaisesRegex(NotebookTargetError, "does not exist"):
+            validate_notebook_target("docs/tutorials/good.ipynb", repo_root=self.root)
+
+    def test_rejects_a_symlink_that_escapes_docs(self) -> None:
+        """Resolve symlinks before enforcing the documentation root."""
+        outside = self.root / "outside.ipynb"
+        _write_notebook(outside)
+        link = self.root / "docs" / "tutorials" / "escape.ipynb"
+        link.symlink_to(outside)
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", "docs/tutorials/escape.ipynb"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        with self.assertRaisesRegex(NotebookTargetError, "escapes docs"):
+            validate_notebook_target("docs/tutorials/escape.ipynb", repo_root=self.root)
+
+    def test_rejects_unsafe_target_shapes(self) -> None:
+        """Reject traversal, archives, controls, and non-notebook targets."""
+        invalid_targets = {
+            "": "empty",
+            "/docs/tutorials/good.ipynb": "absolute",
+            "docs/../outside.ipynb": "traversal",
+            "docs//tutorials/good.ipynb": "canonical",
+            "docs/tutorials\\good.ipynb": "POSIX",
+            "docs/tutorials/good.ipynb\n": "control",
+            "docs/archive/snapshot.ipynb": "archived",
+            "docs/.ipynb_checkpoints/good.ipynb": "checkpoints",
+            "tests/good.ipynb": "below docs",
+            "docs/tutorials/good.py": "ipynb",
+        }
+
+        for target, message in invalid_targets.items():
+            with self.subTest(target=target):
+                with self.assertRaisesRegex(NotebookTargetError, message):
+                    validate_notebook_target(target, repo_root=self.root)
+
+
+class ExecutedNotebookTests(unittest.TestCase):
+    """Retain failed outputs while still making the hosted job fail."""
+
+    def test_accepts_a_notebook_without_error_outputs(self) -> None:
+        """Treat ordinary stream output as a successful execution."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            notebook = pathlib.Path(temp_dir) / "executed.ipynb"
+            _write_notebook(
+                notebook,
+                [{"name": "stdout", "output_type": "stream", "text": ["ok\n"]}],
+            )
+
+            self.assertEqual(execution_errors(notebook), [])
+
+    def test_reports_every_error_output_in_cell_order(self) -> None:
+        """Summarize every saved error without discarding the artifact."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            notebook = pathlib.Path(temp_dir) / "failed.ipynb"
+            _write_notebook(
+                notebook,
+                [
+                    {
+                        "ename": "ValueError",
+                        "evalue": "bad value",
+                        "output_type": "error",
+                        "traceback": ["traceback"],
+                    },
+                    {
+                        "ename": "RuntimeError",
+                        "evalue": "backend failed",
+                        "output_type": "error",
+                        "traceback": ["traceback"],
+                    },
+                ],
+            )
+
+            self.assertEqual(
+                execution_errors(notebook),
+                [
+                    "cell 1: ValueError: bad value",
+                    "cell 1: RuntimeError: backend failed",
+                ],
+            )
+
+    def test_rejects_malformed_notebook_json(self) -> None:
+        """Report malformed retained output as an infrastructure failure."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            notebook = pathlib.Path(temp_dir) / "broken.ipynb"
+            notebook.write_text("not json")
+
+            with self.assertRaisesRegex(ExecutedNotebookError, "cannot read"):
+                execution_errors(notebook)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notebook_workflow_support.py
+++ b/tests/test_notebook_workflow_support.py
@@ -54,9 +54,21 @@ class NotebookTargetTests(unittest.TestCase):
             text=True,
         )
         self.good = self.root / "docs" / "tutorials" / "good.ipynb"
+        self.skipped = self.root / "docs" / "tutorials" / "skipped.ipynb"
         _write_notebook(self.good)
+        _write_notebook(self.skipped)
+        skip_list = self.root / ".github" / "notebook-skip-list.txt"
+        skip_list.parent.mkdir(parents=True)
+        skip_list.write_text("docs/tutorials/skipped.ipynb\n")
         subprocess.run(
-            ["git", "-C", str(self.root), "add", "docs/tutorials/good.ipynb"],
+            [
+                "git",
+                "-C",
+                str(self.root),
+                "add",
+                "docs/tutorials/good.ipynb",
+                "docs/tutorials/skipped.ipynb",
+            ],
             check=True,
             capture_output=True,
             text=True,
@@ -89,6 +101,13 @@ class NotebookTargetTests(unittest.TestCase):
 
         with self.assertRaisesRegex(NotebookTargetError, "does not exist"):
             validate_notebook_target("docs/tutorials/good.ipynb", repo_root=self.root)
+
+    def test_rejects_a_notebook_disabled_by_ci_policy(self) -> None:
+        """Apply the shared full-suite skip policy to targeted runs."""
+        with self.assertRaisesRegex(NotebookTargetError, "CI skip policy"):
+            validate_notebook_target(
+                "docs/tutorials/skipped.ipynb", repo_root=self.root
+            )
 
     def test_rejects_a_symlink_that_escapes_docs(self) -> None:
         """Resolve symlinks before enforcing the documentation root."""
@@ -178,6 +197,15 @@ class ExecutedNotebookTests(unittest.TestCase):
             notebook.write_text("not json")
 
             with self.assertRaisesRegex(ExecutedNotebookError, "cannot read"):
+                execution_errors(notebook)
+
+    def test_rejects_a_non_object_notebook_root(self) -> None:
+        """Return a controlled error for valid JSON with the wrong root type."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            notebook = pathlib.Path(temp_dir) / "list.ipynb"
+            notebook.write_text("[]")
+
+            with self.assertRaisesRegex(ExecutedNotebookError, "not a JSON object"):
                 execution_errors(notebook)
 
 


### PR DESCRIPTION
## Summary

- add a validated `notebook_path` input for one tracked, non-archive documentation notebook
- retain the executed notebook and diagnostic logs for seven days, including when saved cell errors make the job fail
- keep the scheduled four-shard notebook suite unchanged and pass the targeted input through the drift dispatcher

## Safety

- keep workflow permissions at `contents: read`
- reject absolute, traversing, archived, untracked, checkpoint, and docs-escaping symlink targets before environment setup
- pass the selected path through a quoted environment variable and pin `actions/upload-artifact` to the verified v7.0.1 commit
- fail retained outputs that contain cell errors or machine-local paths

## Verification

- `python3 -m unittest tests.test_notebook_workflow_support` — 10 passed
- `ruff check` and `ruff format --check` on the two helpers and their tests
- Actionlint 1.7.12 on `check_notebooks.yml` and `drift.yml`
- targeted final-head run 33037120526 — passed in 1m29s; full shards skipped
- downloaded artifact 9632430950 — executed notebook has 14/14 cells executed, zero errors, zero path leaks, and no credential-pattern matches

Supports #1243.
