### PR TITLE
fix(docs): use the dual-alpha drift learner

### DIFF
--- a/.github/workflows/check_notebooks.yml
+++ b/.github/workflows/check_notebooks.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: ""
+      full_run:
+        description: "Set FULL_RUN=1 for the targeted notebook"
+        type: boolean
+        required: false
+        default: false
   workflow_call:  # Called by drift.yml (monthly notebook drift run)
     inputs:
       notebook_path:
@@ -15,6 +20,11 @@ on:
         type: string
         required: false
         default: ""
+      full_run:
+        description: "Set FULL_RUN=1 for the targeted notebook"
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -111,6 +121,7 @@ jobs:
       - name: Execute and inspect target notebook
         shell: bash
         env:
+          FULL_RUN: ${{ inputs.full_run && '1' || '0' }}
           TARGET_NOTEBOOK: ${{ inputs.notebook_path }}
         run: |
           set -uo pipefail

--- a/docs/tutorials/rlssm_hssm_custom_models.ipynb
+++ b/docs/tutorials/rlssm_hssm_custom_models.ipynb
@@ -9245,7 +9245,7 @@
     "    model_name=\"2AB_RW_DualAlpha_Angle_Tutorial\",\n",
     "    description=\"Two-arm angle RLSSM with separate positive/negative learning rates.\",\n",
     "    decision_process=\"angle\",\n",
-    "    learning_process=rl.learning.RescorlaWagnerDualAlphaRule(\n",
+    "    learning_process=rl.learning.RescorlaWagnerDualAlphaDrift(\n",
     "        n_actions=2,\n",
     "        initial_q=0.5,\n",
     "    ),\n",

--- a/docs/tutorials/rlssm_hssm_custom_models.ipynb
+++ b/docs/tutorials/rlssm_hssm_custom_models.ipynb
@@ -45,10 +45,10 @@
    "id": "814def5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:05.695881Z",
-     "iopub.status.busy": "2026-07-06T16:23:05.695699Z",
-     "iopub.status.idle": "2026-07-06T16:23:08.844883Z",
-     "shell.execute_reply": "2026-07-06T16:23:08.844439Z"
+     "iopub.execute_input": "2026-08-28T01:39:52.440661Z",
+     "iopub.status.busy": "2026-08-28T01:39:52.440572Z",
+     "iopub.status.idle": "2026-08-28T01:40:00.062017Z",
+     "shell.execute_reply": "2026-08-28T01:40:00.061679Z"
     }
    },
    "outputs": [
@@ -105,10 +105,10 @@
    "id": "b3e4874a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:08.846158Z",
-     "iopub.status.busy": "2026-07-06T16:23:08.846062Z",
-     "iopub.status.idle": "2026-07-06T16:23:08.848576Z",
-     "shell.execute_reply": "2026-07-06T16:23:08.848180Z"
+     "iopub.execute_input": "2026-08-28T01:40:00.063367Z",
+     "iopub.status.busy": "2026-08-28T01:40:00.063251Z",
+     "iopub.status.idle": "2026-08-28T01:40:00.066261Z",
+     "shell.execute_reply": "2026-08-28T01:40:00.065961Z"
     }
    },
    "outputs": [
@@ -168,10 +168,10 @@
    "id": "a586640b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:08.849620Z",
-     "iopub.status.busy": "2026-07-06T16:23:08.849544Z",
-     "iopub.status.idle": "2026-07-06T16:23:09.156295Z",
-     "shell.execute_reply": "2026-07-06T16:23:09.155859Z"
+     "iopub.execute_input": "2026-08-28T01:40:00.067255Z",
+     "iopub.status.busy": "2026-08-28T01:40:00.067141Z",
+     "iopub.status.idle": "2026-08-28T01:40:01.225243Z",
+     "shell.execute_reply": "2026-08-28T01:40:01.224829Z"
     }
    },
    "outputs": [
@@ -179,15 +179,51 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2AB_RW_DDM                         Two-armed bandit with a Rescorla-Wagner delta-rule learner and a DDM decision process.\n",
-      "2AB_RW_Angle                       Two-armed bandit with a Rescorla-Wagner delta-rule learner and an angle decision process.\n",
-      "2AB_RW_Weibull                     Two-armed bandit with a Rescorla-Wagner delta-rule learner and a Weibull-bound DDM decision process.\n",
-      "2AB_RW_DualAlpha_Angle             Two-armed bandit with a dual-alpha Rescorla-Wagner learner and an angle decision process.\n",
-      "2AB_RW_InvTempSoftmax              Two-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
-      "2AB_RW_DualAlpha_InvTempSoftmax    Two-armed bandit with a dual-alpha Rescorla-Wagner learner and a choice-only inverse-temperature softmax decision process.\n",
-      "3AB_RW_InvTempSoftmax              Three-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
-      "4AB_RW_InvTempSoftmax              Four-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n"
+      "2AB_RW_Angle                 Two-armed bandit with a Rescorla-Wagner delta-rule learner and an angle decision process.\n",
+      "2AB_RW_DDM                   Two-armed bandit with a Rescorla-Wagner delta-rule learner and a DDM decision process.\n",
+      "2AB_RW_DualAlpha_Angle       Two-armed bandit with a dual-alpha Rescorla-Wagner learner and an angle decision process.\n",
+      "2AB_RW_DualAlpha_InvTempSoftmax Two-armed bandit with a dual-alpha Rescorla-Wagner learner and a choice-only inverse-temperature softmax decision process.\n",
+      "2AB_RW_InvTempSoftmax        Two-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "2AB_RW_Weibull               Two-armed bandit with a Rescorla-Wagner delta-rule learner and a Weibull-bound DDM decision process.\n",
+      "3AB_RW_InvTempSoftmax        Three-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "4AB_RW_InvTempSoftmax        Four-armed bandit with a Rescorla-Wagner delta-rule learner and a choice-only inverse-temperature softmax decision process.\n",
+      "4AB_RW_RaceNoBiasAngle       Four-armed bandit with a Rescorla-Wagner delta-rule learner and a no-bias angled race decision process. The RW-to-race scaling contract is v_i = scaler * q_i for i=0..3.\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be5d61cc32ce4b01ba559f484e295770",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "angle.onnx: reconstructing file:   0%|          |  0.00B / 85.3kB            "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "03c3569b0ec145f694eeaeb375a8497d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "angle.onnx: downloading bytes:           |  0.00B            "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -246,10 +282,10 @@
    "id": "5e443a82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:09.157450Z",
-     "iopub.status.busy": "2026-07-06T16:23:09.157376Z",
-     "iopub.status.idle": "2026-07-06T16:23:09.159705Z",
-     "shell.execute_reply": "2026-07-06T16:23:09.159344Z"
+     "iopub.execute_input": "2026-08-28T01:40:01.226284Z",
+     "iopub.status.busy": "2026-08-28T01:40:01.226159Z",
+     "iopub.status.idle": "2026-08-28T01:40:01.228893Z",
+     "shell.execute_reply": "2026-08-28T01:40:01.228604Z"
     }
    },
    "outputs": [
@@ -305,10 +341,10 @@
    "id": "1ddb0e76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:09.160712Z",
-     "iopub.status.busy": "2026-07-06T16:23:09.160653Z",
-     "iopub.status.idle": "2026-07-06T16:23:09.164042Z",
-     "shell.execute_reply": "2026-07-06T16:23:09.163705Z"
+     "iopub.execute_input": "2026-08-28T01:40:01.229835Z",
+     "iopub.status.busy": "2026-08-28T01:40:01.229752Z",
+     "iopub.status.idle": "2026-08-28T01:40:01.234289Z",
+     "shell.execute_reply": "2026-08-28T01:40:01.233899Z"
     }
    },
    "outputs": [
@@ -323,7 +359,7 @@
     {
      "data": {
       "text/plain": [
-       "RLSSMConfig(model_name='tutorial_2AB_RW_Angle', description='Tutorial RW + angle RLSSM registered entirely HSSM-side.', response=['rt', 'response'], choices=(-1, 1), list_params=['rl_alpha', 'scaler', 'a', 'z', 't', 'theta'], bounds={'rl_alpha': (0.0, 1.0), 'scaler': (0.0, 10.0), 'a': (0.3, 3.0), 'z': (0.1, 0.9), 't': (0.001, 2.0), 'theta': (-0.1, 1.3)}, loglik=None, loglik_kind='approx_differentiable', backend=None, extra_fields=['feedback'], rv=None, decision_process_loglik_kind='approx_differentiable', learning_process_kind='blackbox', params_default=[0.2, 2.0, 1.65, 0.5, 1.0005, 0.6], decision_process='angle', learning_process={'v': <function compute_v at 0x123306700>}, ssm_logp_func=<function make_jax_matrix_logp_funcs_from_onnx.<locals>.logp at 0x123306840>)"
+       "RLSSMConfig(model_name='tutorial_2AB_RW_Angle', description='Tutorial RW + angle RLSSM registered entirely HSSM-side.', response=['rt', 'response'], choices=(-1, 1), list_params=['rl_alpha', 'scaler', 'a', 'z', 't', 'theta'], bounds={'rl_alpha': (0.0, 1.0), 'scaler': (0.0, 10.0), 'a': (0.3, 3.0), 'z': (0.1, 0.9), 't': (0.001, 2.0), 'theta': (-0.1, 1.3)}, loglik=None, loglik_kind='approx_differentiable', backend=None, extra_fields=['feedback'], rv=None, decision_process_loglik_kind='approx_differentiable', learning_process_kind='blackbox', params_default=[0.2, 2.0, 1.65, 0.5, 1.0005, 0.6], decision_process='angle', learning_process={'v': <function compute_v at 0x7fce145cf880>}, ssm_logp_func=<function make_jax_matrix_logp_funcs_from_onnx.<locals>.logp at 0x7fce145cf4c0>)"
       ]
      },
      "execution_count": 5,
@@ -387,10 +423,10 @@
    "id": "41f39560",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:09.165029Z",
-     "iopub.status.busy": "2026-07-06T16:23:09.164960Z",
-     "iopub.status.idle": "2026-07-06T16:23:10.178231Z",
-     "shell.execute_reply": "2026-07-06T16:23:10.177838Z"
+     "iopub.execute_input": "2026-08-28T01:40:01.235091Z",
+     "iopub.status.busy": "2026-08-28T01:40:01.235010Z",
+     "iopub.status.idle": "2026-08-28T01:40:02.810472Z",
+     "shell.execute_reply": "2026-08-28T01:40:02.810058Z"
     }
    },
    "outputs": [
@@ -550,10 +586,10 @@
    "id": "a836ae6d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:10.179359Z",
-     "iopub.status.busy": "2026-07-06T16:23:10.179291Z",
-     "iopub.status.idle": "2026-07-06T16:23:10.396836Z",
-     "shell.execute_reply": "2026-07-06T16:23:10.396409Z"
+     "iopub.execute_input": "2026-08-28T01:40:02.811512Z",
+     "iopub.status.busy": "2026-08-28T01:40:02.811412Z",
+     "iopub.status.idle": "2026-08-28T01:40:04.966446Z",
+     "shell.execute_reply": "2026-08-28T01:40:04.966008Z"
     }
    },
    "outputs": [
@@ -626,10 +662,10 @@
    "id": "c7d01b25",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:23:10.398202Z",
-     "iopub.status.busy": "2026-07-06T16:23:10.397856Z",
-     "iopub.status.idle": "2026-07-06T16:28:49.287170Z",
-     "shell.execute_reply": "2026-07-06T16:28:49.286699Z"
+     "iopub.execute_input": "2026-08-28T01:40:04.967865Z",
+     "iopub.status.busy": "2026-08-28T01:40:04.967563Z",
+     "iopub.status.idle": "2026-08-28T01:43:55.473806Z",
+     "shell.execute_reply": "2026-08-28T01:43:55.473365Z"
     }
    },
    "outputs": [
@@ -652,7381 +688,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "  0%|                                                 | 0/1200 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   0%| | 0/1200 [00:10<?, ?it/s, 886 steps of size 3.13e-03. acc. prob=0"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 18/1200 [00:10<11:21,  1.73it/s, 1023 steps of size 4.42e-03. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 19/1200 [00:11<12:28,  1.58it/s, 1023 steps of size 6.31e-03. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 20/1200 [00:12<12:32,  1.57it/s, 511 steps of size 7.12e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 21/1200 [00:13<12:37,  1.56it/s, 511 steps of size 1.01e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 22/1200 [00:13<12:43,  1.54it/s, 511 steps of size 6.25e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 23/1200 [00:14<12:48,  1.53it/s, 511 steps of size 8.88e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 24/1200 [00:14<11:37,  1.69it/s, 255 steps of size 1.25e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 25/1200 [00:15<10:30,  1.86it/s, 255 steps of size 1.40e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 26/1200 [00:15<09:34,  2.04it/s, 255 steps of size 1.88e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 27/1200 [00:15<07:58,  2.45it/s, 127 steps of size 2.57e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 28/1200 [00:15<06:43,  2.91it/s, 127 steps of size 3.51e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 29/1200 [00:16<08:32,  2.29it/s, 511 steps of size 4.95e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   2%| | 30/1200 [00:17<13:38,  1.43it/s, 1023 steps of size 6.88e-03. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 31/1200 [00:18<13:30,  1.44it/s, 511 steps of size 9.36e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 32/1200 [00:19<13:24,  1.45it/s, 511 steps of size 1.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 33/1200 [00:19<11:25,  1.70it/s, 255 steps of size 9.86e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 34/1200 [00:19<09:59,  1.95it/s, 255 steps of size 1.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 35/1200 [00:20<08:57,  2.17it/s, 255 steps of size 1.41e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 36/1200 [00:20<08:14,  2.35it/s, 255 steps of size 1.90e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 37/1200 [00:20<07:44,  2.50it/s, 255 steps of size 2.49e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 39/1200 [00:22<09:56,  1.95it/s, 930 steps of size 4.01e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 40/1200 [00:23<13:57,  1.38it/s, 1023 steps of size 5.39e-03. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   3%| | 41/1200 [00:24<13:43,  1.41it/s, 511 steps of size 7.28e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 42/1200 [00:24<12:25,  1.55it/s, 348 steps of size 9.63e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 43/1200 [00:25<11:01,  1.75it/s, 289 steps of size 1.15e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 44/1200 [00:25<09:43,  1.98it/s, 255 steps of size 1.54e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 45/1200 [00:25<08:52,  2.17it/s, 255 steps of size 1.87e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 46/1200 [00:25<07:13,  2.66it/s, 127 steps of size 6.50e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 47/1200 [00:26<08:56,  2.15it/s, 511 steps of size 8.61e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 48/1200 [00:27<10:11,  1.88it/s, 511 steps of size 1.13e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 49/1200 [00:27<09:06,  2.11it/s, 255 steps of size 1.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 50/1200 [00:27<08:20,  2.30it/s, 255 steps of size 1.58e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 51/1200 [00:28<07:47,  2.46it/s, 255 steps of size 1.79e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 52/1200 [00:28<07:24,  2.58it/s, 255 steps of size 2.07e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 53/1200 [00:28<06:10,  3.10it/s, 127 steps of size 2.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   4%| | 54/1200 [00:29<05:17,  3.62it/s, 127 steps of size 2.82e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 56/1200 [00:29<05:52,  3.25it/s, 511 steps of size 5.02e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 57/1200 [00:30<07:45,  2.46it/s, 511 steps of size 6.54e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 58/1200 [00:31<09:04,  2.10it/s, 511 steps of size 7.21e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 59/1200 [00:31<10:08,  1.87it/s, 511 steps of size 9.34e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 60/1200 [00:32<10:54,  1.74it/s, 511 steps of size 1.21e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 61/1200 [00:32<09:38,  1.97it/s, 255 steps of size 1.36e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 62/1200 [00:33<08:41,  2.18it/s, 255 steps of size 1.71e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 63/1200 [00:33<08:02,  2.36it/s, 255 steps of size 1.23e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 64/1200 [00:33<07:35,  2.49it/s, 255 steps of size 1.58e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 65/1200 [00:33<06:17,  3.01it/s, 127 steps of size 1.65e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 66/1200 [00:34<06:19,  2.99it/s, 255 steps of size 1.78e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 67/1200 [00:34<05:22,  3.51it/s, 127 steps of size 2.18e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 68/1200 [00:34<04:43,  3.99it/s, 127 steps of size 2.60e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 69/1200 [00:34<04:15,  4.42it/s, 127 steps of size 1.72e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 70/1200 [00:35<04:53,  3.85it/s, 255 steps of size 1.82e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 71/1200 [00:35<04:22,  4.31it/s, 127 steps of size 2.11e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 72/1200 [00:35<04:00,  4.69it/s, 127 steps of size 8.64e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 73/1200 [00:35<04:46,  3.94it/s, 255 steps of size 1.06e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 74/1200 [00:36<05:19,  3.52it/s, 255 steps of size 1.33e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 75/1200 [00:36<05:38,  3.32it/s, 255 steps of size 1.67e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 76/1200 [00:36<05:51,  3.20it/s, 255 steps of size 1.14e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 77/1200 [00:37<06:00,  3.12it/s, 255 steps of size 1.44e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   6%| | 78/1200 [00:37<06:08,  3.05it/s, 255 steps of size 1.74e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 79/1200 [00:37<05:14,  3.57it/s, 127 steps of size 1.63e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 80/1200 [00:38<05:32,  3.37it/s, 255 steps of size 2.01e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 81/1200 [00:38<04:50,  3.85it/s, 127 steps of size 2.08e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 82/1200 [00:38<04:16,  4.35it/s, 117 steps of size 7.06e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 83/1200 [00:39<06:49,  2.72it/s, 511 steps of size 8.32e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 84/1200 [00:39<06:43,  2.77it/s, 255 steps of size 1.01e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 85/1200 [00:39<06:37,  2.80it/s, 255 steps of size 1.27e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 86/1200 [00:40<06:31,  2.84it/s, 255 steps of size 1.41e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 87/1200 [00:40<06:29,  2.86it/s, 255 steps of size 1.73e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 88/1200 [00:40<06:26,  2.88it/s, 255 steps of size 1.50e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   7%| | 89/1200 [00:40<05:26,  3.40it/s, 127 steps of size 1.19e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 90/1200 [00:41<05:41,  3.25it/s, 255 steps of size 1.14e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 91/1200 [00:41<05:52,  3.15it/s, 255 steps of size 1.42e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 92/1200 [00:42<05:59,  3.08it/s, 255 steps of size 1.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 93/1200 [00:42<06:03,  3.05it/s, 255 steps of size 9.60e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 94/1200 [00:43<08:01,  2.29it/s, 511 steps of size 1.19e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 95/1200 [00:43<07:33,  2.44it/s, 255 steps of size 1.45e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 96/1200 [00:43<07:16,  2.53it/s, 255 steps of size 1.59e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 97/1200 [00:44<07:00,  2.63it/s, 255 steps of size 1.80e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 98/1200 [00:44<05:51,  3.14it/s, 127 steps of size 2.13e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 99/1200 [00:44<05:01,  3.65it/s, 127 steps of size 2.18e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 100/1200 [00:44<04:26,  4.12it/s, 127 steps of size 1.26e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   8%| | 101/1200 [00:45<06:52,  2.67it/s, 511 steps of size 1.51e-01. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 103/1200 [00:45<05:17,  3.45it/s, 255 steps of size 1.92e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 104/1200 [00:46<05:34,  3.28it/s, 255 steps of size 2.21e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 105/1200 [00:46<04:55,  3.70it/s, 127 steps of size 2.76e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 106/1200 [00:46<05:15,  3.47it/s, 255 steps of size 3.55e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 107/1200 [00:46<04:40,  3.90it/s, 127 steps of size 4.51e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 108/1200 [00:46<04:14,  4.29it/s, 127 steps of size 5.74e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 109/1200 [00:47<03:54,  4.64it/s, 127 steps of size 7.50e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 111/1200 [00:47<02:50,  6.40it/s, 63 steps of size 8.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   9%| | 113/1200 [00:47<02:18,  7.83it/s, 63 steps of size 9.17e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 115/1200 [00:47<02:01,  8.90it/s, 63 steps of size 7.19e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 117/1200 [00:47<01:51,  9.68it/s, 63 steps of size 7.72e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 119/1200 [00:47<01:45, 10.26it/s, 63 steps of size 8.28e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 121/1200 [00:48<01:40, 10.69it/s, 63 steps of size 4.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 122/1200 [00:48<01:57,  9.21it/s, 127 steps of size 5.58e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 124/1200 [00:48<02:03,  8.69it/s, 127 steps of size 5.57e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 125/1200 [00:48<02:15,  7.94it/s, 127 steps of size 5.79e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 126/1200 [00:48<02:25,  7.38it/s, 127 steps of size 7.23e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 128/1200 [00:49<02:03,  8.67it/s, 63 steps of size 1.07e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 130/1200 [00:49<01:51,  9.58it/s, 63 steps of size 1.20e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 132/1200 [00:49<02:30,  7.10it/s, 255 steps of size 2.39e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 133/1200 [00:49<03:11,  5.57it/s, 255 steps of size 3.08e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 134/1200 [00:50<03:08,  5.64it/s, 127 steps of size 4.05e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 135/1200 [00:50<03:07,  5.68it/s, 127 steps of size 4.42e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 136/1200 [00:50<03:07,  5.69it/s, 127 steps of size 5.66e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 137/1200 [00:50<03:05,  5.73it/s, 127 steps of size 6.70e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 138/1200 [00:50<03:04,  5.77it/s, 127 steps of size 7.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 140/1200 [00:51<02:41,  6.54it/s, 127 steps of size 3.77e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 141/1200 [00:51<02:45,  6.38it/s, 127 steps of size 4.49e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 142/1200 [00:51<02:49,  6.26it/s, 127 steps of size 5.43e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 143/1200 [00:51<02:51,  6.15it/s, 127 steps of size 3.85e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 144/1200 [00:51<03:44,  4.71it/s, 255 steps of size 4.35e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 145/1200 [00:52<03:31,  4.98it/s, 127 steps of size 5.48e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 146/1200 [00:52<03:10,  5.55it/s, 96 steps of size 4.70e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 147/1200 [00:52<03:07,  5.62it/s, 127 steps of size 5.99e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%| | 149/1200 [00:52<02:42,  6.45it/s, 127 steps of size 4.66e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  12%|▏| 150/1200 [00:52<02:46,  6.30it/s, 127 steps of size 5.65e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 153/1200 [00:53<02:06,  8.26it/s, 127 steps of size 3.50e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 154/1200 [00:53<02:16,  7.66it/s, 127 steps of size 3.57e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 155/1200 [00:53<02:24,  7.21it/s, 127 steps of size 4.26e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 156/1200 [00:53<02:32,  6.86it/s, 127 steps of size 4.68e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 157/1200 [00:53<02:38,  6.58it/s, 127 steps of size 5.55e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 158/1200 [00:53<02:43,  6.39it/s, 127 steps of size 3.03e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 159/1200 [00:54<03:35,  4.82it/s, 255 steps of size 4.07e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 160/1200 [00:54<03:24,  5.09it/s, 127 steps of size 5.35e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  13%|▏| 161/1200 [00:54<03:15,  5.30it/s, 127 steps of size 6.68e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 162/1200 [00:54<03:11,  5.41it/s, 127 steps of size 7.24e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 164/1200 [00:54<02:23,  7.20it/s, 63 steps of size 9.86e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 166/1200 [00:55<02:01,  8.53it/s, 63 steps of size 6.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 167/1200 [00:55<02:13,  7.77it/s, 127 steps of size 8.56e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 169/1200 [00:55<01:55,  8.96it/s, 63 steps of size 5.34e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 170/1200 [00:55<02:08,  8.05it/s, 127 steps of size 7.13e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 172/1200 [00:55<02:08,  7.98it/s, 127 steps of size 3.33e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 173/1200 [00:56<02:18,  7.39it/s, 127 steps of size 4.45e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  14%|▏| 174/1200 [00:56<02:26,  6.98it/s, 127 steps of size 5.84e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 176/1200 [00:56<02:02,  8.36it/s, 63 steps of size 1.46e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 177/1200 [00:56<02:52,  5.92it/s, 255 steps of size 1.96e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 178/1200 [00:57<03:34,  4.76it/s, 255 steps of size 2.56e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 179/1200 [00:57<04:08,  4.10it/s, 255 steps of size 3.40e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 180/1200 [00:57<04:35,  3.71it/s, 255 steps of size 4.45e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 181/1200 [00:57<04:07,  4.12it/s, 127 steps of size 5.78e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 183/1200 [00:58<02:56,  5.77it/s, 63 steps of size 8.35e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 185/1200 [00:58<02:20,  7.21it/s, 63 steps of size 8.16e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 187/1200 [00:58<02:16,  7.43it/s, 127 steps of size 6.49e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 189/1200 [00:58<01:58,  8.51it/s, 63 steps of size 8.45e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 191/1200 [00:58<01:47,  9.37it/s, 63 steps of size 1.00e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 193/1200 [00:59<01:40, 10.07it/s, 63 steps of size 7.50e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 195/1200 [00:59<01:35, 10.56it/s, 63 steps of size 1.05e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  16%|▏| 197/1200 [00:59<01:31, 10.95it/s, 63 steps of size 1.24e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 199/1200 [00:59<01:43,  9.70it/s, 127 steps of size 4.15e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 200/1200 [00:59<01:55,  8.65it/s, 127 steps of size 5.16e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 201/1200 [00:59<02:06,  7.87it/s, 127 steps of size 6.46e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 202/1200 [01:00<02:17,  7.27it/s, 127 steps of size 7.92e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 204/1200 [01:00<01:56,  8.54it/s, 63 steps of size 9.56e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 206/1200 [01:00<01:44,  9.48it/s, 63 steps of size 3.42e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 207/1200 [01:00<02:32,  6.50it/s, 255 steps of size 3.97e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 208/1200 [01:00<02:36,  6.34it/s, 127 steps of size 4.60e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 209/1200 [01:01<02:40,  6.19it/s, 127 steps of size 5.59e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 210/1200 [01:01<02:42,  6.08it/s, 127 steps of size 5.17e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 211/1200 [01:01<02:43,  6.05it/s, 127 steps of size 5.59e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 212/1200 [01:01<02:45,  5.98it/s, 127 steps of size 6.25e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 214/1200 [01:01<02:08,  7.65it/s, 63 steps of size 9.03e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 216/1200 [01:01<01:50,  8.88it/s, 63 steps of size 4.49e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 217/1200 [01:02<02:03,  7.99it/s, 127 steps of size 5.58e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 218/1200 [01:02<02:13,  7.37it/s, 127 steps of size 6.75e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 220/1200 [01:02<01:52,  8.71it/s, 63 steps of size 8.81e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  18%|▏| 222/1200 [01:02<01:58,  8.24it/s, 127 steps of size 6.73e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 224/1200 [01:02<01:46,  9.13it/s, 63 steps of size 9.20e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 226/1200 [01:03<01:39,  9.83it/s, 63 steps of size 7.25e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 228/1200 [01:03<01:34, 10.29it/s, 63 steps of size 8.84e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 230/1200 [01:03<02:14,  7.20it/s, 255 steps of size 3.77e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 231/1200 [01:03<02:20,  6.91it/s, 127 steps of size 4.57e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 232/1200 [01:04<02:26,  6.62it/s, 127 steps of size 5.62e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  19%|▏| 233/1200 [01:04<02:30,  6.42it/s, 127 steps of size 6.71e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 235/1200 [01:04<02:03,  7.85it/s, 63 steps of size 8.03e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 237/1200 [01:04<02:02,  7.85it/s, 127 steps of size 5.38e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 238/1200 [01:04<02:11,  7.33it/s, 127 steps of size 5.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 240/1200 [01:05<02:08,  7.49it/s, 127 steps of size 7.06e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 241/1200 [01:05<02:15,  7.06it/s, 127 steps of size 8.01e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 242/1200 [01:05<02:22,  6.74it/s, 127 steps of size 9.05e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 244/1200 [01:05<01:58,  8.04it/s, 63 steps of size 6.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 246/1200 [01:05<01:45,  9.06it/s, 63 steps of size 7.15e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 248/1200 [01:05<01:36,  9.82it/s, 63 steps of size 9.26e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 250/1200 [01:06<01:31, 10.37it/s, 63 steps of size 3.20e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 251/1200 [01:06<02:15,  7.01it/s, 255 steps of size 3.83e-01. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 253/1200 [01:06<01:57,  8.08it/s, 127 steps of size 4.73e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 255/1200 [01:06<01:44,  9.05it/s, 63 steps of size 6.41e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  21%|▏| 257/1200 [01:07<01:36,  9.81it/s, 63 steps of size 5.92e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 258/1200 [01:07<01:48,  8.71it/s, 127 steps of size 7.27e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 260/1200 [01:07<01:38,  9.58it/s, 63 steps of size 2.65e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 261/1200 [01:07<02:22,  6.59it/s, 255 steps of size 3.63e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 262/1200 [01:07<02:26,  6.40it/s, 127 steps of size 4.19e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 263/1200 [01:08<02:28,  6.29it/s, 127 steps of size 5.75e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 264/1200 [01:08<02:32,  6.15it/s, 127 steps of size 7.23e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 266/1200 [01:08<02:18,  6.75it/s, 127 steps of size 6.32e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 268/1200 [01:08<01:55,  8.06it/s, 63 steps of size 7.65e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  22%|▏| 270/1200 [01:08<01:42,  9.08it/s, 63 steps of size 9.05e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 272/1200 [01:08<01:34,  9.85it/s, 63 steps of size 9.78e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 274/1200 [01:09<01:28, 10.42it/s, 63 steps of size 5.64e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 275/1200 [01:09<01:41,  9.11it/s, 127 steps of size 7.38e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 277/1200 [01:09<01:48,  8.52it/s, 127 steps of size 3.76e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 278/1200 [01:09<01:58,  7.76it/s, 127 steps of size 4.69e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 279/1200 [01:09<02:07,  7.22it/s, 127 steps of size 6.01e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 280/1200 [01:10<02:14,  6.84it/s, 127 steps of size 7.84e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 282/1200 [01:10<01:51,  8.26it/s, 63 steps of size 5.86e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 283/1200 [01:10<02:01,  7.55it/s, 127 steps of size 7.16e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 285/1200 [01:10<01:43,  8.80it/s, 63 steps of size 6.16e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 286/1200 [01:10<01:54,  7.95it/s, 127 steps of size 7.96e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 288/1200 [01:10<01:40,  9.11it/s, 63 steps of size 7.11e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 290/1200 [01:11<01:31,  9.95it/s, 63 steps of size 4.28e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 291/1200 [01:11<01:44,  8.73it/s, 127 steps of size 5.46e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 292/1200 [01:11<01:56,  7.83it/s, 127 steps of size 6.32e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  24%|▏| 294/1200 [01:11<01:40,  9.01it/s, 63 steps of size 9.34e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▏| 296/1200 [01:11<01:31,  9.85it/s, 63 steps of size 6.94e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▏| 298/1200 [01:11<01:26, 10.45it/s, 63 steps of size 6.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▎| 300/1200 [01:12<01:22, 10.88it/s, 63 steps of size 6.08e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▎| 302/1200 [01:12<01:20, 11.19it/s, 63 steps of size 8.37e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▎| 304/1200 [01:12<01:18, 11.41it/s, 63 steps of size 9.83e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 306/1200 [01:12<01:29, 10.03it/s, 127 steps of size 6.79e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 308/1200 [01:12<01:24, 10.51it/s, 63 steps of size 6.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 310/1200 [01:13<01:21, 10.87it/s, 63 steps of size 1.02e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 312/1200 [01:13<01:19, 11.15it/s, 63 steps of size 7.92e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 314/1200 [01:13<01:18, 11.34it/s, 63 steps of size 9.02e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 316/1200 [01:13<01:16, 11.48it/s, 63 steps of size 9.10e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  26%|▎| 318/1200 [01:13<01:16, 11.60it/s, 63 steps of size 1.19e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 320/1200 [01:13<01:10, 12.52it/s, 63 steps of size 6.13e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 321/1200 [01:14<01:24, 10.36it/s, 127 steps of size 7.09e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 323/1200 [01:14<01:21, 10.74it/s, 63 steps of size 9.98e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 325/1200 [01:14<01:12, 11.99it/s, 31 steps of size 1.25e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 327/1200 [01:14<01:07, 12.99it/s, 31 steps of size 9.98e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  27%|▎| 329/1200 [01:14<01:04, 13.50it/s, 31 steps of size 3.83e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 330/1200 [01:14<01:20, 10.79it/s, 127 steps of size 4.21e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 331/1200 [01:14<01:35,  9.10it/s, 127 steps of size 4.16e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 332/1200 [01:15<01:48,  8.01it/s, 127 steps of size 4.96e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 333/1200 [01:15<01:58,  7.31it/s, 127 steps of size 5.71e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 335/1200 [01:15<01:40,  8.63it/s, 63 steps of size 7.17e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 337/1200 [01:15<01:30,  9.56it/s, 63 steps of size 9.25e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 339/1200 [01:15<01:24, 10.21it/s, 63 steps of size 3.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 340/1200 [01:15<01:36,  8.90it/s, 127 steps of size 3.86e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 341/1200 [01:16<01:47,  7.99it/s, 127 steps of size 4.18e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  28%|▎| 342/1200 [01:16<01:56,  7.35it/s, 127 steps of size 4.89e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 343/1200 [01:16<02:04,  6.89it/s, 127 steps of size 5.58e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 344/1200 [01:16<02:10,  6.56it/s, 127 steps of size 6.35e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 346/1200 [01:17<02:31,  5.62it/s, 255 steps of size 3.52e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 347/1200 [01:17<02:30,  5.68it/s, 127 steps of size 4.26e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 348/1200 [01:17<02:28,  5.72it/s, 127 steps of size 4.78e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 349/1200 [01:17<02:20,  6.04it/s, 104 steps of size 5.32e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 350/1200 [01:17<02:21,  6.00it/s, 127 steps of size 5.77e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 351/1200 [01:17<02:22,  5.97it/s, 127 steps of size 6.90e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  29%|▎| 353/1200 [01:18<01:50,  7.67it/s, 63 steps of size 9.01e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 355/1200 [01:18<01:27,  9.60it/s, 31 steps of size 9.82e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 357/1200 [01:18<01:15, 11.15it/s, 63 steps of size 1.13e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 359/1200 [01:18<01:25,  9.81it/s, 127 steps of size 4.83e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 360/1200 [01:18<01:36,  8.67it/s, 127 steps of size 5.69e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 361/1200 [01:18<01:46,  7.85it/s, 127 steps of size 6.35e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 363/1200 [01:19<01:32,  9.02it/s, 63 steps of size 6.97e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 365/1200 [01:19<01:24,  9.88it/s, 63 steps of size 9.76e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 367/1200 [01:19<01:19, 10.49it/s, 63 steps of size 8.49e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 369/1200 [01:19<01:16, 10.91it/s, 63 steps of size 9.85e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 371/1200 [01:19<01:13, 11.22it/s, 63 steps of size 3.90e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 372/1200 [01:19<01:26,  9.61it/s, 127 steps of size 4.51e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 373/1200 [01:20<01:37,  8.47it/s, 127 steps of size 5.06e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 375/1200 [01:20<01:26,  9.50it/s, 63 steps of size 6.70e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 377/1200 [01:20<01:20, 10.21it/s, 63 steps of size 7.95e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 379/1200 [01:20<01:16, 10.75it/s, 63 steps of size 8.21e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 381/1200 [01:20<01:13, 11.11it/s, 63 steps of size 7.80e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 383/1200 [01:20<01:12, 11.33it/s, 63 steps of size 9.71e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 385/1200 [01:21<01:10, 11.50it/s, 63 steps of size 5.22e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 386/1200 [01:21<01:23,  9.80it/s, 127 steps of size 6.14e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 387/1200 [01:21<01:34,  8.62it/s, 127 steps of size 7.10e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 389/1200 [01:21<01:24,  9.60it/s, 63 steps of size 4.43e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  32%|▎| 390/1200 [01:21<01:35,  8.47it/s, 127 steps of size 5.22e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 392/1200 [01:21<01:25,  9.48it/s, 63 steps of size 6.60e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 393/1200 [01:22<01:35,  8.43it/s, 127 steps of size 7.65e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 395/1200 [01:22<01:25,  9.46it/s, 63 steps of size 7.36e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 397/1200 [01:22<01:30,  8.84it/s, 127 steps of size 5.93e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 398/1200 [01:22<01:39,  8.07it/s, 127 steps of size 6.49e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  33%|▎| 400/1200 [01:22<01:27,  9.14it/s, 63 steps of size 8.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 402/1200 [01:23<01:22,  9.67it/s, 63 steps of size 6.22e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 403/1200 [01:23<01:32,  8.57it/s, 127 steps of size 3.99e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 404/1200 [01:23<01:41,  7.81it/s, 127 steps of size 4.65e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 405/1200 [01:23<01:49,  7.25it/s, 127 steps of size 5.40e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 406/1200 [01:23<01:55,  6.85it/s, 127 steps of size 6.19e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 408/1200 [01:23<01:34,  8.34it/s, 63 steps of size 7.08e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 409/1200 [01:24<01:43,  7.61it/s, 127 steps of size 2.63e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 410/1200 [01:24<01:51,  7.10it/s, 127 steps of size 3.05e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 411/1200 [01:24<02:32,  5.18it/s, 255 steps of size 3.46e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 412/1200 [01:24<02:27,  5.36it/s, 127 steps of size 4.03e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 413/1200 [01:24<02:23,  5.50it/s, 127 steps of size 4.67e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  34%|▎| 414/1200 [01:25<02:19,  5.62it/s, 127 steps of size 4.88e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 415/1200 [01:25<02:17,  5.71it/s, 127 steps of size 5.29e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 416/1200 [01:25<02:15,  5.77it/s, 127 steps of size 5.97e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 417/1200 [01:25<02:14,  5.80it/s, 127 steps of size 4.50e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 418/1200 [01:25<02:14,  5.82it/s, 127 steps of size 5.14e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 419/1200 [01:25<02:13,  5.83it/s, 127 steps of size 5.75e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 421/1200 [01:26<01:57,  6.61it/s, 127 steps of size 4.85e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 422/1200 [01:26<02:01,  6.41it/s, 127 steps of size 5.49e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 423/1200 [01:26<02:04,  6.26it/s, 127 steps of size 6.30e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 425/1200 [01:26<01:39,  7.83it/s, 63 steps of size 7.18e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 427/1200 [01:26<01:26,  8.98it/s, 63 steps of size 8.50e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 429/1200 [01:27<01:18,  9.82it/s, 63 steps of size 7.38e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 431/1200 [01:27<01:13, 10.40it/s, 63 steps of size 8.67e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 433/1200 [01:27<01:10, 10.85it/s, 63 steps of size 7.21e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 435/1200 [01:27<01:08, 11.14it/s, 63 steps of size 6.97e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  36%|▎| 437/1200 [01:27<01:07, 11.37it/s, 63 steps of size 7.57e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 439/1200 [01:27<01:05, 11.54it/s, 63 steps of size 7.90e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 441/1200 [01:28<01:05, 11.66it/s, 63 steps of size 8.78e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 443/1200 [01:28<01:04, 11.74it/s, 63 steps of size 8.84e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 445/1200 [01:28<01:04, 11.79it/s, 63 steps of size 9.59e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 447/1200 [01:28<01:03, 11.86it/s, 63 steps of size 9.78e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 450/1200 [01:28<00:53, 14.03it/s, 63 steps of size 5.46e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 452/1200 [01:28<01:04, 11.55it/s, 127 steps of size 6.48e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 454/1200 [01:29<01:04, 11.63it/s, 63 steps of size 7.95e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 456/1200 [01:29<01:04, 11.57it/s, 63 steps of size 8.02e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 458/1200 [01:29<01:03, 11.65it/s, 63 steps of size 8.58e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 460/1200 [01:29<01:12, 10.21it/s, 127 steps of size 4.68e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 461/1200 [01:29<01:21,  9.05it/s, 127 steps of size 4.80e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  38%|▍| 462/1200 [01:30<01:30,  8.17it/s, 127 steps of size 5.41e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 464/1200 [01:30<01:19,  9.20it/s, 63 steps of size 5.74e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 466/1200 [01:30<01:13,  9.95it/s, 63 steps of size 7.14e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 468/1200 [01:30<01:20,  9.14it/s, 127 steps of size 7.94e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 470/1200 [01:30<01:13,  9.87it/s, 63 steps of size 5.14e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 471/1200 [01:31<01:23,  8.75it/s, 127 steps of size 5.61e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 472/1200 [01:31<01:31,  7.96it/s, 127 steps of size 5.80e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  39%|▍| 473/1200 [01:31<01:38,  7.36it/s, 127 steps of size 6.52e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 475/1200 [01:31<01:23,  8.67it/s, 63 steps of size 7.79e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 477/1200 [01:31<01:15,  9.58it/s, 63 steps of size 5.71e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 479/1200 [01:31<01:10, 10.25it/s, 63 steps of size 5.80e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 480/1200 [01:32<01:20,  8.96it/s, 127 steps of size 5.79e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 481/1200 [01:32<01:29,  8.03it/s, 127 steps of size 6.06e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 483/1200 [01:32<01:30,  7.94it/s, 127 steps of size 7.69e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 485/1200 [01:32<01:19,  8.99it/s, 63 steps of size 8.06e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 486/1200 [01:32<01:28,  8.11it/s, 127 steps of size 7.25e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  41%|▍| 488/1200 [01:32<01:14,  9.55it/s, 63 steps of size 8.46e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  41%|▍| 490/1200 [01:33<01:09, 10.23it/s, 63 steps of size 8.05e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  41%|▍| 492/1200 [01:33<01:06, 10.71it/s, 63 steps of size 9.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  41%|▍| 494/1200 [01:33<01:03, 11.08it/s, 63 steps of size 1.06e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  41%|▍| 497/1200 [01:33<00:49, 14.19it/s, 31 steps of size 5.99e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 498/1200 [01:33<01:00, 11.53it/s, 127 steps of size 6.38e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 500/1200 [01:33<01:00, 11.63it/s, 63 steps of size 7.85e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 502/1200 [01:34<00:55, 12.68it/s, 63 steps of size 8.01e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 504/1200 [01:34<00:48, 14.26it/s, 63 steps of size 7.34e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 506/1200 [01:34<00:51, 13.43it/s, 63 steps of size 6.85e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 508/1200 [01:34<00:53, 12.91it/s, 63 steps of size 7.65e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  42%|▍| 510/1200 [01:34<00:54, 12.55it/s, 63 steps of size 8.00e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 512/1200 [01:34<00:55, 12.35it/s, 63 steps of size 8.30e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 514/1200 [01:34<00:56, 12.19it/s, 63 steps of size 5.07e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 515/1200 [01:35<01:06, 10.24it/s, 127 steps of size 5.41e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 516/1200 [01:35<01:16,  8.91it/s, 127 steps of size 6.09e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 517/1200 [01:35<01:25,  8.00it/s, 127 steps of size 6.19e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 519/1200 [01:35<01:14,  9.15it/s, 63 steps of size 7.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  43%|▍| 521/1200 [01:35<01:08,  9.98it/s, 63 steps of size 8.71e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 523/1200 [01:35<01:04, 10.55it/s, 63 steps of size 1.04e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 525/1200 [01:36<01:01, 10.93it/s, 63 steps of size 8.74e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 527/1200 [01:36<00:59, 11.23it/s, 63 steps of size 5.93e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 528/1200 [01:36<01:09,  9.61it/s, 127 steps of size 6.26e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 530/1200 [01:36<01:05, 10.26it/s, 63 steps of size 7.59e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 532/1200 [01:36<01:11,  9.36it/s, 127 steps of size 7.00e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  44%|▍| 534/1200 [01:37<01:06,  9.99it/s, 63 steps of size 7.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 536/1200 [01:37<01:03, 10.52it/s, 63 steps of size 7.37e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 538/1200 [01:37<01:00, 10.90it/s, 63 steps of size 7.87e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 540/1200 [01:37<00:59, 11.17it/s, 63 steps of size 9.14e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 542/1200 [01:37<00:57, 11.38it/s, 63 steps of size 1.13e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 544/1200 [01:37<00:56, 11.54it/s, 63 steps of size 9.39e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 546/1200 [01:38<00:51, 12.59it/s, 63 steps of size 9.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 548/1200 [01:38<00:52, 12.35it/s, 63 steps of size 9.23e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 550/1200 [01:38<00:53, 12.17it/s, 63 steps of size 9.16e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 552/1200 [01:38<00:53, 12.08it/s, 63 steps of size 1.02e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 554/1200 [01:38<00:53, 12.00it/s, 63 steps of size 9.44e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 556/1200 [01:38<01:02, 10.38it/s, 127 steps of size 6.29e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  46%|▍| 558/1200 [01:39<00:59, 10.79it/s, 63 steps of size 7.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 560/1200 [01:39<00:57, 11.09it/s, 63 steps of size 8.35e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 562/1200 [01:39<00:56, 11.28it/s, 63 steps of size 7.24e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 563/1200 [01:39<01:05,  9.65it/s, 127 steps of size 7.18e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 565/1200 [01:39<00:58, 10.85it/s, 63 steps of size 8.16e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 567/1200 [01:39<00:56, 11.14it/s, 63 steps of size 8.11e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  47%|▍| 569/1200 [01:40<00:56, 11.26it/s, 63 steps of size 8.61e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 571/1200 [01:40<00:55, 11.42it/s, 63 steps of size 7.67e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 573/1200 [01:40<00:54, 11.60it/s, 63 steps of size 9.06e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 575/1200 [01:40<00:53, 11.72it/s, 63 steps of size 1.00e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 577/1200 [01:40<00:52, 11.84it/s, 63 steps of size 6.18e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 579/1200 [01:41<01:00, 10.24it/s, 127 steps of size 7.17e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  48%|▍| 581/1200 [01:41<00:57, 10.69it/s, 63 steps of size 8.23e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 583/1200 [01:41<00:56, 11.00it/s, 63 steps of size 8.52e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 585/1200 [01:41<00:54, 11.24it/s, 63 steps of size 5.46e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 586/1200 [01:41<01:03,  9.67it/s, 127 steps of size 6.01e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 588/1200 [01:41<00:59, 10.29it/s, 63 steps of size 5.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 590/1200 [01:42<00:56, 10.74it/s, 63 steps of size 7.09e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  49%|▍| 592/1200 [01:42<00:55, 11.04it/s, 63 steps of size 7.20e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▍| 594/1200 [01:42<00:53, 11.25it/s, 63 steps of size 7.95e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▍| 596/1200 [01:42<00:52, 11.40it/s, 63 steps of size 9.41e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▍| 598/1200 [01:42<00:52, 11.55it/s, 63 steps of size 9.30e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▌| 600/1200 [01:42<00:51, 11.67it/s, 63 steps of size 9.73e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▌| 602/1200 [01:43<00:51, 11.71it/s, 63 steps of size 1.03e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▌| 604/1200 [01:43<00:46, 12.73it/s, 31 steps of size 1.22e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 607/1200 [01:43<00:41, 14.15it/s, 63 steps of size 8.57e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 609/1200 [01:43<00:43, 13.46it/s, 63 steps of size 7.45e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 611/1200 [01:43<00:45, 12.96it/s, 63 steps of size 7.55e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 613/1200 [01:43<00:46, 12.63it/s, 63 steps of size 8.91e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 615/1200 [01:44<00:54, 10.78it/s, 127 steps of size 7.22e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  51%|▌| 617/1200 [01:44<00:52, 11.05it/s, 63 steps of size 6.56e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 619/1200 [01:44<00:51, 11.26it/s, 63 steps of size 6.63e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 621/1200 [01:44<00:50, 11.43it/s, 63 steps of size 6.97e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 623/1200 [01:44<00:50, 11.54it/s, 63 steps of size 7.35e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 625/1200 [01:45<00:49, 11.61it/s, 63 steps of size 7.40e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 627/1200 [01:45<00:49, 11.69it/s, 63 steps of size 8.49e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  52%|▌| 629/1200 [01:45<00:43, 13.27it/s, 14 steps of size 6.73e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 631/1200 [01:45<00:44, 12.82it/s, 63 steps of size 7.66e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 633/1200 [01:45<00:52, 10.79it/s, 127 steps of size 6.17e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 635/1200 [01:45<00:50, 11.11it/s, 63 steps of size 7.21e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 637/1200 [01:46<00:49, 11.33it/s, 63 steps of size 7.60e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 639/1200 [01:46<00:48, 11.52it/s, 63 steps of size 8.90e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  53%|▌| 641/1200 [01:46<00:48, 11.62it/s, 63 steps of size 8.26e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 643/1200 [01:46<00:47, 11.68it/s, 63 steps of size 8.59e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 645/1200 [01:46<00:47, 11.69it/s, 63 steps of size 8.42e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 647/1200 [01:46<00:47, 11.71it/s, 63 steps of size 7.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 649/1200 [01:47<00:46, 11.75it/s, 63 steps of size 9.50e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 651/1200 [01:47<00:46, 11.77it/s, 63 steps of size 1.02e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  54%|▌| 653/1200 [01:47<00:46, 11.77it/s, 63 steps of size 1.11e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 655/1200 [01:47<00:46, 11.80it/s, 63 steps of size 1.17e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 658/1200 [01:47<00:35, 15.32it/s, 31 steps of size 9.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 660/1200 [01:47<00:38, 14.20it/s, 63 steps of size 7.67e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 662/1200 [01:47<00:39, 13.47it/s, 63 steps of size 8.44e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 664/1200 [01:48<00:41, 12.94it/s, 63 steps of size 8.25e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 666/1200 [01:48<00:42, 12.59it/s, 63 steps of size 7.89e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 668/1200 [01:48<00:43, 12.33it/s, 63 steps of size 6.88e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 670/1200 [01:48<00:43, 12.17it/s, 63 steps of size 7.87e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 672/1200 [01:48<00:43, 12.06it/s, 63 steps of size 8.89e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 674/1200 [01:49<00:43, 12.01it/s, 63 steps of size 4.27e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 675/1200 [01:49<00:51, 10.14it/s, 127 steps of size 4.64e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 676/1200 [01:49<00:59,  8.87it/s, 127 steps of size 4.93e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  56%|▌| 678/1200 [01:49<00:53,  9.78it/s, 63 steps of size 5.54e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 680/1200 [01:49<00:50, 10.40it/s, 63 steps of size 5.49e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 681/1200 [01:49<00:57,  9.05it/s, 127 steps of size 5.84e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 683/1200 [01:50<00:52,  9.89it/s, 63 steps of size 6.66e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 684/1200 [01:50<00:59,  8.67it/s, 127 steps of size 6.04e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 686/1200 [01:50<01:01,  8.32it/s, 127 steps of size 6.40e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 688/1200 [01:50<00:55,  9.27it/s, 63 steps of size 7.17e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  57%|▌| 690/1200 [01:50<00:52,  9.81it/s, 63 steps of size 8.48e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 692/1200 [01:50<00:50, 10.16it/s, 63 steps of size 8.58e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 694/1200 [01:51<00:47, 10.62it/s, 63 steps of size 9.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 696/1200 [01:51<00:45, 10.98it/s, 63 steps of size 5.72e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 697/1200 [01:51<00:53,  9.48it/s, 127 steps of size 5.68e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 699/1200 [01:51<00:56,  8.86it/s, 127 steps of size 4.86e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 700/1200 [01:51<01:02,  8.05it/s, 127 steps of size 5.32e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 701/1200 [01:52<01:06,  7.46it/s, 127 steps of size 5.82e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  58%|▌| 702/1200 [01:52<01:10,  7.02it/s, 127 steps of size 6.24e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  59%|▌| 704/1200 [01:52<00:59,  8.41it/s, 63 steps of size 6.89e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  59%|▌| 706/1200 [01:52<00:52,  9.42it/s, 63 steps of size 8.04e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  59%|▌| 708/1200 [01:52<00:48, 10.13it/s, 63 steps of size 8.89e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  59%|▌| 710/1200 [01:52<00:46, 10.65it/s, 63 steps of size 1.02e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  59%|▌| 712/1200 [01:53<00:44, 11.05it/s, 63 steps of size 1.12e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 714/1200 [01:53<00:42, 11.37it/s, 63 steps of size 8.73e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 716/1200 [01:53<00:42, 11.51it/s, 63 steps of size 7.12e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 718/1200 [01:53<00:41, 11.63it/s, 63 steps of size 6.75e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 720/1200 [01:53<00:41, 11.68it/s, 63 steps of size 7.12e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 722/1200 [01:53<00:40, 11.74it/s, 63 steps of size 6.96e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 724/1200 [01:54<00:40, 11.74it/s, 63 steps of size 7.60e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 726/1200 [01:54<00:40, 11.77it/s, 63 steps of size 6.73e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 728/1200 [01:54<00:39, 11.91it/s, 63 steps of size 7.15e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 730/1200 [01:54<00:39, 11.90it/s, 63 steps of size 7.07e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 732/1200 [01:54<00:39, 11.90it/s, 63 steps of size 8.39e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 734/1200 [01:54<00:36, 12.86it/s, 31 steps of size 7.90e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 736/1200 [01:55<00:37, 12.50it/s, 63 steps of size 6.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  61%|▌| 737/1200 [01:55<00:44, 10.42it/s, 127 steps of size 6.20e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 738/1200 [01:55<00:51,  9.03it/s, 127 steps of size 6.27e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 740/1200 [01:55<00:46,  9.90it/s, 63 steps of size 5.57e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 741/1200 [01:55<00:52,  8.67it/s, 127 steps of size 5.66e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 742/1200 [01:55<00:58,  7.83it/s, 127 steps of size 6.16e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 744/1200 [01:56<00:58,  7.83it/s, 127 steps of size 4.97e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 745/1200 [01:56<01:02,  7.30it/s, 127 steps of size 5.11e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 746/1200 [01:56<01:05,  6.90it/s, 127 steps of size 5.25e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 747/1200 [01:56<01:08,  6.59it/s, 127 steps of size 5.72e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 748/1200 [01:56<01:10,  6.39it/s, 127 steps of size 6.23e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  62%|▌| 749/1200 [01:57<01:12,  6.23it/s, 127 steps of size 6.76e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 751/1200 [01:57<00:57,  7.86it/s, 63 steps of size 6.51e-01. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 754/1200 [01:57<01:00,  7.42it/s, 255 steps of size 3.54e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 755/1200 [01:57<01:03,  7.06it/s, 127 steps of size 3.88e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 756/1200 [01:57<01:05,  6.77it/s, 127 steps of size 4.50e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 757/1200 [01:58<01:07,  6.54it/s, 127 steps of size 5.41e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 758/1200 [01:58<01:09,  6.36it/s, 127 steps of size 7.20e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 760/1200 [01:58<01:03,  6.93it/s, 127 steps of size 5.34e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  63%|▋| 761/1200 [01:58<01:05,  6.65it/s, 127 steps of size 6.74e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 763/1200 [01:58<00:54,  8.06it/s, 63 steps of size 5.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 764/1200 [01:59<00:58,  7.45it/s, 127 steps of size 5.40e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 766/1200 [01:59<00:50,  8.58it/s, 63 steps of size 8.54e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 768/1200 [01:59<00:44,  9.76it/s, 63 steps of size 2.91e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 769/1200 [01:59<01:04,  6.63it/s, 255 steps of size 3.84e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 770/1200 [01:59<01:06,  6.42it/s, 127 steps of size 4.74e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 771/1200 [02:00<01:09,  6.19it/s, 127 steps of size 6.21e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 773/1200 [02:00<01:47,  3.95it/s, 511 steps of size 1.36e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  64%|▋| 774/1200 [02:01<02:29,  2.85it/s, 511 steps of size 1.87e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 775/1200 [02:02<03:03,  2.32it/s, 511 steps of size 2.55e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 776/1200 [02:02<02:53,  2.45it/s, 255 steps of size 3.43e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 777/1200 [02:02<02:25,  2.91it/s, 127 steps of size 4.52e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 778/1200 [02:02<02:04,  3.38it/s, 127 steps of size 5.05e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 780/1200 [02:03<01:24,  4.94it/s, 63 steps of size 7.92e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 782/1200 [02:03<01:12,  5.77it/s, 127 steps of size 3.68e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 783/1200 [02:03<01:11,  5.79it/s, 127 steps of size 4.90e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 784/1200 [02:03<01:11,  5.82it/s, 127 steps of size 6.38e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 786/1200 [02:03<00:53,  7.81it/s, 31 steps of size 4.15e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 787/1200 [02:03<00:56,  7.28it/s, 127 steps of size 4.09e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 788/1200 [02:04<00:59,  6.87it/s, 127 steps of size 5.11e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 789/1200 [02:04<01:02,  6.57it/s, 127 steps of size 5.70e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 791/1200 [02:04<00:49,  8.34it/s, 50 steps of size 7.86e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 793/1200 [02:04<00:43,  9.39it/s, 63 steps of size 2.29e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 794/1200 [02:04<00:48,  8.33it/s, 127 steps of size 2.91e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 795/1200 [02:04<00:53,  7.58it/s, 127 steps of size 3.66e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 796/1200 [02:05<00:57,  7.09it/s, 127 steps of size 2.97e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 797/1200 [02:05<01:18,  5.16it/s, 255 steps of size 3.70e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  66%|▋| 798/1200 [02:05<01:15,  5.34it/s, 127 steps of size 4.79e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  67%|▋| 799/1200 [02:05<01:13,  5.48it/s, 127 steps of size 5.42e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  67%|▋| 800/1200 [02:05<01:11,  5.60it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 801/1200 [02:06<01:10,  5.67it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 802/1200 [02:06<01:09,  5.72it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 803/1200 [02:06<01:08,  5.76it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 804/1200 [02:06<01:08,  5.79it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 805/1200 [02:06<01:08,  5.81it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 806/1200 [02:07<01:07,  5.83it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 807/1200 [02:07<01:07,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  67%|▋| 809/1200 [02:07<00:58,  6.66it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 810/1200 [02:07<01:00,  6.44it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 811/1200 [02:07<01:01,  6.29it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 812/1200 [02:07<01:02,  6.19it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 813/1200 [02:08<01:03,  6.06it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 814/1200 [02:08<01:04,  6.02it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 815/1200 [02:08<01:04,  5.97it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 816/1200 [02:08<01:04,  5.94it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 818/1200 [02:08<00:57,  6.69it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 819/1200 [02:09<00:58,  6.48it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 821/1200 [02:09<00:50,  7.49it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  68%|▋| 822/1200 [02:09<00:53,  7.04it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 823/1200 [02:09<00:56,  6.71it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 824/1200 [02:09<00:57,  6.49it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 825/1200 [02:09<00:59,  6.30it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 826/1200 [02:10<01:00,  6.17it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 827/1200 [02:10<01:01,  6.08it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 828/1200 [02:10<01:01,  6.02it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 829/1200 [02:10<01:02,  5.98it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 830/1200 [02:10<01:01,  5.97it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 831/1200 [02:10<01:02,  5.94it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 832/1200 [02:11<01:02,  5.92it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  69%|▋| 833/1200 [02:11<01:02,  5.92it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 834/1200 [02:11<01:01,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 835/1200 [02:11<01:01,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 837/1200 [02:11<00:54,  6.70it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 838/1200 [02:12<00:55,  6.48it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 839/1200 [02:12<00:57,  6.31it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 840/1200 [02:12<00:58,  6.19it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 841/1200 [02:12<00:58,  6.13it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 842/1200 [02:12<00:59,  6.06it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 843/1200 [02:12<00:59,  6.00it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 844/1200 [02:13<00:59,  5.96it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 845/1200 [02:13<00:59,  5.93it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 846/1200 [02:13<00:59,  5.93it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 847/1200 [02:13<00:59,  5.93it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 848/1200 [02:13<00:54,  6.44it/s, 92 steps of size 4.44e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 849/1200 [02:13<00:55,  6.28it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 850/1200 [02:14<00:56,  6.16it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 851/1200 [02:14<00:57,  6.07it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 852/1200 [02:14<00:57,  6.03it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 853/1200 [02:14<00:58,  5.96it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 854/1200 [02:14<00:58,  5.93it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 855/1200 [02:14<00:58,  5.92it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  71%|▋| 857/1200 [02:15<00:51,  6.66it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 858/1200 [02:15<00:53,  6.44it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 859/1200 [02:15<00:54,  6.29it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 860/1200 [02:15<00:55,  6.16it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 861/1200 [02:15<00:55,  6.08it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 863/1200 [02:16<00:49,  6.76it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 864/1200 [02:16<00:51,  6.52it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 865/1200 [02:16<00:53,  6.31it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 866/1200 [02:16<00:54,  6.18it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 867/1200 [02:16<00:54,  6.09it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 868/1200 [02:16<00:55,  6.03it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 869/1200 [02:17<00:55,  5.98it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 870/1200 [02:17<00:55,  5.96it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 871/1200 [02:17<00:55,  5.94it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 872/1200 [02:17<00:55,  5.91it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 873/1200 [02:17<00:55,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 874/1200 [02:17<00:55,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 875/1200 [02:18<00:55,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 876/1200 [02:18<00:55,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 877/1200 [02:18<00:54,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 878/1200 [02:18<00:54,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 879/1200 [02:18<00:54,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 880/1200 [02:18<00:54,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  73%|▋| 881/1200 [02:19<00:54,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 882/1200 [02:19<00:54,  5.84it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 883/1200 [02:19<00:54,  5.84it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 884/1200 [02:19<00:54,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 885/1200 [02:19<00:53,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 886/1200 [02:20<00:53,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 887/1200 [02:20<00:53,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 888/1200 [02:20<00:53,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 889/1200 [02:20<00:52,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 890/1200 [02:20<00:52,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 891/1200 [02:20<00:52,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 892/1200 [02:21<00:52,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 893/1200 [02:21<00:52,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  74%|▋| 894/1200 [02:21<00:52,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▋| 895/1200 [02:21<00:51,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▋| 896/1200 [02:21<00:51,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▋| 897/1200 [02:21<00:51,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▋| 898/1200 [02:22<00:51,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▋| 899/1200 [02:22<00:51,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 900/1200 [02:22<00:51,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 901/1200 [02:22<00:51,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 902/1200 [02:22<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 903/1200 [02:22<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 904/1200 [02:23<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 905/1200 [02:23<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 906/1200 [02:23<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 907/1200 [02:23<00:50,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 908/1200 [02:23<00:49,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 909/1200 [02:23<00:49,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 910/1200 [02:24<00:49,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 911/1200 [02:24<00:49,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 912/1200 [02:24<00:48,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 913/1200 [02:24<00:48,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 914/1200 [02:24<00:48,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 915/1200 [02:24<00:48,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 916/1200 [02:25<00:48,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  76%|▊| 918/1200 [02:25<00:42,  6.64it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 919/1200 [02:25<00:43,  6.40it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 920/1200 [02:25<00:44,  6.24it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 922/1200 [02:25<00:40,  6.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 923/1200 [02:26<00:42,  6.59it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 924/1200 [02:26<00:43,  6.38it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 925/1200 [02:26<00:44,  6.22it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 926/1200 [02:26<00:44,  6.13it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 927/1200 [02:26<00:45,  6.06it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 928/1200 [02:27<00:45,  6.01it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  77%|▊| 929/1200 [02:27<00:45,  5.98it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 930/1200 [02:27<00:45,  5.95it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 931/1200 [02:27<00:45,  5.92it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 932/1200 [02:27<00:45,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 933/1200 [02:27<00:45,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 934/1200 [02:28<00:45,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 935/1200 [02:28<00:45,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 936/1200 [02:28<00:44,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 937/1200 [02:28<00:44,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 938/1200 [02:28<00:44,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 939/1200 [02:28<00:44,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 940/1200 [02:29<00:44,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 941/1200 [02:29<00:44,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  78%|▊| 942/1200 [02:29<00:44,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 943/1200 [02:29<00:43,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 944/1200 [02:29<00:43,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 945/1200 [02:29<00:43,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 946/1200 [02:30<00:43,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 947/1200 [02:30<00:43,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 948/1200 [02:30<00:42,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 949/1200 [02:30<00:42,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 950/1200 [02:30<00:42,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 951/1200 [02:30<00:42,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 952/1200 [02:31<00:42,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 954/1200 [02:31<00:37,  6.62it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 955/1200 [02:31<00:38,  6.32it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 956/1200 [02:31<00:39,  6.12it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 957/1200 [02:31<00:40,  6.02it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 958/1200 [02:32<00:40,  5.98it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 959/1200 [02:32<00:40,  5.95it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 960/1200 [02:32<00:40,  5.92it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 961/1200 [02:32<00:40,  5.89it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 962/1200 [02:32<00:40,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 963/1200 [02:32<00:40,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 964/1200 [02:33<00:40,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 965/1200 [02:33<00:40,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 966/1200 [02:33<00:40,  5.85it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 967/1200 [02:33<00:39,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 968/1200 [02:33<00:51,  4.50it/s, 255 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 969/1200 [02:34<00:54,  4.24it/s, 191 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 970/1200 [02:34<00:49,  4.62it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 971/1200 [02:34<00:46,  4.93it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 972/1200 [02:34<00:44,  5.18it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 973/1200 [02:34<00:42,  5.36it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 974/1200 [02:35<00:41,  5.51it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 975/1200 [02:35<00:40,  5.60it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 976/1200 [02:35<00:39,  5.64it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  81%|▊| 977/1200 [02:35<00:39,  5.68it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 978/1200 [02:35<00:38,  5.75it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 979/1200 [02:35<00:38,  5.77it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 980/1200 [02:36<00:38,  5.67it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 981/1200 [02:36<00:38,  5.69it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 982/1200 [02:36<00:38,  5.73it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 983/1200 [02:36<00:37,  5.77it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 984/1200 [02:36<00:37,  5.80it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 985/1200 [02:36<00:36,  5.81it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 986/1200 [02:37<00:36,  5.83it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 987/1200 [02:37<00:36,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 988/1200 [02:37<00:36,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 989/1200 [02:37<00:35,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  82%|▊| 990/1200 [02:37<00:35,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 991/1200 [02:37<00:35,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 992/1200 [02:38<00:35,  5.90it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 993/1200 [02:38<00:35,  5.88it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 994/1200 [02:38<00:35,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 995/1200 [02:38<00:34,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 996/1200 [02:38<00:34,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 997/1200 [02:39<00:34,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 998/1200 [02:39<00:34,  5.86it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 999/1200 [02:39<00:34,  5.87it/s, 127 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 1000/1200 [02:39<00:34,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  83%|▊| 1001/1200 [02:39<00:33,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1002/1200 [02:39<00:33,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1003/1200 [02:40<00:33,  5.84it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1004/1200 [02:40<00:33,  5.84it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1005/1200 [02:40<00:33,  5.85it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1006/1200 [02:40<00:33,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1007/1200 [02:40<00:32,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1008/1200 [02:40<00:32,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1009/1200 [02:41<00:32,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1010/1200 [02:41<00:32,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1011/1200 [02:41<00:32,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1012/1200 [02:41<00:32,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1013/1200 [02:41<00:31,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  84%|▊| 1014/1200 [02:41<00:31,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1015/1200 [02:42<00:31,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1016/1200 [02:42<00:31,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1017/1200 [02:42<00:31,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1018/1200 [02:42<00:31,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1019/1200 [02:42<00:30,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1020/1200 [02:42<00:30,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1022/1200 [02:43<00:26,  6.64it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1023/1200 [02:43<00:27,  6.41it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1024/1200 [02:43<00:28,  6.26it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1025/1200 [02:43<00:28,  6.16it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1026/1200 [02:43<00:28,  6.09it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1027/1200 [02:44<00:28,  6.02it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1028/1200 [02:44<00:28,  5.97it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1030/1200 [02:44<00:25,  6.70it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1031/1200 [02:44<00:26,  6.47it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1032/1200 [02:44<00:26,  6.31it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1034/1200 [02:45<00:24,  6.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1035/1200 [02:45<00:24,  6.61it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1036/1200 [02:45<00:25,  6.42it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1037/1200 [02:45<00:25,  6.28it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  86%|▊| 1038/1200 [02:45<00:26,  6.16it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1039/1200 [02:45<00:26,  6.07it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1040/1200 [02:46<00:26,  6.02it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1041/1200 [02:46<00:26,  5.93it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1042/1200 [02:46<00:26,  5.94it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1043/1200 [02:46<00:26,  5.93it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1044/1200 [02:46<00:26,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1045/1200 [02:46<00:26,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1046/1200 [02:47<00:26,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1047/1200 [02:47<00:26,  5.81it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1048/1200 [02:47<00:26,  5.80it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  87%|▊| 1049/1200 [02:47<00:26,  5.81it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1050/1200 [02:47<00:25,  5.82it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1051/1200 [02:47<00:25,  5.77it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1052/1200 [02:48<00:25,  5.75it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1053/1200 [02:48<00:25,  5.78it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1054/1200 [02:48<00:25,  5.72it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1055/1200 [02:48<00:25,  5.75it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1056/1200 [02:48<00:24,  5.77it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1057/1200 [02:49<00:24,  5.77it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1058/1200 [02:49<00:24,  5.76it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1059/1200 [02:49<00:24,  5.78it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1060/1200 [02:49<00:24,  5.78it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  88%|▉| 1061/1200 [02:49<00:24,  5.71it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1063/1200 [02:49<00:20,  6.68it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1064/1200 [02:50<00:21,  6.40it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1065/1200 [02:50<00:21,  6.20it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1066/1200 [02:50<00:21,  6.10it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1067/1200 [02:50<00:22,  6.00it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1069/1200 [02:50<00:16,  7.94it/s, 49 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1070/1200 [02:50<00:17,  7.31it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1071/1200 [02:51<00:18,  6.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1072/1200 [02:51<00:19,  6.58it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  89%|▉| 1073/1200 [02:51<00:19,  6.37it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1074/1200 [02:51<00:20,  6.22it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1075/1200 [02:51<00:20,  6.11it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1076/1200 [02:51<00:20,  6.04it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1077/1200 [02:52<00:20,  5.99it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1078/1200 [02:52<00:20,  5.95it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1079/1200 [02:52<00:20,  5.92it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1080/1200 [02:52<00:20,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1081/1200 [02:52<00:20,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1082/1200 [02:53<00:20,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1083/1200 [02:53<00:19,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1084/1200 [02:53<00:19,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1085/1200 [02:53<00:19,  5.92it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1086/1200 [02:53<00:19,  5.92it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1087/1200 [02:53<00:19,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1088/1200 [02:54<00:19,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1089/1200 [02:54<00:18,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1090/1200 [02:54<00:18,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1091/1200 [02:54<00:18,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1092/1200 [02:54<00:18,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1093/1200 [02:54<00:18,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1095/1200 [02:55<00:15,  6.66it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1096/1200 [02:55<00:16,  6.45it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  91%|▉| 1097/1200 [02:55<00:16,  6.30it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1098/1200 [02:55<00:16,  6.19it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1099/1200 [02:55<00:16,  6.09it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1100/1200 [02:55<00:16,  6.05it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1101/1200 [02:56<00:16,  5.99it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1102/1200 [02:56<00:16,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1103/1200 [02:56<00:16,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1104/1200 [02:56<00:16,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1105/1200 [02:56<00:16,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1106/1200 [02:57<00:15,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1107/1200 [02:57<00:15,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1108/1200 [02:57<00:15,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1109/1200 [02:57<00:20,  4.52it/s, 255 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  92%|▉| 1110/1200 [02:57<00:18,  4.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1111/1200 [02:58<00:17,  5.12it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1112/1200 [02:58<00:16,  5.32it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1113/1200 [02:58<00:15,  5.47it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1114/1200 [02:58<00:15,  5.59it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1115/1200 [02:58<00:14,  5.69it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1116/1200 [02:58<00:14,  5.74it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1117/1200 [02:59<00:14,  5.78it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1118/1200 [02:59<00:14,  5.81it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1119/1200 [02:59<00:14,  5.78it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1120/1200 [02:59<00:12,  6.51it/s, 81 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 1121/1200 [02:59<00:12,  6.30it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1122/1200 [02:59<00:12,  6.16it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1123/1200 [03:00<00:12,  6.08it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1124/1200 [03:00<00:12,  6.00it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1125/1200 [03:00<00:12,  5.99it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1126/1200 [03:00<00:12,  5.94it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1127/1200 [03:00<00:12,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1129/1200 [03:00<00:10,  6.67it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1130/1200 [03:01<00:10,  6.45it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1131/1200 [03:01<00:10,  6.30it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1132/1200 [03:01<00:11,  6.17it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1133/1200 [03:01<00:11,  6.08it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  94%|▉| 1134/1200 [03:01<00:10,  6.01it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1135/1200 [03:01<00:10,  5.96it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1136/1200 [03:02<00:10,  5.93it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1137/1200 [03:02<00:10,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1138/1200 [03:02<00:10,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1139/1200 [03:02<00:10,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1140/1200 [03:02<00:10,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1141/1200 [03:02<00:10,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1142/1200 [03:03<00:09,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1143/1200 [03:03<00:09,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1144/1200 [03:03<00:09,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1145/1200 [03:03<00:09,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1146/1200 [03:03<00:09,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1147/1200 [03:04<00:09,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1148/1200 [03:04<00:08,  5.83it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1149/1200 [03:04<00:08,  5.84it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1150/1200 [03:04<00:08,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1151/1200 [03:04<00:08,  5.86it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1152/1200 [03:04<00:08,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1153/1200 [03:05<00:07,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1154/1200 [03:05<00:07,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1155/1200 [03:05<00:07,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1156/1200 [03:05<00:07,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1157/1200 [03:05<00:07,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  96%|▉| 1158/1200 [03:05<00:07,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1159/1200 [03:06<00:06,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1160/1200 [03:06<00:06,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1161/1200 [03:06<00:06,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1162/1200 [03:06<00:06,  5.87it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1163/1200 [03:06<00:06,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1164/1200 [03:06<00:06,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1165/1200 [03:07<00:05,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1166/1200 [03:07<00:05,  5.92it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1167/1200 [03:07<00:05,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1168/1200 [03:07<00:05,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  97%|▉| 1169/1200 [03:07<00:05,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1170/1200 [03:07<00:05,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1171/1200 [03:08<00:04,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1172/1200 [03:08<00:04,  5.88it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1173/1200 [03:08<00:04,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1175/1200 [03:08<00:03,  7.71it/s, 63 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1176/1200 [03:08<00:03,  7.15it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1178/1200 [03:09<00:02,  7.41it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1179/1200 [03:09<00:02,  7.00it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1180/1200 [03:09<00:02,  6.69it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1181/1200 [03:09<00:02,  6.46it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  98%|▉| 1182/1200 [03:09<00:02,  6.28it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1183/1200 [03:09<00:02,  6.17it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1185/1200 [03:10<00:01,  8.14it/s, 63 steps of size 4.44e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1186/1200 [03:10<00:01,  7.44it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1187/1200 [03:10<00:01,  6.95it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1188/1200 [03:10<00:01,  6.63it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1189/1200 [03:10<00:01,  6.41it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1190/1200 [03:10<00:01,  6.22it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1191/1200 [03:11<00:01,  6.11it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1192/1200 [03:11<00:01,  6.04it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 1193/1200 [03:11<00:01,  5.99it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1194/1200 [03:11<00:01,  5.97it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1195/1200 [03:11<00:00,  5.94it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1196/1200 [03:11<00:00,  5.92it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1197/1200 [03:12<00:00,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1198/1200 [03:12<00:00,  5.91it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|▉| 1199/1200 [03:12<00:00,  5.90it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|█| 1200/1200 [03:12<00:00,  5.89it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|█| 1200/1200 [03:12<00:00,  6.23it/s, 127 steps of size 4.44e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "  0%|                                                 | 0/1200 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 60/1200 [00:09<03:06,  6.12it/s, 511 steps of size 9.51e-03. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  10%| | 120/1200 [00:24<03:49,  4.70it/s, 127 steps of size 5.98e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  15%|▏| 180/1200 [00:32<02:56,  5.80it/s, 127 steps of size 6.25e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  20%|▏| 240/1200 [00:40<02:36,  6.15it/s, 63 steps of size 7.94e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  25%|▎| 300/1200 [00:50<02:24,  6.23it/s, 127 steps of size 5.91e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  30%|▎| 360/1200 [00:57<02:03,  6.81it/s, 127 steps of size 7.06e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  35%|▎| 420/1200 [01:03<01:42,  7.58it/s, 63 steps of size 9.45e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  40%|▍| 480/1200 [01:09<01:26,  8.28it/s, 127 steps of size 8.43e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 540/1200 [01:15<01:13,  8.92it/s, 63 steps of size 9.11e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  50%|▌| 600/1200 [01:22<01:08,  8.74it/s, 127 steps of size 6.15e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  55%|▌| 660/1200 [01:29<01:02,  8.68it/s, 127 steps of size 4.50e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  60%|▌| 720/1200 [01:35<00:53,  8.98it/s, 63 steps of size 8.38e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  65%|▋| 780/1200 [01:42<00:46,  9.00it/s, 127 steps of size 5.29e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  70%|▋| 840/1200 [01:47<00:37,  9.53it/s, 63 steps of size 6.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  75%|▊| 900/1200 [01:53<00:30,  9.88it/s, 63 steps of size 6.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  80%|▊| 960/1200 [01:58<00:23, 10.06it/s, 63 steps of size 6.31e-02. ac"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 1020/1200 [02:04<00:17, 10.19it/s, 63 steps of size 6.31e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  90%|▉| 1080/1200 [02:09<00:11, 10.42it/s, 63 steps of size 6.31e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  95%|▉| 1140/1200 [02:15<00:05, 10.62it/s, 63 steps of size 6.31e-02. a"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|█| 1200/1200 [02:21<00:00, 10.56it/s, 127 steps of size 6.31e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|█| 1200/1200 [02:21<00:00,  8.51it/s, 127 steps of size 6.31e-02. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "There were 19 divergences after tuning. Increase `target_accept` or reparameterize.\n"
+      "There were 18 divergences after tuning. Increase `target_accept` or reparameterize.\n"
      ]
     },
     {
@@ -8041,13 +703,6 @@
      "output_type": "stream",
      "text": [
       "The rhat statistic is larger than 1.01 for some parameters. This indicates problems during sampling. See https://arxiv.org/abs/1903.08008 for details\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The effective sample size per chain is smaller than 100 for some parameters.  A higher number is needed for reliable rhat and ess computation. See https://arxiv.org/abs/1903.08008 for details\n"
      ]
     },
     {
@@ -8607,31 +1262,31 @@
        "│         * participant_id__factor_dim             (participant_id__factor_dim) &lt;U2 96B ...\n",
        "│         * rl_alpha_1|participant_id__factor_dim  (rl_alpha_1|participant_id__factor_dim) &lt;U2 96B ...\n",
        "│       Data variables: (12/24)\n",
-       "│           a_1|participant_id_offset              (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_1|participant_id_offset       (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
+       "│           theta_1|participant_id_offset          (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           scaler_1|participant_id_offset         (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           scaler_1|participant_id                (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           a_Intercept                            (chain, draw) float32 3kB ...\n",
        "│           z_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
-       "│           theta_1|participant_id                 (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_1|participant_id              (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
-       "│           t_Intercept                            (chain, draw) float32 3kB ...\n",
-       "│           ...                                     ...\n",
        "│           t_1|participant_id_offset              (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_Intercept                     (chain, draw) float32 3kB ...\n",
-       "│           a_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
-       "│           t_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           t_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
+       "│           ...                                     ...\n",
        "│           scaler_1|participant_id_sigma          (chain, draw) float32 3kB ...\n",
+       "│           z_Intercept                            (chain, draw) float32 3kB ...\n",
+       "│           rl_alpha_1|participant_id_offset       (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
+       "│           theta_Intercept                        (chain, draw) float32 3kB ...\n",
+       "│           t_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           a_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.612283+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.114260+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 [&#x27;chain&#x27;, &#x27;draw&#x27;]\n",
        "│           inference_library:           numpyro\n",
        "│           inference_library_version:   0.21.0\n",
-       "│           sampling_time:               335.468196\n",
+       "│           sampling_time:               228.017227\n",
        "│           tuning_steps:                800\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /sample_stats\n",
        "│       Dimensions:          (chain: 2, draw: 400)\n",
        "│       Coordinates:\n",
@@ -8643,16 +1298,16 @@
        "│           diverging        (chain, draw) bool 800B ...\n",
        "│           energy           (chain, draw) float32 3kB ...\n",
        "│           n_steps          (chain, draw) int32 3kB ...\n",
-       "│           tree_depth       (chain, draw) int64 6kB 7 7 7 7 7 7 7 6 ... 6 6 6 6 6 6 6 7\n",
+       "│           tree_depth       (chain, draw) int64 6kB 6 7 6 7 6 7 6 6 ... 7 7 6 7 7 7 7 5\n",
        "│           lp               (chain, draw) float32 3kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623322+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.126598+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 [&#x27;chain&#x27;, &#x27;draw&#x27;]\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /observed_data\n",
        "│       Dimensions:                  (__obs__: 1800, rt,response_extra_dim_0: 2)\n",
        "│       Coordinates:\n",
@@ -8661,22 +1316,22 @@
        "│       Data variables:\n",
        "│           rt,response              (__obs__, rt,response_extra_dim_0) float32 14kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623923+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.127403+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 []\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /constant_data\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623995+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.127494+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 []\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "└── Group: /log_likelihood\n",
        "        Dimensions:      (chain: 2, draw: 400, __obs__: 1800)\n",
        "        Coordinates:\n",
@@ -8684,10 +1339,10 @@
        "          * draw         (draw) int64 3kB 0 1 2 3 4 5 6 ... 393 394 395 396 397 398 399\n",
        "          * __obs__      (__obs__) int64 14kB 0 1 2 3 4 5 ... 1795 1796 1797 1798 1799\n",
        "        Data variables:\n",
-       "            rt,response  (chain, draw, __obs__) float64 12MB -1.463 -0.9025 ... -0.7486\n",
+       "            rt,response  (chain, draw, __obs__) float64 12MB -1.384 -1.446 ... -0.8204\n",
        "        Attributes:\n",
        "            modeling_interface:          bambi\n",
-       "            modeling_interface_version:  0.18.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataTree</div></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-children'><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-801b7b25-8023-4621-9f92-2ffdd4a0e6a8' type='checkbox' checked /><label for='group-801b7b25-8023-4621-9f92-2ffdd4a0e6a8' title='Expand/collapse group'>/posterior<span>(39)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-933d707d-e41c-41d8-a477-3505518d1a81' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-933d707d-e41c-41d8-a477-3505518d1a81' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li><li><span class='xr-has-index'>participant_id__factor_dim</span>: 12</li><li><span class='xr-has-index'>rl_alpha_1|participant_id__factor_dim</span>: 12</li></ul></div></li><li class='xr-section-item'><input id='section-594335f7-4cf9-4963-8662-9e80579d6123' class='xr-section-summary-in' type='checkbox' checked /><label for='section-594335f7-4cf9-4963-8662-9e80579d6123' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-f0b7a068-3d8a-4e7b-976e-c4ac21b6b7ff' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f0b7a068-3d8a-4e7b-976e-c4ac21b6b7ff' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33a4765a-8cc3-41cb-b519-f97da58a3902' class='xr-var-data-in' type='checkbox'><label for='data-33a4765a-8cc3-41cb-b519-f97da58a3902' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-4b38de39-8833-49ff-8036-6c2329db2263' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4b38de39-8833-49ff-8036-6c2329db2263' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-02affc25-bd17-44b0-a637-b9e62bfdcd7f' class='xr-var-data-in' type='checkbox'><label for='data-02affc25-bd17-44b0-a637-b9e62bfdcd7f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>participant_id__factor_dim</span></div><div class='xr-var-dims'>(participant_id__factor_dim)</div><div class='xr-var-dtype'>&lt;U2</div><div class='xr-var-preview xr-preview'>&#x27;0&#x27; &#x27;1&#x27; &#x27;2&#x27; &#x27;3&#x27; ... &#x27;9&#x27; &#x27;10&#x27; &#x27;11&#x27;</div><input id='attrs-7eda5630-eeee-4e6d-9414-d709dadedb9a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7eda5630-eeee-4e6d-9414-d709dadedb9a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fe2272f6-11f3-4014-b197-739df1d0434f' class='xr-var-data-in' type='checkbox'><label for='data-fe2272f6-11f3-4014-b197-739df1d0434f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;0&#x27;, &#x27;1&#x27;, &#x27;2&#x27;, &#x27;3&#x27;, &#x27;4&#x27;, &#x27;5&#x27;, &#x27;6&#x27;, &#x27;7&#x27;, &#x27;8&#x27;, &#x27;9&#x27;, &#x27;10&#x27;, &#x27;11&#x27;],dtype=&#x27;&lt;U2&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>rl_alpha_1|participant_id__factor_dim</span></div><div class='xr-var-dims'>(rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>&lt;U2</div><div class='xr-var-preview xr-preview'>&#x27;0&#x27; &#x27;1&#x27; &#x27;2&#x27; &#x27;3&#x27; ... &#x27;9&#x27; &#x27;10&#x27; &#x27;11&#x27;</div><input id='attrs-c6845d15-9ab0-43ce-8fc6-234758c64ce8' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c6845d15-9ab0-43ce-8fc6-234758c64ce8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a09ee67e-dd06-4189-9b8c-6d1592b152ed' class='xr-var-data-in' type='checkbox'><label for='data-a09ee67e-dd06-4189-9b8c-6d1592b152ed' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;0&#x27;, &#x27;1&#x27;, &#x27;2&#x27;, &#x27;3&#x27;, &#x27;4&#x27;, &#x27;5&#x27;, &#x27;6&#x27;, &#x27;7&#x27;, &#x27;8&#x27;, &#x27;9&#x27;, &#x27;10&#x27;, &#x27;11&#x27;],dtype=&#x27;&lt;U2&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-203e9d7a-e06f-40e1-81ea-cf14b34c2844' class='xr-section-summary-in' type='checkbox' /><label for='section-203e9d7a-e06f-40e1-81ea-cf14b34c2844' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(24)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-10e259b9-7447-4cae-a808-04590242cc28' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-10e259b9-7447-4cae-a808-04590242cc28' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ece581ec-d052-44a4-bcf6-b82058dcd59d' class='xr-var-data-in' type='checkbox'><label for='data-ece581ec-d052-44a4-bcf6-b82058dcd59d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.69288945, -0.74149424, -0.82277924, ...,  0.04981707,-1.9040338 ,  0.6762876 ],[-0.14757203, -0.33454216, -0.12724605, ...,  0.10676881,-1.8211361 ,  0.51503   ],[-0.25835073, -0.7140849 ,  0.31022146, ...,  0.78233176,-1.8626676 ,  1.1343755 ],...,[ 0.18483435, -0.5524385 , -0.8162698 , ...,  0.5927488 ,-1.7893698 ,  1.1353195 ],[-0.9875508 , -0.5914181 , -0.69536173, ...,  0.821407  ,-1.9200008 ,  0.32903573],[-0.36663336, -0.10723178, -0.43682137, ..., -0.0202283 ,-1.4056547 ,  0.8174605 ]],[[-0.5900139 ,  0.06509311, -0.47407448, ...,  1.1826198 ,-1.6070135 ,  0.43119472],[ 0.04348743, -0.03094507, -0.24547745, ...,  0.26884216,-1.3317015 ,  0.6431895 ],[-0.17037827, -0.91419435, -0.376672  , ...,  0.15767087,-2.2011776 ,  0.95565844],...,[-1.0841621 ,  0.12015247, -1.5393021 , ...,  0.9453673 ,-1.7276617 ,  1.5014397 ],[-0.6341941 , -0.42656893, -0.7844778 , ...,  1.2356532 ,-2.4214404 ,  0.19075465],[-1.1763048 , -0.78677773, -0.1507609 , ..., -0.18860611,-1.9756078 ,  0.83518744]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e0726fb0-24e3-4ed8-8604-4b08efec3baf' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e0726fb0-24e3-4ed8-8604-4b08efec3baf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0b24d51c-9b36-4906-8a39-74ae12415f87' class='xr-var-data-in' type='checkbox'><label for='data-0b24d51c-9b36-4906-8a39-74ae12415f87' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 2.3732574e+00,  5.0580744e-02,  1.0591979e+00, ...,-2.0687232e+00,  1.2378081e+00, -3.5922056e-01],[ 1.6182644e+00,  2.9944882e-01, -5.3922296e-02, ...,1.6131285e-01, -8.5980612e-01,  1.7909298e+00],[ 1.2769297e+00,  5.9202141e-01,  1.0435563e+00, ...,-2.3944678e+00,  4.3629184e-01,  4.8993304e-02],...,[ 1.7033443e+00,  6.7657870e-01,  1.5345695e+00, ...,6.1122650e-01, -1.7768271e-01,  2.0202940e+00],[ 1.6257133e+00,  2.5074065e+00, -1.6403106e-01, ...,-3.8896533e-04,  1.3737167e+00,  9.4654888e-01],[-7.2306305e-02, -1.6538242e-01,  1.7635099e+00, ...,-2.5301328e-01,  3.9126962e-01, -5.5616397e-01]],[[ 3.3062040e-03,  9.8631769e-01,  1.4469011e-01, ...,-5.4574358e-01, -1.2050515e+00, -1.0143961e+00],[ 4.3986908e-01,  3.3771273e-02,  7.6077950e-01, ...,-1.5432442e+00,  2.3251338e+00, -2.6140022e-01],[ 1.5501138e+00,  2.9781365e-01, -1.3909388e+00, ...,1.6937638e-02, -4.7175926e-01,  1.6194129e+00],...,[ 1.0825534e+00,  2.7962072e+00, -7.9078533e-02, ...,-1.0671338e+00, -1.8501911e-01,  6.8395883e-01],[-1.2006704e+00, -1.2953135e-01, -3.6380526e-02, ...,-1.0138707e+00,  7.4665654e-01, -6.8541312e-01],[ 9.0259618e-01,  1.6823248e+00,  1.0567973e+00, ...,-9.1232890e-01, -2.1802767e-01,  5.5470634e-01]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-6871c26b-de1d-4295-8c40-6acd93ac681e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6871c26b-de1d-4295-8c40-6acd93ac681e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-019b1c16-510f-425f-acee-ecbe4b5aa0c8' class='xr-var-data-in' type='checkbox'><label for='data-019b1c16-510f-425f-acee-ecbe4b5aa0c8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.04745084, 0.05716437, 0.04911159, 0.06358554, 0.07860275,0.07208163, 0.06385949, 0.07695439, 0.07018612, 0.08465979,0.11510481, 0.0874906 , 0.07056119, 0.08000026, 0.05333165,0.08226501, 0.06171974, 0.103048  , 0.05284891, 0.03937292,0.06721032, 0.04866264, 0.06266159, 0.06659343, 0.09504394,0.06924086, 0.04958708, 0.05221962, 0.05488931, 0.03711922,0.04422087, 0.06940621, 0.05576034, 0.06562687, 0.04822001,0.05449815, 0.07224102, 0.04459452, 0.04446911, 0.08645812,0.0501302 , 0.08812822, 0.05352691, 0.05102237, 0.04546085,0.07709091, 0.07070298, 0.06421015, 0.04670106, 0.05499671,0.05135373, 0.04578815, 0.0739151 , 0.08473948, 0.05704119,0.06128597, 0.0609903 , 0.09121656, 0.0439542 , 0.07403108,0.05559215, 0.05276656, 0.06468515, 0.07722086, 0.06482072,0.06934286, 0.04854771, 0.07819745, 0.09176673, 0.0928257 ,0.05341529, 0.0604985 , 0.07430977, 0.05019422, 0.04805714,0.12146258, 0.15501885, 0.05174693, 0.07079686, 0.09437151,0.10346509, 0.06705516, 0.07789502, 0.04999718, 0.05656521,0.13703915, 0.05356551, 0.03861361, 0.06334441, 0.03755877,0.04851452, 0.03621876, 0.07638521, 0.03448115, 0.05180241,0.03681945, 0.07810704, 0.09689012, 0.08564819, 0.05239081,...0.0750962 , 0.12766495, 0.0944986 , 0.11748874, 0.09778731,0.04851621, 0.05339713, 0.04228593, 0.04590538, 0.05311053,0.06006359, 0.0461404 , 0.04316712, 0.06328192, 0.04791284,0.04792547, 0.05167129, 0.03622808, 0.0699845 , 0.03769594,0.03446791, 0.03665687, 0.09524063, 0.07907157, 0.08660746,0.06869008, 0.05650963, 0.05917755, 0.05074608, 0.05910579,0.06078176, 0.10734129, 0.06296305, 0.06468067, 0.06192949,0.05823873, 0.06615794, 0.07061701, 0.08255098, 0.05720943,0.06056941, 0.09187467, 0.06444895, 0.06208578, 0.08880212,0.08331412, 0.07021127, 0.05951654, 0.07506653, 0.0727607 ,0.04960511, 0.05605045, 0.0619268 , 0.0632931 , 0.04660231,0.06779554, 0.02388657, 0.02806906, 0.04462519, 0.05365036,0.07189161, 0.06117416, 0.06531525, 0.06591333, 0.07078223,0.07520975, 0.07369237, 0.10018733, 0.05948507, 0.0527687 ,0.07433979, 0.05518882, 0.07252419, 0.08023889, 0.07154766,0.05548396, 0.03958467, 0.0932427 , 0.04460194, 0.05452567,0.06053916, 0.05297501, 0.07322907, 0.07068804, 0.06487811,0.04767563, 0.0579536 , 0.06823193, 0.06257509, 0.05539468,0.07947224, 0.08460239, 0.06671901, 0.0737031 , 0.09785429,0.0870841 , 0.06601241, 0.06837558, 0.06072389, 0.02597368]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-aa4a8847-8927-4d91-a567-ce2661d5dd58' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-aa4a8847-8927-4d91-a567-ce2661d5dd58' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-825970d7-b096-4ee0-94f1-2d6243e42c88' class='xr-var-data-in' type='checkbox'><label for='data-825970d7-b096-4ee0-94f1-2d6243e42c88' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.13942479,  0.10709463,  0.21932602, ..., -0.04345706,0.0815094 ,  0.04396473],[-0.02375701,  0.22392444,  0.32002392, ..., -0.1620775 ,0.15696058, -0.0780836 ],[-0.14356658,  0.04093328,  0.2659634 , ..., -0.13189088,-0.06113296, -0.10208902],...,[-0.05360602,  0.195012  ,  0.24250054, ..., -0.13416101,0.09445538,  0.02063266],[-0.1584822 ,  0.17677203,  0.31078723, ...,  0.02791628,0.12978162, -0.02907198],[ 0.00292039,  0.27918822,  0.2732625 , ..., -0.13808568,0.15160622,  0.08650666]],[[-0.15445189,  0.15090662,  0.26175362, ...,  0.03756431,0.06845698, -0.03760127],[-0.07080156,  0.23805569,  0.22850573, ..., -0.14469329,0.13925283, -0.0266118 ],[-0.08838325,  0.11990938,  0.2574135 , ..., -0.1783222 ,0.15233938, -0.02124238],...,[-0.26951388,  0.18010007,  0.03901846, ..., -0.0675225 ,0.10653283,  0.0482507 ],[-0.10623519,  0.20770574,  0.28020176, ..., -0.02648001,0.06601461, -0.06402642],[-0.18392806,  0.1371155 ,  0.3280284 , ..., -0.11897936,0.1843044 ,  0.06145591]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e5fd908e-7a36-472c-8716-bac0b3a11967' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e5fd908e-7a36-472c-8716-bac0b3a11967' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1ec612f0-09f5-4899-8395-1583a18ea25b' class='xr-var-data-in' type='checkbox'><label for='data-1ec612f0-09f5-4899-8395-1583a18ea25b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 5.5918649e-02,  1.1917826e-03,  2.4956802e-02, ...,-4.8743218e-02,  2.9165212e-02, -8.4639490e-03],[ 6.2888473e-02,  1.1637083e-02, -2.0955110e-03, ...,6.2688878e-03, -3.3413507e-02,  6.9598533e-02],[ 3.2369845e-02,  1.5007592e-02,  2.6453888e-02, ...,-6.0699150e-02,  1.1059887e-02,  1.2419678e-03],...,[ 4.7410764e-02,  1.8831842e-02,  4.2713095e-02, ...,1.7012835e-02, -4.9456079e-03,  5.6232717e-02],[ 1.3748572e-02,  2.1205004e-02, -1.3872021e-03, ...,-3.2894593e-06,  1.1617450e-02,  8.0049140e-03],[-3.8950231e-03, -8.9088818e-03,  9.4997413e-02, ...,-1.3629414e-02,  2.1077059e-02, -2.9959649e-02]],[[ 1.5648222e-04,  4.6682291e-02,  6.8481644e-03, ...,-2.5829975e-02, -5.7034936e-02, -4.8011236e-02],[ 1.2111683e-02,  9.2988339e-04,  2.0947870e-02, ...,-4.2492837e-02,  6.4021967e-02, -7.1975887e-03],[ 2.8338900e-02,  5.4445756e-03, -2.5428891e-02, ...,3.0965084e-04, -8.6246179e-03,  2.9605813e-02],...,[ 2.5449038e-02,  6.5734200e-02, -1.8590053e-03, ...,-2.5086548e-02, -4.3494930e-03,  1.6078738e-02],[-2.4241714e-02, -2.6152574e-03, -7.3452824e-04, ...,-2.0470202e-02,  1.5075107e-02, -1.3838594e-02],[ 9.8009855e-03,  1.8267794e-02,  1.1475403e-02, ...,-9.9066701e-03, -2.3674883e-03,  6.0233679e-03]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-0a499fee-3853-4863-b04f-0bf6e65f2bb1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0a499fee-3853-4863-b04f-0bf6e65f2bb1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7489aa6e-db7e-40f7-9b4c-b980d2b28a27' class='xr-var-data-in' type='checkbox'><label for='data-7489aa6e-db7e-40f7-9b4c-b980d2b28a27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.20343167, 0.21818034, 0.21052761, 0.26648036, 0.20159107,0.21445875, 0.18813907, 0.22455536, 0.23370141, 0.23234743,0.23135248, 0.25710443, 0.21073328, 0.22715503, 0.1973981 ,0.24123427, 0.22451097, 0.22874197, 0.27764735, 0.27286434,0.19209322, 0.21689932, 0.26438862, 0.26282054, 0.23066123,0.22805606, 0.22505656, 0.20861466, 0.23860556, 0.25476152,0.25926635, 0.21957219, 0.24870238, 0.2384081 , 0.23270062,0.25270602, 0.23071589, 0.20060651, 0.20115742, 0.2011193 ,0.25194103, 0.24125585, 0.26780033, 0.20331433, 0.25653762,0.19323328, 0.21453486, 0.20729741, 0.24792601, 0.25371066,0.27453503, 0.2520215 , 0.2292233 , 0.27608272, 0.26372615,0.24351925, 0.27100626, 0.21514907, 0.25293687, 0.3104911 ,0.21443294, 0.21162926, 0.19795176, 0.20443518, 0.23233137,0.23978415, 0.24086474, 0.2738529 , 0.19252996, 0.21474998,0.20400225, 0.2366507 , 0.23638877, 0.24866685, 0.24893598,0.2461719 , 0.25523522, 0.20436865, 0.1933347 , 0.22233911,0.21702202, 0.21286589, 0.22879753, 0.21472521, 0.20981269,0.26509202, 0.20829915, 0.20242031, 0.22048856, 0.24622546,0.2275408 , 0.24052039, 0.18469405, 0.22025697, 0.22523278,0.24033464, 0.22373356, 0.23827899, 0.23119588, 0.2714335 ,...0.27386633, 0.2585236 , 0.27407798, 0.24153559, 0.24193716,0.23308109, 0.21242738, 0.22567014, 0.24308096, 0.25697607,0.24664152, 0.2634408 , 0.23739696, 0.2658371 , 0.26595345,0.21183287, 0.25136605, 0.19289193, 0.22413802, 0.18838345,0.20161797, 0.19604713, 0.2222512 , 0.22835132, 0.23352419,0.21443027, 0.2101106 , 0.2095095 , 0.23719338, 0.21691887,0.23078027, 0.26154578, 0.27938157, 0.26559818, 0.2817964 ,0.28417894, 0.21695392, 0.23843516, 0.2650768 , 0.26861283,0.22357585, 0.24393244, 0.2534848 , 0.2584308 , 0.24369527,0.22769184, 0.22899692, 0.21938036, 0.18527037, 0.2226635 ,0.23879184, 0.2343466 , 0.22009069, 0.23397416, 0.2706399 ,0.24925104, 0.24943155, 0.2411975 , 0.2123649 , 0.22348613,0.2175983 , 0.20745164, 0.2596245 , 0.2670803 , 0.22919063,0.2342252 , 0.2557174 , 0.19795226, 0.27532485, 0.28244504,0.25091663, 0.24721657, 0.23224472, 0.22027527, 0.21622892,0.26128575, 0.25407305, 0.2305747 , 0.24381892, 0.2589592 ,0.23186421, 0.23509525, 0.19550169, 0.20826674, 0.19341244,0.19979423, 0.21051729, 0.18946142, 0.22594455, 0.2290343 ,0.27968836, 0.27629226, 0.23352478, 0.2560393 , 0.23586458,0.23224258, 0.23584178, 0.24104288, 0.27773806, 0.3174794 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a8e11f9e-6f0e-4c8a-8ceb-2a5032b92b5a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a8e11f9e-6f0e-4c8a-8ceb-2a5032b92b5a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d3c4a285-728f-4027-8fab-faff49779709' class='xr-var-data-in' type='checkbox'><label for='data-d3c4a285-728f-4027-8fab-faff49779709' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.16937564, -0.181257  , -0.20112698, ...,  0.0121777 ,-0.4654378 ,  0.16531734],[-0.02439594, -0.05530501, -0.02103575, ...,  0.01765054,-0.30106205,  0.08514245],[-0.05397534, -0.14918858,  0.06481232, ...,  0.1634469 ,-0.38915363,  0.23699683],...,[ 0.03831888, -0.11452862, -0.16922474, ...,  0.12288555,-0.37096268,  0.23536842],[-0.23327501, -0.13970225, -0.16425537, ...,  0.19402924,-0.45353436,  0.07772341],[-0.10018889, -0.02930293, -0.11936897, ..., -0.00552773,-0.38411936,  0.22338517]],[[-0.15432023,  0.01702533, -0.12399586, ...,  0.3093184 ,-0.42032003,  0.1127805 ],[ 0.01026265, -0.00730276, -0.05793048, ...,  0.06344435,-0.31426966,  0.15178697],[-0.02919121, -0.15663055, -0.06453589, ...,  0.02701403,-0.37713167,  0.16373466],...,[-0.2248576 ,  0.02491988, -0.3192546 , ...,  0.19607124,-0.3583208 ,  0.31140187],[-0.12097306, -0.08136839, -0.1496398 , ...,  0.23570189,-0.4618918 ,  0.03638661],[-0.2367848 , -0.15837477, -0.03034748, ..., -0.03796555,-0.39768085,  0.16811943]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7f7d7b1e-36ac-4048-9709-8cd20bc766b9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7f7d7b1e-36ac-4048-9709-8cd20bc766b9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-53386f7c-f45d-404f-adf7-6a5d14bf4a55' class='xr-var-data-in' type='checkbox'><label for='data-53386f7c-f45d-404f-adf7-6a5d14bf4a55' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.02356198, 0.03886168, 0.02534975, 0.04309566, 0.03300703,0.03776066, 0.05877794, 0.03115421, 0.03298716, 0.057144  ,0.04269402, 0.02719378, 0.00835521, 0.05805966, 0.0181232 ,0.04672005, 0.01918038, 0.02744655, 0.08477928, 0.11566207,0.04299012, 0.04937791, 0.06859752, 0.02509041, 0.04873933,0.0210437 , 0.02139471, 0.03527158, 0.03084262, 0.02599031,0.04418524, 0.045618  , 0.03521217, 0.03647967, 0.02590968,0.01462822, 0.04895571, 0.03184907, 0.03515225, 0.03408333,0.02370658, 0.05495514, 0.04844933, 0.03097043, 0.03698262,0.04198934, 0.04357812, 0.02150144, 0.03717332, 0.01918946,0.09447464, 0.02984905, 0.05573415, 0.02259668, 0.03371277,0.05258552, 0.06007022, 0.04997503, 0.02353594, 0.03639027,0.06438194, 0.0554697 , 0.08679732, 0.03357769, 0.05264398,0.0201289 , 0.02853506, 0.0506359 , 0.03469235, 0.03334003,0.03351449, 0.07572581, 0.06058509, 0.05008996, 0.05645019,0.01792451, 0.02508521, 0.06167863, 0.03993152, 0.04259161,0.06173079, 0.0278063 , 0.04282971, 0.05202649, 0.04112809,0.05261168, 0.0544245 , 0.03323542, 0.04991744, 0.03855524,0.05048121, 0.03225347, 0.05413878, 0.0834377 , 0.0571381 ,0.04897349, 0.03166907, 0.05202715, 0.02714485, 0.06046574,...0.07579607, 0.04125248, 0.0324    , 0.04265762, 0.08862187,0.04693291, 0.02636201, 0.0275712 , 0.02227457, 0.01575517,0.04586035, 0.05769838, 0.03100018, 0.03689473, 0.0225323 ,0.04047453, 0.04644603, 0.04215358, 0.0300051 , 0.04961735,0.02847627, 0.02726466, 0.04477447, 0.02867321, 0.05629473,0.03538432, 0.05484887, 0.06870419, 0.08058985, 0.06160891,0.08592261, 0.04222712, 0.05718221, 0.0742923 , 0.03747001,0.05303413, 0.02839544, 0.03305808, 0.01847446, 0.02929857,0.02457505, 0.05571005, 0.02170182, 0.02780058, 0.04142902,0.06045507, 0.03884993, 0.05583933, 0.08150847, 0.040976  ,0.0199903 , 0.0221161 , 0.10881996, 0.03441904, 0.02389634,0.03389779, 0.03656467, 0.03793135, 0.03245383, 0.02320006,0.026003  , 0.00701476, 0.00688058, 0.00314223, 0.00266267,0.00174264, 0.00396146, 0.00680952, 0.02048779, 0.01834334,0.03261826, 0.02168806, 0.02825497, 0.03274313, 0.05354839,0.06588999, 0.05109017, 0.01261324, 0.00602646, 0.00578297,0.00763165, 0.01396765, 0.04080802, 0.02119081, 0.03709273,0.05694408, 0.0595403 , 0.03983696, 0.0282523 , 0.06452972,0.04515916, 0.06059051, 0.04558469, 0.04107645, 0.03563511,0.03091555, 0.03037005, 0.02350834, 0.02019015, 0.01085866]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f93c7f4c-8968-43af-a639-f4e445fa1021' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f93c7f4c-8968-43af-a639-f4e445fa1021' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-369b91a7-a6d5-46b8-9628-9424e8514fb2' class='xr-var-data-in' type='checkbox'><label for='data-369b91a7-a6d5-46b8-9628-9424e8514fb2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.36301076, 0.35927963, 0.4750826 , 0.3390352 , 0.38012224,0.31743902, 0.57189226, 0.5395183 , 0.40869647, 0.3781472 ,0.36086822, 0.3672483 , 0.43228528, 0.44892946, 0.44465998,0.3313766 , 0.3102559 , 0.32858223, 0.3640346 , 0.39449605,0.4373342 , 0.40805584, 0.49301028, 0.4854475 , 0.3578377 ,0.34447888, 0.31196076, 0.34711787, 0.39364275, 0.42340964,0.45494673, 0.32928258, 0.49328032, 0.39077356, 0.43744823,0.4430202 , 0.4232607 , 0.43654302, 0.43035683, 0.49920884,0.3657204 , 0.4498496 , 0.34034127, 0.34666556, 0.48472196,0.41766557, 0.30219963, 0.4255443 , 0.43334365, 0.52858555,0.45844552, 0.44047153, 0.37095875, 0.44031784, 0.45352295,0.41545603, 0.41363376, 0.4093887 , 0.47062376, 0.42764127,0.3647693 , 0.36843225, 0.33478785, 0.32964927, 0.46427262,0.47267562, 0.41807148, 0.3495896 , 0.37941614, 0.35194993,0.33779016, 0.41979873, 0.4182672 , 0.35791057, 0.3514112 ,0.3789177 , 0.41274992, 0.30489466, 0.23855989, 0.41164616,0.36872703, 0.37563056, 0.3917894 , 0.44443265, 0.4280055 ,0.3414205 , 0.41705462, 0.42787167, 0.44513643, 0.39405444,0.37276363, 0.42042282, 0.42440245, 0.3476318 , 0.3881497 ,0.39037216, 0.32966796, 0.36507347, 0.36350828, 0.4063172 ,...0.41257155, 0.40002245, 0.36986017, 0.39766294, 0.40270486,0.46643606, 0.40960148, 0.4121867 , 0.52507496, 0.4794846 ,0.56320757, 0.4411981 , 0.46090284, 0.46903086, 0.36901665,0.48156658, 0.42436448, 0.38381457, 0.3507126 , 0.35948038,0.3996896 , 0.42145938, 0.3967192 , 0.36775547, 0.40899292,0.38367528, 0.3669768 , 0.43549344, 0.45342317, 0.41931465,0.43597353, 0.39846733, 0.37239236, 0.3583915 , 0.35977468,0.33814818, 0.49353176, 0.48922887, 0.44047654, 0.42737865,0.42447504, 0.43855447, 0.39731854, 0.39683846, 0.39729628,0.35984093, 0.36971402, 0.3865152 , 0.4438235 , 0.39478204,0.4419364 , 0.42418155, 0.38658085, 0.4169158 , 0.3775553 ,0.36318824, 0.32481506, 0.36367473, 0.3895073 , 0.42327178,0.38455355, 0.28776026, 0.40751842, 0.3814294 , 0.43527502,0.41798675, 0.38575563, 0.4336451 , 0.2710228 , 0.3138619 ,0.4287065 , 0.3529128 , 0.36227363, 0.3497305 , 0.4555687 ,0.40968084, 0.46734518, 0.47551087, 0.42347693, 0.4038166 ,0.45181373, 0.4355831 , 0.43022504, 0.37180492, 0.44226643,0.42939603, 0.40135947, 0.43141747, 0.40967226, 0.3475343 ,0.31598246, 0.34080946, 0.3705003 , 0.48705775, 0.50632095,0.5214736 , 0.4282544 , 0.3907752 , 0.3774458 , 0.3299237 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1a37cd11-4195-4d35-a269-5156aebfd615' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1a37cd11-4195-4d35-a269-5156aebfd615' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1791b1b8-3272-462f-9cc3-0ab5c4f4bf70' class='xr-var-data-in' type='checkbox'><label for='data-1791b1b8-3272-462f-9cc3-0ab5c4f4bf70' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-1.4914384 ,  1.1456001 ,  2.3461485 , ..., -0.46486378,0.8719128 ,  0.47029433],[-0.09413075,  0.8872402 ,  1.2680085 , ..., -0.6421884 ,0.62191397, -0.30938518],[-0.5940579 ,  0.16937603,  1.1005185 , ..., -0.54574555,-0.25295943, -0.4224297 ],...,[-0.2305244 ,  0.83861905,  1.0428362 , ..., -0.57693875,0.40619078,  0.08872759],[-0.8790813 ,  0.9805328 ,  1.7238986 , ...,  0.15484819,0.7198827 , -0.16125873],[ 0.01570479,  1.5013733 ,  1.469507  , ..., -0.7425749 ,0.8152834 ,  0.46520156]],[[-1.1138244 ,  1.0882578 ,  1.887627  , ...,  0.27089366,0.49367508, -0.2711602 ],[-0.50463957,  1.6967468 ,  1.6286793 , ..., -1.0313044 ,0.99252737, -0.18967617],[-0.62752384,  0.8513603 ,  1.8276439 , ..., -1.2660931 ,1.0816144 , -0.15082155],...,[-1.4031917 ,  0.9376694 ,  0.20314491, ..., -0.35154778,0.55465037,  0.2512115 ],[-0.9132466 ,  1.7855341 ,  2.4087434 , ..., -0.22763434,0.56749195, -0.55040056],[-1.3459129 ,  1.003357  ,  2.4003823 , ..., -0.870644  ,1.3486668 ,  0.44971007]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d8fdc402-ea05-4c50-8465-6f2c2404473c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d8fdc402-ea05-4c50-8465-6f2c2404473c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f930e3f-4220-4c18-a943-80d8e2baaf60' class='xr-var-data-in' type='checkbox'><label for='data-2f930e3f-4220-4c18-a943-80d8e2baaf60' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.09348343, 0.2523831 , 0.24167101, 0.10069656, 0.17332557,0.1832512 , 0.16645864, 0.1640871 , 0.1692304 , 0.2695056 ,0.23778157, 0.20596698, 0.15431328, 0.17577173, 0.13481341,0.17421773, 0.16124837, 0.17516781, 0.14203212, 0.15042858,0.12702596, 0.17658238, 0.26488385, 0.26093087, 0.13529667,0.14781132, 0.14703728, 0.18756332, 0.15717712, 0.11514491,0.12283142, 0.15158492, 0.13507682, 0.12818989, 0.12387499,0.15532823, 0.16072503, 0.07855622, 0.07924378, 0.21505499,0.14506723, 0.11837296, 0.2005904 , 0.08426863, 0.15617837,0.11858044, 0.16028786, 0.10375245, 0.13201882, 0.19667436,0.15523243, 0.09086096, 0.14541651, 0.2329864 , 0.23019081,0.14629117, 0.1695675 , 0.12401825, 0.12138392, 0.14131074,0.13381676, 0.13842447, 0.13100493, 0.28464213, 0.18276608,0.15844706, 0.17340247, 0.14806661, 0.13162906, 0.14668024,0.13207193, 0.1704316 , 0.10838196, 0.16865355, 0.16648322,0.24240133, 0.17293666, 0.34204707, 0.2872572 , 0.21310207,0.2417748 , 0.1348012 , 0.15090919, 0.17054734, 0.1823909 ,0.14159875, 0.11426088, 0.12023354, 0.11436838, 0.18264666,0.08802325, 0.16103183, 0.1675502 , 0.141255  , 0.18635495,0.11119002, 0.19687405, 0.13530667, 0.14141536, 0.13769755,...0.1821226 , 0.12653613, 0.14931992, 0.11439486, 0.1115003 ,0.14564118, 0.10858296, 0.12632076, 0.25038475, 0.2385323 ,0.2428735 , 0.12895916, 0.21582913, 0.11449412, 0.11922   ,0.10412443, 0.12808162, 0.2213838 , 0.1492423 , 0.2450727 ,0.11541687, 0.0909088 , 0.19377974, 0.1691628 , 0.09783803,0.14336078, 0.13612528, 0.16224678, 0.14065638, 0.08108256,0.07633342, 0.2381317 , 0.18775982, 0.15794142, 0.17706776,0.1574693 , 0.15657023, 0.18604109, 0.1808056 , 0.13919646,0.15200505, 0.10188547, 0.1405878 , 0.14982113, 0.15153004,0.21149167, 0.19966142, 0.22572732, 0.15421079, 0.09193432,0.11678639, 0.11451907, 0.15139021, 0.20046648, 0.15616974,0.13798794, 0.1534096 , 0.13985308, 0.18247956, 0.13418955,0.1312017 , 0.22295943, 0.12900713, 0.12842841, 0.19492781,0.26299497, 0.23444858, 0.24476638, 0.1665931 , 0.17231287,0.15224935, 0.14962415, 0.19858292, 0.25218138, 0.13360158,0.14429814, 0.09409909, 0.20324229, 0.134109  , 0.12140094,0.20074196, 0.16068205, 0.16316779, 0.09854402, 0.14606875,0.13576631, 0.12492772, 0.07260533, 0.15664122, 0.21387139,0.13250321, 0.15222187, 0.1679778 , 0.30122307, 0.25691435,0.17769185, 0.18074104, 0.19207203, 0.11632695, 0.13665673]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f406d6cc-1370-4b0c-a3c8-500c96355b18' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f406d6cc-1370-4b0c-a3c8-500c96355b18' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-78c15965-cef1-4e8d-a95a-719798f750cd' class='xr-var-data-in' type='checkbox'><label for='data-78c15965-cef1-4e8d-a95a-719798f750cd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1.2125142 , 1.1329023 , 1.1535814 , 1.0698693 , 1.147999  ,1.2123386 , 1.2218351 , 1.2124746 , 1.2181168 , 1.2630213 ,1.2656242 , 1.1818634 , 1.1619396 , 1.0329871 , 1.1793554 ,1.1230178 , 1.1062341 , 1.1387607 , 1.1349835 , 1.1844009 ,1.216449  , 1.1845661 , 1.2055702 , 1.1622607 , 1.2079468 ,1.1605589 , 1.1892002 , 1.2796155 , 1.1793216 , 1.2502978 ,1.2657415 , 1.1567676 , 1.2068204 , 1.243321  , 1.2544456 ,1.287705  , 1.1775627 , 1.1080122 , 1.0984867 , 1.2000928 ,1.017493  , 1.20891   , 1.1342583 , 1.1132923 , 1.2094815 ,1.2456502 , 1.0448232 , 1.1619065 , 1.1492679 , 1.188359  ,1.1859632 , 1.2411312 , 1.014265  , 1.2194142 , 1.20292   ,1.2190946 , 1.1821419 , 1.1780456 , 1.2020371 , 1.1210972 ,1.1911768 , 1.1849583 , 1.0800807 , 1.1950929 , 1.0517691 ,1.1458861 , 1.1055537 , 1.1436465 , 1.1638595 , 1.1245806 ,1.0882621 , 1.1826149 , 1.2261568 , 1.0665302 , 1.0636977 ,1.2088244 , 1.2800413 , 1.1865563 , 1.181733  , 1.1163371 ,1.1148701 , 1.2519797 , 1.2281958 , 1.1733366 , 1.169708  ,1.0450144 , 1.1994148 , 1.219927  , 1.2742722 , 1.0766376 ,1.1593335 , 1.2393773 , 1.191996  , 1.1421897 , 1.1156944 ,1.1118898 , 1.1862279 , 1.1887158 , 1.0488896 , 1.0767103 ,...1.1970651 , 1.1390884 , 1.0972791 , 1.1615252 , 1.124875  ,1.1850331 , 1.164675  , 1.1897098 , 1.1740854 , 1.139395  ,1.2355134 , 1.247753  , 1.1504908 , 1.2486417 , 1.096411  ,1.2497852 , 1.1452665 , 1.2075679 , 1.046607  , 1.1326716 ,1.1870267 , 1.1554545 , 1.1497185 , 1.1976271 , 1.2061945 ,1.1348865 , 1.0724833 , 1.1069438 , 1.1267985 , 1.162776  ,1.1600809 , 1.1532788 , 1.1340443 , 1.166931  , 1.1134764 ,1.1141102 , 1.197598  , 1.1149893 , 1.1572173 , 1.2364426 ,1.2325623 , 1.2741996 , 1.222048  , 1.1932578 , 1.1867504 ,1.1776124 , 1.1831378 , 1.1405997 , 1.1805774 , 1.2152559 ,1.2267387 , 1.1686397 , 1.234258  , 1.147408  , 1.1935468 ,1.1544534 , 1.1910121 , 1.2332444 , 1.1472412 , 1.1168318 ,1.0861658 , 1.1201333 , 1.1715549 , 1.1316506 , 1.1485133 ,1.0989363 , 1.053835  , 1.1202589 , 1.0193479 , 1.0409853 ,1.1807909 , 0.9857892 , 1.040233  , 1.2070295 , 1.3148236 ,1.244359  , 1.1706692 , 1.1829941 , 1.1925573 , 1.1677582 ,1.2423664 , 1.2031438 , 1.1459033 , 1.1034456 , 1.1571498 ,1.1803538 , 1.173216  , 1.2266523 , 1.0677662 , 1.1493112 ,1.0504956 , 1.0480875 , 1.1408496 , 1.1472005 , 1.1562213 ,1.1529787 , 1.1701436 , 1.1496849 , 1.2146528 , 1.1867158 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-dafce86a-87c0-4328-ab59-05e675045982' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-dafce86a-87c0-4328-ab59-05e675045982' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-36cdf08f-3d14-49fd-8496-885555071e15' class='xr-var-data-in' type='checkbox'><label for='data-36cdf08f-3d14-49fd-8496-885555071e15' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.519939  , 0.4955169 , 0.49576834, 0.49275792, 0.49266946,0.49463227, 0.5249807 , 0.506526  , 0.4805195 , 0.48984668,0.49368766, 0.48351768, 0.48864955, 0.49238184, 0.4790095 ,0.48742524, 0.4787511 , 0.44634086, 0.51155686, 0.5094243 ,0.5101066 , 0.52622515, 0.51463276, 0.51662207, 0.47981974,0.4631674 , 0.5026901 , 0.5237778 , 0.5025745 , 0.50082284,0.49542546, 0.49557868, 0.5092256 , 0.46612906, 0.47780854,0.4819841 , 0.4930833 , 0.5124552 , 0.5257864 , 0.5148074 ,0.5127858 , 0.49688968, 0.5332512 , 0.49237263, 0.5193859 ,0.47407797, 0.4811453 , 0.488577  , 0.48906052, 0.5493633 ,0.5101908 , 0.51887214, 0.501979  , 0.47689563, 0.48055053,0.48921594, 0.49028432, 0.50022227, 0.46619043, 0.47941965,0.49798214, 0.4989634 , 0.5101898 , 0.4744369 , 0.53704387,0.51646346, 0.5134571 , 0.49096915, 0.5098413 , 0.49896607,0.5134141 , 0.49444813, 0.4679189 , 0.5076055 , 0.51686454,0.5248521 , 0.47624493, 0.505178  , 0.48729336, 0.53799874,0.5517333 , 0.4982874 , 0.5159104 , 0.5211916 , 0.51048785,0.4625833 , 0.50712854, 0.48728374, 0.50808454, 0.4929507 ,0.52214104, 0.5213203 , 0.5137195 , 0.49837488, 0.5057289 ,0.48380363, 0.5064014 , 0.48062655, 0.48078263, 0.45918384,...0.4838697 , 0.4580489 , 0.4785043 , 0.4594547 , 0.44572985,0.4969889 , 0.49218214, 0.49690148, 0.49826485, 0.50818425,0.4999564 , 0.4996364 , 0.49610654, 0.48730356, 0.4880802 ,0.5158132 , 0.49338546, 0.50330883, 0.47380847, 0.49372706,0.465995  , 0.49716556, 0.50747824, 0.48372647, 0.5256593 ,0.5484138 , 0.53048295, 0.497725  , 0.5299141 , 0.5214187 ,0.5182081 , 0.5061811 , 0.5281897 , 0.4964839 , 0.49659625,0.49824166, 0.5073992 , 0.5355776 , 0.5097606 , 0.53252584,0.49194387, 0.47866046, 0.5034344 , 0.50143164, 0.4983557 ,0.47824055, 0.48091424, 0.49529305, 0.49725702, 0.48187715,0.5184588 , 0.49697423, 0.4678638 , 0.4682651 , 0.50164944,0.4915264 , 0.4844646 , 0.48724523, 0.48370785, 0.48440468,0.46609843, 0.47948658, 0.5242944 , 0.5433472 , 0.5260929 ,0.535163  , 0.5348957 , 0.5864405 , 0.5258761 , 0.5103637 ,0.49291408, 0.48061776, 0.49439752, 0.49806768, 0.5211088 ,0.5101889 , 0.49748304, 0.47048688, 0.4934992 , 0.49657047,0.4951572 , 0.50933796, 0.49018097, 0.48720896, 0.50579023,0.4955269 , 0.5067321 , 0.5220327 , 0.48474145, 0.48185116,0.45486546, 0.47865805, 0.4910978 , 0.4818093 , 0.46166348,0.47909972, 0.5119051 , 0.51560366, 0.5248007 , 0.5247281 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e3861860-3b57-4385-9be0-5a2ca1046478' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e3861860-3b57-4385-9be0-5a2ca1046478' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9a70f0fc-bbef-47f5-9cd4-ebfe984d7ed4' class='xr-var-data-in' type='checkbox'><label for='data-9a70f0fc-bbef-47f5-9cd4-ebfe984d7ed4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-5.47429398e-02, -4.60530259e-03,  2.22961437e-02, ...,-6.16278946e-02,  7.17039034e-02, -7.33701065e-02],[-6.91851154e-02, -2.85674687e-02, -2.07316335e-02, ...,2.83640884e-02,  5.63348196e-02, -1.01033121e-01],[-8.49487042e-05, -2.18412802e-02,  4.67902869e-02, ...,-4.46950011e-02,  7.45894909e-02, -4.36461754e-02],...,[-5.80359586e-02, -1.50682908e-02,  1.20297335e-02, ...,7.41658732e-04,  4.57827598e-02, -1.04695700e-01],[-2.49779671e-02, -4.65855049e-03,  1.23641379e-02, ...,-4.21497822e-02,  9.58853066e-02, -6.79687411e-02],[-5.77317663e-02,  1.10067483e-02,  2.94177029e-02, ...,3.64703429e-03,  6.86448216e-02, -1.37391135e-01]],[[-3.26288715e-02,  7.41377333e-03, -1.13025242e-02, ...,-5.67690767e-02,  9.54948552e-03, -7.86339864e-02],[-4.37924825e-02, -4.58025448e-02,  1.94943487e-03, ...,-5.23337349e-03,  8.62422884e-02, -3.30878310e-02],[-8.92738346e-03,  7.40436185e-03,  3.74604040e-03, ...,-1.24674067e-02,  7.90440142e-02, -1.59894496e-01],...,[-3.39853056e-02,  1.77456264e-03, -3.86439413e-02, ...,-5.37742414e-02,  3.90168764e-02, -4.82476018e-02],[-6.56476393e-02, -2.95084007e-02,  4.33105305e-02, ...,6.77099749e-02,  5.62922917e-02, -7.76903331e-02],[-2.91605648e-02, -1.53674213e-02, -2.41425373e-02, ...,-7.02694729e-02,  4.94185686e-02, -5.01327701e-02]]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-3e013db8-030c-4304-8eeb-bed349e46687' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3e013db8-030c-4304-8eeb-bed349e46687' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-09d219bb-40ee-4475-8760-38b2cc35d0b4' class='xr-var-data-in' type='checkbox'><label for='data-09d219bb-40ee-4475-8760-38b2cc35d0b4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 1.4844339 , -0.15309456,  1.9200152 , ...,  0.12092485,0.01208335,  1.4481009 ],[ 2.29344   ,  0.31003076, -1.8673457 , ..., -0.8109149 ,-0.03119551, -0.62743807],[-0.3152511 ,  1.0905766 ,  1.5806466 , ...,  0.95269406,0.2246513 ,  0.24616916],...,[ 1.5672427 ,  0.09552758, -0.09338631, ..., -1.280362  ,-0.05595003,  0.23875467],[ 0.25278595,  0.9991156 ,  0.7840444 , ..., -0.9993054 ,1.1533357 , -0.681431  ],[ 1.7248616 ,  0.47164923, -0.47108155, ...,  0.06860457,-0.91133153,  1.2509171 ]],[[ 1.8248031 ,  0.8118769 ,  0.03060282, ..., -1.3046502 ,0.48090616,  1.3987124 ],[ 1.8039583 ,  1.1297163 ,  1.404726  , ...,  0.57215565,-0.18369673,  0.9607966 ],[ 0.67618126,  1.1820723 , -0.19420795, ..., -0.38958254,-0.285486  , -0.91230124],...,[ 1.5064344 , -1.2037091 ,  0.74395114, ..., -0.33973587,-3.0300114 ,  0.7604541 ],[ 1.2915949 ,  1.2614542 , -0.6666823 , ...,  0.6354286 ,0.16826148, -0.24202827],[ 0.7672614 ,  0.20729479,  0.14141095, ..., -1.0344527 ,-0.70616895,  0.13770993]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-8f085db6-93cf-407f-96fb-86f0928563e9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8f085db6-93cf-407f-96fb-86f0928563e9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13d08f2a-242e-4d9a-b9c0-b9b48a9b388c' class='xr-var-data-in' type='checkbox'><label for='data-13d08f2a-242e-4d9a-b9c0-b9b48a9b388c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-1.1536770e+00, -9.7054191e-02,  4.6987882e-01, ...,-1.2987736e+00,  1.5111198e+00, -1.5462343e+00],[-1.2102840e+00, -4.9974260e-01, -3.6266705e-01, ...,4.9618477e-01,  9.8548836e-01, -1.7674143e+00],[-1.7297078e-03, -4.4472760e-01,  9.5273411e-01, ...,-9.1007030e-01,  1.5187757e+00, -8.8871437e-01],...,[-7.2821182e-01, -1.8907084e-01,  1.5094425e-01, ...,9.3060350e-03,  5.7446361e-01, -1.3136795e+00],[-2.4475002e-01, -4.5647446e-02,  1.2115169e-01, ...,-4.1301042e-01,  9.3954527e-01, -6.6600102e-01],[-8.3792460e-01,  1.5975304e-01,  4.2697147e-01, ...,5.2933417e-02,  9.9631774e-01, -1.9941086e+00]],[[-5.8023649e-01,  1.3183850e-01, -2.0099184e-01, ...,-1.0095197e+00,  1.6981769e-01, -1.3983415e+00],[-5.4335594e-01, -5.6829584e-01,  2.4187645e-02, ...,-6.4933166e-02,  1.0700526e+00, -4.1053781e-01],[-9.7537234e-02,  8.0897272e-02,  4.0927827e-02, ...,-1.3621420e-01,  8.6360514e-01, -1.7469472e+00],...,[-4.9703866e-01,  2.5953164e-02, -5.6517166e-01, ...,-7.8645390e-01,  5.7062590e-01, -7.0562619e-01],[-1.0810843e+00, -4.8594385e-01,  7.1323711e-01, ...,1.1150467e+00,  9.2702049e-01, -1.2794031e+00],[-1.1226966e+00, -5.9165359e-01, -9.2949998e-01, ...,-2.7054105e+00,  1.9026401e+00, -1.9301373e+00]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-bf1d5a69-290f-4812-a5dd-7df259b6f375' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bf1d5a69-290f-4812-a5dd-7df259b6f375' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7792a97c-80f6-4680-ba4d-9eb0816b7b35' class='xr-var-data-in' type='checkbox'><label for='data-7792a97c-80f6-4680-ba4d-9eb0816b7b35' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[2.5142624, 1.8657235, 2.2685506, 2.1297243, 2.2016122, 2.2217443,2.0892553, 2.1090035, 2.1652284, 2.1297185, 2.2679157, 2.3455155,2.209915 , 1.8394998, 2.2761686, 2.402908 , 2.3565054, 2.215785 ,2.1606   , 2.140484 , 2.1162772, 2.3164237, 1.7699192, 2.0128226,2.104962 , 2.0784662, 2.0665355, 2.046668 , 2.3565133, 2.3321133,2.2815306, 2.3643575, 2.1110938, 2.085448 , 2.1094549, 2.0158014,2.2455235, 2.1814573, 2.231413 , 2.2907376, 1.8842523, 2.271089 ,2.2317984, 2.2556438, 2.0179875, 2.1879828, 1.9456528, 2.212389 ,1.9875817, 2.3613496, 1.780088 , 2.715717 , 2.041208 , 2.2005699,1.8543553, 2.151137 , 1.9219712, 2.1918063, 2.0106835, 2.172189 ,2.1644187, 2.154835 , 2.0776968, 2.1940522, 2.2608607, 1.9266696,1.9922286, 2.1040683, 2.521027 , 2.1779213, 2.2298927, 2.0849733,2.1751122, 2.044402 , 2.0199692, 2.2274737, 2.0519514, 2.1288838,1.9796404, 2.3774376, 2.263957 , 2.0996788, 1.9742733, 2.1540434,2.1567187, 2.0193906, 2.1850977, 2.1456165, 2.1327846, 1.9952145,1.9234421, 2.2139947, 1.8682597, 1.909333 , 1.9484346, 2.0683439,2.3246114, 2.0544243, 2.4408062, 1.8941661, 1.9324183, 2.1950698,2.3288612, 2.0963047, 2.2779315, 2.095779 , 2.080818 , 2.3339088,2.0268788, 2.1818461, 2.2209976, 2.098036 , 2.1693642, 2.152505 ,2.051317 , 2.2850263, 2.394742 , 1.8734747, 2.2900927, 2.1367843,...2.3406801, 2.167222 , 2.258671 , 2.543205 , 1.8725004, 2.0062058,2.3640509, 2.0055592, 2.135902 , 2.1466875, 2.0356462, 2.1032445,2.3851464, 2.030143 , 1.8687327, 2.4156084, 2.0899606, 2.0630047,2.1695726, 1.970627 , 2.192421 , 2.2721174, 2.2721412, 2.4490879,2.4576719, 2.2989268, 1.7685226, 1.7925239, 2.2300558, 2.0706367,1.9817772, 2.0462906, 2.3235269, 2.1880417, 2.1411524, 1.8909113,2.197217 , 1.9177427, 2.1865175, 2.1629431, 2.1348665, 2.0356982,2.2279558, 2.1148195, 2.3307085, 2.3203707, 2.1384947, 2.1953254,2.1255677, 2.0963411, 2.1744094, 2.0711424, 2.1284602, 2.117244 ,1.8603072, 2.2163541, 1.9706005, 2.0650024, 2.1369615, 2.1678524,2.0402799, 2.0123246, 2.3811815, 2.042725 , 2.066339 , 2.123695 ,2.3472626, 2.09061  , 2.2458692, 2.1792698, 1.8924601, 2.454787 ,2.213567 , 2.1677558, 2.014131 , 1.9847969, 2.2544281, 2.090547 ,2.2434993, 1.9773467, 2.3802166, 2.1755066, 2.2227695, 2.197967 ,2.2629652, 2.3582284, 2.38981  , 2.3420355, 2.0605958, 2.223513 ,1.8708591, 2.1307836, 2.0355024, 2.1877255, 2.0386143, 2.0408325,2.0049279, 2.0579188, 1.8555402, 2.241761 , 2.047414 , 2.3617477,2.2263978, 1.9589593, 2.257446 , 1.9755064, 2.513744 , 2.3101146,2.1652105, 1.9750669, 2.4824975, 2.2576087, 2.2247632, 2.372143 ,2.2822602, 2.2814844, 2.4739604, 2.6184783]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d144a6bb-6f1b-4ca9-9456-80e81474b8a4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d144a6bb-6f1b-4ca9-9456-80e81474b8a4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5c8563dc-d7d7-47ba-a624-615a98de9cf0' class='xr-var-data-in' type='checkbox'><label for='data-5c8563dc-d7d7-47ba-a624-615a98de9cf0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.29346526, -0.03026604,  0.37957755, ...,  0.02390625,0.00238882,  0.28628242],[ 0.08824843,  0.01192956, -0.0718529 , ..., -0.03120289,-0.00120036, -0.02414296],[-0.01795714,  0.06212075,  0.09003582, ...,  0.05426677,0.01279645,  0.01402214],...,[ 0.32781366,  0.01998111, -0.01953323, ..., -0.267808  ,-0.01170284,  0.04993932],[ 0.03874976,  0.15315522,  0.12018678, ..., -0.15318432,0.17679574, -0.1044571 ],[ 0.39158756,  0.1070764 , -0.10694753, ...,  0.01557499,-0.20689549,  0.28399006]],[[ 0.54683447,  0.24329324,  0.00917067, ..., -0.39096147,0.14411202,  0.41914886],[ 0.4986035 ,  0.31224695,  0.38825804, ...,  0.15814047,-0.0507727 ,  0.26555854],[ 0.5746344 ,  1.0045522 , -0.16504239, ..., -0.3310762 ,-0.24261259, -0.7752946 ],...,[ 0.09593057, -0.07665285,  0.04737521, ..., -0.02163457,-0.19295278,  0.04842613],[ 0.36816695,  0.35957542, -0.19003668, ...,  0.18112786,0.04796265, -0.06898975],[ 0.6816214 ,  0.184157  ,  0.12562697, ..., -0.91898936,-0.62734795,  0.12233905]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-54983c87-7d5e-4e01-89e7-814c77c44e68' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-54983c87-7d5e-4e01-89e7-814c77c44e68' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-27179430-1b3e-4abe-bfb3-b924720940d7' class='xr-var-data-in' type='checkbox'><label for='data-27179430-1b3e-4abe-bfb3-b924720940d7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 7.94298828e-01,  1.59690812e-01,  6.08845949e-01, ...,1.07644856e+00, -6.36738300e-01, -1.48447382e+00],[ 7.94387877e-01,  2.75256664e-01,  8.96165192e-01, ...,8.65953743e-01, -1.00602329e+00, -6.13627255e-01],[ 6.41367972e-01,  3.17802429e-01,  5.02097368e-01, ...,5.38474560e-01, -6.14411950e-01, -1.56794918e+00],...,[-3.30681473e-01, -1.44947991e-01,  2.79708773e-01, ...,-7.53029823e-01, -1.11632836e+00, -1.41511059e+00],[ 5.44062495e-01, -5.18963456e-01,  3.70169371e-01, ...,4.01729882e-01, -1.51545060e+00, -2.31545424e+00],[ 5.63294888e-01, -1.60215542e-01,  4.66988981e-01, ...,-7.09434748e-02, -1.17999876e+00, -1.24353647e+00]],[[ 3.63227546e-01, -5.93292892e-01,  4.93152916e-01, ...,-1.36183992e-01, -9.69087958e-01, -1.38626289e+00],[ 1.77403286e-01, -2.54893839e-01,  4.45082247e-01, ...,4.86457020e-01, -1.19661164e+00, -1.73108125e+00],[-1.23910114e-01, -1.96999907e-01,  3.88084441e-01, ...,-5.89098374e-04, -1.01399016e+00, -5.95303237e-01],...,[ 1.70400351e-01, -4.95139271e-01,  6.36232316e-01, ...,3.29443216e-02, -7.40619838e-01, -1.52766979e+00],[-1.72791466e-01, -3.97299290e-01, -1.57652110e-01, ...,-8.40135872e-01, -5.70170701e-01, -7.96350300e-01],[-5.40884078e-01, -7.57943630e-01, -5.90958476e-01, ...,-1.44963607e-01, -1.50087714e+00, -2.10586119e+00]]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b1d76ce7-218e-4925-a70e-1fd16602a919' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b1d76ce7-218e-4925-a70e-1fd16602a919' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8c35d684-6d10-48a7-9caf-95f6eaf4d79f' class='xr-var-data-in' type='checkbox'><label for='data-8c35d684-6d10-48a7-9caf-95f6eaf4d79f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.07916272, 0.07936626, 0.09505858, 0.08254598, 0.08069269,0.1042911 , 0.08827384, 0.07905237, 0.07301386, 0.12404939,0.09457587, 0.07143744, 0.08088882, 0.11794879, 0.0521661 ,0.10074447, 0.07559489, 0.06864943, 0.13495605, 0.14714731,0.07977072, 0.07034962, 0.1614333 , 0.09784939, 0.09527703,0.09486006, 0.08142561, 0.11560709, 0.10740826, 0.08909308,0.06891222, 0.09012144, 0.09854522, 0.0939286 , 0.09901112,0.09924736, 0.08759031, 0.08588253, 0.09640491, 0.1108046 ,0.08523116, 0.11572164, 0.07734247, 0.09151275, 0.07900243,0.12090681, 0.10299305, 0.10030749, 0.1034257 , 0.07796464,0.15295109, 0.06602383, 0.11732801, 0.0680172 , 0.1011074 ,0.1168494 , 0.11329237, 0.09874234, 0.08913907, 0.07398859,0.12457282, 0.12344145, 0.09064701, 0.09823634, 0.08510981,0.09164119, 0.08732761, 0.13118792, 0.08769037, 0.09165707,0.08339685, 0.09732847, 0.08771976, 0.12989162, 0.13518855,0.09807742, 0.10443582, 0.11100323, 0.10278586, 0.06433175,0.06756175, 0.0939398 , 0.11134994, 0.09085399, 0.12383917,0.08999356, 0.10832153, 0.08206613, 0.09684699, 0.11190793,0.0967874 , 0.08844367, 0.122743  , 0.15416837, 0.10886667,0.10450156, 0.07311153, 0.07209986, 0.05217551, 0.10909582,...0.11670126, 0.08318391, 0.0907827 , 0.07340259, 0.08274022,0.10399579, 0.09228916, 0.09856212, 0.10124917, 0.11133815,0.11155031, 0.12009738, 0.09688594, 0.11126763, 0.05579538,0.08916271, 0.06404166, 0.10387037, 0.0799838 , 0.11178113,0.07082273, 0.07588482, 0.12680091, 0.1084624 , 0.11085738,0.09578285, 0.1022885 , 0.08318539, 0.12699993, 0.05926803,0.06797218, 0.11878616, 0.10482423, 0.07821038, 0.05896056,0.09703983, 0.10135532, 0.11019832, 0.12157482, 0.07732837,0.09098386, 0.08540221, 0.08826341, 0.08455318, 0.06099232,0.1054536 , 0.08360151, 0.09344913, 0.08358321, 0.08393881,0.08508196, 0.07461999, 0.14821182, 0.071452  , 0.1155965 ,0.09047537, 0.06282111, 0.06911394, 0.07979655, 0.09573571,0.08879352, 0.09203762, 0.08717392, 0.10496673, 0.10293251,0.10414282, 0.08635825, 0.05995756, 0.08972638, 0.08536649,0.08924264, 0.08763833, 0.10398428, 0.10557625, 0.1042559 ,0.09628285, 0.14713891, 0.08863164, 0.07819027, 0.08917487,0.10558625, 0.07026803, 0.10229886, 0.06614442, 0.07712353,0.07523808, 0.08694777, 0.08733334, 0.07211424, 0.11926702,0.07835258, 0.07226037, 0.0873617 , 0.08335927, 0.09911149,0.09769469, 0.08753386, 0.09163858, 0.08190953, 0.09423105]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a9b4d96c-128f-42a5-9563-fa15e4002327' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a9b4d96c-128f-42a5-9563-fa15e4002327' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4dd72ccb-1c0d-4d25-bf81-c41773b51222' class='xr-var-data-in' type='checkbox'><label for='data-4dd72ccb-1c0d-4d25-bf81-c41773b51222' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.24444829, 0.16531551, 0.20892274, 0.2739736 , 0.13738525,0.17525584, 0.29614034, 0.34357762, 0.21658427, 0.16196282,0.18658568, 0.19852868, 0.14267679, 0.13939618, 0.2719986 ,0.20352265, 0.19528922, 0.19089183, 0.17446414, 0.16340296,0.19466873, 0.23762248, 0.1671184 , 0.10775609, 0.19239268,0.30813825, 0.22618312, 0.13204108, 0.13168171, 0.17588858,0.1365114 , 0.14685643, 0.20547429, 0.2970283 , 0.30298582,0.22955945, 0.2228172 , 0.1931004 , 0.20017545, 0.17105734,0.13195135, 0.22974752, 0.10267754, 0.30733317, 0.14275233,0.18466325, 0.1831361 , 0.17873183, 0.19790514, 0.24552943,0.15909705, 0.28900602, 0.32380083, 0.19042905, 0.25822407,0.23580183, 0.2372519 , 0.20730177, 0.17986606, 0.16099526,0.20090425, 0.19166732, 0.21585222, 0.15094708, 0.30869594,0.19394247, 0.17744212, 0.17214528, 0.2019941 , 0.20710899,0.20369948, 0.20118056, 0.16186851, 0.24375175, 0.2370401 ,0.2186106 , 0.2761569 , 0.20644656, 0.2238587 , 0.15909743,0.29103953, 0.1478133 , 0.16155335, 0.2752436 , 0.14623302,0.23490128, 0.23968406, 0.24364884, 0.2328827 , 0.1474532 ,0.19233245, 0.26179922, 0.15954125, 0.251852  , 0.215976  ,0.19781691, 0.37932977, 0.21609917, 0.2696381 , 0.1682979 ,...0.19948465, 0.25420177, 0.18682009, 0.25971213, 0.22312053,0.37017828, 0.24685353, 0.20424582, 0.30450842, 0.21638396,0.1686876 , 0.25527766, 0.19119233, 0.18904789, 0.22661461,0.17603959, 0.15246953, 0.18637818, 0.19164802, 0.12399626,0.2286452 , 0.20804934, 0.1260757 , 0.24575514, 0.2179089 ,0.22882424, 0.23282753, 0.19969386, 0.16870874, 0.22681323,0.19386321, 0.2031966 , 0.14535227, 0.11898184, 0.13479272,0.15739895, 0.17940935, 0.21615401, 0.18978392, 0.19180252,0.21028268, 0.2144718 , 0.2681177 , 0.28660882, 0.17394675,0.15261054, 0.12770039, 0.17574893, 0.13619572, 0.20911612,0.16437048, 0.17225957, 0.18578808, 0.12239301, 0.19105077,0.19467035, 0.16940662, 0.18283288, 0.30567756, 0.20730379,0.22403127, 0.11252071, 0.24790502, 0.26594102, 0.264254  ,0.3242096 , 0.25187466, 0.23696122, 0.14785887, 0.16151594,0.16607898, 0.26083365, 0.17729789, 0.17273687, 0.30207422,0.18190366, 0.20507574, 0.24995083, 0.18315464, 0.16682263,0.14472419, 0.13946322, 0.20342878, 0.16624948, 0.19013527,0.21923107, 0.16811778, 0.34259275, 0.20201987, 0.19478387,0.20830552, 0.32429624, 0.27152693, 0.26939422, 0.1993252 ,0.1837001 , 0.1823307 , 0.20740218, 0.19075085, 0.20129545]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-94c6ae60-8e67-42a6-9dda-608a98d63eff' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-94c6ae60-8e67-42a6-9dda-608a98d63eff' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5fb3d1b1-6d66-4ee4-893c-95af0fedfe00' class='xr-var-data-in' type='checkbox'><label for='data-5fb3d1b1-6d66-4ee4-893c-95af0fedfe00' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 6.94991723e-02,  1.39725497e-02,  5.32725081e-02, ...,9.41865742e-02, -5.57130203e-02, -1.29887775e-01],[ 6.01065159e-02,  2.08270028e-02,  6.78073913e-02, ...,6.55214712e-02, -7.61196837e-02, -4.64294553e-02],[ 5.16227968e-02,  2.55794656e-02,  4.04131040e-02, ...,4.33410518e-02, -4.94531430e-02, -1.26202002e-01],...,[-3.01855598e-02, -1.32312709e-02,  2.55326256e-02, ...,-6.87387362e-02, -1.01901680e-01, -1.29175380e-01],[ 3.08189746e-02, -2.93972138e-02,  2.09686216e-02, ...,2.27563977e-02, -8.58442411e-02, -1.31161273e-01],[ 3.73983569e-02, -1.06370533e-02,  3.10044009e-02, ...,-4.71008942e-03, -7.83426464e-02, -8.25610533e-02]],[[ 2.91746445e-02, -4.76536267e-02,  3.96103263e-02, ...,-1.09383762e-02, -7.78376982e-02, -1.11345433e-01],[ 1.39899645e-02, -2.01008450e-02,  3.50990407e-02, ...,3.83618400e-02, -9.43644047e-02, -1.36512503e-01],[-9.66086145e-03, -1.53594306e-02,  3.02576590e-02, ...,-4.59300500e-05, -7.90574551e-02, -4.64138240e-02],...,[ 2.11369656e-02, -6.14185482e-02,  7.89201483e-02, ...,4.08651168e-03, -9.18686837e-02, -1.89496696e-01],[-3.09162065e-02, -7.10856095e-02, -2.82074418e-02, ...,-1.50318846e-01, -1.02016121e-01, -1.42484650e-01],[-5.88986427e-02, -8.25349689e-02, -6.43514097e-02, ...,-1.57855637e-02, -1.63435444e-01, -2.29314134e-01]]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f2139d61-6303-4a23-98cf-3673bb9bc45e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f2139d61-6303-4a23-98cf-3673bb9bc45e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-878d0986-75ed-47e5-8bc8-7c69953ce04d' class='xr-var-data-in' type='checkbox'><label for='data-878d0986-75ed-47e5-8bc8-7c69953ce04d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.08749752, 0.07566394, 0.08048858, 0.05942251, 0.08656505,0.12185976, 0.06887336, 0.0905668 , 0.05403268, 0.07181049,0.0550974 , 0.06646974, 0.0836788 , 0.0908078 , 0.07794502,0.12717618, 0.08268905, 0.08199009, 0.06042007, 0.08039746,0.07375756, 0.08004567, 0.07369493, 0.05209222, 0.06773813,0.07567891, 0.06394383, 0.07015068, 0.06110496, 0.05618365,0.07204464, 0.06970027, 0.07037816, 0.13688137, 0.15274332,0.12264106, 0.04977913, 0.07876818, 0.08162527, 0.07093899,0.05320951, 0.07532281, 0.06193871, 0.07772235, 0.0625428 ,0.1044555 , 0.08000522, 0.06374399, 0.08369675, 0.08106692,0.10279923, 0.09621546, 0.12413957, 0.06413788, 0.07954515,0.09487127, 0.08290483, 0.04747   , 0.06979456, 0.18748829,0.04298115, 0.04195834, 0.1148258 , 0.09162779, 0.05987021,0.09955552, 0.10133713, 0.12494878, 0.09806998, 0.06577738,0.08450206, 0.08529033, 0.08643976, 0.10094264, 0.10307201,0.08249924, 0.08703554, 0.08950563, 0.10133018, 0.07853633,0.13012244, 0.06427832, 0.06555421, 0.10947937, 0.0986587 ,0.08324643, 0.12616539, 0.15661672, 0.12120757, 0.08905131,0.06446747, 0.06053576, 0.1022647 , 0.08084394, 0.07096756,0.04814326, 0.08076878, 0.0578785 , 0.05871171, 0.06860586,...0.08393703, 0.13742442, 0.16588452, 0.16658449, 0.12747233,0.06536341, 0.08070491, 0.054926  , 0.08905615, 0.07083647,0.084295  , 0.07507804, 0.08032234, 0.07883497, 0.09715426,0.04897055, 0.03900881, 0.08737577, 0.06539333, 0.06196475,0.07782749, 0.08772838, 0.08647447, 0.08982432, 0.06083963,0.05096257, 0.08472867, 0.10690733, 0.15537757, 0.1090062 ,0.12436836, 0.06025395, 0.07437796, 0.07608658, 0.07549697,0.06678806, 0.06567252, 0.0882093 , 0.07614212, 0.08778889,0.06291485, 0.08579191, 0.07262758, 0.07168292, 0.07558706,0.08700459, 0.08335356, 0.11345679, 0.10092745, 0.07527902,0.05134162, 0.05790048, 0.06061584, 0.07270308, 0.08926713,0.08099414, 0.07754322, 0.0746849 , 0.11100458, 0.0919131 ,0.1136789 , 0.09457454, 0.07708218, 0.07295642, 0.07259703,0.07386626, 0.07742231, 0.08950511, 0.06289942, 0.05502244,0.09478045, 0.0668821 , 0.08814944, 0.07755594, 0.07491109,0.07334865, 0.07315613, 0.06798056, 0.09187512, 0.07666565,0.07815414, 0.0586658 , 0.07820864, 0.06924605, 0.05804982,0.05555929, 0.05697025, 0.05014225, 0.06789628, 0.05180866,0.05355003, 0.05774009, 0.06560262, 0.1360202 , 0.08399522,0.0845034 , 0.1132824 , 0.12404297, 0.17892207, 0.10889328]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4df0b30b-e7ea-463a-9b95-9082623d3ec0' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4df0b30b-e7ea-463a-9b95-9082623d3ec0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4fed479a-703a-4df0-bb57-e4fda7b44a7f' class='xr-var-data-in' type='checkbox'><label for='data-4fed479a-703a-4df0-bb57-e4fda7b44a7f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1.97695076e-01, 3.84786278e-02, 5.69613837e-02, 3.43336016e-01,1.38459280e-01, 1.90572232e-01, 1.33345187e-01, 6.11790605e-02,1.12512149e-01, 4.44112457e-02, 6.76324144e-02, 3.73359144e-01,2.86807477e-01, 1.78793713e-01, 3.65423918e-01, 3.47535670e-01,3.22127968e-01, 1.96506962e-01, 6.88896999e-02, 1.48905516e-01,2.71045297e-01, 2.27266297e-01, 2.44580239e-01, 2.80097753e-01,3.53799820e-01, 3.99208426e-01, 3.10158968e-01, 2.37433150e-01,3.82996798e-01, 6.04612827e-01, 2.25865901e-01, 3.08724642e-01,3.41910899e-01, 2.03977376e-01, 2.32600570e-01, 2.04068542e-01,4.61158305e-01, 1.03728384e-01, 1.19963206e-01, 2.49195382e-01,3.08207601e-01, 1.96159989e-01, 2.88961619e-01, 2.84978867e-01,3.82614993e-02, 1.65507257e-01, 3.29561859e-01, 6.30331412e-02,2.21853942e-01, 3.89133066e-01, 8.60731676e-02, 1.84900612e-01,8.73754025e-02, 3.34833086e-01, 2.24541515e-01, 1.26366824e-01,7.60329217e-02, 1.63013399e-01, 6.80231154e-02, 8.63916129e-02,2.11252749e-01, 2.30888680e-01, 1.77355334e-02, 3.90561782e-02,8.78479332e-03, 1.89907119e-01, 2.19105810e-01, 1.39205471e-01,5.77525973e-01, 2.33141899e-01, 1.47716805e-01, 1.84099078e-01,1.43102616e-01, 2.05544516e-01, 2.08333850e-01, 8.06813091e-02,2.83166945e-01, 4.45452213e-01, 1.89513877e-01, 4.80097622e-01,...3.67701426e-02, 2.36079738e-01, 1.09601408e-01, 1.47840455e-01,5.99866986e-01, 2.88175106e-01, 1.41279578e-01, 3.81505996e-01,9.74494666e-02, 2.33950958e-01, 3.11483234e-01, 3.29780489e-01,3.52081746e-01, 2.85780430e-01, 3.52991819e-01, 2.29452848e-01,6.07846260e-01, 6.09655023e-01, 4.49380070e-01, 3.27497303e-01,1.52883738e-01, 6.08975232e-01, 1.44054830e-01, 7.52023160e-02,5.44204637e-02, 3.89243886e-02, 4.71061587e-01, 1.26620367e-01,2.17646286e-01, 9.29729640e-02, 2.61041969e-01, 2.47778982e-01,8.76330361e-02, 7.00069547e-01, 6.85151741e-02, 1.74426273e-01,2.65077621e-01, 4.51663256e-01, 1.74055740e-01, 6.62162423e-01,3.20429981e-01, 3.15098554e-01, 7.27077842e-01, 4.52747136e-01,6.28486395e-01, 3.96356940e-01, 5.46176553e-01, 7.37296104e-01,4.04685140e-01, 2.93163717e-01, 3.47137809e-01, 5.12665212e-01,3.88504088e-01, 4.65411365e-01, 5.20303994e-02, 3.33318263e-01,2.22954780e-01, 6.36856675e-01, 5.32518804e-01, 4.02580142e-01,2.15710104e-01, 3.59249949e-01, 3.65403518e-02, 2.71128677e-02,1.96245294e-02, 5.99751668e-03, 2.19957888e-01, 1.45105854e-01,3.14748555e-01, 4.68219250e-01, 2.16391817e-01, 2.18449295e-01,1.46661639e-01, 2.59205550e-01, 1.11677386e-01, 3.90649796e-01,1.06556244e-01, 6.36805445e-02, 2.85048336e-01, 8.88382196e-01]],      dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0002d0ac-dcf6-45eb-a499-11dd9e4f5ba7' class='xr-section-summary-in' type='checkbox' /><label for='section-0002d0ac-dcf6-45eb-a499-11dd9e4f5ba7' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(11)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-07-06T16:28:47.612283+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.2.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[&#x27;chain&#x27;, &#x27;draw&#x27;]</dd><dt><span>inference_library :</span></dt><dd>numpyro</dd><dt><span>inference_library_version :</span></dt><dd>0.21.0</dd><dt><span>sampling_time :</span></dt><dd>335.468196</dd><dt><span>tuning_steps :</span></dt><dd>800</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.18.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-fac40a87-a161-4cde-9d13-69abf7b8ad41' type='checkbox' checked /><label for='group-fac40a87-a161-4cde-9d13-69abf7b8ad41' title='Expand/collapse group'>/sample_stats<span>(16)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-5f78d98c-4dcf-4a55-b61c-e051fba0753f' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-5f78d98c-4dcf-4a55-b61c-e051fba0753f' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li></ul></div></li><li class='xr-section-item'><input id='section-42aa0957-4551-4e1f-ac75-503aa4f3fa50' class='xr-section-summary-in' type='checkbox' checked /><label for='section-42aa0957-4551-4e1f-ac75-503aa4f3fa50' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-723bfc58-7b4a-4a59-aba4-2e6dc5a93820' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-723bfc58-7b4a-4a59-aba4-2e6dc5a93820' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4d9e3f9b-1336-432c-addd-59b57547d6b2' class='xr-var-data-in' type='checkbox'><label for='data-4d9e3f9b-1336-432c-addd-59b57547d6b2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-6107df22-2a11-4b73-ba43-d84eada0615f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6107df22-2a11-4b73-ba43-d84eada0615f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3c2423a6-63cf-41d4-8de8-303f978cc535' class='xr-var-data-in' type='checkbox'><label for='data-3c2423a6-63cf-41d4-8de8-303f978cc535' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-32c1dd9c-6167-4116-9140-9b0267d2821e' class='xr-section-summary-in' type='checkbox' checked /><label for='section-32c1dd9c-6167-4116-9140-9b0267d2821e' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>acceptance_rate</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7e2420cb-657d-4048-84db-9295d9c083d1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7e2420cb-657d-4048-84db-9295d9c083d1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a7a3bea6-eae8-4708-8e99-6384ce94bfc8' class='xr-var-data-in' type='checkbox'><label for='data-a7a3bea6-eae8-4708-8e99-6384ce94bfc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.95637107, 0.9017923 , 0.99679023, 0.9746883 , 0.87229884,0.99776816, 0.98683333, 0.9842481 , 0.9217249 , 0.8654877 ,0.99708045, 0.9230262 , 0.99930495, 0.96451896, 0.93732804,0.9481791 , 0.9216973 , 0.8554022 , 0.9948878 , 0.9244154 ,0.9609494 , 0.97978556, 0.987522  , 0.8884533 , 0.99715656,0.9585158 , 0.9709815 , 0.99409425, 0.97975904, 0.99019736,0.9980451 , 0.9977645 , 0.98396456, 0.9954767 , 0.90118206,0.9428254 , 0.9921434 , 0.93737614, 0.9502295 , 0.9928039 ,0.9742202 , 0.9963147 , 0.9979532 , 0.963143  , 0.99539447,0.99159825, 0.99174225, 0.9394213 , 0.98688775, 0.9341868 ,0.99265844, 0.9969879 , 0.9905177 , 0.9894284 , 0.9468667 ,0.9969009 , 0.99424565, 0.97321445, 0.9408641 , 0.9949583 ,0.9533947 , 0.9850762 , 0.99249715, 0.96829236, 0.9819388 ,0.95341134, 0.9945047 , 0.9767253 , 0.9968979 , 0.95533884,0.83907396, 0.99240184, 0.7855681 , 0.999842  , 0.9943879 ,0.9996992 , 0.9894317 , 0.9907006 , 0.9798967 , 0.8958009 ,0.9582544 , 0.93161803, 0.9821065 , 0.9975295 , 0.98598224,0.8448914 , 0.9973672 , 0.8647186 , 0.8842801 , 0.9037394 ,0.9827817 , 0.94172347, 0.92566115, 0.9932416 , 0.9826301 ,0.99943155, 0.9864379 , 0.83077615, 0.9827776 , 0.9954817 ,...0.93406194, 0.8790448 , 0.9501851 , 0.885512  , 0.98595816,0.8909709 , 0.6904565 , 0.9464745 , 0.879668  , 0.7924191 ,0.9873494 , 1.        , 0.9614334 , 0.9820905 , 0.96116805,0.9025987 , 0.9771844 , 0.9886985 , 0.91602385, 0.99092174,0.89739263, 0.9578284 , 0.9616267 , 0.9793762 , 0.99299103,0.9414162 , 0.9765787 , 0.81417376, 0.9827902 , 0.6442527 ,0.9789173 , 0.91946036, 0.847442  , 0.93288493, 0.92086494,0.9982192 , 0.9871009 , 0.99549043, 0.69014025, 0.9007037 ,0.95446676, 0.9851497 , 0.8898813 , 0.97430736, 0.990721  ,0.9116577 , 0.9543056 , 0.86251974, 0.90170133, 0.4262306 ,0.8413689 , 0.9920411 , 0.815684  , 0.4295096 , 0.99777937,0.9722127 , 0.9985186 , 0.95944166, 0.9711887 , 0.9945802 ,0.97515017, 0.903946  , 0.93065214, 0.97525084, 0.97814375,0.9746826 , 0.99891686, 0.9891677 , 0.86352575, 0.88247776,0.9901771 , 0.97755796, 0.9762583 , 0.9693625 , 0.9960326 ,0.95733196, 0.97878736, 0.92206705, 0.8849918 , 0.78164816,0.9323931 , 0.9963633 , 0.9048466 , 0.9650903 , 0.99283206,0.9923354 , 0.9608782 , 0.9746107 , 0.9385618 , 0.9229466 ,0.6595391 , 0.95575434, 0.9873599 , 0.9339861 , 0.6836976 ,0.7365255 , 0.9588638 , 0.95199853, 0.9545085 , 0.9590754 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>step_size</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-7c1ea3f7-8c73-4c19-a088-307978dc8384' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7c1ea3f7-8c73-4c19-a088-307978dc8384' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-073d72a2-b42d-4259-a7ed-6637ffd32718' class='xr-var-data-in' type='checkbox'><label for='data-073d72a2-b42d-4259-a7ed-6637ffd32718' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,0.04443179, 0.04443179, 0.04443179, 0.04443179, 0.04443179,...0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ,0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 , 0.0631496 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>diverging</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>bool</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-cbded33d-5f9b-4b32-862e-26ffb2408103' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cbded33d-5f9b-4b32-862e-26ffb2408103' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b93be63f-6d44-4630-b41e-d7db9341a321' class='xr-var-data-in' type='checkbox'><label for='data-b93be63f-6d44-4630-b41e-d7db9341a321' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False,  True, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False,  True, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,...False, False, False,  True, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False,  True, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False,  True, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False,  True, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False]], dtype=bool)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>energy</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2fe2b841-bdba-4bc4-9d82-3b16afab2d79' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2fe2b841-bdba-4bc4-9d82-3b16afab2d79' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1a57359a-e645-43c9-ada3-593bced3b952' class='xr-var-data-in' type='checkbox'><label for='data-1a57359a-e645-43c9-ada3-593bced3b952' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1510.1527, 1508.1685, 1510.0267, 1502.4604, 1500.3811, 1494.5237,1491.6917, 1496.6393, 1490.3264, 1508.4507, 1496.671 , 1505.7985,1503.2286, 1507.8502, 1508.8086, 1495.827 , 1494.0026, 1498.4236,1500.9453, 1509.431 , 1495.678 , 1498.3517, 1489.7916, 1504.486 ,1503.0891, 1495.4773, 1504.0118, 1500.2255, 1511.0131, 1504.2692,1519.0804, 1523.7229, 1505.0237, 1492.334 , 1493.0876, 1493.2592,1497.2289, 1507.8269, 1512.5677, 1512.8994, 1508.9333, 1526.9413,1510.9296, 1522.181 , 1509.2102, 1511.3958, 1502.0941, 1505.8075,1512.4678, 1512.0583, 1501.2258, 1492.9817, 1487.0659, 1481.5249,1491.8506, 1487.2917, 1497.3864, 1493.9625, 1509.5483, 1504.5105,1500.8844, 1501.839 , 1510.3313, 1514.4689, 1499.072 , 1500.5679,1492.098 , 1485.0192, 1485.6971, 1488.7063, 1492.0751, 1489.4722,1509.7247, 1502.9652, 1505.3386, 1496.0059, 1487.1234, 1480.0054,1476.6003, 1484.9966, 1477.2129, 1495.636 , 1500.5178, 1482.6526,1486.8306, 1491.3607, 1477.8679, 1488.8234, 1509.5621, 1500.3225,1516.5079, 1524.2307, 1508.2777, 1503.3558, 1502.3854, 1501.6859,1496.8384, 1491.3083, 1497.4607, 1501.3541, 1491.2205, 1500.9296,1495.7625, 1488.7511, 1494.5194, 1497.9685, 1504.3959, 1510.8807,1513.0809, 1491.8573, 1492.8804, 1483.3557, 1476.1344, 1488.7184,1497.0018, 1490.3894, 1492.1954, 1506.5538, 1500.8097, 1495.28  ,...1505.0189, 1496.5914, 1501.3274, 1506.4072, 1505.5612, 1501.6472,1495.1925, 1484.367 , 1500.8744, 1493.4072, 1490.0626, 1497.3354,1501.9167, 1513.4032, 1508.4897, 1509.919 , 1489.4229, 1492.476 ,1489.4313, 1476.1294, 1479.6732, 1479.9269, 1463.9159, 1468.6924,1485.7267, 1492.5507, 1508.8733, 1522.3102, 1510.1329, 1506.8021,1500.9646, 1505.7964, 1500.1548, 1530.2688, 1527.4316, 1514.4998,1504.2152, 1510.6425, 1525.2933, 1529.4637, 1513.3358, 1505.553 ,1488.2119, 1495.0973, 1491.029 , 1494.3108, 1495.8241, 1498.7224,1490.9844, 1487.6373, 1484.3279, 1498.0515, 1505.4742, 1495.2042,1492.0243, 1488.5363, 1499.7238, 1492.0964, 1491.7086, 1486.9768,1488.6505, 1501.1089, 1486.3584, 1486.2543, 1486.8999, 1485.7955,1488.411 , 1498.6632, 1520.3453, 1506.7345, 1491.3807, 1501.9221,1515.2437, 1513.0475, 1511.167 , 1494.701 , 1503.8091, 1496.3861,1481.1229, 1503.5184, 1509.5133, 1491.674 , 1505.959 , 1488.8915,1496.5604, 1495.9058, 1500.4484, 1511.2001, 1515.6439, 1491.1869,1504.3805, 1494.5077, 1490.0579, 1498.6583, 1506.0903, 1500.3851,1483.6034, 1498.4897, 1505.0587, 1505.2717, 1508.1432, 1515.1409,1517.0896, 1513.5311, 1523.0314, 1517.0603, 1511.024 , 1495.1998,1486.1962, 1488.4009, 1486.2908, 1487.5647, 1488.5361, 1497.408 ,1527.8167, 1510.6489, 1509.9453, 1506.8907]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>n_steps</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4b202d5f-e427-4d3c-a952-972a426cbac8' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4b202d5f-e427-4d3c-a952-972a426cbac8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d3fca55e-eba0-41c0-8c46-2879fa480407' class='xr-var-data-in' type='checkbox'><label for='data-d3fca55e-eba0-41c0-8c46-2879fa480407' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[127, 127, 127, 127, 127, 127, 127,  63, 127, 127, 127, 127, 127,127, 127, 127,  63, 127, 127,  29, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127,  63, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127,  92, 127, 127, 127, 127,127, 127, 127,  63, 127, 127, 127, 127, 127,  63, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,  63,127, 127, 127,  63, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127,  63, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 255, 191,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,  63,127, 127, 127, 127, 127, 127, 127,  63, 127, 127, 127,  63, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,...63,  63,  26,  63,  63, 127,  63,  63,  63,  63,  63,  63,  63,127, 127,  63,  63,  11,  63,  63,  63,  63,  63,  63,  63,  63,63,  63, 127,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,127,  63, 127,  63,  63,  63,  63,  63,  63,  63,  63,  63, 127,121,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  35,  63,  63,  63,  58,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  63, 127,  63,  63,127,  63,  63, 127, 127,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  63,  61,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,63, 127,  63,  63,  63,  63,  63, 127,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  27,  63,  63,  63,63,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63, 127,  63,127,  63, 127,  63,  63,  63,  63,  63,  63,  63,  63,  63,  63,63,  63,  63,  63,  63,  63, 127,  63,  63,  63,  63,  63,  63,127,  63,  63,  63, 127,  63,  63,  63,  63,  63,  63,  63,  63,63,  63, 127,  51,  63,  63,  63,  63,  63,  63,  63, 127, 127,63,  63,  63,  63,  63,  63,  63,  63,  63, 127]], dtype=int32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tree_depth</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>7 7 7 7 7 7 7 6 ... 6 6 6 6 6 6 6 7</div><input id='attrs-b1fad687-695d-4cd8-ad07-f38dbbd9afc1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b1fad687-695d-4cd8-ad07-f38dbbd9afc1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a95e1243-6e39-4349-9cda-7b8cde74ca1b' class='xr-var-data-in' type='checkbox'><label for='data-a95e1243-6e39-4349-9cda-7b8cde74ca1b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 5, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,6, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7,7, 7, 7, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,8, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6,6, 7, 6, 7, 7, 7, 7, 7, 7, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7],[6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7,6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 1, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6,6, 6, 6, 7, 6, 7, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 7, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6,7, 5, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 5, 6, 6, 7, 6, 6, 6, 6, 6,6, 6, 7, 7, 6, 6, 4, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 7,6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 7, 6, 6, 7, 6, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 7, 6,6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 5, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 6, 7, 6, 7, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 7, 6, 6, 6, 6, 6,6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 6, 6, 6, 6, 6, 6,6, 6, 6, 7]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lp</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f1381d8f-bad5-425d-8360-69d0dfb00d9a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f1381d8f-bad5-425d-8360-69d0dfb00d9a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd5864a7-d5d8-40fd-8d94-6fc3a63d0ec5' class='xr-var-data-in' type='checkbox'><label for='data-dd5864a7-d5d8-40fd-8d94-6fc3a63d0ec5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1466.0818, 1464.4799, 1460.4015, 1456.1318, 1454.5237, 1452.4841,1459.8677, 1457.186 , 1453.0153, 1455.4808, 1463.4495, 1453.1364,1460.7008, 1462.6482, 1457.0283, 1449.5952, 1456.4005, 1453.1406,1461.4651, 1462.828 , 1457.0137, 1458.3739, 1452.8369, 1466.3093,1454.3687, 1461.8718, 1458.0225, 1464.0508, 1458.9778, 1465.8699,1472.9028, 1472.5059, 1456.5145, 1451.1788, 1457.7455, 1456.4335,1460.4242, 1459.2809, 1471.7761, 1461.8722, 1475.9635, 1474.6001,1471.4811, 1469.2463, 1466.23  , 1461.574 , 1456.109 , 1470.4764,1467.9207, 1466.5156, 1455.4857, 1454.4576, 1445.454 , 1447.0847,1446.6417, 1457.0164, 1457.0981, 1454.0094, 1465.1228, 1462.6603,1462.8947, 1459.3113, 1463.7739, 1459.987 , 1448.9147, 1455.5526,1451.1752, 1451.2352, 1444.9495, 1452.4573, 1451.5089, 1450.0624,1466.2186, 1465.4343, 1462.185 , 1454.6873, 1442.6528, 1440.0332,1440.8738, 1441.2483, 1435.8756, 1458.17  , 1452.8384, 1449.2565,1449.5968, 1439.8088, 1445.8956, 1460.14  , 1455.5365, 1464.0796,1474.6193, 1465.0403, 1462.4644, 1460.9943, 1463.0963, 1458.7981,1449.2734, 1455.3817, 1455.7145, 1460.0144, 1456.4081, 1459.0625,1449.7827, 1449.6947, 1458.3146, 1458.1764, 1471.1531, 1461.9617,1456.4326, 1454.2412, 1450.8582, 1443.8685, 1440.1051, 1452.9556,1451.0424, 1449.3036, 1447.7191, 1462.5232, 1456.3038, 1456.3209,...1461.681 , 1457.5062, 1461.5002, 1459.5857, 1460.2521, 1461.3613,1449.1362, 1446.7324, 1459.1727, 1450.9148, 1451.841 , 1455.9288,1466.2351, 1464.4574, 1469.1035, 1455.9598, 1449.3933, 1450.0244,1439.1672, 1440.3688, 1442.4293, 1434.3093, 1432.3107, 1443.6351,1452.4875, 1459.3386, 1462.9535, 1471.1194, 1461.3044, 1459.0573,1459.2677, 1458.6356, 1468.9993, 1487.1895, 1469.7804, 1463.2778,1465.3105, 1476.5846, 1488.9077, 1477.2485, 1462.8658, 1453.6995,1453.6963, 1457.1832, 1447.1776, 1452.1321, 1455.5577, 1453.1846,1453.2767, 1440.1902, 1453.6948, 1458.6018, 1464.5834, 1449.1084,1455.58  , 1449.2457, 1457.0762, 1451.5544, 1454.4353, 1447.0317,1452.3755, 1456.1088, 1446.483 , 1449.3737, 1437.062 , 1445.4832,1453.6819, 1469.996 , 1471.5397, 1454.4753, 1451.0961, 1459.7712,1475.4078, 1461.3086, 1469.9122, 1460.9353, 1457.8889, 1448.7281,1454.1992, 1468.0062, 1452.0172, 1462.445 , 1459.3617, 1456.6542,1451.6863, 1455.3201, 1464.1549, 1469.809 , 1450.9009, 1457.2897,1454.7446, 1453.5955, 1450.4792, 1460.9078, 1462.9464, 1448.4933,1454.4222, 1464.4117, 1474.1829, 1469.8555, 1466.1934, 1484.3197,1471.0977, 1477.1975, 1472.2913, 1467.7266, 1458.7557, 1452.1482,1451.5538, 1442.4465, 1447.158 , 1444.7137, 1451.5273, 1462.0361,1468.0026, 1462.4086, 1463.774 , 1462.3818]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2b0287a8-377b-46f0-b6e0-e8b1d88aaf5b' class='xr-section-summary-in' type='checkbox' checked /><label for='section-2b0287a8-377b-46f0-b6e0-e8b1d88aaf5b' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-07-06T16:28:47.623322+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.2.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[&#x27;chain&#x27;, &#x27;draw&#x27;]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.18.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-d0eed585-04e0-4eed-8c1c-01bdb969d705' type='checkbox' checked /><label for='group-d0eed585-04e0-4eed-8c1c-01bdb969d705' title='Expand/collapse group'>/observed_data<span>(10)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-7cbed3f4-c0e0-47e4-a40e-80a8821d36de' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-7cbed3f4-c0e0-47e4-a40e-80a8821d36de' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>__obs__</span>: 1800</li><li><span class='xr-has-index'>rt,response_extra_dim_0</span>: 2</li></ul></div></li><li class='xr-section-item'><input id='section-475cc14d-ba71-47d1-9cc5-52da63dcca0c' class='xr-section-summary-in' type='checkbox' checked /><label for='section-475cc14d-ba71-47d1-9cc5-52da63dcca0c' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>__obs__</span></div><div class='xr-var-dims'>(__obs__)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 ... 1796 1797 1798 1799</div><input id='attrs-06921e32-3236-4779-a908-05d7123304be' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-06921e32-3236-4779-a908-05d7123304be' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e47744d-2835-4e0a-9aa7-f7f7a879646d' class='xr-var-data-in' type='checkbox'><label for='data-0e47744d-2835-4e0a-9aa7-f7f7a879646d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([   0,    1,    2, ..., 1797, 1798, 1799], shape=(1800,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>rt,response_extra_dim_0</span></div><div class='xr-var-dims'>(rt,response_extra_dim_0)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-55929808-f0ad-4acd-922e-1d9006f286c2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-55929808-f0ad-4acd-922e-1d9006f286c2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e1ef1ca9-bc68-436d-96d6-d00ba61b7942' class='xr-var-data-in' type='checkbox'><label for='data-e1ef1ca9-bc68-436d-96d6-d00ba61b7942' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-06c64401-fe40-412c-8b10-20076d7a6523' class='xr-section-summary-in' type='checkbox' checked /><label for='section-06c64401-fe40-412c-8b10-20076d7a6523' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>rt,response</span></div><div class='xr-var-dims'>(__obs__, rt,response_extra_dim_0)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>1.398 -1.0 0.4245 ... 1.148 -1.0</div><input id='attrs-58258884-eb83-4047-857d-205d667021b9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-58258884-eb83-4047-857d-205d667021b9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-730372a6-aff4-4668-8c3f-ff49b8161596' class='xr-var-data-in' type='checkbox'><label for='data-730372a6-aff4-4668-8c3f-ff49b8161596' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[ 1.3978789 , -1.        ],[ 0.42447704, -1.        ],[ 0.49828485, -1.        ],...,[ 0.3929206 , -1.        ],[ 0.9278363 , -1.        ],[ 1.1475817 , -1.        ]], shape=(1800, 2), dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-04bd5548-3448-4077-9012-bde61e835c75' class='xr-section-summary-in' type='checkbox' checked /><label for='section-04bd5548-3448-4077-9012-bde61e835c75' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-07-06T16:28:47.623923+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.2.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.18.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-8884e536-fe00-4ed6-a863-6d72b672b5e6' type='checkbox' checked /><label for='group-8884e536-fe00-4ed6-a863-6d72b672b5e6' title='Expand/collapse group'>/constant_data<span>(7)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-e4a779e0-249c-40f4-8e29-e787cdc9932e' class='xr-section-summary-in' type='checkbox' checked /><label for='section-e4a779e0-249c-40f4-8e29-e787cdc9932e' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-07-06T16:28:47.623995+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.2.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.18.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 1.2em'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-2853f870-3b31-4d73-84d3-207f353f36d3' type='checkbox' checked /><label for='group-2853f870-3b31-4d73-84d3-207f353f36d3' title='Expand/collapse group'>/log_likelihood<span>(6)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-a03715f9-1a42-4f2b-ad6b-b58855e54850' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-a03715f9-1a42-4f2b-ad6b-b58855e54850' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li><li><span class='xr-has-index'>__obs__</span>: 1800</li></ul></div></li><li class='xr-section-item'><input id='section-729c4d24-4d86-4e94-adfe-36602ce4787b' class='xr-section-summary-in' type='checkbox' checked /><label for='section-729c4d24-4d86-4e94-adfe-36602ce4787b' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-c6768e1d-9c65-4522-b0c7-c52554e3004a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c6768e1d-9c65-4522-b0c7-c52554e3004a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-abfbb53f-09ea-4ebe-9110-7803b8428622' class='xr-var-data-in' type='checkbox'><label for='data-abfbb53f-09ea-4ebe-9110-7803b8428622' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-567cc027-f137-4152-a84a-834ee7101339' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-567cc027-f137-4152-a84a-834ee7101339' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b44fb5bd-f880-4c7d-834d-4a9fe89aebb6' class='xr-var-data-in' type='checkbox'><label for='data-b44fb5bd-f880-4c7d-834d-4a9fe89aebb6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>__obs__</span></div><div class='xr-var-dims'>(__obs__)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 ... 1796 1797 1798 1799</div><input id='attrs-fe870bbf-de32-4c0b-80b6-58050cb7c2c6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fe870bbf-de32-4c0b-80b6-58050cb7c2c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e93204a-fb3c-487f-9951-712f4b69a407' class='xr-var-data-in' type='checkbox'><label for='data-9e93204a-fb3c-487f-9951-712f4b69a407' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([   0,    1,    2, ..., 1797, 1798, 1799], shape=(1800,))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9833b9f3-b26d-4be9-b29e-a8e878763536' class='xr-section-summary-in' type='checkbox' checked /><label for='section-9833b9f3-b26d-4be9-b29e-a8e878763536' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>rt,response</span></div><div class='xr-var-dims'>(chain, draw, __obs__)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.463 -0.9025 ... -0.3959 -0.7486</div><input id='attrs-d7d537db-0947-443a-9989-2ad133cf1aa3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d7d537db-0947-443a-9989-2ad133cf1aa3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4cab18b3-a2ed-4ec0-ac03-cc06a4f3bf3b' class='xr-var-data-in' type='checkbox'><label for='data-4cab18b3-a2ed-4ec0-ac03-cc06a4f3bf3b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[-1.46306813, -0.90252364, -0.64737201, ...,  0.14495325,-0.46385241, -0.81378913],[-1.38472688, -0.77236867, -0.47124547, ...,  0.23681039,-0.53916574, -0.90916133],[-1.40204024, -1.31411898, -0.87581617, ..., -0.02654791,-0.44785053, -0.77188891],...,[-1.34632528, -0.75923979, -0.61553311, ...,  0.23809421,-0.49602365, -0.85148144],[-1.51601171, -0.95843881, -0.65351367, ...,  0.0124532 ,-0.49508965, -0.82659596],[-1.49911821, -0.49016488, -0.29849419, ...,  0.29478267,-0.57878858, -0.94908917]],[[-1.51078343, -0.76726109, -0.53859258, ...,  0.10472441,-0.5012266 , -0.85822451],[-1.37443578, -1.05887067, -0.68619418, ...,  0.0645977 ,-0.4455539 , -0.8034426 ],[-1.3589747 , -1.23487365, -0.98140258, ...,  0.12771845,-0.55154121, -0.90081918],...,[-1.66601932, -0.58721811, -0.48519215, ..., -0.00942194,-0.41328299, -0.73428589],[-1.43339431, -0.86654496, -0.61242759, ..., -0.01617625,-0.4724921 , -0.81797063],[-1.62788284, -0.72879827, -0.59577668, ...,  0.1128369 ,-0.39590514, -0.74856371]]], shape=(2, 400, 1800))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e689b4e9-93f2-4b96-a3d3-4bf339f6d08d' class='xr-section-summary-in' type='checkbox' checked /><label for='section-e689b4e9-93f2-4b96-a3d3-4bf339f6d08d' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.18.0</dd></dl></div></li></ul></div></div></div></li></ul></div></div>"
+       "            modeling_interface_version:  0.20.0</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.DataTree</div></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-children'><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-46b0bb7c-4e53-48a2-9a74-d9e247df417d' type='checkbox' checked /><label for='group-46b0bb7c-4e53-48a2-9a74-d9e247df417d' title='Expand/collapse group'>/posterior<span>(39)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-dc36a451-7d9d-414b-b68c-ffe2f4a74e07' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-dc36a451-7d9d-414b-b68c-ffe2f4a74e07' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li><li><span class='xr-has-index'>participant_id__factor_dim</span>: 12</li><li><span class='xr-has-index'>rl_alpha_1|participant_id__factor_dim</span>: 12</li></ul></div></li><li class='xr-section-item'><input id='section-ae191701-f69d-476c-ba81-a3231d2c8695' class='xr-section-summary-in' type='checkbox' checked /><label for='section-ae191701-f69d-476c-ba81-a3231d2c8695' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-c01ec472-276b-4d60-a435-15b857db71d3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c01ec472-276b-4d60-a435-15b857db71d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e69ec8c-d658-4b71-a150-abc0ca4d2468' class='xr-var-data-in' type='checkbox'><label for='data-9e69ec8c-d658-4b71-a150-abc0ca4d2468' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-16ec3edc-a195-4643-80bd-eef6a8cbca4e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-16ec3edc-a195-4643-80bd-eef6a8cbca4e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-642a4c79-5270-4d77-89fe-ee591ca14824' class='xr-var-data-in' type='checkbox'><label for='data-642a4c79-5270-4d77-89fe-ee591ca14824' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>participant_id__factor_dim</span></div><div class='xr-var-dims'>(participant_id__factor_dim)</div><div class='xr-var-dtype'>&lt;U2</div><div class='xr-var-preview xr-preview'>&#x27;0&#x27; &#x27;1&#x27; &#x27;2&#x27; &#x27;3&#x27; ... &#x27;9&#x27; &#x27;10&#x27; &#x27;11&#x27;</div><input id='attrs-b6cfc4e7-8adc-47f6-b9b7-2cdfb70851c2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b6cfc4e7-8adc-47f6-b9b7-2cdfb70851c2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9a46938b-e349-4000-b8e4-b09fc348535e' class='xr-var-data-in' type='checkbox'><label for='data-9a46938b-e349-4000-b8e4-b09fc348535e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;0&#x27;, &#x27;1&#x27;, &#x27;2&#x27;, &#x27;3&#x27;, &#x27;4&#x27;, &#x27;5&#x27;, &#x27;6&#x27;, &#x27;7&#x27;, &#x27;8&#x27;, &#x27;9&#x27;, &#x27;10&#x27;, &#x27;11&#x27;],dtype=&#x27;&lt;U2&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>rl_alpha_1|participant_id__factor_dim</span></div><div class='xr-var-dims'>(rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>&lt;U2</div><div class='xr-var-preview xr-preview'>&#x27;0&#x27; &#x27;1&#x27; &#x27;2&#x27; &#x27;3&#x27; ... &#x27;9&#x27; &#x27;10&#x27; &#x27;11&#x27;</div><input id='attrs-bccbe62c-387b-4749-a0f4-206b938b8c2b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bccbe62c-387b-4749-a0f4-206b938b8c2b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b2b202a1-8cc9-4431-a2f8-06574b3d72a4' class='xr-var-data-in' type='checkbox'><label for='data-b2b202a1-8cc9-4431-a2f8-06574b3d72a4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;0&#x27;, &#x27;1&#x27;, &#x27;2&#x27;, &#x27;3&#x27;, &#x27;4&#x27;, &#x27;5&#x27;, &#x27;6&#x27;, &#x27;7&#x27;, &#x27;8&#x27;, &#x27;9&#x27;, &#x27;10&#x27;, &#x27;11&#x27;],dtype=&#x27;&lt;U2&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-5aafee8e-297c-4119-9500-aacbbd396bdc' class='xr-section-summary-in' type='checkbox' /><label for='section-5aafee8e-297c-4119-9500-aacbbd396bdc' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(24)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c2be5d61-0dbc-4807-a714-1e027404586d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c2be5d61-0dbc-4807-a714-1e027404586d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-54106c17-9326-4672-a0e6-da715f82adc5' class='xr-var-data-in' type='checkbox'><label for='data-54106c17-9326-4672-a0e6-da715f82adc5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.6107107 ,  1.1798196 ,  2.2483704 , ..., -0.7405831 ,1.4405513 ,  0.17928807],[-0.5927971 ,  1.1109769 ,  1.3406607 , ..., -0.78060585,0.03829796, -0.00303728],[-1.1464826 ,  2.0671365 ,  2.3217502 , ..., -1.2755405 ,1.8582186 ,  0.41875702],...,[-0.24171388, -0.00654751,  0.9023832 , ..., -0.786946  ,0.21903726, -0.6284744 ],[-0.18332462,  0.44275495,  1.0400993 , ..., -1.6158231 ,-0.61426467, -0.7979618 ],[-0.52444124,  0.96287996,  1.6698228 , ..., -0.52156276,0.90074885, -0.366946  ]],[[-1.051099  ,  0.9925639 ,  3.028001  , ..., -0.86780185,1.3650287 ,  0.4446505 ],[-1.063934  ,  0.9772168 ,  3.013797  , ..., -0.8566574 ,1.3361909 ,  0.47993508],[-1.6794277 ,  0.4444337 ,  2.6377888 , ..., -0.5479038 ,0.30881348,  0.2320394 ],...,[-0.16853097,  1.1947709 ,  1.3790786 , ..., -0.98424846,2.396306  , -0.2399129 ],[-1.25639   ,  0.92232436,  2.1178107 , ..., -0.14153694,-1.0573628 , -0.17865089],[-1.1175848 ,  0.9210124 ,  1.5567899 , ..., -0.32632154,-1.0878423 , -0.3165011 ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9e09c7d4-b8a6-4bb3-9820-22f36e4e0a4d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9e09c7d4-b8a6-4bb3-9820-22f36e4e0a4d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-790c7951-b3fb-497d-8177-5eb8ffcdcae8' class='xr-var-data-in' type='checkbox'><label for='data-790c7951-b3fb-497d-8177-5eb8ffcdcae8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.24697031, -0.05625479,  1.4734635 , ..., -0.14555068,-1.2739254 , -0.30290836],[ 0.30971247,  0.9429353 , -0.43776572, ...,  0.14203985,0.44753742,  0.7560781 ],[ 0.27039325, -0.04762632,  0.48794433, ..., -0.43468818,-0.20023   , -0.30789396],...,[ 2.5773554 ,  0.93005747,  0.6629898 , ..., -0.64691764,-0.00976006, -0.37058064],[ 1.178824  ,  0.46278048,  0.21233149, ...,  0.9490994 ,-0.0489198 ,  0.720815  ],[ 1.6867226 ,  2.1866207 , -0.08762329, ...,  0.276551  ,0.8062145 ,  0.3340689 ]],[[-0.12806614, -0.25898734,  0.7425378 , ...,  1.7640593 ,-0.2677502 ,  0.10884291],[-0.17770009, -0.23060857,  0.6758091 , ...,  1.6823001 ,-0.26201892,  0.12761118],[ 0.24633054,  0.05807883, -0.3877935 , ...,  0.5575588 ,-0.19103001,  1.6656833 ],...,[ 0.09967527,  0.27739027, -0.13148674, ..., -0.5326192 ,2.487628  ,  0.8675555 ],[ 0.8523162 ,  0.50041413,  0.11248286, ..., -2.2847645 ,-1.4281231 ,  0.11127558],[ 0.50896376,  0.70715773,  0.3511999 , ..., -1.5011159 ,-1.4729884 , -0.18434168]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4823895b-4352-4b4e-9c7c-f042b5db340f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4823895b-4352-4b4e-9c7c-f042b5db340f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-93e24550-d4c1-401a-a8f1-a2127edba7b0' class='xr-var-data-in' type='checkbox'><label for='data-93e24550-d4c1-401a-a8f1-a2127edba7b0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.03413476, -0.0077752 ,  0.20365335, ..., -0.02011715,-0.17607437, -0.04186619],[ 0.00620156,  0.01888097, -0.00876565, ...,  0.00284415,0.00896131,  0.01513941],[ 0.05817427, -0.01024665,  0.1049797 , ..., -0.09352181,-0.04307886, -0.06624243],...,[ 0.9167395 ,  0.33081216,  0.23581885, ..., -0.23010214,-0.00347156, -0.13181183],[ 0.60341763,  0.23688856,  0.10868847, ...,  0.48582602,-0.02504112,  0.36897156],[ 0.7750805 ,  1.0047929 , -0.04026454, ...,  0.12708034,0.37047058,  0.15351088]],[[-0.01770244, -0.03579954,  0.10264019, ...,  0.24384399,-0.03701082,  0.01504524],[-0.02493452, -0.03235853,  0.09482818, ...,  0.236057  ,-0.03676597,  0.01790615],[ 0.08995634,  0.02120955, -0.14161657, ...,  0.20361237,-0.06976139,  0.6082834 ],...,[ 0.00537625,  0.01496179, -0.00709209, ..., -0.02872825,0.13417692,  0.04679395],[ 0.15547082,  0.09128044,  0.02051798, ..., -0.41676342,-0.26050365,  0.02029776],[ 0.07631347,  0.10603045,  0.05265852, ..., -0.22507566,-0.22085825, -0.02763999]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c6531414-bec7-4eed-8ca0-88ae31376f22' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c6531414-bec7-4eed-8ca0-88ae31376f22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-79a18f0c-5b0f-43c0-b22c-4843cd6f491d' class='xr-var-data-in' type='checkbox'><label for='data-79a18f0c-5b0f-43c0-b22c-4843cd6f491d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1.2421416 , 1.2233444 , 1.2222657 , 1.1293608 , 1.1003951 ,1.210441  , 1.1585485 , 1.1697412 , 1.2029774 , 1.2096176 ,1.2267091 , 1.2874775 , 1.134723  , 1.2767923 , 1.2119138 ,1.2110286 , 1.1039399 , 1.1635755 , 1.1271603 , 1.1714163 ,1.1793704 , 1.1557633 , 1.173295  , 1.1743457 , 1.153484  ,1.1283144 , 1.0980531 , 1.1163082 , 1.187083  , 1.1997571 ,1.2248145 , 1.2123532 , 1.1734203 , 1.1678244 , 1.1693158 ,1.2154069 , 1.1834611 , 1.1604195 , 1.1404848 , 1.141304  ,1.2948269 , 1.2752023 , 1.2552254 , 1.1624862 , 1.1668714 ,1.2946215 , 1.1921623 , 1.2006811 , 1.1208423 , 1.1737515 ,1.1278965 , 1.1648431 , 1.2516632 , 1.2855457 , 1.2314081 ,1.1700928 , 1.1523508 , 1.1915846 , 1.2150868 , 1.2433598 ,1.1503549 , 1.1586158 , 1.1217759 , 1.0929208 , 1.0865444 ,1.1464998 , 1.1300641 , 1.1297555 , 1.1398185 , 1.1540608 ,1.0420786 , 1.1476569 , 1.1434617 , 1.1119177 , 1.1629605 ,1.2023413 , 1.0898166 , 1.206444  , 1.193373  , 1.3191746 ,1.1933552 , 1.2965977 , 1.3018255 , 1.1647787 , 1.2834501 ,1.2268836 , 1.1716313 , 1.1017692 , 1.1003506 , 1.1413813 ,1.1945294 , 1.1216085 , 1.1232688 , 1.1407009 , 1.2248826 ,1.1763787 , 1.1654575 , 1.1877224 , 1.009108  , 1.1233625 ,...1.1241024 , 1.2155011 , 1.189828  , 1.178204  , 1.1402841 ,1.1685449 , 1.1487513 , 1.1974131 , 1.1580102 , 1.0309659 ,1.2166209 , 1.223552  , 1.1768421 , 1.2887212 , 1.1441042 ,1.2260853 , 1.189925  , 1.1841803 , 1.045205  , 1.160107  ,1.1576827 , 1.1485622 , 1.1176171 , 1.1639252 , 1.1486611 ,1.1880555 , 1.12849   , 1.1610061 , 1.2046115 , 1.1262302 ,1.2497092 , 1.1825408 , 1.1315441 , 1.234364  , 1.1450619 ,1.1127259 , 1.2064711 , 1.2863922 , 1.2445985 , 1.2046871 ,1.2394339 , 1.2059808 , 1.1841431 , 1.1810808 , 1.1936035 ,1.1987039 , 1.2027957 , 1.1867114 , 1.2607213 , 1.2051274 ,1.1667831 , 1.1616869 , 1.0995903 , 1.2047147 , 1.1339136 ,1.1906935 , 1.1146923 , 1.0911148 , 1.0559441 , 1.1812544 ,1.2368621 , 1.15265   , 1.123389  , 1.1023991 , 1.1692388 ,1.0611404 , 1.2032123 , 1.2332724 , 1.2071431 , 1.1970923 ,1.173238  , 1.0403818 , 1.1151124 , 1.1043519 , 1.0707531 ,1.0414053 , 1.2014298 , 1.1336031 , 1.1723325 , 1.158447  ,1.2294424 , 1.2528987 , 1.2128546 , 1.091918  , 1.1275353 ,1.1862717 , 1.1896633 , 1.092248  , 1.1032277 , 1.1993893 ,1.1213005 , 1.1117661 , 1.2141366 , 1.1259611 , 1.1652251 ,1.1336715 , 1.2043428 , 1.1137239 , 1.2702878 , 1.2579669 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f403baf6-bbf3-4ba9-9db4-932b50e135b2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f403baf6-bbf3-4ba9-9db4-932b50e135b2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2e8b58ce-8245-4544-b773-e3121d4eaade' class='xr-var-data-in' type='checkbox'><label for='data-2e8b58ce-8245-4544-b773-e3121d4eaade' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.05878806, 0.05210121, 0.0634628 , 0.07873084, 0.0663999 ,0.09088412, 0.05465176, 0.06932922, 0.09176663, 0.09285229,0.05384463, 0.07277398, 0.05439412, 0.04124367, 0.05064388,0.06061241, 0.07019261, 0.07388902, 0.04004949, 0.05241699,0.08248401, 0.09163922, 0.0769636 , 0.05995631, 0.05400118,0.04878606, 0.07265259, 0.06672364, 0.06439341, 0.04873034,0.06592679, 0.06684723, 0.05158302, 0.051115  , 0.03476868,0.0382369 , 0.05405874, 0.05274879, 0.05291126, 0.05291655,0.07620273, 0.05163543, 0.05216714, 0.10450368, 0.06024098,0.06290645, 0.05591701, 0.06175187, 0.04182317, 0.04683915,0.05429512, 0.05432501, 0.06112967, 0.09148335, 0.09855399,0.08511192, 0.07358508, 0.04164719, 0.05191313, 0.05025494,0.07880872, 0.07585327, 0.04876909, 0.04281665, 0.04335861,0.03573066, 0.03295699, 0.03141397, 0.04546084, 0.05988983,0.05537599, 0.04574434, 0.06224673, 0.08476587, 0.0792376 ,0.0710146 , 0.03651989, 0.05502546, 0.06023706, 0.04531848,0.04479032, 0.07942525, 0.05080713, 0.12986067, 0.05547357,0.07490055, 0.06710228, 0.07157184, 0.0756425 , 0.0648101 ,0.05410905, 0.05083023, 0.04704824, 0.06011561, 0.05818414,0.05529138, 0.06693555, 0.11150955, 0.09006813, 0.05647697,...0.12277003, 0.1127247 , 0.05390232, 0.05213708, 0.05696265,0.0360062 , 0.06519998, 0.07149968, 0.05630852, 0.0650474 ,0.04697888, 0.07237236, 0.08119053, 0.07758597, 0.06131989,0.03529173, 0.06572177, 0.05821091, 0.06703713, 0.04736461,0.04905727, 0.06203882, 0.06660901, 0.07769513, 0.05582985,0.08255321, 0.05255584, 0.06692322, 0.04478099, 0.06648879,0.07247284, 0.04763935, 0.0398132 , 0.05999692, 0.06875257,0.05325668, 0.0659335 , 0.06363022, 0.10237236, 0.06135595,0.07568146, 0.08071549, 0.06295572, 0.06411123, 0.06750655,0.05405293, 0.07060264, 0.04652855, 0.06503899, 0.08825141,0.05526669, 0.05130399, 0.09931073, 0.04918148, 0.03161352,0.03986089, 0.04343216, 0.05246258, 0.05637613, 0.04562825,0.07921238, 0.06174432, 0.0530265 , 0.06637792, 0.06071418,0.07226324, 0.07210888, 0.08845069, 0.05104273, 0.07553926,0.05114456, 0.05015077, 0.0574339 , 0.06011393, 0.06313509,0.08918618, 0.05889399, 0.05289161, 0.08457415, 0.09865369,0.10013062, 0.06087022, 0.0660226 , 0.06542248, 0.08107527,0.04625966, 0.06341682, 0.06038365, 0.04352797, 0.07651178,0.07790357, 0.07602103, 0.05890409, 0.0984135 , 0.08989833,0.07278326, 0.0610732 , 0.09115531, 0.0474635 , 0.04698059]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-3627b2b3-e7e4-473b-9e89-8525f17e71c3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3627b2b3-e7e4-473b-9e89-8525f17e71c3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a87ac484-89aa-4853-adbd-8d75fcbb1ab4' class='xr-var-data-in' type='checkbox'><label for='data-a87ac484-89aa-4853-adbd-8d75fcbb1ab4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.56222844,  0.05479908,  1.1375062 , ...,  0.98893553,-1.1966528 , -1.5862378 ],[ 0.41152385,  0.62358266,  1.761759  , ...,  0.71280575,-1.1638023 , -1.6706924 ],[-0.50310254, -0.43835014,  0.58700293, ...,  0.2109352 ,-1.0794442 , -1.3020186 ],...,[-0.40832487,  0.3013747 ,  0.32759005, ...,  0.46656173,-0.6389986 , -0.8570806 ],[-0.09621204,  0.00616006,  0.5997939 , ...,  0.63523847,-0.5505551 , -1.3625925 ],[ 0.64030796,  0.05106212,  0.5188453 , ...,  0.13404833,-0.9716656 , -1.1849964 ]],[[ 0.14355694,  0.12002355, -0.02889116, ..., -0.10075524,-0.7129214 , -0.9416238 ],[ 0.15003194,  0.1289425 , -0.04465081, ..., -0.11296512,-0.7550851 , -0.88541615],[ 0.27978528, -0.24507345,  0.3789375 , ..., -0.03272301,-0.97780865, -1.3347902 ],...,[-0.21055901, -0.39213797, -0.02061082, ...,  0.4215503 ,-1.8666699 , -1.196016  ],[ 0.30640066, -0.7525851 ,  0.5549185 , ..., -0.01071579,-1.341322  , -2.055743  ],[ 0.46488526, -0.829309  ,  0.77683705, ..., -0.14059283,-1.1542723 , -2.206098  ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-1f364164-7bed-4a9f-925c-6b9967bafe8b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1f364164-7bed-4a9f-925c-6b9967bafe8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6583bf02-e56b-4e29-9e10-288953fef6bd' class='xr-var-data-in' type='checkbox'><label for='data-6583bf02-e56b-4e29-9e10-288953fef6bd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.14566587, 0.32113883, 0.19015114, 0.17646989, 0.2019195 ,0.17703712, 0.15406007, 0.17513008, 0.16243427, 0.10956517,0.2268189 , 0.27067816, 0.24720998, 0.22357345, 0.17497724,0.17816594, 0.22305559, 0.2066372 , 0.20621343, 0.15621084,0.14780025, 0.13631415, 0.25748226, 0.26828143, 0.32508498,0.40591842, 0.13462286, 0.11227291, 0.20490919, 0.14456701,0.16519213, 0.15024161, 0.15877454, 0.1474199 , 0.1277638 ,0.12535952, 0.14663559, 0.303484  , 0.28895503, 0.26307204,0.30268246, 0.22194944, 0.2385288 , 0.16285491, 0.18970719,0.3246171 , 0.21338427, 0.21002218, 0.31216365, 0.13894565,0.18015215, 0.14502   , 0.1586599 , 0.29178935, 0.14104638,0.12415076, 0.12790734, 0.21844396, 0.27004087, 0.29263118,0.16398938, 0.15776524, 0.12225416, 0.15999429, 0.17095661,0.15037508, 0.16063747, 0.1620654 , 0.16386238, 0.15192953,0.17462093, 0.25269684, 0.15645818, 0.15657872, 0.2076304 ,0.26395792, 0.1802657 , 0.2533018 , 0.2416574 , 0.25842336,0.18060035, 0.21493733, 0.21145496, 0.15217221, 0.19395466,0.21994384, 0.2101053 , 0.2504202 , 0.18393731, 0.18048544,0.21091627, 0.17966941, 0.20240456, 0.15612464, 0.23161304,0.2404553 , 0.35051793, 0.25902462, 0.2808336 , 0.35130122,...0.13015257, 0.20780134, 0.22452722, 0.17944306, 0.17863214,0.27678078, 0.18575703, 0.2732871 , 0.12221541, 0.26622462,0.15297589, 0.3103971 , 0.14953516, 0.14995623, 0.21924515,0.15952331, 0.18247962, 0.15887193, 0.20822072, 0.37315747,0.27869284, 0.14673533, 0.16501155, 0.23376474, 0.12435914,0.1270017 , 0.16869664, 0.23928346, 0.16836095, 0.191677  ,0.16491559, 0.15948734, 0.14959903, 0.18660113, 0.15572889,0.14522848, 0.14198917, 0.2800057 , 0.2609771 , 0.14292511,0.17783839, 0.17931947, 0.22403185, 0.24588814, 0.17316589,0.22039282, 0.24955125, 0.19910459, 0.25626314, 0.16820833,0.13120899, 0.21429482, 0.14169759, 0.1937207 , 0.1694096 ,0.16686454, 0.18122151, 0.1886579 , 0.22711961, 0.21592018,0.17293882, 0.12223216, 0.18280286, 0.18409523, 0.17104685,0.30376214, 0.22276185, 0.26121217, 0.16409932, 0.15327   ,0.14341334, 0.18384025, 0.21942556, 0.16593505, 0.13018852,0.17775288, 0.21377042, 0.2153525 , 0.22941314, 0.20817848,0.1705787 , 0.27266315, 0.20884751, 0.26475048, 0.2587186 ,0.26577488, 0.19102558, 0.1378824 , 0.18221086, 0.16832463,0.20291696, 0.2896582 , 0.13597697, 0.31663913, 0.19028181,0.1672928 , 0.14662243, 0.11915199, 0.21416838, 0.20448864]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9685c561-e2c8-4e49-8dc7-505efecb6f19' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9685c561-e2c8-4e49-8dc7-505efecb6f19' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ce0f0f16-327e-4a3c-954b-90683b334805' class='xr-var-data-in' type='checkbox'><label for='data-ce0f0f16-327e-4a3c-954b-90683b334805' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.07095244, 0.04791702, 0.08342511, 0.08643937, 0.09599587,0.10908994, 0.11303408, 0.11138592, 0.07714956, 0.07602766,0.05011542, 0.04254174, 0.06026599, 0.05375595, 0.05249835,0.0417423 , 0.07085127, 0.072689  , 0.08145831, 0.10649376,0.09019835, 0.09398842, 0.09998517, 0.0973091 , 0.12028643,0.11472094, 0.10487828, 0.10602501, 0.07344542, 0.05849743,0.04516785, 0.0599151 , 0.08901691, 0.08454413, 0.07109579,0.06742926, 0.05214456, 0.04337943, 0.0531404 , 0.07017905,0.1012767 , 0.05634036, 0.08906516, 0.06971385, 0.06119503,0.05690078, 0.06511041, 0.05088062, 0.06153525, 0.10981   ,0.11774389, 0.10481709, 0.07550055, 0.15237692, 0.06936773,0.07336158, 0.07199848, 0.13285975, 0.08899835, 0.07407378,0.07807651, 0.0783769 , 0.07676554, 0.06917771, 0.08689992,0.11195853, 0.09739753, 0.10837031, 0.12315736, 0.07690473,0.09395013, 0.07262152, 0.08042075, 0.06462879, 0.0762985 ,0.06725881, 0.0832919 , 0.0708808 , 0.06398382, 0.07521013,0.05359225, 0.07679476, 0.07433045, 0.12002892, 0.06874312,0.0988917 , 0.09690671, 0.06688324, 0.04907013, 0.05979972,0.06127445, 0.05529171, 0.06550731, 0.09496806, 0.09382491,0.05687277, 0.05626592, 0.04534998, 0.06841066, 0.1043236 ,...0.07348812, 0.09146757, 0.07851429, 0.07595789, 0.07735954,0.04729652, 0.1055939 , 0.10911106, 0.06323589, 0.08462637,0.07391894, 0.12011767, 0.07632516, 0.08077957, 0.07879852,0.05391991, 0.08788298, 0.06500544, 0.07141139, 0.10671115,0.09000085, 0.09247573, 0.09360518, 0.08130006, 0.09889837,0.08007354, 0.08380744, 0.06035023, 0.08121274, 0.10871916,0.13064411, 0.05615162, 0.08104257, 0.11269853, 0.07231914,0.07686149, 0.0598715 , 0.08284053, 0.06868686, 0.10002432,0.13193138, 0.12801796, 0.09307247, 0.08850747, 0.07273528,0.08053523, 0.07306463, 0.07238836, 0.07257425, 0.08823803,0.08085658, 0.10966383, 0.10497274, 0.07591741, 0.0698344 ,0.0554071 , 0.10123506, 0.09622039, 0.11607988, 0.0784272 ,0.09522177, 0.05943231, 0.07643101, 0.07415786, 0.08622621,0.06514687, 0.07200012, 0.07679701, 0.05615951, 0.05706657,0.08212137, 0.06958193, 0.07841593, 0.0567296 , 0.08515377,0.12930071, 0.06569357, 0.07832618, 0.14075339, 0.13412061,0.13532183, 0.0558827 , 0.07203001, 0.06234167, 0.05671284,0.05001491, 0.0548132 , 0.15355167, 0.06126017, 0.09726597,0.05880246, 0.06326634, 0.08936609, 0.09648224, 0.06405015,0.06511474, 0.03964089, 0.11742923, 0.04772947, 0.04740262]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-77a70c37-30a2-4165-b9b0-134b1e85bbb2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-77a70c37-30a2-4165-b9b0-134b1e85bbb2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a716c6c7-aadd-48ca-ae7f-6599d09f5527' class='xr-var-data-in' type='checkbox'><label for='data-a716c6c7-aadd-48ca-ae7f-6599d09f5527' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.13577333, 0.06532635, 0.1198548 , 0.10719303, 0.09349468,0.09604807, 0.12546206, 0.09412307, 0.09113283, 0.10991817,0.07711153, 0.11728435, 0.10018831, 0.0649609 , 0.09963389,0.09892006, 0.10366376, 0.073188  , 0.10383875, 0.06249827,0.07645519, 0.0978471 , 0.06217906, 0.08953778, 0.08450174,0.09153666, 0.12560983, 0.12480413, 0.08146494, 0.08812475,0.10542858, 0.085251  , 0.0666262 , 0.06743466, 0.07072826,0.08477122, 0.08711234, 0.1058616 , 0.12225898, 0.07808907,0.08591139, 0.08193056, 0.09612709, 0.10379117, 0.08188703,0.07474585, 0.11096489, 0.08592892, 0.10098297, 0.09769467,0.13328412, 0.14595921, 0.08767948, 0.06237297, 0.05395269,0.06346177, 0.08907323, 0.07773037, 0.09296786, 0.12109864,0.12202474, 0.1199186 , 0.07826963, 0.08198135, 0.09630894,0.08102315, 0.09276431, 0.09136519, 0.07708368, 0.09837689,0.07763408, 0.08020793, 0.07647155, 0.07611152, 0.09038229,0.10765935, 0.07382987, 0.13941719, 0.1231648 , 0.14360045,0.10087797, 0.08909236, 0.06199963, 0.09006837, 0.09521399,0.1030404 , 0.09708207, 0.0967141 , 0.09428506, 0.08595037,0.06765871, 0.0893543 , 0.09249265, 0.05447434, 0.0970464 ,0.09155309, 0.10723247, 0.06721213, 0.06964409, 0.07867131,...0.08520949, 0.10997651, 0.11160119, 0.12109406, 0.13509817,0.10462539, 0.07052761, 0.07630286, 0.09499481, 0.08713157,0.1356974 , 0.07484481, 0.13398018, 0.12345573, 0.06519023,0.084429  , 0.12210423, 0.06908974, 0.11053488, 0.0780649 ,0.09779352, 0.11552034, 0.07301369, 0.09623102, 0.09323492,0.07638083, 0.09939401, 0.11375444, 0.1432927 , 0.05032036,0.11466767, 0.09338019, 0.10844625, 0.08832772, 0.10259481,0.12856263, 0.12789352, 0.06561859, 0.08594196, 0.10573738,0.10034732, 0.10038918, 0.09424064, 0.09058842, 0.06295991,0.0993612 , 0.13855155, 0.10030113, 0.1020467 , 0.08571493,0.09022206, 0.11260591, 0.06100971, 0.12173512, 0.05933513,0.09133646, 0.11612754, 0.10754746, 0.08834291, 0.07638571,0.11950255, 0.09508684, 0.09081404, 0.09969709, 0.09077775,0.09348534, 0.08562608, 0.05943754, 0.08951615, 0.07909591,0.10603753, 0.07382608, 0.08516042, 0.05971568, 0.08314518,0.10471871, 0.05195684, 0.1111476 , 0.07451499, 0.07591809,0.08815346, 0.10012998, 0.10479575, 0.08699431, 0.08487294,0.07133268, 0.09097749, 0.14009923, 0.06698538, 0.09487222,0.09297266, 0.07603964, 0.11270992, 0.07132748, 0.13500142,0.09418785, 0.09198636, 0.08710994, 0.09528954, 0.11369934]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a45d84f5-f1b9-48e0-9490-43b3ca26afaa' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a45d84f5-f1b9-48e0-9490-43b3ca26afaa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-68182b16-d07a-42f3-a9ff-6e2ad7466e62' class='xr-var-data-in' type='checkbox'><label for='data-68182b16-d07a-42f3-a9ff-6e2ad7466e62' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.20921631, 0.19635995, 0.23927596, 0.25514704, 0.22901691,0.23963726, 0.259987  , 0.28604653, 0.25406426, 0.2595761 ,0.22830185, 0.21256027, 0.21872209, 0.22638333, 0.21282285,0.20370592, 0.22256452, 0.21277992, 0.25625214, 0.25688106,0.2500508 , 0.24187651, 0.20317054, 0.19697642, 0.20064378,0.20283103, 0.26998863, 0.28298104, 0.23845758, 0.26710704,0.25182453, 0.21186301, 0.23997417, 0.24338762, 0.25231177,0.26149908, 0.24500829, 0.2136344 , 0.20534503, 0.20318453,0.19076395, 0.2497331 , 0.21718067, 0.20426762, 0.28253728,0.24620321, 0.22349586, 0.22261767, 0.24920206, 0.26601464,0.28103298, 0.25131357, 0.27820766, 0.32693377, 0.27029717,0.27908576, 0.29013407, 0.3080845 , 0.2701798 , 0.26525134,0.24137768, 0.24038401, 0.20572937, 0.22297348, 0.23391065,0.2120188 , 0.22857744, 0.22425164, 0.19142175, 0.20341806,0.20571907, 0.19917308, 0.21839756, 0.23446424, 0.23836695,0.25941032, 0.24351226, 0.2017544 , 0.21967256, 0.21814412,0.2483736 , 0.22136253, 0.21782446, 0.21292289, 0.18412247,0.1959594 , 0.21101524, 0.23976411, 0.21537407, 0.22104317,0.19800064, 0.19719452, 0.19723345, 0.21306351, 0.2261438 ,0.23316863, 0.2235496 , 0.23202217, 0.23338073, 0.20930783,...0.28592116, 0.25304386, 0.208626  , 0.22855219, 0.22917369,0.23028456, 0.23016092, 0.219739  , 0.24946195, 0.23177402,0.25794932, 0.25407675, 0.2793748 , 0.27735865, 0.30159503,0.24042778, 0.26138857, 0.26154685, 0.24397822, 0.30297133,0.29694733, 0.18688352, 0.22674626, 0.24479729, 0.24588166,0.2783329 , 0.24031647, 0.25561357, 0.2391331 , 0.22454056,0.27431178, 0.21903117, 0.26219675, 0.22809047, 0.2325001 ,0.25710863, 0.19602281, 0.2240762 , 0.2548572 , 0.2634212 ,0.31798312, 0.3210675 , 0.30409884, 0.2910072 , 0.2613642 ,0.18041104, 0.18993272, 0.19317816, 0.24751925, 0.1809566 ,0.24086012, 0.27535856, 0.27009585, 0.22070684, 0.21385425,0.2373485 , 0.22576243, 0.23066483, 0.21783315, 0.22759087,0.23846728, 0.22863023, 0.2622154 , 0.26446247, 0.1889314 ,0.22162338, 0.21298413, 0.18417062, 0.2529282 , 0.24453694,0.2294398 , 0.24112163, 0.25975   , 0.24088958, 0.2711096 ,0.25587842, 0.2288727 , 0.25069788, 0.24303319, 0.2449874 ,0.23098852, 0.22541186, 0.27670822, 0.2079023 , 0.19465537,0.20398632, 0.21245117, 0.37494197, 0.24165241, 0.22283141,0.26672375, 0.25700465, 0.20098215, 0.24834724, 0.21194196,0.25589836, 0.23883441, 0.2726169 , 0.23771638, 0.21483867]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-33ede4cb-b2c5-49de-b64b-f3e5206adbb9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-33ede4cb-b2c5-49de-b64b-f3e5206adbb9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8b1afae-23e5-4bc2-b12a-c9e25ebfa931' class='xr-var-data-in' type='checkbox'><label for='data-f8b1afae-23e5-4bc2-b12a-c9e25ebfa931' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[2.1502252, 2.2865808, 2.2443311, 2.1352677, 2.2056956, 2.146545 ,2.0822785, 2.0617535, 2.0917985, 2.013871 , 2.2761683, 2.1306326,1.853506 , 2.081061 , 1.9748105, 1.9596285, 2.28885  , 2.1934154,2.028365 , 1.9892676, 1.9629024, 2.0112443, 2.4723794, 2.2798867,2.2462668, 2.250899 , 2.017782 , 1.9131575, 2.1297474, 2.2038753,2.2293954, 2.2218132, 2.1219602, 2.1467922, 2.1483266, 2.2473505,2.0345147, 2.0965252, 2.180718 , 2.3800716, 2.497125 , 2.2943015,2.0776377, 2.291345 , 1.9289107, 2.2686145, 2.0112736, 2.3142426,2.0425422, 2.1715322, 1.8527246, 1.9693302, 2.1320493, 2.3332896,2.5180233, 2.1717513, 2.0379004, 2.2195735, 2.0949676, 2.03727  ,2.1719673, 2.1592283, 2.2375546, 2.2021701, 2.151708 , 1.7771902,1.9472959, 1.9703772, 2.0853355, 2.094125 , 2.2514627, 2.233666 ,2.1752334, 2.2750568, 2.5038145, 1.9638754, 2.2603734, 2.0921702,2.1576924, 1.8659445, 2.2689579, 2.4593928, 2.5864153, 1.9676408,2.2501755, 2.2172205, 2.0802383, 2.153358 , 2.2083595, 2.2370303,2.379865 , 2.197871 , 2.2410343, 2.4595368, 2.2381692, 1.9967016,2.28937  , 2.1722453, 2.598615 , 2.0723326, 1.9528452, 2.084033 ,2.2008266, 2.2253032, 2.2022908, 2.1132386, 2.281918 , 2.1303701,2.1862347, 2.0818994, 2.076724 , 2.1531785, 2.332993 , 2.006571 ,2.261679 , 2.1083403, 2.2915766, 2.0745454, 2.3125603, 2.217262 ,...1.9325135, 2.2400594, 2.1433203, 2.4463978, 2.1336815, 2.0975142,2.3493676, 1.9823257, 2.2308319, 2.2863321, 2.192619 , 2.1845846,2.2941387, 2.3192327, 1.8018167, 2.2422717, 2.2956464, 2.390583 ,2.1066253, 1.9184381, 2.0666084, 1.9747413, 2.1095912, 2.2520611,1.8395569, 1.8977371, 2.5076334, 2.1448252, 1.9847157, 2.3499236,2.083706 , 2.0074682, 2.3118014, 2.2607   , 2.2434382, 2.5311584,2.036637 , 2.1065257, 2.2592983, 1.9253733, 1.9626389, 2.1111596,2.0667148, 2.331243 , 2.2783608, 2.1524417, 2.248675 , 2.1732051,2.0983262, 2.0347543, 2.1748734, 2.263188 , 1.9810648, 2.086996 ,1.8512372, 2.471318 , 2.243701 , 2.041678 , 2.0287857, 2.0245895,2.0493572, 1.988942 , 2.4690428, 2.1455412, 2.2554965, 1.9784604,2.2009964, 2.4566407, 2.2177293, 2.2025414, 2.7229784, 1.8291041,2.1456711, 2.165279 , 2.2513423, 2.3528175, 2.1833003, 2.1731274,2.0282028, 2.125931 , 2.262183 , 2.1132011, 2.2506802, 2.0608106,2.0527172, 2.2100868, 2.293736 , 2.039464 , 2.0424142, 2.2692132,2.6036747, 2.055553 , 2.3661895, 2.1828272, 2.4302409, 1.9958016,2.1960783, 2.2119074, 1.9875479, 2.257749 , 2.137463 , 2.1934571,2.2244744, 2.042402 , 2.4128377, 1.7964576, 2.587903 , 1.9785807,2.2243118, 2.040869 , 2.1897511, 2.2476327, 2.1915102, 2.0967271,2.4010148, 2.0102253, 2.3900137, 2.2673733]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-938e1683-c330-4e55-8082-b7d6b9676b37' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-938e1683-c330-4e55-8082-b7d6b9676b37' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-52a01729-77d9-4531-9dc3-d3ebabb28c39' class='xr-var-data-in' type='checkbox'><label for='data-52a01729-77d9-4531-9dc3-d3ebabb28c39' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.14977875, -0.01370148,  0.08822216, ..., -0.07417076,0.04011277,  0.01023048],[ 0.02442164,  0.05341784,  0.01395201, ..., -0.00780757,0.00311159,  0.03552842],[ 0.05712008,  0.0352449 ,  0.0420269 , ..., -0.04861841,0.02993913,  0.04622938],...,[ 0.04468568, -0.00033014,  0.08315676, ...,  0.0128149 ,0.01622108,  0.08673953],[ 0.03878683,  0.05752399,  0.02991371, ..., -0.03294393,0.00695955, -0.0077006 ],[-0.01961471, -0.03769916,  0.08886605, ..., -0.02066671,0.02470866,  0.00905711]],[[ 0.04171458, -0.00410859,  0.03161368, ..., -0.05684895,0.00647448,  0.0076645 ],[ 0.04364085, -0.00314854,  0.03238473, ..., -0.05925134,0.0025656 ,  0.01013258],[ 0.01565343,  0.05436841,  0.12163565, ..., -0.07369585,-0.03800202, -0.03754899],...,[ 0.06293795,  0.00045638,  0.00736416, ..., -0.05446506,-0.03350823, -0.00738914],[ 0.01630197,  0.0035482 ,  0.01705156, ..., -0.02493256,0.0352183 ,  0.03073428],[ 0.01617612, -0.01811848,  0.01498716, ..., -0.01614598,0.03764196,  0.02938383]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-351d7628-5b56-4bba-8fd2-d9c7475cce43' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-351d7628-5b56-4bba-8fd2-d9c7475cce43' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b22e67de-7bcd-4510-aec6-b0b8135c6f21' class='xr-var-data-in' type='checkbox'><label for='data-b22e67de-7bcd-4510-aec6-b0b8135c6f21' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.7612322 , -1.4562286 , -1.526907  , ..., -0.01637003,-2.72615   ,  1.3065109 ],[-0.42930466, -0.4203435 , -0.7779228 , ...,  0.2802222 ,-1.3185263 ,  0.61099505],[-0.30618382, -0.23298548, -0.7830517 , ...,  0.14547664,-2.0440724 ,  1.0799823 ],...,[ 0.14938667, -1.0870878 , -0.41625902, ..., -0.19446205,-1.5791155 ,  0.14702572],[ 0.31361985, -0.31307513, -0.33108512, ..., -0.04809491,-2.039523  ,  0.84199315],[-0.11492782, -0.38222533, -0.3055164 , ...,  0.73855674,-1.2619526 ,  1.1580285 ]],[[-0.20785682, -0.9362875 ,  0.30965534, ...,  1.0725315 ,-1.5404328 ,  1.9422857 ],[-0.21871226, -0.93831825,  0.3163737 , ...,  1.0858384 ,-1.5742689 ,  1.9285334 ],[-0.394706  , -0.3918608 , -0.30458918, ...,  1.0190352 ,-1.4502956 ,  2.0917192 ],...,[ 0.5620495 , -0.38814273, -0.628514  , ...,  0.6490142 ,-0.38211817,  1.289675  ],[-1.3011699 , -0.6925579 , -0.6678445 , ...,  0.67494726,-2.8002493 ,  0.34941903],[-0.5807836 , -0.6504621 , -0.70723546, ...,  0.7150908 ,-2.6367579 ,  0.28927338]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-0624114c-61a6-4e91-b5bd-9ae85681f328' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0624114c-61a6-4e91-b5bd-9ae85681f328' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-625d6faf-77a2-4634-8063-aa1c0873dee6' class='xr-var-data-in' type='checkbox'><label for='data-625d6faf-77a2-4634-8063-aa1c0873dee6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.09540367, 0.12534024, 0.10298517, 0.13485003, 0.13961704,0.140849  , 0.12342553, 0.13762495, 0.18642172, 0.24781476,0.11928104, 0.15501058, 0.14546901, 0.15676574, 0.24492219,0.20324129, 0.1348039 , 0.14503454, 0.12712413, 0.17420332,0.1620608 , 0.12726909, 0.10735808, 0.08876736, 0.09548202,0.08910446, 0.21320409, 0.21408461, 0.14503445, 0.1783269 ,0.17503427, 0.13683185, 0.16034377, 0.16931836, 0.15047294,0.18574253, 0.20923978, 0.12095051, 0.12108476, 0.13187288,0.10317328, 0.1300134 , 0.12069727, 0.09744047, 0.19796984,0.20157635, 0.17930399, 0.1203109 , 0.14832395, 0.16184044,0.10396991, 0.1304108 , 0.13694258, 0.12128039, 0.1756659 ,0.1776305 , 0.3796449 , 0.1923698 , 0.18528627, 0.17233956,0.1673312 , 0.17125668, 0.16415393, 0.13631812, 0.13806413,0.19269611, 0.19347766, 0.18478444, 0.16300505, 0.16402346,0.1063586 , 0.13657355, 0.07230803, 0.09946243, 0.21993743,0.24051882, 0.19434848, 0.22477256, 0.23594171, 0.20257328,0.1430359 , 0.14028762, 0.11564982, 0.1990237 , 0.2330265 ,0.2389679 , 0.14322907, 0.12474602, 0.20345078, 0.19204682,0.1986    , 0.15170899, 0.12942874, 0.20867816, 0.08836934,0.14848565, 0.16797508, 0.15576188, 0.12274579, 0.13939406,...0.16093285, 0.1254743 , 0.15036805, 0.16650736, 0.16387454,0.16989444, 0.11132351, 0.15068701, 0.1340835 , 0.15152349,0.20152411, 0.09668555, 0.16720945, 0.11651286, 0.1096951 ,0.10177277, 0.10967575, 0.09917156, 0.1548217 , 0.12933333,0.11135215, 0.22755553, 0.21575648, 0.09404768, 0.19426617,0.17329599, 0.1260213 , 0.10750198, 0.12101901, 0.08628373,0.09670596, 0.19129607, 0.19206803, 0.1229356 , 0.1336448 ,0.14274994, 0.16157772, 0.20294192, 0.16914098, 0.1633054 ,0.13817772, 0.14473003, 0.1874927 , 0.1857491 , 0.14414151,0.13972087, 0.14385387, 0.18839549, 0.07369827, 0.21902463,0.07409661, 0.09691519, 0.19792135, 0.10241859, 0.12002409,0.13353738, 0.14545459, 0.1968336 , 0.16363712, 0.16421469,0.16749394, 0.20916745, 0.13000457, 0.13283935, 0.32896212,0.32712162, 0.14503817, 0.14079174, 0.25038242, 0.1325836 ,0.09303982, 0.14762692, 0.08564152, 0.15202698, 0.16277254,0.16021499, 0.15693437, 0.15358919, 0.21025917, 0.21247339,0.16993621, 0.15389043, 0.17271772, 0.10693611, 0.11221415,0.13313562, 0.10585068, 0.1787883 , 0.23274991, 0.11451973,0.13791947, 0.14577383, 0.20479123, 0.14676407, 0.19515157,0.16774553, 0.11016802, 0.13684753, 0.14955096, 0.14975516]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-afdc728d-f91b-4c37-a241-90437416d9cc' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-afdc728d-f91b-4c37-a241-90437416d9cc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ba0057f3-9052-4350-a2a5-6421fd967e57' class='xr-var-data-in' type='checkbox'><label for='data-ba0057f3-9052-4350-a2a5-6421fd967e57' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.06469822, 0.03644332, 0.03517828, 0.02457888, 0.05656719,0.012071  , 0.02321158, 0.00738908, 0.01846483, 0.03625273,0.01647095, 0.01151802, 0.02098303, 0.00848932, 0.02864081,0.03325479, 0.0385609 , 0.03062276, 0.03290069, 0.04976826,0.05471846, 0.04352739, 0.02618038, 0.05569603, 0.0599002 ,0.0523829 , 0.04572352, 0.05127653, 0.02881102, 0.03661417,0.03940074, 0.02900901, 0.03669467, 0.03943878, 0.05543434,0.02369757, 0.02202138, 0.05900032, 0.06591474, 0.02562577,0.07200734, 0.01867087, 0.03324061, 0.06041548, 0.05530831,0.04221366, 0.04805111, 0.02030017, 0.03368021, 0.03554441,0.06665161, 0.09898964, 0.03649623, 0.04053944, 0.03065611,0.05338189, 0.04893626, 0.04897929, 0.0194479 , 0.03579974,0.07164336, 0.06222489, 0.03350448, 0.02706093, 0.0348114 ,0.01561422, 0.01820018, 0.02274625, 0.02717912, 0.02884027,0.03680968, 0.04457229, 0.03634634, 0.03862575, 0.02683675,0.04496907, 0.03649851, 0.04669063, 0.04532935, 0.0503627 ,0.0383631 , 0.03318047, 0.02370989, 0.05007316, 0.02270577,0.04250085, 0.0440073 , 0.07224808, 0.04456884, 0.05081358,0.03069988, 0.0635695 , 0.05164726, 0.02987821, 0.0459402 ,0.03824386, 0.05565076, 0.04143978, 0.03144187, 0.04103579,...0.03131355, 0.05398817, 0.05612093, 0.03901181, 0.0876167 ,0.04938799, 0.03279152, 0.03041203, 0.01690201, 0.02771651,0.03352831, 0.0234773 , 0.05817949, 0.03950796, 0.02138454,0.03034189, 0.06946778, 0.01505164, 0.06537263, 0.02200012,0.02039699, 0.03425569, 0.00884662, 0.01163783, 0.02600918,0.01866797, 0.03635061, 0.06436345, 0.05177678, 0.03701877,0.05401027, 0.05360322, 0.05251534, 0.04104757, 0.06293927,0.07165986, 0.07727546, 0.05080525, 0.05294484, 0.04218082,0.04065486, 0.06718341, 0.06055911, 0.05178338, 0.03352325,0.03319233, 0.0516861 , 0.03479766, 0.05460407, 0.0572355 ,0.03920091, 0.04559885, 0.05447581, 0.06990242, 0.03228999,0.04653048, 0.04493891, 0.0483526 , 0.03195077, 0.02138518,0.05202542, 0.03408437, 0.03269564, 0.01822636, 0.04097725,0.03486262, 0.02103569, 0.03178256, 0.04238655, 0.0498744 ,0.05409725, 0.02742691, 0.02669637, 0.09223284, 0.04807129,0.03983203, 0.01456292, 0.04259402, 0.01319702, 0.01278227,0.01658752, 0.05393298, 0.06134555, 0.04316216, 0.04029094,0.06187347, 0.05245545, 0.08278162, 0.01699847, 0.03971386,0.06032188, 0.10336311, 0.04227573, 0.05124121, 0.06875253,0.03284097, 0.03457979, 0.02758848, 0.03510674, 0.03991117]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-33edb3d8-781a-4333-a51d-0925d7ab5676' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-33edb3d8-781a-4333-a51d-0925d7ab5676' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a5c48a9f-23d2-426c-bbcf-8d894cd59629' class='xr-var-data-in' type='checkbox'><label for='data-a5c48a9f-23d2-426c-bbcf-8d894cd59629' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.05826404,  0.11255912,  0.2145028 , ..., -0.07065435,0.13743389,  0.01710474],[-0.07430133,  0.13925011,  0.16803873, ..., -0.09784132,0.00480028, -0.00038069],[-0.11807071,  0.21288441,  0.23910585, ..., -0.13136175,0.19136895,  0.04312576],...,[-0.06440392, -0.00174456,  0.24043722, ..., -0.20967934,0.05836181, -0.16745508],[-0.03146436,  0.07599088,  0.17851423, ..., -0.27732682,-0.10542742, -0.13695571],[-0.08798878,  0.16154838,  0.28015658, ..., -0.08750584,0.15112425, -0.06156482]],[[-0.11365515,  0.10732576,  0.32741722, ..., -0.09383526,0.14760032,  0.04807998],[-0.11339308,  0.10415085,  0.32120764, ..., -0.09130174,0.14240997,  0.05115103],[-0.16543171,  0.04377886,  0.2598349 , ..., -0.05397116,0.03041961,  0.022857  ],...,[-0.02306305,  0.16350144,  0.1887235 , ..., -0.13469197,0.32792854, -0.03283149],[-0.18789433,  0.13793449,  0.31672063, ..., -0.02116698,-0.15812962, -0.02671741],[-0.1673641 ,  0.13792637,  0.23313732, ..., -0.04886834,-0.16291001, -0.04739768]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9c25cf2a-7feb-4888-9da7-1dd47aaad062' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9c25cf2a-7feb-4888-9da7-1dd47aaad062' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a34ce9f6-b8af-4dfe-aec5-868439e4c65a' class='xr-var-data-in' type='checkbox'><label for='data-a34ce9f6-b8af-4dfe-aec5-868439e4c65a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.00451696, -0.03104324, -0.01345799, ..., -0.07346988,0.09251218, -0.08419338],[-0.07007313, -0.07090447,  0.00444291, ..., -0.01548898,0.00252539, -0.10147811],[-0.01187902, -0.05247187, -0.03517109, ..., -0.05306194,0.04847442, -0.1023695 ],...,[ 0.01325978, -0.00972564,  0.07179214, ...,  0.00958205,0.09459203, -0.11443756],[ 0.041692  , -0.01352269,  0.02460085, ...,  0.03135201,0.05934709, -0.05352819],[-0.05845701,  0.00945989,  0.00225041, ...,  0.01590473,0.07727058, -0.08527739]],[[-0.0752772 , -0.07965439, -0.03640682, ..., -0.06603773,0.0082712 , -0.08881288],[-0.07455731, -0.08048311, -0.03618294, ..., -0.06539731,0.0076651 , -0.09244265],[-0.03650957, -0.03484757, -0.00150394, ...,  0.00241182,0.02946727, -0.07222022],...,[-0.03946705, -0.02836476, -0.00314226, ..., -0.05894341,0.07025379, -0.05131265],[-0.0301997 , -0.00205976,  0.01993455, ..., -0.06904385,0.04064004, -0.07618881],[-0.00189783,  0.00317662,  0.02303381, ..., -0.05862431,0.02457881, -0.06517332]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-3ffc210a-c25a-492e-96b4-195af064b1f3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3ffc210a-c25a-492e-96b4-195af064b1f3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5735d8fe-60f2-4574-a5d7-fada843268a0' class='xr-var-data-in' type='checkbox'><label for='data-5735d8fe-60f2-4574-a5d7-fada843268a0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.07683472, -0.52805346, -0.22892389, ..., -1.2497417 ,1.573656  , -1.4321511 ],[-1.3449426 , -1.3608989 ,  0.08527458, ..., -0.29728636,0.04847081, -1.9477113 ],[-0.18718088, -0.82681304, -0.55420005, ..., -0.83611083,0.7638242 , -1.6130631 ],...,[ 0.2805368 , -0.20576511,  1.518904  , ...,  0.20272721,2.0012805 , -2.4211516 ],[ 1.0825604 , -0.3511256 ,  0.6387772 , ...,  0.8140756 ,1.5409864 , -1.3898948 ],[-1.1761353 ,  0.19032985,  0.04527746, ...,  0.31999788,1.554658  , -1.7157522 ]],[[-1.0469259 , -1.107802  , -0.50633174, ..., -0.9184269 ,0.11503258, -1.2351748 ],[-1.043235  , -1.126151  , -0.5062858 , ..., -0.91506463,0.1072531 , -1.2934935 ],[-0.9061565 , -0.864906  , -0.0373273 , ...,  0.05986052,0.73136866, -1.7924838 ],...,[-0.43296492, -0.31116953, -0.03447149, ..., -0.6466262 ,0.77070427, -0.56291455],[-0.6362722 , -0.04339664,  0.4199975 , ..., -1.4546727 ,0.8562378 , -1.6052085 ],[-0.04039614,  0.0676157 ,  0.49028367, ..., -1.2478412 ,0.5231696 , -1.3872393 ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>scaler_1|participant_id_sigma</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-8543eeb2-f596-4186-a476-eab12ddb18f1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8543eeb2-f596-4186-a476-eab12ddb18f1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c85c51b7-b6a1-4532-a2f4-09b36fde5237' class='xr-var-data-in' type='checkbox'><label for='data-c85c51b7-b6a1-4532-a2f4-09b36fde5237' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1.38214037e-01, 2.00236067e-02, 2.15146884e-01, 1.20407492e-01,1.68563202e-01, 3.07042688e-01, 3.74335051e-01, 1.43145517e-01,4.44564551e-01, 2.08603099e-01, 4.12932336e-01, 3.23855460e-01,4.44665730e-01, 4.07933444e-01, 2.03801975e-01, 3.69635046e-01,5.46223577e-03, 2.55934894e-03, 1.48309348e-03, 2.78047562e-01,1.79049000e-01, 9.15602073e-02, 2.09066272e-01, 2.67948836e-01,3.11296612e-01, 2.29999200e-01, 6.72946870e-02, 5.01998588e-02,1.70903280e-01, 1.73905417e-01, 1.46146432e-01, 5.96385859e-02,3.99111986e-01, 3.30898583e-01, 1.77018911e-01, 2.77444124e-01,1.51200324e-01, 2.31142402e-01, 2.83942521e-01, 2.31347904e-01,3.75327080e-01, 3.83137316e-01, 3.56718004e-01, 2.27735832e-01,2.01664180e-01, 5.21041811e-01, 1.86523974e-01, 1.15705952e-01,3.25341284e-01, 4.71128300e-02, 2.35561356e-01, 4.37366724e-01,3.24578017e-01, 1.72460273e-01, 2.67053217e-01, 4.64525402e-01,2.21695006e-01, 6.04224913e-02, 4.79658633e-01, 1.56957775e-01,2.88323164e-01, 3.04477692e-01, 8.67535248e-02, 1.51616454e-01,4.17106561e-02, 4.11512166e-01, 2.23564073e-01, 2.47848108e-01,4.90868539e-01, 1.71917319e-01, 9.22891051e-02, 1.58453166e-01,1.58954918e-01, 4.37877834e-01, 3.65245312e-01, 2.28266239e-01,1.39902398e-01, 3.97756577e-01, 4.18927521e-01, 2.28267655e-01,...4.54280615e-01, 5.70846915e-01, 5.55861890e-01, 3.23896497e-01,1.42938554e-01, 2.58727968e-01, 3.91297579e-01, 2.16913670e-01,4.17038918e-01, 2.08656147e-01, 4.30434823e-01, 1.54336527e-01,1.59549806e-02, 4.24454242e-01, 2.61140168e-01, 1.10367566e-01,1.52862966e-01, 2.34250039e-01, 1.61456823e-01, 6.97412789e-02,1.60721868e-01, 2.18310982e-01, 2.71750279e-02, 1.28798727e-02,6.64979964e-02, 4.50565755e-01, 3.92563105e-01, 6.53728172e-02,1.88965499e-01, 2.95511007e-01, 4.61276263e-01, 6.48032963e-01,3.82076651e-01, 1.88372344e-01, 1.28545269e-01, 1.08276822e-01,1.73262298e-01, 1.18505254e-01, 1.27092212e-01, 7.15967491e-02,2.02344313e-01, 2.15138018e-01, 5.11378288e-01, 3.70342195e-01,3.08147669e-01, 3.05688351e-01, 5.94446898e-01, 3.27194631e-01,2.36988366e-01, 1.15520522e-01, 2.14807957e-01, 2.61273175e-01,6.36600435e-01, 1.70356873e-02, 1.42271817e-01, 9.10263509e-02,2.89155960e-01, 3.77639607e-02, 2.49550417e-01, 2.16824919e-01,2.95547336e-01, 2.83128440e-01, 1.58275068e-01, 3.45999181e-01,3.92391384e-01, 7.74935037e-02, 3.92334402e-01, 1.39483824e-01,4.31509078e-01, 2.66492903e-01, 9.14799273e-02, 1.84559643e-01,1.53280586e-01, 1.54245004e-01, 2.89744526e-01, 2.17764378e-02,2.06632733e-01, 5.39376959e-02, 1.82409793e-01, 1.49938896e-01]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>z_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-682c1745-c43f-429d-a993-ba6c3bc3ed22' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-682c1745-c43f-429d-a993-ba6c3bc3ed22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2aa23a31-ebee-4122-a3a8-afd634fad509' class='xr-var-data-in' type='checkbox'><label for='data-2aa23a31-ebee-4122-a3a8-afd634fad509' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.5260428 , 0.51651907, 0.5191409 , 0.50564426, 0.49988642,0.48114467, 0.48882824, 0.47398126, 0.47959614, 0.46009734,0.4977917 , 0.50032353, 0.49147877, 0.48071206, 0.47876632,0.49725586, 0.49586868, 0.45142913, 0.4886192 , 0.46994388,0.48442605, 0.4751066 , 0.4675424 , 0.48567772, 0.4837287 ,0.48251766, 0.48858833, 0.47052163, 0.5044742 , 0.48513818,0.49997443, 0.50094587, 0.50759226, 0.51188576, 0.503568  ,0.5156592 , 0.5033262 , 0.50531316, 0.5192632 , 0.5125614 ,0.5108596 , 0.49663264, 0.47263354, 0.46071866, 0.5113693 ,0.4968061 , 0.49333212, 0.48235914, 0.49187472, 0.52660805,0.51810247, 0.5065242 , 0.4954459 , 0.47106123, 0.4678268 ,0.49370658, 0.50477207, 0.48958325, 0.47083858, 0.46513528,0.44141206, 0.44474062, 0.49148437, 0.5109176 , 0.49701512,0.5072984 , 0.4999429 , 0.511205  , 0.4973917 , 0.5069746 ,0.5147181 , 0.5084238 , 0.48372197, 0.4858048 , 0.4385447 ,0.46069235, 0.51589936, 0.50195843, 0.51754045, 0.49423984,0.50172275, 0.49160007, 0.4893808 , 0.5256193 , 0.49670035,0.50575525, 0.49873343, 0.5039296 , 0.50310457, 0.48887032,0.5249744 , 0.5093089 , 0.5137027 , 0.49573553, 0.48926073,0.47881654, 0.5163721 , 0.47629306, 0.49619138, 0.51178837,...0.45801428, 0.46698827, 0.513968  , 0.51632786, 0.5071226 ,0.50354576, 0.49415433, 0.4745661 , 0.53136414, 0.5173917 ,0.4798912 , 0.50247514, 0.48637688, 0.4689368 , 0.48869923,0.50715864, 0.48025638, 0.5118479 , 0.48156953, 0.50547785,0.52292013, 0.47707608, 0.4758898 , 0.49648798, 0.5075859 ,0.4750376 , 0.50849605, 0.5288184 , 0.5411714 , 0.5026554 ,0.5294276 , 0.49571684, 0.504172  , 0.4747946 , 0.5064145 ,0.49933553, 0.50297797, 0.49143368, 0.47661966, 0.5124079 ,0.52349836, 0.5306203 , 0.5286317 , 0.52551687, 0.5060641 ,0.4931281 , 0.49527875, 0.5097414 , 0.50978905, 0.4986168 ,0.4888653 , 0.5176358 , 0.5707485 , 0.4573311 , 0.47132263,0.49036676, 0.5339988 , 0.531659  , 0.5093394 , 0.511237  ,0.49546856, 0.47681224, 0.51494056, 0.5225839 , 0.5108876 ,0.51212   , 0.48314756, 0.5112496 , 0.49638283, 0.4762268 ,0.5054732 , 0.5022617 , 0.4819286 , 0.4984145 , 0.4872022 ,0.47000766, 0.49743512, 0.52545273, 0.47143996, 0.47553352,0.48365968, 0.49293512, 0.516367  , 0.47777918, 0.50251776,0.4923011 , 0.5106531 , 0.46835405, 0.4909079 , 0.54429   ,0.49518883, 0.50683725, 0.50936913, 0.47538346, 0.4551046 ,0.4632566 , 0.55425125, 0.46482408, 0.52647656, 0.50198394]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>rl_alpha_1|participant_id_offset</span></div><div class='xr-var-dims'>(chain, draw, rl_alpha_1|participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4ca14a78-9e2e-4710-969c-3669a19640ea' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4ca14a78-9e2e-4710-969c-3669a19640ea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-947588d8-f549-4e89-a7ba-615fdac4d1cd' class='xr-var-data-in' type='checkbox'><label for='data-947588d8-f549-4e89-a7ba-615fdac4d1cd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 2.3150368 , -0.21177518,  1.3635949 , ..., -1.1464112 ,0.6199981 ,  0.1581262 ],[ 0.67012674,  1.4657787 ,  0.38284135, ..., -0.21423861,0.08538177,  0.97489536],[ 1.6237317 ,  1.0018938 ,  1.1946832 , ..., -1.3820577 ,0.85106874,  1.3141457 ],...,[ 0.7501091 , -0.00554183,  1.3958976 , ...,  0.21511532,0.27229255,  1.4560392 ],[ 1.2502517 ,  1.8542238 ,  0.9642361 , ..., -1.0619122 ,0.22433352, -0.24822056],[-0.2928364 , -0.56282675,  1.326719  , ..., -0.30854216,0.36888608,  0.13521738]],[[ 1.1964843 , -0.11784537,  0.90676385, ..., -1.6305784 ,0.18570535,  0.21983814],[ 1.194435  , -0.08617434,  0.88635874, ..., -1.6216886 ,0.07021965,  0.27732527],[ 0.29559326,  1.0266718 ,  2.2969198 , ..., -1.3916435 ,-0.71761525, -0.70906025],...,[ 2.2813125 ,  0.01654244,  0.2669288 , ..., -1.9741952 ,-1.214573  , -0.26783428],[ 0.46435446,  0.10106895,  0.48570612, ..., -0.71019286,1.0031776 ,  0.8754525 ],[ 0.40530297, -0.45397016,  0.37551296, ..., -0.40454775,0.9431435 ,  0.7362306 ]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>theta_Intercept</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-cb14efa5-e2ba-44b5-9f62-58cbdb2305a7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cb14efa5-e2ba-44b5-9f62-58cbdb2305a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7685004e-683a-4b38-81fd-a44ad8e4beda' class='xr-var-data-in' type='checkbox'><label for='data-7685004e-683a-4b38-81fd-a44ad8e4beda' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.37184334, 0.3752415 , 0.38162804, 0.37385112, 0.35584903,0.32069033, 0.2572299 , 0.25447956, 0.31239724, 0.32066405,0.40466678, 0.39973614, 0.37523726, 0.3987366 , 0.48094735,0.5004539 , 0.32986134, 0.3715378 , 0.37262133, 0.4407532 ,0.44005278, 0.40711045, 0.4233292 , 0.40927002, 0.41607863,0.42325023, 0.44889316, 0.4281754 , 0.445002  , 0.44875097,0.4652218 , 0.38231552, 0.4363919 , 0.42841506, 0.40570274,0.39017794, 0.39495537, 0.5012791 , 0.4705955 , 0.44992507,0.44412547, 0.4629282 , 0.47210506, 0.37463927, 0.4407064 ,0.46436587, 0.4161343 , 0.44424763, 0.4249587 , 0.48256913,0.38229895, 0.42288676, 0.4333711 , 0.42739502, 0.39859802,0.4004385 , 0.44307902, 0.4248455 , 0.48949093, 0.43666825,0.39274704, 0.39131567, 0.33993095, 0.36984834, 0.33198732,0.41190708, 0.36816216, 0.35625613, 0.35106054, 0.37718236,0.30947238, 0.38277152, 0.37580892, 0.36441892, 0.36672142,0.37413839, 0.38187614, 0.29337326, 0.3311122 , 0.38858184,0.37802926, 0.3770608 , 0.3618849 , 0.40753755, 0.47269255,0.42319596, 0.40018106, 0.4252517 , 0.41156563, 0.41228962,0.4300655 , 0.3635583 , 0.3947772 , 0.4486918 , 0.4033714 ,0.39311007, 0.30284742, 0.3504504 , 0.35943228, 0.35830978,...0.36330026, 0.43362302, 0.39317605, 0.39518538, 0.39640495,0.44748113, 0.3578765 , 0.40418354, 0.44015273, 0.39789397,0.46893066, 0.36544597, 0.343747  , 0.43493837, 0.3720645 ,0.45126614, 0.37874055, 0.45144987, 0.39172012, 0.42134932,0.41405162, 0.420662  , 0.39295477, 0.33621624, 0.4364847 ,0.42341435, 0.3749435 , 0.33595124, 0.45454678, 0.3554715 ,0.5255507 , 0.29586193, 0.30501932, 0.46173444, 0.40476975,0.37438822, 0.4914175 , 0.34688306, 0.33914545, 0.42167038,0.4399255 , 0.439352  , 0.40755537, 0.38985154, 0.40522003,0.38728198, 0.40887854, 0.42876208, 0.40132433, 0.5026821 ,0.38901237, 0.3709975 , 0.43746626, 0.39225602, 0.4456236 ,0.46698022, 0.4178585 , 0.36575118, 0.36673266, 0.3678502 ,0.47379687, 0.3411522 , 0.34312603, 0.3437655 , 0.468294  ,0.42350784, 0.4368377 , 0.46835378, 0.28869128, 0.45234624,0.38744986, 0.3930576 , 0.38377443, 0.4343526 , 0.3448816 ,0.35999885, 0.34945482, 0.3266029 , 0.46992   , 0.45542946,0.4684069 , 0.42751095, 0.3766642 , 0.40277022, 0.41864297,0.42120054, 0.3992919 , 0.33207247, 0.37528285, 0.44615403,0.38772425, 0.41259754, 0.44026604, 0.46752957, 0.50782174,0.29752004, 0.34930724, 0.39108765, 0.39774287, 0.39795798]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>t_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-bca4fa5a-d2c5-4741-a5a4-a085543eca95' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bca4fa5a-d2c5-4741-a5a4-a085543eca95' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-58ddda3a-c859-451c-b5c5-abeac21117bd' class='xr-var-data-in' type='checkbox'><label for='data-58ddda3a-c859-451c-b5c5-abeac21117bd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[ 0.03989148,  0.00388813,  0.08070884, ...,  0.07016739,-0.08490543, -0.11254743],[ 0.019719  ,  0.02988022,  0.08441824, ...,  0.03415553,-0.05576593, -0.0800546 ],[-0.04197139, -0.03656941,  0.04897078, ...,  0.01759729,-0.09005275, -0.10862105],...,[-0.03891871,  0.02872496,  0.03122363, ...,  0.04446945,-0.06090495, -0.08169102],[-0.00916721,  0.00058694,  0.05714915, ...,  0.06052635,-0.05245761, -0.1298296 ],[ 0.06161047,  0.0049132 ,  0.04992333, ...,  0.01289814,-0.09349372, -0.11402042]],[[ 0.02271204,  0.01898884, -0.00457085, ..., -0.01594041,-0.11279078, -0.14897363],[ 0.02355974,  0.02024803, -0.00701158, ..., -0.01773908,-0.11857213, -0.1390382 ],[ 0.03222767, -0.02822932,  0.04364874, ..., -0.00376927,-0.11263101, -0.1537507 ],...,[-0.02472578, -0.04604846, -0.00242031, ...,  0.04950233,-0.21920161, -0.14044724],[ 0.01462434, -0.03592049,  0.02648597, ..., -0.00051146,-0.06402059, -0.09811952],[ 0.02203678, -0.03931142,  0.03682411, ..., -0.00666447,-0.05471553, -0.10457483]]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>a_1|participant_id</span></div><div class='xr-var-dims'>(chain, draw, participant_id__factor_dim)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d1b70d6c-754a-4bbd-ae66-cc6e8a1c51ba' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d1b70d6c-754a-4bbd-ae66-cc6e8a1c51ba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-745f5257-312d-4621-be09-6e8ab6bd3be2' class='xr-var-data-in' type='checkbox'><label for='data-745f5257-312d-4621-be09-6e8ab6bd3be2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[[-0.11088555, -0.21212281, -0.22241823, ..., -0.00238455,-0.397107  ,  0.19031405],[-0.1378664 , -0.13498862, -0.24982122, ...,  0.08999023,-0.42343   ,  0.19621423],[-0.0582212 , -0.04430246, -0.14889818, ...,  0.02766255,-0.3886827 ,  0.20535986],...,[ 0.04474414, -0.3256034 , -0.12467747, ..., -0.05824507,-0.47297505,  0.04403699],[ 0.07248401, -0.07235811, -0.07652059, ..., -0.01111572,-0.47137576,  0.19460197],[-0.02550923, -0.08483825, -0.06781203, ...,  0.16392912,-0.2801014 ,  0.25703454]],[[-0.03535808, -0.15926987,  0.05267481, ...,  0.18244603,-0.26203972,  0.33039805],[-0.03740749, -0.16048542,  0.05411103, ...,  0.18571657,-0.26925537,  0.32984704],[-0.06981827, -0.06931499, -0.05387779, ...,  0.18025383,-0.25653806,  0.3699974 ],...,[ 0.06696932, -0.04624798, -0.0748887 , ...,  0.07733133,-0.04553014,  0.15366735],[-0.27866945, -0.148324  , -0.14303117, ...,  0.14455236,-0.5997249 ,  0.07483451],[-0.11876365, -0.1330121 , -0.14462161, ...,  0.14622794,-0.539187  ,  0.05915312]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c4be03d6-bc31-4225-a41a-3acd88096f04' class='xr-section-summary-in' type='checkbox' /><label for='section-c4be03d6-bc31-4225-a41a-3acd88096f04' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(11)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-08-28T01:43:54.114260+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.3.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[&#x27;chain&#x27;, &#x27;draw&#x27;]</dd><dt><span>inference_library :</span></dt><dd>numpyro</dd><dt><span>inference_library_version :</span></dt><dd>0.21.0</dd><dt><span>sampling_time :</span></dt><dd>228.017227</dd><dt><span>tuning_steps :</span></dt><dd>800</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.20.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-2d5fc371-0276-4d43-b471-a567befec993' type='checkbox' checked /><label for='group-2d5fc371-0276-4d43-b471-a567befec993' title='Expand/collapse group'>/sample_stats<span>(16)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-93dee3d8-c162-420f-90be-45431b5c0822' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-93dee3d8-c162-420f-90be-45431b5c0822' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li></ul></div></li><li class='xr-section-item'><input id='section-ec6ed001-ec3c-462a-93fb-81ffb62f73f9' class='xr-section-summary-in' type='checkbox' checked /><label for='section-ec6ed001-ec3c-462a-93fb-81ffb62f73f9' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-d38e66a2-c9bf-469c-915c-e232b82b8f99' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d38e66a2-c9bf-469c-915c-e232b82b8f99' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6efdb1ba-ef7f-4105-8d6a-72b1b589e795' class='xr-var-data-in' type='checkbox'><label for='data-6efdb1ba-ef7f-4105-8d6a-72b1b589e795' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-57952c5f-ecca-4513-aec5-cb4cf058ba83' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-57952c5f-ecca-4513-aec5-cb4cf058ba83' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cce1e76a-ec83-446b-9003-be0f6a193f2a' class='xr-var-data-in' type='checkbox'><label for='data-cce1e76a-ec83-446b-9003-be0f6a193f2a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-da4b7b22-7b5c-4a4c-93c2-81d1259f8b65' class='xr-section-summary-in' type='checkbox' checked /><label for='section-da4b7b22-7b5c-4a4c-93c2-81d1259f8b65' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>acceptance_rate</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-f5a9c251-35f7-47b6-af57-cc28ac730393' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f5a9c251-35f7-47b6-af57-cc28ac730393' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-74ba905d-49a0-4581-8490-86424f18a273' class='xr-var-data-in' type='checkbox'><label for='data-74ba905d-49a0-4581-8490-86424f18a273' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.9428862 , 0.875544  , 0.9980183 , 0.9668852 , 0.802719  ,0.99840707, 0.9796786 , 0.98057926, 0.9935452 , 0.8228565 ,0.9873417 , 0.9787398 , 1.        , 0.97186846, 0.8217668 ,0.8622413 , 0.94624907, 0.85172325, 0.9768916 , 0.9897178 ,0.8395415 , 0.9928495 , 0.9988222 , 0.8496526 , 0.9930968 ,0.9537113 , 0.93887764, 0.96314746, 0.9887822 , 0.95642763,0.9975288 , 0.9993298 , 0.9706102 , 0.9911264 , 0.9101404 ,0.99409014, 0.997289  , 0.9400379 , 0.8468843 , 0.85260385,0.930182  , 0.95979875, 0.97896415, 0.92557955, 0.92944103,0.9777217 , 0.8088216 , 0.9386659 , 0.9459834 , 0.81447536,0.9997198 , 0.9990799 , 0.9795731 , 0.981867  , 0.77300817,0.99481547, 0.97561693, 0.89625055, 0.8847989 , 0.987505  ,0.87175316, 0.76710653, 0.99946666, 0.96932644, 0.9908804 ,0.96518284, 0.9991287 , 0.9586446 , 0.9814285 , 0.95617074,0.9133639 , 0.960453  , 0.6573735 , 0.99839944, 0.9981537 ,0.9952509 , 0.9994737 , 0.9564034 , 0.9964285 , 0.92015415,0.9435219 , 0.9555493 , 0.95764714, 0.9289612 , 0.97998756,0.67451805, 0.97212   , 0.82349026, 0.9479094 , 0.98744375,0.98951304, 0.83718747, 0.9564135 , 0.9699264 , 0.9457537 ,0.90286314, 0.96261054, 0.9879896 , 0.93389386, 0.9693558 ,...0.98323184, 0.93692863, 0.99281466, 0.98961663, 0.98494655,0.92148954, 0.91236264, 0.95997185, 0.94362974, 0.9418049 ,0.98999804, 0.96320134, 0.95907754, 0.97451043, 0.93569213,0.91632515, 0.9840833 , 0.8662429 , 0.98884296, 0.94326544,0.91148627, 0.92074955, 0.9588357 , 0.96952075, 0.996083  ,0.9882609 , 0.99426484, 0.9291558 , 0.9500141 , 0.97808343,0.994416  , 0.9629365 , 0.9481176 , 0.9312252 , 0.90583766,0.9753043 , 0.83482367, 0.9862406 , 0.8760137 , 0.9933994 ,0.97344244, 0.82167655, 0.33855903, 0.97688156, 0.98963684,0.9459821 , 0.93868816, 0.98598665, 0.9660773 , 0.676939  ,0.85019803, 0.9803852 , 0.86970794, 0.6248614 , 0.99294025,0.97305727, 0.9633859 , 0.99681354, 0.95355064, 0.927023  ,0.9946849 , 0.96981794, 0.93144685, 0.96455723, 0.9524279 ,0.97320414, 0.9666881 , 0.98811483, 0.9753506 , 0.9523712 ,0.97730076, 0.9545743 , 0.97294927, 0.9943132 , 0.99536467,0.9408122 , 0.8677437 , 0.9881613 , 0.87207884, 0.8832622 ,0.39308846, 0.98535943, 0.9991909 , 0.958753  , 0.96770567,0.9855424 , 0.9787708 , 0.9755398 , 0.4628831 , 0.965815  ,0.95201755, 0.9836658 , 0.99672335, 0.9480437 , 0.9953432 ,0.95970386, 0.98704505, 0.9669607 , 0.7751795 , 0.8668781 ]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>step_size</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e0d47fcb-d3a9-457b-b035-6450d3d55f47' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e0d47fcb-d3a9-457b-b035-6450d3d55f47' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5e16b6a1-30bb-440b-89fe-5bf4ee1587b6' class='xr-var-data-in' type='checkbox'><label for='data-5e16b6a1-30bb-440b-89fe-5bf4ee1587b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,0.05776346, 0.05776346, 0.05776346, 0.05776346, 0.05776346,...0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859,0.05004859, 0.05004859, 0.05004859, 0.05004859, 0.05004859]],      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>diverging</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>bool</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-da7c247e-9314-4e28-a697-f8eb9b931e4b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-da7c247e-9314-4e28-a697-f8eb9b931e4b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-118e3eaf-8117-4034-99c5-0774b3432bbf' class='xr-var-data-in' type='checkbox'><label for='data-118e3eaf-8117-4034-99c5-0774b3432bbf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[False, False, False, False, False, False, False, False, False,False, False,  True, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,True, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False,  True, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,...False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False,  True, False, False, False,False, False, False, False, False, False, False, False, False,False, False,  True, False, False, False, False, False, False,True, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False,  True, False, False, False, False, False, False, False,False, False, False, False, False, False, False, False, False,False, False, False,  True]], dtype=bool)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>energy</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5eb58fb5-6ccc-4e19-ac41-de2bf7a8428d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5eb58fb5-6ccc-4e19-ac41-de2bf7a8428d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-02a0d09d-79d9-466a-8972-7fe425a9884c' class='xr-var-data-in' type='checkbox'><label for='data-02a0d09d-79d9-466a-8972-7fe425a9884c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1513.2217, 1511.6072, 1520.2942, 1505.2566, 1504.6066, 1497.9032,1494.657 , 1504.0759, 1500.5043, 1505.9501, 1509.0422, 1508.6163,1519.1576, 1520.2273, 1515.2703, 1503.5134, 1510.8104, 1505.2853,1508.8129, 1515.4642, 1490.3097, 1499.8309, 1483.4846, 1497.3335,1493.4749, 1503.0826, 1504.8728, 1497.126 , 1498.835 , 1511.3683,1522.7426, 1524.6704, 1506.5018, 1495.0701, 1498.7582, 1503.0251,1506.6229, 1515.101 , 1514.1881, 1498.4678, 1502.4607, 1509.351 ,1503.1716, 1502.1907, 1490.2672, 1499.9558, 1494.8658, 1503.0371,1510.3667, 1512.7318, 1501.4349, 1491.8663, 1489.9045, 1485.1182,1487.809 , 1494.7075, 1492.249 , 1486.4407, 1502.0139, 1496.1383,1496.1573, 1485.3201, 1504.394 , 1520.578 , 1512.2483, 1523.0425,1510.7034, 1511.4392, 1508.131 , 1505.938 , 1497.7181, 1497.2452,1523.339 , 1506.938 , 1498.7657, 1495.0732, 1479.9911, 1492.8772,1496.6981, 1494.8557, 1491.1814, 1511.8867, 1521.8217, 1497.4613,1491.9456, 1492.7428, 1484.1642, 1489.5079, 1496.9753, 1510.8754,1508.2089, 1508.7965, 1498.127 , 1485.8428, 1491.1353, 1488.2765,1492.5361, 1497.9603, 1490.4818, 1492.4532, 1481.3074, 1488.2307,1491.2874, 1495.2578, 1498.2526, 1492.9243, 1506.5049, 1508.0822,1516.3257, 1505.3746, 1498.4779, 1489.1102, 1482.0598, 1491.9219,1499.1493, 1489.8351, 1488.0422, 1505.6035, 1494.0227, 1489.0011,...1501.8916, 1495.9266, 1501.2253, 1503.6068, 1507.6871, 1492.696 ,1488.8955, 1487.9795, 1501.8103, 1496.2388, 1493.7247, 1500.1979,1510.3188, 1502.7681, 1505.1827, 1505.7471, 1490.1836, 1493.0924,1484.9122, 1491.3398, 1497.5376, 1499.9552, 1484.2238, 1486.9185,1495.397 , 1490.01  , 1502.9128, 1525.6493, 1504.0104, 1499.1079,1499.5813, 1498.4883, 1507.7197, 1524.676 , 1514.9556, 1509.5265,1502.4908, 1498.1404, 1500.5771, 1496.6097, 1486.94  , 1499.0459,1491.1635, 1495.0245, 1501.492 , 1506.2155, 1510.4701, 1507.4878,1500.7263, 1491.071 , 1505.479 , 1509.9513, 1507.0059, 1488.8776,1494.1162, 1485.0494, 1500.3004, 1490.105 , 1497.5095, 1482.7915,1487.7161, 1500.6749, 1488.7777, 1489.0774, 1488.127 , 1502.2236,1499.378 , 1500.1206, 1506.6691, 1500.1144, 1489.8135, 1502.2177,1518.9949, 1511.338 , 1515.1807, 1492.5566, 1486.5453, 1497.1066,1494.5582, 1505.1956, 1508.0593, 1497.1217, 1502.8933, 1481.433 ,1487.2307, 1495.0801, 1505.3519, 1514.2297, 1517.4889, 1509.8677,1513.7239, 1510.2827, 1497.7542, 1500.2924, 1502.9749, 1503.9841,1494.9513, 1486.0378, 1489.5475, 1479.2343, 1490.0721, 1503.8567,1495.1807, 1501.9889, 1514.0182, 1512.4767, 1509.3861, 1508.7822,1490.0117, 1479.827 , 1492.8403, 1490.971 , 1486.1244, 1502.625 ,1532.9491, 1527.612 , 1514.2972, 1512.8827]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>n_steps</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-9f6fff3a-005d-4fe8-bd18-c1133850d959' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9f6fff3a-005d-4fe8-bd18-c1133850d959' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cc396103-c512-4582-ad01-b0a07fc9cf39' class='xr-var-data-in' type='checkbox'><label for='data-cc396103-c512-4582-ad01-b0a07fc9cf39' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[ 63, 127,  63, 127,  63, 127,  63,  63,  63,  63, 127,  96,  63,127,  63,  63,  63, 127, 127,  63,  63, 127, 127,  63,  63, 127,63,  63,  63, 127,  63, 127,  63,  63,  63,  63,  63, 127, 127,63,  63, 255,  63, 127, 127,  63, 127,  63,  63, 127, 127,  63,127,  63, 127, 127,  63,  63,  63,  63,  63,  63,  63,  63, 127,63, 127,  63,  63, 127,  63,  63,  63,  63,  63,  63,  63,  63,63, 127,  63,  63,  63,  63, 127,  63,  63,  63,  63,  63,  63,63,  63, 127,  63,  63,  63,  63, 127,  63,  63,  63, 127,  63,127,  63, 127,  63,  63,  63, 127,  63,  63,  63,  63,  63, 127,63, 127, 127,  63, 127,  63,  63, 127,  63, 127,  63,  63,  63,63,  63,  63,  63,  63,  87,  63,  63,  63, 127,  63,  63,  63,127, 127,  63,  63,  63,  63,  63, 127, 127,  63,  63, 127,  63,127, 127, 127, 127,  63,  63,  63,   4, 127, 127,  63, 127, 127,63,  63,  63,  63,  63,  63, 127,  63, 127,  63, 127, 127,  63,63, 127, 127,  63, 127,  51,  63,  63, 127, 127, 107,  63, 127,127,  63,  63,  63, 127,  63,  63,  63, 127,  63, 127,  63,  63,127, 127,  63, 127, 127, 127, 127, 127,  63, 127,  63, 127,  63,127,  63,  63,  63, 127, 127, 127,  63, 127,  63,  63, 127,  63,127,  63, 127, 127, 127,  63, 127,  63, 127, 127, 127, 127,  63,63,  63,  63,  63,  63, 127, 127, 127,  63, 127, 127,  63, 127,...63, 127, 127,  63, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127, 127, 127, 127,  63, 127,  63, 127,  63,  63, 127, 127,127, 127,  51, 127, 127,  63, 127, 127, 127, 127, 127, 127, 127,127,  63,  63,  63, 127, 127, 127, 127,  63, 111, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127,  63,  63,  63, 127, 127,127, 127, 127,  63,  63,  63, 127, 127,  63, 127, 127, 127, 127,127,  63,  63,  37, 127, 127,  63, 127, 127, 255, 127,  63, 127,127,  63, 127,  63, 127, 127, 127, 127,  63, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127,  63, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,  63, 127,127,  63,  63, 127, 127,  63,  63, 127, 127, 127, 127, 127, 127,127, 127,  63, 127, 127,  63, 127, 127, 127, 127, 127,  63, 127,127, 127,  63, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,127,  63, 127,  63, 127, 127, 127, 127,  55, 127, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 109, 127, 127,127, 127, 127, 127,  99, 127,  63, 127, 127,  63, 127, 127, 127,127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127,  63,  63,127,  63, 127,  63, 127, 127, 127, 127, 127, 127, 127, 127, 127,127, 127,  29, 127, 127, 127, 127,  63,  63, 127, 127, 127, 127,63,  63, 127, 127,  63, 127, 127, 127, 127,  27]], dtype=int32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tree_depth</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>6 7 6 7 6 7 6 6 ... 7 7 6 7 7 7 7 5</div><input id='attrs-7b708c75-bf28-41c0-8286-afbed55abcd9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7b708c75-bf28-41c0-8286-afbed55abcd9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-45eb39ed-5ea5-419f-b28d-aaa922c1b9da' class='xr-var-data-in' type='checkbox'><label for='data-45eb39ed-5ea5-419f-b28d-aaa922c1b9da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[6, 7, 6, 7, 6, 7, 6, 6, 6, 6, 7, 7, 6, 7, 6, 6, 6, 7, 7, 6, 6, 7,7, 6, 6, 7, 6, 6, 6, 7, 6, 7, 6, 6, 6, 6, 6, 7, 7, 6, 6, 8, 6, 7,7, 6, 7, 6, 6, 7, 7, 6, 7, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6,7, 6, 6, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 7, 6, 6, 6,6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 7, 6, 6, 6, 7, 6, 7, 6, 7, 6, 6, 6,7, 6, 6, 6, 6, 6, 7, 6, 7, 7, 6, 7, 6, 6, 7, 6, 7, 6, 6, 6, 6, 6,6, 6, 6, 7, 6, 6, 6, 7, 6, 6, 6, 7, 7, 6, 6, 6, 6, 6, 7, 7, 6, 6,7, 6, 7, 7, 7, 7, 6, 6, 6, 3, 7, 7, 6, 7, 7, 6, 6, 6, 6, 6, 6, 7,6, 7, 6, 7, 7, 6, 6, 7, 7, 6, 7, 6, 6, 6, 7, 7, 7, 6, 7, 7, 6, 6,6, 7, 6, 6, 6, 7, 6, 7, 6, 6, 7, 7, 6, 7, 7, 7, 7, 7, 6, 7, 6, 7,6, 7, 6, 6, 6, 7, 7, 7, 6, 7, 6, 6, 7, 6, 7, 6, 7, 7, 7, 6, 7, 6,7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 7, 7, 7, 6, 7, 7, 6, 7, 7, 7, 7, 6,6, 6, 6, 6, 6, 7, 6, 6, 6, 6, 6, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6,6, 7, 6, 6, 6, 7, 6, 6, 6, 6, 7, 6, 6, 6, 6, 7, 7, 6, 7, 7, 7, 6,7, 7, 6, 6, 6, 7, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 7, 7, 6, 7, 7, 6,6, 6, 6, 6, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 6, 6,7, 7, 7, 7, 6, 6, 7, 6, 6, 6, 6, 7, 7, 6, 7, 7, 6, 7, 6, 7, 7, 7,6, 7, 6, 7, 7, 6, 6, 6, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 7, 6, 7, 6,6, 6, 6, 7],[7, 5, 7, 7, 7, 7, 6, 7, 7, 7, 6, 7, 6, 7, 6, 6, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 6, 6, 7,7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7,7, 7, 7, 6, 6, 7, 7, 6, 7, 7, 7, 7, 7, 6, 7, 6, 6, 7, 6, 7, 6, 7,7, 6, 7, 7, 6, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 6, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 6, 7, 6, 7, 6, 6, 7, 7, 7, 7, 6, 7, 7, 6, 7,7, 7, 7, 7, 7, 7, 7, 6, 6, 6, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 6, 6, 6, 7, 7, 7, 7, 7, 6, 6, 6, 7, 7, 6, 7, 7, 7,7, 7, 6, 6, 6, 7, 7, 6, 7, 7, 8, 7, 6, 7, 7, 6, 7, 6, 7, 7, 7, 7,6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 6, 6, 7, 7, 6, 6, 7, 7, 7, 7, 7, 7,7, 7, 6, 7, 7, 6, 7, 7, 7, 7, 7, 6, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 6, 7, 6, 7, 7, 7, 7, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 7, 7, 6, 7, 7, 7, 7,7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 7, 6, 7, 6, 7, 7, 7, 7, 7, 7,7, 7, 7, 7, 7, 5, 7, 7, 7, 7, 6, 6, 7, 7, 7, 7, 6, 6, 7, 7, 6, 7,7, 7, 7, 5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>lp</span></div><div class='xr-var-dims'>(chain, draw)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c2a7d7bb-c192-46dc-858e-338347719fc9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c2a7d7bb-c192-46dc-858e-338347719fc9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bba7ce21-4ad3-4909-a679-9cf1291348ff' class='xr-var-data-in' type='checkbox'><label for='data-bba7ce21-4ad3-4909-a679-9cf1291348ff' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>Array([[1469.5586, 1474.8151, 1463.2518, 1460.3812, 1457.9615, 1455.3253,1467.257 , 1467.6246, 1450.2601, 1467.7827, 1466.3823, 1469.4987,1473.2145, 1468.854 , 1464.5448, 1466.6189, 1462.8628, 1460.4515,1467.7439, 1457.1707, 1458.4895, 1451.9597, 1445.6982, 1456.8695,1462.1406, 1462.782 , 1454.9141, 1451.8727, 1465.9691, 1469.4979,1473.8344, 1473.9059, 1459.3551, 1456.6747, 1467.5768, 1465.8389,1468.1813, 1461.0184, 1457.1953, 1455.4081, 1458.3351, 1466.872 ,1451.459 , 1450.3025, 1454.8082, 1453.9199, 1453.3113, 1468.2546,1468.3124, 1466.8285, 1454.2994, 1457.4485, 1449.2142, 1442.8652,1454.1385, 1451.7181, 1449.4247, 1446.7163, 1456.7883, 1457.827 ,1446.0647, 1453.4724, 1469.8541, 1473.2156, 1471.3746, 1474.1244,1477.527 , 1473.6045, 1462.1652, 1458.1151, 1459.052 , 1463.6847,1470.2161, 1458.7131, 1461.2601, 1447.5823, 1455.319 , 1460.3672,1450.6812, 1455.1991, 1452.3131, 1479.3057, 1466.7246, 1454.3096,1451.1595, 1446.0536, 1446.7036, 1447.4786, 1466.3065, 1455.8145,1458.9434, 1455.2244, 1444.7693, 1449.8805, 1449.4822, 1454.3143,1456.3475, 1448.4344, 1446.7972, 1450.1859, 1443.7136, 1454.21  ,1456.5265, 1453.4276, 1453.1995, 1460.2251, 1468.2169, 1465.1698,1469.952 , 1459.6438, 1456.7958, 1449.6179, 1443.4008, 1455.2263,1450.4193, 1445.0487, 1446.9186, 1455.708 , 1450.2365, 1449.651 ,...1460.8536, 1457.3126, 1458.6057, 1461.8481, 1451.5154, 1454.4485,1452.7466, 1447.7849, 1462.2462, 1454.7947, 1454.5297, 1464.5215,1455.7563, 1461.3013, 1464.4747, 1456.7816, 1450.1683, 1445.4454,1454.3687, 1458.2578, 1462.4791, 1454.8588, 1450.5708, 1453.4817,1449.9531, 1454.9845, 1466.7507, 1465.2642, 1452.6864, 1457.7312,1451.8695, 1466.2657, 1463.5499, 1474.6754, 1464.5869, 1461.7721,1452.7877, 1452.2225, 1455.9275, 1450.8346, 1456.0742, 1456.2783,1453.5634, 1467.6503, 1459.0996, 1466.8691, 1465.4512, 1462.7657,1456.6725, 1461.5543, 1465.6038, 1460.2722, 1457.7661, 1450.6843,1452.132 , 1449.7578, 1455.2578, 1457.5917, 1450.564 , 1445.3862,1451.5553, 1458.3987, 1449.3912, 1450.1642, 1453.9858, 1456.7648,1455.6417, 1456.3247, 1464.7836, 1452.2295, 1452.1638, 1463.7858,1473.7515, 1465.9829, 1468.1056, 1443.4918, 1458.1597, 1462.244 ,1455.9673, 1466.2719, 1457.5286, 1459.224 , 1452.127 , 1447.0739,1450.5885, 1460.4861, 1467.051 , 1470.6841, 1469.5148, 1466.5294,1470.6471, 1461.3923, 1452.1907, 1456.91  , 1466.4835, 1459.7717,1441.9846, 1448.8893, 1448.1051, 1451.8385, 1454.9406, 1462.3076,1459.5872, 1468.3895, 1467.5858, 1466.23  , 1472.3004, 1456.3789,1442.8761, 1448.5656, 1450.9059, 1442.1658, 1456.8628, 1466.9797,1484.9878, 1466.6852, 1469.7317, 1469.3099]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d0de1f9a-7abe-4d3c-880f-0cdcfcbe8460' class='xr-section-summary-in' type='checkbox' checked /><label for='section-d0de1f9a-7abe-4d3c-880f-0cdcfcbe8460' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-08-28T01:43:54.126598+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.3.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[&#x27;chain&#x27;, &#x27;draw&#x27;]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.20.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-dfcbd9dd-acdc-4edb-8471-854db725c865' type='checkbox' checked /><label for='group-dfcbd9dd-acdc-4edb-8471-854db725c865' title='Expand/collapse group'>/observed_data<span>(10)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-cc5f9127-7a28-4a70-9de5-29431f659d52' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-cc5f9127-7a28-4a70-9de5-29431f659d52' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>__obs__</span>: 1800</li><li><span class='xr-has-index'>rt,response_extra_dim_0</span>: 2</li></ul></div></li><li class='xr-section-item'><input id='section-4d3a6114-95ac-4f9e-8944-20dbaf94398f' class='xr-section-summary-in' type='checkbox' checked /><label for='section-4d3a6114-95ac-4f9e-8944-20dbaf94398f' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>__obs__</span></div><div class='xr-var-dims'>(__obs__)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 ... 1796 1797 1798 1799</div><input id='attrs-0b893aa2-6fef-48f8-a7a6-99da013599e3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0b893aa2-6fef-48f8-a7a6-99da013599e3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-321c3276-cb2b-4e61-8f63-f9ea92191f2a' class='xr-var-data-in' type='checkbox'><label for='data-321c3276-cb2b-4e61-8f63-f9ea92191f2a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([   0,    1,    2, ..., 1797, 1798, 1799], shape=(1800,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>rt,response_extra_dim_0</span></div><div class='xr-var-dims'>(rt,response_extra_dim_0)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-88e4882e-a9f5-4b5c-8910-f1cc1f1c44ee' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-88e4882e-a9f5-4b5c-8910-f1cc1f1c44ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a2826052-1466-4b64-abfa-04dc8e157c9f' class='xr-var-data-in' type='checkbox'><label for='data-a2826052-1466-4b64-abfa-04dc8e157c9f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4f615bac-9f70-4b04-b7b5-3da1b500ce1d' class='xr-section-summary-in' type='checkbox' checked /><label for='section-4f615bac-9f70-4b04-b7b5-3da1b500ce1d' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>rt,response</span></div><div class='xr-var-dims'>(__obs__, rt,response_extra_dim_0)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>1.398 -1.0 0.4245 ... 1.148 -1.0</div><input id='attrs-191028aa-6ec4-45e8-904e-c8cd019d59ec' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-191028aa-6ec4-45e8-904e-c8cd019d59ec' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bec62e80-33c8-40d0-af03-0673e54e3f31' class='xr-var-data-in' type='checkbox'><label for='data-bec62e80-33c8-40d0-af03-0673e54e3f31' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[ 1.3978789 , -1.        ],[ 0.42447704, -1.        ],[ 0.49828485, -1.        ],...,[ 0.3929206 , -1.        ],[ 0.9278363 , -1.        ],[ 1.1475817 , -1.        ]], shape=(1800, 2), dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-22646a1f-5a32-4dec-a3a3-b396a5c27f0c' class='xr-section-summary-in' type='checkbox' checked /><label for='section-22646a1f-5a32-4dec-a3a3-b396a5c27f0c' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-08-28T01:43:54.127403+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.3.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.20.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 100%'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-6ab2b6b4-cd33-45e6-94ac-459a447a42c2' type='checkbox' checked /><label for='group-6ab2b6b4-cd33-45e6-94ac-459a447a42c2' title='Expand/collapse group'>/constant_data<span>(7)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-f22a4f59-5663-4e5d-8f71-554c33e223e1' class='xr-section-summary-in' type='checkbox' checked /><label for='section-f22a4f59-5663-4e5d-8f71-554c33e223e1' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>created_at :</span></dt><dd>2026-08-28T01:43:54.127494+00:00</dd><dt><span>creation_library :</span></dt><dd>ArviZ</dd><dt><span>creation_library_version :</span></dt><dd>1.3.0</dd><dt><span>creation_library_language :</span></dt><dd>Python</dd><dt><span>sample_dims :</span></dt><dd>[]</dd><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.20.0</dd></dl></div></li></ul></div></div><div class='xr-group-box'><div class='xr-group-box-vline' style='height: 1.2em'></div><div class='xr-group-box-hline'></div><div class='xr-group-box-contents'><input id='group-2f9823a5-27a3-4412-bed0-543835405004' type='checkbox' checked /><label for='group-2f9823a5-27a3-4412-bed0-543835405004' title='Expand/collapse group'>/log_likelihood<span>(6)</span></label><ul class='xr-sections'><li class='xr-section-item'><input id='section-39f0a0b9-59f6-4eee-9616-16559a13f973' class='xr-section-summary-in' type='checkbox' disabled /><label for='section-39f0a0b9-59f6-4eee-9616-16559a13f973' class='xr-section-summary'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>chain</span>: 2</li><li><span class='xr-has-index'>draw</span>: 400</li><li><span class='xr-has-index'>__obs__</span>: 1800</li></ul></div></li><li class='xr-section-item'><input id='section-b731915d-9032-4c99-831c-e260184e91bc' class='xr-section-summary-in' type='checkbox' checked /><label for='section-b731915d-9032-4c99-831c-e260184e91bc' class='xr-section-summary' title='Expand/collapse section'>Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>chain</span></div><div class='xr-var-dims'>(chain)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1</div><input id='attrs-b44543f1-30b0-4c79-a4ec-726a8be15e26' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b44543f1-30b0-4c79-a4ec-726a8be15e26' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-abbefb7b-bfd2-4e88-80e0-d5776aff4955' class='xr-var-data-in' type='checkbox'><label for='data-abbefb7b-bfd2-4e88-80e0-d5776aff4955' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>draw</span></div><div class='xr-var-dims'>(draw)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 ... 395 396 397 398 399</div><input id='attrs-26edaf7c-d07a-4d09-97d3-ff1c3b6a47f5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-26edaf7c-d07a-4d09-97d3-ff1c3b6a47f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e39c92f4-bae3-4c4d-90d8-47e2ac37df92' class='xr-var-data-in' type='checkbox'><label for='data-e39c92f4-bae3-4c4d-90d8-47e2ac37df92' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([  0,   1,   2, ..., 397, 398, 399], shape=(400,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>__obs__</span></div><div class='xr-var-dims'>(__obs__)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 ... 1796 1797 1798 1799</div><input id='attrs-328a6e80-1b78-4d76-9a5f-34a33cb1f570' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-328a6e80-1b78-4d76-9a5f-34a33cb1f570' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d48c51da-00b7-4c41-a338-a1cae2518b7c' class='xr-var-data-in' type='checkbox'><label for='data-d48c51da-00b7-4c41-a338-a1cae2518b7c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([   0,    1,    2, ..., 1797, 1798, 1799], shape=(1800,))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-474a1e4a-8b7a-4728-ae09-e758dbfbafba' class='xr-section-summary-in' type='checkbox' checked /><label for='section-474a1e4a-8b7a-4728-ae09-e758dbfbafba' class='xr-section-summary' title='Expand/collapse section'>Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>rt,response</span></div><div class='xr-var-dims'>(chain, draw, __obs__)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.384 -1.446 ... -0.4684 -0.8204</div><input id='attrs-61563af4-8103-49e1-a386-bb7e49477073' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-61563af4-8103-49e1-a386-bb7e49477073' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2120609d-8b3f-40aa-ab46-11a0887fc718' class='xr-var-data-in' type='checkbox'><label for='data-2120609d-8b3f-40aa-ab46-11a0887fc718' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[[-1.38445342, -1.44575131, -1.22809875, ...,  0.01584599,-0.41892195, -0.75033778],[-1.50146902, -0.5055989 , -0.45442918, ...,  0.05902255,-0.44482279, -0.78303194],[-1.42600811, -1.1077224 , -1.02131987, ...,  0.16971117,-0.39845708, -0.75293159],...,[-1.20150757, -1.41213655, -1.21743798, ...,  0.30701795,-0.56020498, -0.90970033],[-1.31141889, -1.56154394, -1.18549716, ...,  0.08988139,-0.49230185, -0.82793665],[-1.39239705, -0.84401423, -0.43222588, ...,  0.13069594,-0.53839111, -0.87491339]],[[-1.44539833, -0.90128839, -0.64389479, ..., -0.03026807,-0.39972964, -0.73072702],[-1.44601166, -0.9156968 , -0.64847314, ..., -0.03201159,-0.38560939, -0.72131765],[-1.49254525, -0.90972912, -0.63188928, ...,  0.11220393,-0.40719014, -0.74930876],...,[-1.34010422, -0.70966125, -0.53465426, ...,  0.10996237,-0.53138441, -0.88225824],[-1.5709219 , -0.83128691, -0.63931721, ...,  0.0239279 ,-0.37098268, -0.72696924],[-1.41191506, -1.36364591, -1.04740047, ...,  0.2068482 ,-0.4683615 , -0.82042432]]], shape=(2, 400, 1800))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a057d9ee-f972-4546-a7a0-7c50e9fad587' class='xr-section-summary-in' type='checkbox' checked /><label for='section-a057d9ee-f972-4546-a7a0-7c50e9fad587' class='xr-section-summary' title='Expand/collapse section'>Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>modeling_interface :</span></dt><dd>bambi</dd><dt><span>modeling_interface_version :</span></dt><dd>0.20.0</dd></dl></div></li></ul></div></div></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataTree>\n",
@@ -8702,31 +1357,31 @@
        "│         * participant_id__factor_dim             (participant_id__factor_dim) <U2 96B ...\n",
        "│         * rl_alpha_1|participant_id__factor_dim  (rl_alpha_1|participant_id__factor_dim) <U2 96B ...\n",
        "│       Data variables: (12/24)\n",
-       "│           a_1|participant_id_offset              (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_1|participant_id_offset       (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
+       "│           theta_1|participant_id_offset          (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           scaler_1|participant_id_offset         (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           scaler_1|participant_id                (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           a_Intercept                            (chain, draw) float32 3kB ...\n",
        "│           z_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
-       "│           theta_1|participant_id                 (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_1|participant_id              (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
-       "│           t_Intercept                            (chain, draw) float32 3kB ...\n",
-       "│           ...                                     ...\n",
        "│           t_1|participant_id_offset              (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           rl_alpha_Intercept                     (chain, draw) float32 3kB ...\n",
-       "│           a_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
-       "│           t_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
-       "│           t_1|participant_id_sigma               (chain, draw) float32 3kB ...\n",
+       "│           ...                                     ...\n",
        "│           scaler_1|participant_id_sigma          (chain, draw) float32 3kB ...\n",
+       "│           z_Intercept                            (chain, draw) float32 3kB ...\n",
+       "│           rl_alpha_1|participant_id_offset       (chain, draw, rl_alpha_1|participant_id__factor_dim) float32 38kB ...\n",
+       "│           theta_Intercept                        (chain, draw) float32 3kB ...\n",
+       "│           t_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
+       "│           a_1|participant_id                     (chain, draw, participant_id__factor_dim) float32 38kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.612283+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.114260+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 ['chain', 'draw']\n",
        "│           inference_library:           numpyro\n",
        "│           inference_library_version:   0.21.0\n",
-       "│           sampling_time:               335.468196\n",
+       "│           sampling_time:               228.017227\n",
        "│           tuning_steps:                800\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /sample_stats\n",
        "│       Dimensions:          (chain: 2, draw: 400)\n",
        "│       Coordinates:\n",
@@ -8738,16 +1393,16 @@
        "│           diverging        (chain, draw) bool 800B ...\n",
        "│           energy           (chain, draw) float32 3kB ...\n",
        "│           n_steps          (chain, draw) int32 3kB ...\n",
-       "│           tree_depth       (chain, draw) int64 6kB 7 7 7 7 7 7 7 6 ... 6 6 6 6 6 6 6 7\n",
+       "│           tree_depth       (chain, draw) int64 6kB 6 7 6 7 6 7 6 6 ... 7 7 6 7 7 7 7 5\n",
        "│           lp               (chain, draw) float32 3kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623322+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.126598+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 ['chain', 'draw']\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /observed_data\n",
        "│       Dimensions:                  (__obs__: 1800, rt,response_extra_dim_0: 2)\n",
        "│       Coordinates:\n",
@@ -8756,22 +1411,22 @@
        "│       Data variables:\n",
        "│           rt,response              (__obs__, rt,response_extra_dim_0) float32 14kB ...\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623923+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.127403+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 []\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "├── Group: /constant_data\n",
        "│       Attributes:\n",
-       "│           created_at:                  2026-07-06T16:28:47.623995+00:00\n",
+       "│           created_at:                  2026-08-28T01:43:54.127494+00:00\n",
        "│           creation_library:            ArviZ\n",
-       "│           creation_library_version:    1.2.0\n",
+       "│           creation_library_version:    1.3.0\n",
        "│           creation_library_language:   Python\n",
        "│           sample_dims:                 []\n",
        "│           modeling_interface:          bambi\n",
-       "│           modeling_interface_version:  0.18.0\n",
+       "│           modeling_interface_version:  0.20.0\n",
        "└── Group: /log_likelihood\n",
        "        Dimensions:      (chain: 2, draw: 400, __obs__: 1800)\n",
        "        Coordinates:\n",
@@ -8779,10 +1434,10 @@
        "          * draw         (draw) int64 3kB 0 1 2 3 4 5 6 ... 393 394 395 396 397 398 399\n",
        "          * __obs__      (__obs__) int64 14kB 0 1 2 3 4 5 ... 1795 1796 1797 1798 1799\n",
        "        Data variables:\n",
-       "            rt,response  (chain, draw, __obs__) float64 12MB -1.463 -0.9025 ... -0.7486\n",
+       "            rt,response  (chain, draw, __obs__) float64 12MB -1.384 -1.446 ... -0.8204\n",
        "        Attributes:\n",
        "            modeling_interface:          bambi\n",
-       "            modeling_interface_version:  0.18.0"
+       "            modeling_interface_version:  0.20.0"
       ]
      },
      "execution_count": 8,
@@ -8822,10 +1477,10 @@
    "id": "7b1142fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:49.289809Z",
-     "iopub.status.busy": "2026-07-06T16:28:49.289725Z",
-     "iopub.status.idle": "2026-07-06T16:28:49.661765Z",
-     "shell.execute_reply": "2026-07-06T16:28:49.661444Z"
+     "iopub.execute_input": "2026-08-28T01:43:55.475545Z",
+     "iopub.status.busy": "2026-08-28T01:43:55.475424Z",
+     "iopub.status.idle": "2026-08-28T01:43:55.977711Z",
+     "shell.execute_reply": "2026-08-28T01:43:55.977350Z"
     }
    },
    "outputs": [
@@ -8833,12 +1488,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "max r-hat: 1.0262178975792724\n"
+      "max r-hat: 1.0146106538529809\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAG4CAYAAADYN3EQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAARttJREFUeJzt3Ql4E9X6x/G3LYWytGVfyo6AiiiKiiLiVRFkvyguCPxd8CqgKKsIKoLLFRAQcblwxV1QrrggoCCIiqiIC4IgKCCLshZR2goUSpv/8x6dmKRJF07apMn38zwxZDIzOZnE9PzmLBPjcrlcAgAAAAAWYm02BgAAAACCBQAAAICgoMUCAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAKLTMzEyJiYmRhx9+OORHL5zKAgDRjGABAEXks88+kz59+kiDBg0kISFBKleuLGeccYb069dPli9fLi6Xi2MPAIgYBAsAKAKjR4+Wtm3bSqVKlWTevHny+++/y/bt2+Xxxx+XX3/9VS6++GL5/vvvOfYAgIhRKtQFAIBI8+yzz8qECRPkiSeekDvuuMO9vGzZsnLppZea2zPPPCOlSvETDACIHLRYAEAQafemBx54QBo3biyDBg0KuN6tt94qp5xyivvxZZddJuecc478/PPP0r17d0lKSpKuXbua5/744w8ZMWKE6VJVunRpqV27tvTv39+0fDi+/vprM87gjTfeyPVaFStWlAEDBrgf792716yrrSevv/66KYd21Tr99NPlzTfftHr/2dnZ8thjj5l96T61xaZnz56yefNm8/yxY8ekWrVqctVVV+XaNicnR+rVqyddunQp8P4Kw/N9v/3226Zbmh7POXPmmOd37twpN998s6SkpJjlDRs2lDFjxpgye/rll1/klltuMWXVMjVr1kwmT57std6aNWvM56jl1XX0taZPn+5+/p133jFl0dYsXx9++KF57rXXXnMvK0jZtAy63e7du833pWbNmhIfHy/vvvtuwO/G0qVLzXOvvvpqoY8nAPgiWABAEGn3Jq0EXn755abCVthByAMHDpSRI0fKtm3b5LrrrpPjx4+bfb388svy9NNPmzChFU6tEF544YWSkZFxwmX96KOP5P3335clS5aY19OWlKuvvlreeuutE96nlvmhhx4y72HPnj2yevVqE7YuuOACc1y0Uty3b1+ZP3++7N+/32tbLYdW2rUCXdD9nYiPP/5YFixYYMqgAaBWrVqyY8cOE+w2btxolmvXteeee05efPFF6d27t3tbPU5nn322fPPNN6Yyru9Bj1dqaqoZN6N0n23atDGf5xdffCG7du0y42q09Urfh9LwpK+rr+Hr+eefN4HkiiuuMI8LWjbHXXfdJc2bNzfr63emU6dOJoj85z//ybWuLtPgeeWVV57QsQQALy4AQNC8++67OiLbNWHChEJt165dO7PdZ5995rX81VdfNcv13tOKFSvM8vHjx5vHX331lXk8d+7cXPtOTk529e/f3/14z549Zt2mTZu6srOzvdY955xzXCeddFK+5T1y5IjZx0MPPZTrvb/wwgte6x46dMhVo0YN1+23324er1+/3qw3ZcoUr/WuuuoqV7Vq1VzHjh0r1P78lcUf533r+/N939ddd52rYsWKrv3793stnzdvntlm5cqV7jJWqFDBtW/fvoCv07lzZ7OvtLQ0r+X6GcTFxbm2b99uHo8aNco83r17t3udgwcPusqWLesaNGhQocs2adIk83jMmDG5yjRx4kTz3MaNG93Ldu7caV7fOY4AYIsWCwAIorxmetKuKdqK4dzGjRvn9XyVKlXMmXhPy5YtM+s6Z68d2lpRo0YN8/yJ0rPmsbHefwZ69OghP/30kzlLrs4880yvMvfq1Svg/rQVQPfne/a7XLly0rp1a/cZ/dNOO03OO+88c2beceDAAXM2/vrrrzfddwqzv8LSLma+71tfSwfUV61a1Wt5u3btzL3zWosWLTLd1qpXrx7w89euTLqOdmfzpN2/tGuXtpgobZnRxy+99JJ7HW0FOXLkiFerTUHL5tAuWL50f9oly7M71n//+1/z+p6vBQA2CBYAEET169c399qlx18ff614ahcVf3TshC+tcCcnJ5tKob+g4jnOorBhR4NJoGUF2a+/96fjJHRaXR2YHhcXZyrwetOxBPpeHP/6179Mt7FVq1aZx6+88ooZL6Bdhk5kf4Xhe5wPHTpkxrHouAfndZzXSkxMNOvoa+l6evP3OTkOHz5sukDpZ+PLWeYcWx2H849//MMrYGkXp5YtW5pAV5iy5fX+nNB6zTXXmBCjZdQudjrJwFlnnWVuABAMBAsACCI9G1+nTh0zXqCw16lwztR70kp1Wlqaqaz62rdvn/sstoYP5TvmQiul6enpfl9Ptw+0TCuizngBfR/OzRno7I+WpUyZMu6Kq54N12CgN91WBxU7tOWjQoUK7kq13msrhA6EPpH92RxnbQHRGbv0miPO6ziv5bzvRx991KynNx0zEYg+ryEwr2Pr2fKgrQU6EH3FihXy3XffmbEbni0IBS1bXu/Pcfvtt5vvkraK6OB1HbNCawWAYCJYAEAQaXchna1HK4ue3U5OlHZ30cqjnrH29Pnnn5sz+k53GJ2hSM9or1+/3mu9hQsXBty3zhakFVRP2h2pUaNGZgaqwurWrZscPXrU70xHvjRU6Bl0DSraNWjdunW5KrmF2Z/tZ6bdo3RAvA6Mzms97T6m3c90sHagdS655BL54IMPTKjzpDNuaUuDdmvy7B6loVBbKvSmocRzQHZBy1YQrVq1MoPA9Xupg7Z9XwsArFmP0gAA5DJixAhXbGys64477nCtWbPGdfjwYVdGRoZr3bp1riFDhpiBtOPGjfMavH322Wfn2o8OZD7vvPNc1atXN4OZ09PTzcDtRo0auRo3buw1QLhfv35moPYHH3xg1lu4cKHrhhtuCDh4u1u3bq5//etfrp9//tksGzp0qFn++uuv5/uJBhowfc0117gqVarkmjlzphmUrO/522+/dd13332uBx980GtdHaiu+6hbt64ZEK3r+irI/go7eHvq1Km5ntu2bZurVq1artatW7s++eQTc/z27t3rWrp0qevKK690rV692qy3detWM8C8ZcuW5nPQ8vzwww+uu+66y7VkyRKzzjfffONKSEhwdezY0fXjjz+6Dhw44HriiSdcpUqVcg0bNizXaw8cONBVrlw5V+XKlV19+vQ54bI5g7d9B3l7ev755806euvdu3eexwsACotgAQBFZPny5a5evXqZinPp0qVNBf/UU0919ejRw/Xaa6+ZsJFfsFBakdRKf7169UzltGbNmiYQ+M5MpDMKaWUxKSnJvJaGCq34BgoWWsHWcujsUFq+0047rUChIq/KvM62NH36dNe5557rKl++vCsxMdFUwh955BFTwfbVrFkzsx8NRf4UZH/BCBbO8zpDUoMGDVzx8fGulJQUEw7efvttr1mkduzY4brppptMZb9MmTLmuE2ePNl19OhR9zoaLrp06WKOvXNsn3rqKVdOTk6u19V1ncr+hx9+eMJlK0iw0O+cBhhdb9myZXkeLwAorBj9j327BwCgpNAuVHoNhalTp8qQIUNCXRwUI+36VrduXTN2RWf/Kuy1VgAgL4yxAAAgSuggcR30rrNyESoABBvBAgCAKKAzQulVzPWq3nqFdwAINoIFAAARTqf31amLdarc119/3YQLAAg2xlgAAAAAsEaLBQAAAABrBAsAAAAA1krZ7yL6purTGTUSExOZUQMAAAARzeVySUZGhqSkpEhsbN5tEgSLQtJQoXOAAwAAANHil19+kTp16uS5DsGikLSlwjm4SUlJJ/7pAAAAAGEuPT3dnFR36sB5IVgUknNBIQ0VBAsAAABEg5i/6sB5YfA2AAAAAGsECwAAAADWCBYAAAAArDHGAgAAIIDs7GzJysri+CBixcfHS1xcXFD2RbAAAADwM3f/3r175eDBgxwbRLyKFStKzZo1ra/RRrAAAADw4YSK6tWrS7ly5bgoLiI2QB8+fFhSU1PN41q1alntj2ABAADg0/3JCRVVqlTh2CCilS1b1txruNDvvE23KAZvRwBX1vFQFwEAgIjhjKnQlgogGpT767tuO54oKMFCE85vv/0WjF2d8P727dsnv//+u0S61PRMmbp0k7lX6bPfla0NOph7230BAIC/2fY3B6Ltux6UYHHrrbfK/fffH4xdnfD++vTpIxMnTpRIl5pxVKYt22zuNUzsHzpB5FiWuT84a6Gs/OmAvLNml7nPznEVeF8AAACADcZYlFBx85bI/geeEPkrO7hcIr8OnSgvte0ki5u2MMtqJSfI2G7NpGNzu4E4AADAvttyTHzRVrsyMzNly5Yt0qxZM4mNpbc7il/siXY30q5K+riwDhw4INu3bze3jIyMQr/uH3/8IWlpaXmur6Pbdb1gvHY46rhprcSP+ztUKKcBa8SKReZ5tTctUwbOWi2L1+8JTUEBAIBVt+XCWL9+vZx++umSnp7OUUf4BwvtbqTdlM4//3xp2rSpDB48uNAv+Nhjj8nFF19sbjql1WmnnSYrV64s0Oued955Uq9ePTNDw7XXXitHjhzxWm/r1q3Stm1bqV+/vlSuXFm6d+9u0rvNa4djS4WGB398w4WTO8bN3yAZmVly+Nhxr1tmVnaxlRsAgGjk2225qMKFDrr96aefzL83btxoQsbOnTvNyVb9t04rqiddf/jhBzl06JA5warreTp27JhZ9/jx3JPC7Nixw0zBW1D6Gtu2bTMzbPnuN1CZHBqMNm3a5Pck8a5du8z78vTrr7+637vScmp5nX1pOfLjbxstn2PPnj2ye/fugNsfPXrUtBb5K7OeHNf3qzd9jZycnDxfXz+bX375xev1S4pCt5PNmzdPHnjgAfMhzpkzp9Av+O9//9vdaqAf3HXXXWdCgn4geXnjjTdk+PDhpqVk8+bN8uWXX5p9eZo/f7489NBDsn//fvOF0HX++9//Wr22Pqfret5CRX+MTEuFR4goSLjYm54pp49bIs3uf9/rdtWMkhWqAAAokaHCqR+6pMjChdZ97r33XvPvm2++WXr16iXTpk2T1atXm1aMUaNGSd26daVnz56yYcMGWbZsmZx77rm5TtDqup4B4oMPPpBGjRqZk8pnnnmmnHzyybJq1ao8y/LEE09I1apVzclevR85cqTXfgOVScNR//79pVq1anLZZZeZbbXu51kR1/eo23l69tlnTX3OMXnyZLnqqqukffv25kR48+bNpUWLFqb+F4huc+WVV5oy64lnXV/L+NVXX8mFF14orVq1Mvtq166d10lrpXVPnaa1ffv25sT1FVdc4TUJ0dKlS83noTfdv578fuGFF3K9vpa5S5cucsopp8gZZ5xhurTpZxLRwaJr165y+eWXW7+wplVNnHqQNQF+//33ea6vrQzXXHON+XfDhg3Nl3T69Ole6+gXU9dTtWvXlo4dO8o333xj9drjx4+X5ORk903/BwhV38z9I6eYf+c3bt95fvBnSyQuh1YJAABCHiqkaMNFSkqK+4Tv559/bs6OT5o0yf28npTVs+5a5/ENFIHoGXitbE+ZMsVsq8FAe5DoMn9n5pW+7tChQ+Xll182dS3dx0cffeR3Xd8yaSDRE9jfffed/Pzzz6ZXycyZM+XFF18s9PH4+uuv5dJLLzVl1pPhWvHXsudFA8/tt99uWgv0pu/xggsukBEjRpjH2qKgZfUsz9NPPy0vvfSSrFmzxpzU1tfTHjVDhgxxr6P1V6fFQt/X66+/bl5H379vmfWkt7bK6H60zGPHjpWIDhYnnXSS1QsuX77cpDBNa61btzaJVJOoHsS8aNr0pPvQNOiZCH0r/RUqVPBqYTiR1x49erQZ0+Hc9IsVCjrgq9qjw82/82sYc56f1qaDZMf+eZGTF286VzY8eLnX7Y0BrYu41AAARJ+AoUKKvuUikAcffFASEhIKtY32+tCz96eeeqrpNqWtCnpyWete2ivEHz0Tr2f3r776avNYu6/fc889BSrTjBkzTIVbW0XUWWedJf369TPLC6tGjRrmJLRzAbhHHnnEtBw43Y380TqinnRWejJZg0nLli2lR48e7vdy0UUXmRDhePzxx00Y0B4uGzduNPvXFgsNSL70oova7UtDoHbt/+STT7ye1xaSvn37mn+XKVPGBDjP1yoJCj09QalSJz6jgfaz04OkKe7uu++W0qVLm/52+oHrc3nR/nmenGaogv5PcqKvrR+s3sJBUp8usuvgYdMdyhWg5cL5DZv81+xQuk7N5ARp26SaxMV6b5EQf+JXVgQAACcQKjz+YJv1/vr7XtS0t0dhaUX5xx9/NF10fE8yB2qx0LEO2oXHkwaT/MqkdTHtquR7Ilkr29r6UVgaTjyvIK0BSWkLio7F9Ue7MfleNM7fMue9a9ct3d8rr7wib7/9ttd6Ghx0PT3JrYHshhtuMPe6P6276olq3xPbGjg8lS9fvsRNNlSs081qc5em3N69e5uKvfr000/9DhLypet50pTXuHHjAl8V0+a1w0l2jw7m2hP+BnD7CxVKp5z1DRUAACC43N2WCzrmVsPFyCmSeM3lRT4VrWclO9AF0XzrRFpf0vEFOoa1oLRe5ju5ju9jf2XSf2uF23dd7b6uFezClNvfa+p+lOe+bGmZ9abXXtOWlUC0C5YGpBUrVrhPiGvriL9B3CVdsU5yrCmtTp06ZpCL9lFbsGCB3HTTTQW62p82HWnz2Nq1a01fNu3vF6hpLdivHW40NGSNu9OrycI3VMhfLRXT+7bkOhYAABRnt+WCVi1ixKwfrFDhVFr1THp+dIC0zsTkOYW/jjHwpKHi448/ltTUVK/l2roQqFKsA7x9T9xqV/SC0K5POqjckw4e1+We5fadncm33GrdunVmbIXjww8/NMdHB0YHi14rRMdg6JiJvHra/PDDD9K5c2f356NjT7QlKBIV6ptcs2ZNqVSpUq7lOrhE+53lR1PdwoULTSDQbkla2deAMGbMGK+WB3/7u+OOO0xyvuWWW8yXVa+yrcEgr7LpPpwPtqCvXZJaLqpVLOdubtV8VOWxu+WG1q2lU0amVE9MkFYNK9NSAQBAMXK6NeXbHUpDxdRRQe0GpV18tIu3noDVsRD+6mwOrazrRDeDBg0yN53e1ZlVyqEzNOlAZZ3taNy4cabupBX2J5980vQcqVixYq796jY6w9H1118vt912m6lAa53NvOV8TubqmIsOHTqYrlY6vkFPAi9evNjr0gA6iZDW3/7zn//I2WefLe+++665aYuAJ60rahcuHfysAePOO+80dUl/Zbbx6KOPmrJqV6cbb7zRTBGrx0YHoL/11ltmnTZt2piB9Fq/1TCnddFIbK0odLCYNWuW3+XPPPNMgfeh03fpF8CTVvTz25+mvAkTJhSqbDotbmFfO9xVTywjg9s1MffuH6+RU8wZD33c+gT3BQAAiilcFEGoUImJiTJ79mwza6aOS9BwoV3AdXyB75W4NYBopV0Dg16XTNfRbbTyHR8f7+42pK0PU6dONTdtCdEWiblz5wasoOugZ23l0O5Bw4YNMy0EGgJ0ULS+prNff2XSmT3fe+89MzvUm2++KQ0aNDAtDTqA2qGDp7WcOkhcWwouueQSUzbfgdA6LawGC634a1d4DU++09R60tDkO25Exzz4diHT3i+eY3N1Gl6dzUnLMHLkSHNc/vGPf5hw5zkdrp7I1qlzk5KSTA8cLa8GjbxeXycbcgaylxQxriBefUPToe9FS3w/jBMZ/K2zN51zzjl5BoviorNM6f802nSoX45w6dNZ1H0zAQCIFjpBjE4dqoOLCzuTUr4DuYsoVIQTrQ961vd0Slbtil6YC+zZ0OlhdWpXDU6w/84Xpu4b1Nqojm53riPhj/axCzQS/0S6YOFPhAoAAEpAy0UUhAqlXYK0+5S2Vuj1xLSLlc7IicgX1GChoSGvqxqeqEBdsAAAAMKZv27LkU5bJ/S6EdolS68noV2htEtWcfHXrQglsCtUNAjHrlAAACD8ukJ5otsyoqErVLFONwsAABCN6LaMaECwAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAllLTM2Xq0k3mvii3iTQbNmyQOnXqyO+//15krzFp0iQZOXKkRKutW7fKmWeeWSzX9iBYAAAAWErNOCrTlm02956yc1yy8qcD8s6aXeZeH+e3TTj77rvvTBDQaxsEw7Fjx2TXrl2SnZ0tRWHPnj3y8MMPy2233eZetnbtWrn66qvl1FNPlbPPPlsee+wxCXRZN72+w0UXXWTe848//uheruUdNWqUnHbaaXLdddfJgQMHvLabNm1avmFm586dZr8rV67M9Zzu8/bbb8+1rt7q1q1rrmp+2WWXyYMPPmjeY177bdSokVl//PjxUtQIFgAAAEVg8fo9cuHED+W6mV/I4DlrzL0+1uUllRMEcnJygrI/rZj/8ssvUrlyZSkKTz/9tAkGDRo0MI81HLRp08ZcnfvNN9+UiRMnmiuEjxkzxu/2w4cPN6FD33NWVpZ7+QsvvCCLFy+W1157TeLi4mTo0KHu5/RCcxpW8gsWx48fN/s9ejR3sNy/f79XWHHWnTp1qgkMCxYskDvvvFM+//xzE5BWrFiR535vvfVWcwX0w4cPS1EiWAAAAASZhoeBs1bLnjTvbk570zLN8qIIF1999ZU5U/3+++9Lx44dpWnTpnLFFVeYrjCetHJ97bXXSuPGjaVly5YyYcIErxYDrZg+8MADcs4555iK/y233CJ79+41Z8K7dOli1tHl+lrOWfV9+/aZVgGt5Gq3m8GDB8vBgwdzlW3p0qVy8cUXm4q+VpA3b94s559/vrmqc0HLF2hf/rzyyity5ZVXuh/PmjVLqlSpYloUmjVrZs766/4nT57sVQb19ttvy/Lly/2e6dfXvvnmm+WMM86Qu+66yzx29O/fX/79739L1apVJdiqVatm3nuTJk2ke/fuJtzoe+jTp48JfYHocVILFy6UokSwAAAACJLMrGzJyMySsfO/F3+da5xl4+ZvkENHjwf1uOsZaj1TrWenhwwZIq+//ro5296hQwf32XatPOsZ/NKlS5sz9hogHn/8cbn33nvd+5kyZYqpkOv9W2+9JRdccIGMGzfOnOXXM/VKK9JffPGFPPTQQ6Zb1IUXXmhaMebMmSMvvvii7NixQ7p27eruYuSUTQPHfffdZ86wa2jw7QpVkPIF2pev7du3y88//yznnnuue5mesa9QoYLExMS4lyUlJZl96vtx6HYalGbPni0JCQm59q3lLlOmjPl32bJl3a0DL730ksTGxkrfvn2luGiw0VafTz/9NOA6WqZWrVrJxx9/XKRlIVgAAAAEyVUzVsrp45bIvvTA4ya0qr03PVOufebvimww6dl3bbHQloOXX37ZdKv53//+Z57Tbj9aaX/++eelRYsW0q1bNxMgtPLunLFft26dOQv+j3/8Q04++WS56aabTDca7fJTvXp1s05KSoo5c65dmGbOnCmJiYkyY8YMs099Xa2Qf/nll6Z1wdNTTz1l9q3jBJyKuaeClK+g+9JwozQQOfS4bNy40XRhUhqKdHC30hYZpSGnd+/eMmLECFMGf3Rsxvz5801w0gCkrTv79++X+++/3xwrHfvQvHlz01qirT150fEezvgJ55ZXSPB1+umnm/tNmzbluZ4eBw1bRYlgAQAAEEG09cDzbLxWjnXQtTNwuXXr1hIfH+/VTUbPuDuDk7UyrIFEWz60O5BW6PWMdyDaz18rtdolqX79+lKvXj0zWFgr6Fu2bPFa11/LgqeClK+g+9IuXapUqVLuZe3btzeBRFs7kpOTTShp166deX9O64q2kmgrxbBhwwLue9CgQSaU6PH973//a8LP4MGDTUvR119/La+++qoJV9p1yXMQtj8aRLS1xPPm2cqSH+f95TcAXtdzjklRIVgAAAAEyRsDWsuLNxWsUjiuW7MiOe56xt/3sdNVR+99z+47j511NFhoS4O2SmhLQc2aNeXRRx8N+Ho6c9Kll15qzrJ/9tlnJmjomAdtMejRo4fXuv66FXkqSPkKui+npSI1NdVruXZx0mU6yFpbGbSM2o1LA5HSlohvv/3WhA5tPXDGlWjriBM2KlasKJ988onpkqWtANoVacuWLWZA9ZIlS+SGG24wgU4HcOvjgoyb8Lz5a4EJxBlDo+XNi75Xz9abokCwAAAACJKE+Dhp26Sa1EpOkL978XvT5fr8WfUqFclx165MDj1DrdeK0MG+Srs2aauAJ61EK2cdZ3C2jqvQwcvaLWn06NFy6NAh0x1KeU7PquvqPmvUqJGrglyuXLlClb2g5SsIbTXRALB69Wq/z2s3Lmcsh7Ze6GxRSoOAlsFpPXDGlWgLhO/sUdpiodeH0EAxc+ZMc3w8w5GOv9DxLYGmsw0GLZ+OG9Gua3nR4+C8x6JCsAAAAAiiuNgYGftXa4RvuHAe6/O6XlHQEKBTlWrXGO3rr4FAxwwo7d6k3ZaeeOIJc5Zez9zr+tdcc41pmTBlGzvWDIjW7bVCrGfjdQyFthBoK4by7JY0cOBAc4E77fLjXIRNt9GuQYW98F1ByldQ2r1JW18WLVrktfyee+6RjIwM82+dQUtnfdJB6OXLlzfLdByJZzhyxpVocKpUKXcY1IHlOk6ixV/jMXT8hU4Hq8dPQ4t22fIcLB4s2gKhn692w9JxIhqOAlm/fr2ZuUtnkipKBAsAAIAg69i8lkzv21JqJnt319HHulyfLyqdO3c2U83q2fRnn33WDNx2rhPRsGFD81gro/q8U3nWfv6Oyy+/3My2pGf79aYtFnPnzjVn47VyrYFBxz3Url3bhAnd57Jly0xLibONzuykLQx5VXb9KUj5CkPLqjNbeQ781nCkF43TkNCvXz9TKb/jjjtOaP+rVq0y4UTDmEOn59XxDHocdCpbndo2WJyB3jqV7UknnWS6nWlwGjBgQJ7b6WfYq1evQoezwopxFWXbTATSgTr6P4l+QfULDwAAIouOGdD+91rJza8fv2P9rjTp+uSnsvCOC6V57b8r03ql7S+3/SapGZlSPTFBWjWs7G6pCLTNidIxDm3btpUjR46YcmurhVaeAw28/vXXX01XpUDdlXQ/etZdu9n40u49esZcX8fz4nbaOqLdr3wDhU7Pqq0PWin23Y+eSdfKvm85A5Uv0L4C+de//mUCkV5bwqGtIdqaomXPrzXBKaNWyj0HgiutD+r2/uqEGRkZuaa29aTHVq+arWMsfMdU6HvX4+EcW2ddpfvTLlb62frbt+9+dVYqnTlKu0IFGoeR13e+MHVfgkUhESwAAIhsJxIsUtMzZfaqn6XPefWkelLRbVOYYIE/6ZgHrRQ7XZqizZEjR0wXNQ0agQQrWHjHLgAAABSaBoOh7ZsW+TYoPD1rH62hQmnrht6KA2MsAAAAIoBeWVkHTdNagVAhWAAAAEQAnTq1oOMOgKJAsAAAAABgjWABAADgBxNnIlq4gjRJLMECAADAQ3x8vLk/fPgwxwVR4fBf33Xnu3+imBUKAADAg14ITi9uptdKUHodhaK4cjIQDi0VGir0u67fef3u2yBYAAAA+HCuUOyECyCSVaxYMShX5SZYAAAA+NAWilq1apnrH+iVl4FIFR8fb91S4SBYAAAABKAVrmBVuoBIx+BtAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAAhjrqzjUhJERLC4/vrrZdSoUaEuBgAAiACp6Zkydekmcw+E+ruXPvtd2dqgg7kPdxERLNLT0+WPP/4IdTEAAEAESM04KtOWbTb38C87xyUrfzog76zZZe71MYL/3dMwsX/oBJFjWeY+3MNFqVAXAAAAACXH4vV75IEFG2RP2t9n1WslJ8jYbs2kY/NaIS1bJEl3QoWT2Vzy52MRSerTRaK2xWLlypVy+eWXS/369aV169by/PPPez3/yiuvyAUXXCB169aVzp07y7p169zPjRgxQqpWrWpuJ598stxwww2ye/fufF/z5ZdflvPPP1/q1KkjF110kcybN8/r+Z49e8rdd98tgwYNkkaNGkmPHj2C+I4BAAAiM1QMnLXaK1SovWmZZrk+D3tx85Z4hwrxDhfh2nJR5C0WR44ckU6dOsmwYcNk5syZkpqaKs8884yceeaZ0rJlS5k8ebI8+OCDMnXqVLnkkkvkxx9/lAkTJsjs2bPN9g888IB7/MS+ffvMut27d5evvvpKYmJi/L7m448/LtOmTZOnn35amjdvbta98cYbzT67dPkz4aWlpcmkSZPkoYcekg8//FAqVapU1IcCAACUIJlZ2XL4WMkYNFsctLvT2Pnf56rrKl2mtbJx8zdIm8ZVJS7Wfx0N+X/nOm5aK/HPLQq8Uhi3XMS4XK4i7RS3ZcsWadKkiezatUtSUlLcy/Vljx07JtWqVTOV+8GDB3s9Fyg0HDp0SJKSkuS7776T0047zSzT1gZtmXjqqafMPqtXr+4VItSYMWNMwFi8eLF5fNlll0l2drZ89NFHeZb/6NGj5uY5nkNbVjSYaDkAAEBkWb8rTbo++Wmoi4Eo1HHTWhmx4s9QkW80ixGpNnVUkYcLrfsmJycXqO5b5F2htJuRdn+69NJLZfz48fLFF19ITk6OCQ4bN26UjIwMU8n35Bkqtm/fLv369ZNmzZqZwKDdqXT7HTt2+H093ae+cW2hqFmzptSoUcNsp60YP/30k9e62mqSHy2zHkznpqECAAAACKa4nGwZ/NkS8+8Ctfdoy8XIKWE1FW2Rd4WKjY2V5cuXy/z582Xp0qVy7bXXStmyZWXRokVy/PifByI+Pj7g9tqNSgOAjsPQFo9SpUpJ7dq1TcuEP1lZWeZeX09bSjzFxcV5PS5Tpky+5R89erTpxuXbYgEAACLbGwNaS7MUeic4vtz2m9z4wlf5HrcXbzpXWjWsXMSfTmTaUidT4h960t21LN8Wi0eHS0x8+MzFVCwl0eCgg6X1pmHinHPOkenTp5vuSfrcqlWrpGnTprm200HaP/zwg1dI+P77793hwR/dj+5zzZo1pqXEloaPggQQAAAQWRLi46Rc6fCptIVa2ybVzOxPOlDbXz96rQjXTE4w6zHG4sTE9rxcJn+8xd0dKtTdoAqryLtCffPNN3LvvfeaMRZqz5498ttvv0mtWrUkMTFRBgwYIPfcc4+ZOUrHVmjXJ32sqlSpIuXLl3fP6KRBQ9fPi/b90pme7r//ftNCot2m9BoXc+fONd2hAAAAUHgaFnRKWfFzNt15rM8TKuwsbtpCssbdGbjJIkxDRbEECx1greHgvPPOkwoVKphZmrp162Yq/2rKlCnSu3dv0+WpXLlyZryF09KgLQUvvfSSWUefO/XUU83UsfrvvOhsT3fccYf07dvXrKsDu9966y0zmxQAAABOjF6nYnrflqZlwpM+1uVcxyI4snt0MOHBX4IL11BRLLNCeTp8+HDAUKDF0Oc1hPijg7z1OR2zceDAAdPaUbp0afdzutzftvqcrutLx0roeI38QorNyHgAAFByZ4VaeMeF0rx2cqiLE7ZTz+qYi9SMTKmemGDGVNBSEfzvntdF8kIUKgpT9y3WjoN5VeJ1JqhAoUJ5hgPtIhXouby280QoAAAA/lRPLCOD2zUx9/BPQ0Trk7zrYwj+d88JETr7kw7UDteWipC0WEQCWiwAAABQnFxZx0M2+1NYXccCAAAAwIkLpyll80KwAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAQNC5so5zVAEgyhAsACBMpaZnytSlm8x9SZI++13Z2qCDuQ+2knpMACAaECwAIEylZhyVacs2m/twkJ3jkpU/HZB31uwy9/rYl4aJ/UMniBzLMvfBDhfhdkwAAH8r5fFvAAD8Wrx+jzywYIPsSfu7paBWcoKM7dZMOjav5R0qnLzhkj8fi0hSny4cWQCIcFHVYjFkyBCpUKGCudWvX1+uvfZa2bFjR6iLBQBhHyoGzlrtFSrU3rRMs1yfzxUqxDtcFEW3KABAeImqFouJEyfKww8/bP69b98+GTdunPzzn/+U1atXS2xsVGUsACVIZla2HD4WmsHQ2t1p7Pzvc+UFpctiROSjR2ZJkw/m5w4VPuHiWHa2lOvV2fpYAADCU1QFizJlypib0laLZ555RhITE2XDhg3SvHlzv9scPXrU3Bzp6enFVl4AUFfNWBm2B+LyTWvllhWL3CEjEJdL5ODwSXLfvPWyuGmLYiwhAKC4RNVp+i1btkjv3r2lUaNGkpSUJNWqVZPs7Ow8u0ONHz9ekpOT3be6desWa5kBIFzF5WTL4M+WmH/nFSo8n9f1dTsAQOSJqhaLTp06yQUXXCALFiyQlJQUKVWqlFSpUkWysrICbjN69GgZNmyYV4sF4QJAcXpjQGtplpIUkoP+5bbf5MYXvvL7XHZsnExr00FGFKDFQsXEiFSbNEzWWXSH2rA7PaxbcAAgmkVNsNi1a5dpsVi0aJE0btzYLPvuu+/yDBW+3acAIBQS4uOkXOnQ/Fy3bVLNzP6kA7X9DaF4v2kLSS4bL7cuzWOMhdJQMXWU9exQeiwAAOEparpCabcnHU8xZ84c0/1p27Ztcuutt4a6WAAQ1uJiY8yUsuKnRcJ5fMnoviY0BGyyCFKoAACEt6gJFqVLl5bZs2fLzJkzTQvEueeeK126dJHy5cuHumgAENb0OhXT+7aUmskJXsv1sS7X5zU0+A0XhAoAiBpR0xVKdevWzdy0+1N8fLxZpuMnEhK8/1gCALxpeGjfrKYZc5GakSnVExOkVcPKpkXD4bRIuK9nQagAgKgSVcHC4YQKRYsFgHBVPbGMDG7XxNyHAw0RrU+qkuc67nAxcopUe3R40Ls/hdsxAQD8Lcbl0tnFUVA6K5ROO5uWlmamrAUA5ObKOi4x8VF57goAorbuGzVjLAAAxYdQAQDRh2ABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAADBAgAAAEDo0WIBAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgghV9Zxjj8AAIgIBAsgiFLTM2Xq0k3mPj/ps9+VrQ06mPtg7hcAACAUCBZAEKVmHJVpyzab+7wcnLVQUodMENexLHOvj4OxXwAAgFAhWADF7PNHZ8uvQyeaf8f8tUwf63IAAICSqpREmXXr1snAgQNzLT/rrLPkySefDEmZED00PFSfNMMrVOi9S8Qs/1xELhjZJ6RlBAAAOBFRFyzq168vEyZMcD/OyMiQPn36SNOmTUNaLkSWzKxsOXzMe2D2H6++lytUiJ9wkVo9USr07pxrfwAAAOEs6oJFUlKSXHjhhebfLpdLevToISkpKTJt2jS/6x89etTcHOnp6cVWVpRcV81Y6fW446a1MmLFIr+hwjdcpN81Se6fv14WN21RDCUFAAAIjqgeYzFmzBj59NNP5Z133pHExES/64wfP16Sk5Pdt7p16xZ7OVGyxeVky+DPluQZKhzO87q+bgcAAFBSRF2LhWPu3LkyceJEWbx4sZx00kkB1xs9erQMGzbMq8WCcIH8vDGgtTRLSXI/Ptxc5ODwSaZFIq9woc+rapOGybpef3eH2rA7PVcrCAAAQDiJymCxdu1aufHGG2XKlCnSrl27PNctU6aMuQGFkRAfJ+VK//2/V7nru0up2Fgz+1OgcOGEiqpT75aKfbvm2h8AAEA4i7quUL/++qv885//lF69esmdd94Z6uIgimhYSL1rgFeIcDiP9XnfUAEAAFASRF2LhY6n2LFjh5l21hnErZhuFsVBp5L9/K/Zn5yWC89QwVSzAACgpIq6YNG1a1dZsWJFruU6MBsoDhoeDqYku7tFOd2fGtNSAQAASrCoCxY1atQwN6AoVE8sI4PbNTH3edHuTrExMbJ/5BSp9uhwSerTJSj7BQAACJUYl17MAQWms0Jp60ZaWpq5JgZgw5V1XGLioy7fAwCACKz7Rt3gbSCcECoAAECkIFgAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGsECAAAAgDWCBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAIFgAAAAACD1aLAAAAABYI1gAAAAAsEawQEi4so5z5AEAACIIwQKFlpqeKVOXbjL3JyJ99ruytUEHc1+UrwMAAIDiE9XBYsaMGfLmm2+GuhglTmrGUZm2bLO5z092jktW/nRA3lmzy9wfnLVQ9g+dIHIsy9znFS4K8zoAAAAIrVISxRYuXCiNGzeWnj17hrooEWnx+j3ywIINsiftzxaHjpvWyogVi8y/Y/Q/LvkzZIhIUp8uoSwqAAAALEVtsJg1a5Z8//33snPnThk0aJBZNmbMGKlRo0aoixYxoWLgrNWaHfyHCgfhAgAAICJEbbCoVauWlC9fXipVqiSnnHKKWVamTJlQF6tEyczKlsPHjvvt/jR2/vf5hwqfcHEsO1vK9erstX8AAACUDFEbLNq1aycNGjQwXaGcFgt/jh49am6O9PT0Yiph+Ltqxsp818k3VPzF5RI5OHyS3DdvvSxu2iKIpQQAAEBxiOrB2wUxfvx4SU5Odt/q1q0b6iKVGHE52TL4syX5hgrP53V93Q4AAAAlS9S2WBTU6NGjZdiwYV4tFoSLP70xoLU0S0nKdcy+3Pab3PjCV5IdGyfT2nQwLRaugoSLGJFqk4bJur+6Q23YnV6gVhEAAACEXlQHixityeZDx10w9sK/hPg4KVc691eobZNqUis5QfamZbq7NeUbLjRUTB3lNTuU7h8AAAAlQ1R3hdKB2wcPHgx1MSJOXGyMjO3WzPxbg4SGi8ltO5nHzoDu/EIFAAAASpaoDhZdunSRuXPnyo033mgGcO/bty/URYoYHZvXkul9W0rN5ATzOGC4IFQAAABEhKjuCnXttddK06ZNZc2aNXLo0CG6PBVBuGjfrKYZc5GakSnVE8+XqivPkAPDJv6ZLggVAAAAESOqg4U666yzzA0FVz2xjAxu18TcF6RbVOuTqvy94KSuEhsTI/tHTpFqjw7Ps/tTYV4HAAAAoRXjcukVBFBQOiuUTjublpYmSUm5Z0RCwbiyjktMfNTnWgAAgIip+0b1GAuEDqECAAAgshAsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIAAACANYIFAAAAAGsECwAAAADWCBYAAAAArBEsAAAAAFgjWAAAAACwRrAAAAAAYI1gAQAAAMAawQIRzZV1PNRFAAAAiAphFyx++eUX2b9/f6iLgTCWmp4pU5duMvd5SZ/9rmxt0MHcl8TyAwAAlCQhDRY7d+6U1NRUr2U33XSTTJkypUj2jciQmnFUpi3bbO4D0TCxf+gEkWNZ5r6g4SI7xyUrfzog76zZZe71cSjKDwAAUNKUCuWLDxgwQBo3biyPP/54ido3wps7VDiZwCV/PhaRpD5dAm63eP0eeWDBBtmT9ndLQq3kBBnbrZl0bF6ryMsNAABQkoWsxWLPnj1y6NAh+f333+WHH34wt2PHjnmto88dOHAg4D4OHz4s27dvl+PHjxdo3/v27XM/prtVlIQK8Q4XgVouNFQMnLXaK1SovWmZZrk+DwAAgDBssXjiiSfkq6++krVr18qqVavMskWLFpn7TZs2SatWrWT37t0mWLRt21bmzZsn5cqVM89nZmbKnXfeKa+++qpUrlzZrDNw4ECZOHGixMXFBdz3Sy+9JHPmzDGPtZtUpUqV5IUXXpCLLrooVIcBFjKzsuXwsb9D5eE570naiEm5Q4VPuDiWnS3lenV2L9buTmPnf+93M10WIyLj5m+QNo2rSlysPrIvNwAAQKSJcblcwe9EXkBdu3bN1V3psssuk88//1yWLVsmrVu3Nq0MLVu2lOHDh8uwYcPc3Zw2b94s//vf/6Rq1apmPMUll1wigwYNksGDBwfctyd92zqWY+rUqbJlyxYpW7as3/WOHj1qbo709HSpW7eupKWlSVJSUpCPCApi/a406frkp17LOm5aKyNW/BlM86r6O1/2yW07yeKmLUJ6wBfecaE0r50c0jIAAADkReu+ycnJBar7ht2sUKpnz54mVKgaNWpI+/bt5dtvv3W/ueeee05uueUWOXjwoAkY2iWqe/fu8tZbbxVo/7/99pvZrmPHjia4bNiwIeC648ePNwfTuWmoQHiJy8mWwZ8tMf/Orz3BeV7X1+0AAAAQAYO3A6ldu7bX4woVKphWCaeblI6pGDNmjOn25Cm/Sv8HH3wgt912mxmDUb16dYmPj5ecnBzZtWuXnH322X63GT16tLulxLPFAqH3xoDW0izlz+R8uLnk3Q3KQ0yMSLVJw2TdX92hvtz2m9z4wlf5bvfiTedKq4aVrcu9YXe6XDVjpfV+AAAAwklYBou8aBhQ2g1Ku0gVVHZ2tlx99dUyatQoGTFihAklWVlZpguUhotAypQpY24IPwnxcVKu9J9f4XLXd5fScXH+B2570lAxdZTX7FBtm1Qzsz/pQG1XgFaOmskJZr1gjLHQcgMAAESakHaFSkhIMJX7wmjWrJkZsP3GG2/kes5zX7771lYK7Tql3ayclo7ly5ebwIHIoGFBQ0PA/lB+QoXSsKBTyv61iu8mhj4fjFABAAAQqULaYnHKKafI/Pnz5euvvzbdnRo1alSgFotJkyaZWaD03126dDHTyr733ntm1igdE+Fv3w0aNJD69evL/fffbwaCb9261dzHaL8YRAwnNORquQgQKhx6nYrpfVvmuo6FtlRwHQsAAIAwDxZDhw6VvXv3Sv/+/c11J3RK2Hr16pnxD55q1qzp9bhfv35mvenTp5tpaFNSUswsULfeemue+9bwoWMzdPtatWqZ7TVoJCYmFtt7RgjCRT6hwjNctG9W04y5SM3IlOqJCWZMBS0VAAAAYT7dbKRPuYWikZqeKbNX/Sx9zqsn1ZMS8r5Y3sgpUu3R4fmGinAsPwAAQEmq+xIsivDgIvRcWcclJr7EzVEAAAAQFkr8dSyAYCFUAAAAFA+CBQAAAABrBAsAAAAA1ggWAAAAAKwRLAAAAABYI1gAAAAAsEawAAAAAGCNYAEAAADAGlcOKyTnQuV6sRAAAAAgkqX/Ved16sB5IVgUUkZGhrmvW7fuiXw2AAAAQImsA+sVuPMS4ypI/IBbTk6O7N69WxITEyUmJqbQiU8DyS+//JLvJdER+fg+gO8C+F0AfyMQ7vUFjQoaKlJSUiQ2Nu9RFLRYFJIe0Dp16th8PuZLQbAA3wfw2wD+ToA6A0pC/TG/lgoHg7cBAAAAWCNYAAAAALBGsChGZcqUkbFjx5p7gO8D+G0AfydAnQGRVF9g8DYAAAAAa7RYAAAAALBGsAAAAABgjWABAAAAwBrXsQiy33//XT7//HMpVaqUXHjhhVK+fPki2Qbh748//pDPPvtMjh8/Lm3atJGKFSvmuf78+fPl8OHDXsuaNWsmZ5xxRhGXFMVxcaHly5fL3r17pWfPnhIfH5/vNkePHpVPP/1UDh06JOedd57UqFGDDypCrFq1SrZt2yadOnXKd254/Q3Ri2J5ql69ulx66aVFXEoUNf3bv3r1anOx3RYtWkiVKlUK9Fvy5Zdfyp49e8zfh6ZNm/JBRUh94ZtvvjG/+/o3v2bNmnmu/+OPP8q3337rtSwuLk6uvvpqCTWCRRAtXLhQevfuLc2bNzcVRP0fX5ede+65Qd0G4e+LL76Qbt26mYspJiQkyIYNG2TOnDmmIhHIbbfdJrVr15aGDRt6/REhWJRszz//vEyYMMF8llu2bDGVifxC5qZNm6RDhw5StmxZU4n8+uuvZfr06XL99dcXW7kRfPPmzZNx48aZsKjfhXXr1uUbLKZOnSpr1qyRc845x71MK5QEi5LtzjvvlDfffNN8llqZ1IAxefJkGTBgQMBt9MrHXbp0Md8drTPoCclbbrnFfEdQcj388MMyY8YMOemkk6R06dLmZMLdd99tZoEKZMGCBfLvf/9bLr/8cvcy3TYcgoX+sUMQpKWluSpVquQaO3ase1nfvn1dTZs2deXk5ARtG4S/48ePuxo1auS6+eab3cvuvvtuV9WqVV1//PFHwO1q167teuGFF4qplCguzz33nGvTpk2uBQsWuPQn9/fff893mzZt2rg6derkys7ONo+ffPJJV0JCgmvnzp3FUGIUlTlz5ri+/fZbc9Pvwrp16/LdpmfPnq7+/fvzoUSY6dOnuzIzM92Pn3/+eVdsbKz5rQhk+PDhroYNG7oOHDhgHq9atcpss3DhwmIpM4rGs88+60pPT3c/XrJkifl9WL58ecBtJk2a5GrRokVYfiSMsQiS9957T9LT081ZCMewYcPMmUdttgzWNgh/K1eulK1bt5rP0jFkyBD57bffZPHixXluq5+9ntXUJtGsrKxiKC2KWr9+/aRJkyYFXn/79u3mjJV+Z2Jj//yJ1rOS2n3qjTfeKMKSoqhde+21cuaZZxZ6u9TUVPO7oN8LPWuNkk9bJjyvSaBdJHNyckwrViCzZs2SG2+8USpXrmwet2rVynSf1uUouW6++WZJTEx0P27fvr15rC2VeTly5IipR37wwQfmNyJcECyCRH8MUlJS3P/Dq9NPP930nQz0Q3Ei2yD86WenfR1PPfVU9zLtL1mtWrV8P1etOD777LPSvXt30wVq7dq1xVBihBPnO6JdHRxaAdG+1PwuRCft8jJz5kwTMLWr5FtvvRXqIiHItHKoTjvtNL/P79+/X/bt2+f1u+DUGfhdiCxffvmlOYHg+1n70q7zjz/+uIwZM0bq1atnulSFA8ZYBElaWppXQDAHt1QpkzoPHjwYtG0Q/vRz1T70GhA96cC8vD5XrTg4YzAyMzPlqquuMmc4169fb74XiJ7vj/L9bcjv+4PIPbP92muvuQf833ffffJ///d/cvbZZ0v9+vVDXTwEwc6dO+X22283rZsnn3yy33X4XYgOBw8elBtuuMGMsctrHFXbtm1N67bzd0Inf+nRo4eZBEDHd4YSLRZBomcUdVS/Jx2sqQOydfBusLZB+NPPVQdn+tLPOq/P1XNgt6537733mpkftHsUoofTPcL3tyG/7w8i02WXXeY1i9j9999vukkuW7YspOVCcGgrhHZ90Rbq//znPwHX43ch8v3xxx9mcH65cuXkf//7X57r6kyBnieftJeDTvqjg7pDjWARJDqaX5ulPPvF79q1y0w12qhRo6Btg/Cnn6u2OHj2edTH+gekMJ9rUlKSuwkc0fX9UT///LPXcn3M7wJ05hcNmPwulHz6N0LPSuvsgTqGxnPMhS/tNq2fu+/vwo4dO/hdiJBQ0alTJzNuYunSpfnOHBiozhAOvwsEiyDp2LGjqTzqQBqHJs4KFSrIRRdd5G6N0ClHN2/eXOBtUPJcfPHF5ozD3Llz3cveeecdExj1M/dc9t1335l///rrr+Z5T9qPWv/QMN1s5FuyZImZoljp4F6tRHh+f3TQrnaX0LNZiGx67ZIPP/zQ/Fv/Pvh2f9NKh/a/Zkrykk0rgBoq9P917caiU0v70ilo3333XfNvHbenU4t6/i7od0N/O/hdKNkOHToknTt3Nvc61sa3G6zauHGj12evJ6U97d6921wfJxx+F+i4HSR6JlFncdE+kjr/sHZn0rnrdV5qDQoqOztbrrvuOnnyySfNLDEF2QYlj5410EFUd911lxw4cMCEA/1cR4wYYQZYOfr3729m+NDgoNe5GDx4sFxxxRXmWhY6WFNn+pg0aZJUqlQppO8HdvQiRp4XM9LAqMFT+8jqZ63uueceOeWUU+T88883M0HpvPR9+vQxvxm1atWSKVOmmMfa/I2Sy/ke6FlmpbPE6RgqHS/hzBymv/9aYdRKp1Y0dNYf7eagfe/1pNRTTz1lxlhwHYuSS08iaRc3vWDm8OHDzUkmh+d3Qa+Bo98RJzjodQtat25t6hH6+/Hiiy+acTa33npryN4L7F1xxRXmWkX6/74GRX8XyNXviF4Dx7lOhX4H9DdBvy96bSTtRqcTfAwaNCjkHwnBIoj0j79WDN5//30z2Fb7umnfSYdWGHQwrueVMvPbBiXT0KFDzaxQ2rytf0R0YLYOxvbkDLRS2kKlF0vSMKGhom7duuZsVaAZQlBy6IwtTquk/v/v/OFo3LixO1jomUg9c+m45pprTPeIV1991WyvQZWL45V8Ggz0N8H5LmhlQm96htKpTGqF0RmjpQP2dfpqrUDq70LVqlXl7bffNpVSlFx6wkD/PuhN//Z78vwuaKXRc+IO/XugwVT/nujZaf2bMnDgQL+tHSg56tata04efPLJJ17LPS+QqyFD/y44tGVD/z7o74J+/o888oj06tXLtGyFWoxezCLUhQAAAABQsjHGAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAACsESwAAAAAWCNYAAAAALBGsAAAAABgjWABAAAAwBrBAgAAAIA1ggUAAAAAawQLAAAAANYIFgAAAADE1v8DfMeb5cFj4xoAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAG4CAYAAADYN3EQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUNlJREFUeJzt3Xd4VNXe9vF7ElIIpEJCEhI6iKE3FQFFQDo8iCjN96ioKAIiRQ7oQVD0AEIELKDHggUUO4IIgqgUQUAQpNeAEBISWiYkpE32+wdmZEhnp+f7ua5czzN71l77N8M4Z9+z1trbYhiGIQAAAAAwwam4CwAAAABQ+hEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAA+ZaUlCSLxaKXXnqpuEspUbUAQHlGsACAQvLrr79q6NChqlWrltzd3eXn56emTZtq2LBhWr9+vQzDKO4SAQAoMAQLACgEkydPVocOHeTr66tly5bp4sWLOnHihObNm6dz586pY8eO2rdvX3GXCQBAgalQ3AUAQFnz7rvvaubMmXrttdc0evRo+/aKFSuqU6dO6tSpk/73v/+pQgW+ggEAZQcjFgBQgAzD0AsvvKB69epp1KhR2bYbPny4GjZsaH/cpUsXtW7dWn/99Zf69u0rLy8v9e7dW5J0+fJlTZgwQbVq1ZKrq6uqV6+uxx9/XOfOnbPv//vvv8tisejLL7/MdCwfHx898cQT9sfR0dGyWCyaN2+ePv/8czVs2FDu7u5q0qSJvvrqK1Ov32az6dVXX1WTJk3k7u4uX19f3XvvvTpy5IgkKSUlRf7+/howYECmfdPT01WjRg316tUrz/3lx7Wv+5tvvlHTpk3l6uqqpUuXSpJOnz6tRx55RMHBwXJ1dVXt2rU1ZcoUpaSkOPRz6tQpPfbYY6pRo4bc3d0VFhamOXPmOLTbtWuX+vbtK19fX7m7u6tp06ZauHCh/flvv/1WFotFy5Yty1TnTz/9JIvFok8//dS+LS+1zZkzRxaLRWfOnNGECRMUGBgoFxcXrVy5MtvPxtq1a2WxWPTJJ5/k+/0EgOsRLACgAO3bt0+nT59Wt27dZLFY8rVvUlKSRowYoYkTJyoiIkKDBw9WWlqaunXrpo8++khvvvmmzp07p08//VRr165V+/btFR8ff8O1/vzzz/rhhx+0Zs0aRUREqFOnTrrvvvv09ddf33CfgwcP1vTp0zVx4kRFRUVp586dMgxDt99+u06fPi1XV1c98MADWr58uWJjYx32XbNmjU6dOqVHHnkkz/3diF9++UUrVqzQ8uXLtWvXLgUFBenkyZNq3bq1Dhw4oOXLl+vixYt677339MEHH2jIkCH2fSMiItSqVSvt2LFDn3zyiWJjY/X1118rJiZG69evl3Q1VLRr105JSUn67bffFBkZqWHDhmn06NGaOHGiJKlXr14KCgrSe++9l6m+999/X76+vrrnnnskKc+1ZXjmmWfUuHFjHThwQG+++aZ69Oih2rVra8GCBZnaLliwQD4+Purfv/8NvZcA4MAAABSYlStXGpKMmTNn5mu/zp07G5KMX3/91WH7J598YkgyPvnkE4ftGzduNCQZM2bMMAzDMLZv325IMr744otMfXt7exuPP/64/XFUVJQhyWjQoIFhs9kc2rZu3dqoW7durvVeuXLFkGRMnz7dvi3jtS9atMihbUJCglGtWjVj5MiRhmEYxt69ew1JRnh4uEO7AQMGGP7+/kZKSkq++suqlqxkvO66detmet2DBw82fHx8jNjYWIfty5YtMyQZW7ZssddYuXJl4+zZs9kep2fPnoaPj48RFxfnsP3xxx83nJ2djRMnThiGYRiTJk0ynJ2djTNnztjbXLp0yahYsaIxatSofNc2e/ZsQ5IxZcqUTDXNmjXLkGQcOHDAvu306dOGs7Oz/X0EALMYsQCAAmTkcKWnwMBAWSwW+9+0adMcnq9SpYpuv/12h23r1q2TxWKx/3qdoX379qpWrZrWrVt3w7X26tVLTk6O/zPQr18/HTt2TCdPnpQkNW/e3KHmQYMGZdvfihUr5OTklOnXbw8PD7Vt29b+i36jRo1066236v3337e3OX/+vJYvX65//etfcnFxyVd/+dW7d+9Mr3vFihXq2LGjqlat6rC9c+fOkmQ/1qpVq9SlSxcFBARk2bdhGPrpp5/UpUsXeXl5OTw3YMAA2Ww2/fLLL5KkRx55RDabTR9++KG9zSeffKIrV644jNrktbYMffv2zVTXI488Ind3d4fpWG+//bZsNpvDsQDADIIFABSgmjVrSro6D/960dHRMgxDBw4cyHLf6tWrZ9p2/vx5eXt7y93dPdNzgYGBDussspNd2KlWrVq22/LS7/Wio6OVnp4uPz8/VahQQc7OznJycpKTk5OWLVum8+fP29s++uij2rdvn7Zu3SpJ+vjjj5WSkqJhw4bdUH/5cf37nJCQoMuXL+vbb7+1HyfjWJ6enpKu/jskJCQoISEhy3+nDImJiUpKSlJgYGCm5zK2Zby39erV05133ukQsN577z21bNlSzZs3z1dtOb0+6Wpovf/++/Xhhx8qMTFRaWlpevfdd9WiRQu1aNEit7cMAPKEYAEABahRo0YKCQnRmjVr8n2fioxf6q/l5+enuLg4JSUlZXru7Nmz9l+xvb29JSnTmovLly/LarVmebyzZ89mu61KlSqSrq4XMAzD/pex0DkrVatWlZubm/3E1WazKT09Xenp6TIMQ2fOnLG3HTRokCpXrmw/qX7//ffVtm1bhYWF3VB/+XH9++zh4aGKFStq6NCh9uNkHCvjdb/yyivy8PCQh4eHIiMjs+3bw8ND7u7uOb631448PPLIIzpy5Ig2btyoP//8Uzt27HAYQchrbTm9vgwjR45UXFycPvnkE33zzTeKiopitAJAgSJYAEABslgsmjJlio4cOeIw7eRGde7cWYZh6Ntvv3XYvnnzZkVHR9unw9SoUUMVKlTQ3r17Hdp999132fa9cuVKpaenO2xbvny56tSpo1q1auW71j59+ig5OTnLKx1dr3Llyrr//vu1dOlS/fLLL9qzZ0+mk9z89GeGxWJR7969tXbtWl28eDHHdr169dK6desUExOTbZu77rpLP/74oy5fvuzw3FdffSUnJyd17NjRvm3AgAHy9vbWe++9p/fee0/u7u4OC7LzWlte3HLLLWrdurUWLlyoBQsWZDoWAJhWDOs6AKDMmzBhguHk5GSMHj3a2LVrl5GYmGjEx8cbe/bsMZ5++mlDkjFt2jR7+86dOxutWrXK1E9KSopx6623GgEBAcbKlSsNq9VqbNy40ahTp45Rr149hwXCw4YNM7y9vY0ff/zRsFqtxnfffWc8+OCD2S7e7tOnj/Hoo48af/31lxEVFWWMHTvWkGR8/vnnub6+7BZM33///Yavr6/xzjvvGGfOnDHi4+ONP/74w/jPf/5jvPjiiw5tf/31V0OSERoaalSuXNmIj4/PdJy89Jffxdtz587N9FxERIQRFBRktG3b1tiwYYNhtVqN6OhoY+3atUb//v2NnTt3GoZhGMePHzf8/f2Nli1bGhs3bjTi4+ONgwcPGs8884yxZs0awzAMY8eOHYa7u7vRvXt349ChQ8b58+eN1157zahQoYIxbty4TMceMWKE4eHhYfj5+RlDhw694doyFm9fv8j7Wu+//74hyZBkDBkyJMf3CwDyi2ABAIVk/fr1xqBBg4zQ0FDD1dXV8Pb2Nm6++WajX79+xqeffmokJiba22YXLAzDMKxWqzF27FijRo0aRoUKFYzAwEDj0UcfzXRlokuXLhlDhgwxvLy8DG9vb+PBBx804uPjsw0Wc+fONT799FOjQYMGhqurq9GoUaM8hQrDyP5k3mazGQsXLjTatGljVKpUyfD09DRatmxp/Pe//zXOnz+fqZ+wsDBDkjFs2LAsj5OX/goiWGQ8P3LkSKNWrVqGi4uLERwcbHTv3t345ptvHK4idfLkSePhhx82goKCDDc3N6NRo0bGnDlzjOTkZHubHTt2GL169TK8vb3t7+0bb7xhpKenZzrujh077Cf7P/300w3XlpdgkZiYaPj5+RmSjHXr1uX4fgFAflkMI5+TgAEApVp0dLSCgoI0d+5cPf3008VdDopQenq6QkND5ebmpmPHjuX7XisAkBPWWAAAUE5s3LhRZ86c0aOPPkqoAFDgCBYAAJQDcXFxmj59unx9fTVixIjiLgdAGUSwAACgjBs0aJD8/PwUGRmpzz//XL6+vsVdEoAyiDUWAAAAAExjxAIAAACAaQQLAAAAAKZVKO4CSpv09HSdOXNGnp6eXFEDAAAAZZphGIqPj1dwcLCcnHIekyBY5NOZM2cUGhpa3GUAAAAARebUqVMKCQnJsQ3BIp88PT0lXX1zvby8irkaAAAAoPBYrVaFhobaz4FzQrDIp4zpT15eXgQLAAAAlAt5WQLA4m0AAAAAphEsAAAAAJhGsAAAAABgGmssAAAAsmGz2ZSamlrcZQCFxsXFRc7OzgXSF8ECAADgOoZhKDo6WpcuXSruUoBC5+Pjo8DAQNP3aCNYAAAAXCcjVAQEBMjDw4Ob4qJMMgxDiYmJiomJkSQFBQWZ6o9gAQAAcA2bzWYPFVWqVCnucoBCVbFiRUlSTEyMAgICTE2LYvF2GWGkphV3CQAAlAkZayo8PDyKuRKgaGR81s2uJyqQYBETE6MLFy4URFc33N/Zs2d18eLFAquhpIqxJmnu2sOKsSbZt1mXrNTxWl1lXbKyQPoDAAB5uyEYUBYU1Ge9QILF8OHD9fzzzxdEVzfc39ChQzVr1qwCq6GkiolP1vx1RxQTnyzpaqiIHTtTSklV7NiZurT4O205dl7f7orUlmPnZUs38tUfAAAAcCNYY1GK2UPF39nBMKRzY2fpww49tLpBM0lSkLe7pvYJU/fG5hbjAACAG2ekpsniUrinXUlJSTp69KjCwsLk5MRsdxS9fH3qrp1udOHCBZ09ezbfBzx//rxOnDihEydOKD4+Pt/HvXz5suLi4nJsn5iYqMuXLxfIsUsq52VrHEKFJGUMYk3YuErdD++WJEXHJWnE4p1avTeq6IsEAACmpiznx969e9WkSRNZrdZCPQ6QnXwFi6FDh2r48OG67bbb1KBBA40ZMybfB3z11VfVsWNHdezYUUFBQWrUqJG2bNmSp+PeeuutqlGjhqpUqaKBAwfqypUrDu2OHz+uDh06qGbNmvLz81Pfvn2VlPTP2oEbOXZJ1P3wbrlMe80hVGS4PlxkNJm2fL/ik1KVmJLm8JeUaiuqsgEAKHeun7JcWOEiNTVVx44dkyQdOHBAe/fu1enTp5WYmKi9e/fKMAxdvnxZBw8eVEJCguLj43XgwAGHPlJSUrR3716lpWW+IMzJkycVHR2d53oSEhIUEREhm82Wqd/saspgtVp1+PDhLH8kjoyM1OnTpx22nTt3zv7apauXCj558qS9r4iIiFzrzWofw/jnRCsqKkpnzpzJdv/k5GQdPXo0y5ovXryovXv3au/evTp58qTS09NzPH58fLxOnTrlcPzSIt/jZMuWLdMLL7ygc+fOaenSpfk+4Msvv2wfNbBarRo8eLAGDhyo5OSc5/h/+eWXGj9+vC5cuKAjR45o27Ztevnllx3aLF++XNOnT1dsbKwiIiK0bds2vf3226aOnZycLKvV6vBXnJyXrdGEjatybJNVuIi2JqnJtDUKe/4Hh78Bb5W+YAUAQGlw/ZRlGSq0cBEbG6vnnntOkvTII49o0KBBmj9/vnbu3KkmTZpo0qRJCg0N1b333qv9+/dr3bp1atOmjUMfx48fV5MmTRwCxI8//qg6derotttuU/PmzXXTTTdp69atOdby2muvqWrVqurQoYOqVq2qiRMnOvSbXU2pqal6/PHH5e/vry5duqhq1aoaP368w4n4c889p0mTJjkc791339XAgQPtj+fMmaMBAwbo7rvvVoMGDdS4cWM1a9ZMJ06cyLbmOXPmqH///urQoYMaNWqkZs2aqUmTJtq+fbvat2+vW265RQ0aNFDnzp0dfrSWpOnTpysgIEB33323goKCdM899zhchGjt2rUaNGiQBg0apA4dOsjPz0+LFi3KdPwBAwaoV69eatiwoZo2baqwsDAdP348x/e6pMl3sOjdu7e6detm+sCJiYk6ffq0Bg0apDNnzmjfvn05tu/YsaPuv/9+SVLt2rU1ceJELVy40KHNvffeq44dO0qSqlevru7du2vHjh2mjj1jxgx5e3vb/0JDQ/P5SguOkZoml5cXSPonPGQn4/kxv66RczqjEgAAFKVMoSJDIYWL4OBg+w++mzdv1t69ezV79mz780eOHFFUVJT27duXKVBk5+jRo+rfv7/Cw8MVFRWl6OhoDR8+XP3798/yl3np6nSssWPH6qOPPtLp06d19OhR/fzzz1m2vb6m1157TcuWLdOff/6pv/76S1u2bNE777yjDz74IH9vhqTff/9dnTp1UnR0tM6dO6eAgAANHz48x3127typkSNH6tSpUzp16pQuX76s22+/XRMmTNCpU6d08uRJ7du3z6GeN998Ux9++KF27dqliIgIRUdH68qVK3r66aftbe6//377iMVff/2lzz//XCNHjtSRI0cy1Tx48GBFRkYqOjpaAQEBmjp1ar5fe3HKd7CoW7euqQOuX79eTZs2lZ+fn9q2basuXbooPT1dkZGROe7XuHFjh8dNmzbVhQsXHBLh9Sf9lStXdhhhuJFjT548WXFxcfa/U6dO5eflFiiLSwWlPvekpCxnQTnIeH5+u66yOV290ckHD7fR/he7Ofx9+UTbwisYAIByKNtQkaEQRy6y8+KLL8rd3T1f+7z99ttq1KiRbr75Zh04cED79+9Xt27ddOHCBW3bti3LfRYtWqRbbrlF9913nySpSpUqevbZZ/NU01tvvaWRI0fqpptukiS1aNFCw4YN01tvvZWvuiWpWrVqmjhxoqSrN4D773//q7Vr19qnG2WladOmGjRokCTJ29tbnTp1UsuWLdWvXz/7a7njjju0a9cu+z7z5s3T4MGDlZycrAMHDujkyZO65557tGzZskz9X7p0SQcPHlRwcLBq1KihDRs2ODzfpEkTPfDAA5IkNzc39e/f3+FYpUG+L09QocKNX9HAZrOpf//+evrpp/Xvf/9brq6uSktLU8WKFWWz5fyrekpKisPjjGGovP5HcqPHdnNzk5ubW56OURRs/bpq/rojOU6Hyvgem/P31aEskgK93dWhvr+cnRzHOtxdbvzuigAAwFGuoSLD3+FCkryG9ir0umrXrp3vfQ4cOKBDhw5pwIABDtvr1q2b7YjFsWPHFBYW5rDt5ptvzrUmm82mEydOZPohuUmTJvroo4/yXftNN93kcAfpRo0aSbo6ClOzZs0s9wkKcryCpoeHR5bbMl57amqqjh49qo8//ljffPONQ7saNWro8uXLqly5svbv368HH3xQ+/fvV1BQkNzd3XXq1KlMP2wHBwc7PK5UqVKpu9hQkV5uNioqShcuXNCQIUPk6uoqSdq0aVOWi4Sut2nTJofHGzZsUL169fJ8V0wzxy5pVjdopjGd68v1hcwLuLMKFZI0tU9YplABAAAKjpGaptiJ4bmHCvsOUuzEcHne363QL0V77Um2lPUN0a4/J3J1dVX79u21fPnyPB/Hw8Mj08V1rn+cVU3Ozs5yd3fP1DYxMVGVKlXKV91ZHTMxMVGSHPoyy9nZWc7Oznr++ec1bNiwbNsNHz5cTZo00caNG+0/iDdt2jTLRdylXZFe5DgoKEghISGaPn269u3bpxUrVujhhx/O093+Dh48qJEjR2r37t368MMPFR4enu3QWkEfuySy9esq/7mTHBZbXB8qpKsjFQsfaMl9LAAAKGQWlwryf2V87gsh7TtI/q+ML7BQkXHSmpqammtbf39/JSQkOFzCf+fOnQ5t2rdvr19++UUxMTEO2202W7Ynxc2bN8/0w+369evzVH+LFi20bt06h20//vijWrRo4VD39Vdnur5uSdqzZ4/OnTtnf/zTTz/J3d1dDRs2zFMteeHk5KTbb79dn3/+eabnrp1pc/DgQfXs2dP+73P69GkdOnSowOooSfL1SQ4MDJSvr2+m7QEBAapSpUqu+zs7O+u7777Ts88+q/79+ysoKEjh4eGaMmWKw8hDVv2NHj1arq6ueuyxx5SWlqZZs2bp4YcfzrG2KlWq2P9h83rs0iRj6DRjyNVikaq8+m892LatesQnKcDTXbfU9mOkAgCAInL9/zZnyyL5z51UoNOgatasqYoVK+rDDz9Ut27dsjxny9CiRQtVr15do0aN0qhRo3T48GH7VaUyPP744/rggw909913a9q0aQoKCtKePXv0+uuva8OGDfLx8cnU7+OPP645c+boX//6l5588kkdOnRIs2bNuvqSc/kx98UXX1TXrl1Vt25dderUSStWrNDq1asdbg3Qu3dvhYeHa8GCBWrVqpVWrlyplStXqkmTJg59paWlacCAAZo6darOnTunp556SqNHj86yZjNeeeUVderUSQ8++KAeeughGYahDRs26M8//9TXX38tSWrXrp1mz56tgIAAJSQk6Nlnny2ToxVSPoPF4sWLs9z+v//9L899NGvWTCtXOi5W6t+/f679ubu7a+bMmfmq7YUXXsj3sUu6AE83jelcXwGeV9d92L/AJobL/5Xx8hraS/lZjn19fwAAwJxcw0UhhApJ8vT01JIlS7Rw4UJ99NFH6tatm4YMGaJGjRpluhN3xYoVtXr1ak2bNk1jxoxRo0aN9NFHH2n06NFycXGRdHXa0KZNmzR37lzNnTtXqampat68ub744otsT9C9vb31yy+/6Pnnn9e4cePUsGFDLViwQIMGDVLFihXt/WZVU8eOHfX999/rtdde01dffaVatWrpp59+UsuWLe1t7rjjDn300UdatGiRPv/8c911112aO3dupoXQnTt31oABA/TKK6/owoULGjVqVKbL1F4rKCgo07qR4ODgTFPIQkJCHNbm3nbbbfr99981d+5cTZw4UT4+Prrzzjv14Ycf2tu8++67mjJlisaPHy8vLy+NHDlSGzZsUEBAQI7H9/Pzsy9kLy0sRgHefSMtLS3TTUuuFRISckOLv7t06aLWrVvnGCyKitVqlbe3t+Li4uTl5VXc5dgZqWmFPj8TAIDyICkpSREREapdu3a+r6R0rSwXchdSqChJ0tLSHM733nzzTU2fPj1fN9gzY8KECdq7d69Wr15dJMcrC3L6zOfn3LdAz0QjIyPt95HIyvr167NdiZ+T7KZg4R+ECgAASpZMIxflIFRI0kMPPaS7775bDRs21I4dO/Tcc8/p3//+d3GXhSJQoGejNWvWzPGuhjcquylYAAAAJVlWU5bLuunTp+u///2vFi5cqGrVqmnBggUaMmRIkR0/q2lFKBoFOhWqPCipU6EAAEDBKKipUNdiyjJKsoKaClWkl5sFAAAojwgVKA8IFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAJgUY03S3LWHFWNNKtR9ypr9+/crJCREFy9eLLRjzJ49WxMnTiy0/ku648ePq3nz5kVybw+CBQAAgEkx8cmav+6IYuKTHbbb0g1tOXZe3+6K1JZj52VLN3LdpyT7888/FRISIqvVWiD9paSkKDIyUjabrUD6u15UVJReeuklPfnkk/Ztu3fv1n333aebb75ZrVq10quvvqrsbuuWlJSkO+64QyEhITp06JB9u81m06RJk9SoUSMNHjxY58+fd9hv/vz5uYaZ06dPKyQkRFu2bMn03ODBgzVy5MhMbUNCQhQaGqqGDRuqS5cuevHFFxUVFZVjv3Xq1FHDhg01Y8aMHOspCAQLAACAQrB6b5Taz/pJg9/5TWOW7tLgd35T+1k/afXeqNx3LqEygkB6enqB9NeoUSOdOnVKfn5+BdLf9d58803dcccdqlWrliTp0KFDateunYKCgvTVV19p1qxZWrhwoaZMmZLl/uPHj5dhGIqMjFRqaqp9+6JFi7R69Wp9+umncnZ21tixY+3PRURE6NVXX801WKSlpSkyMlLJyZmDZWxsrENYyWg7d+5cbdmyRStWrNBTTz2lzZs36+abb9bGjRtz7Hf48OFasGCBEhMTc37DTCJYAAAAFLDVe6M0YvFORcU5TnOKjkvSiMU7CyVcbN++XSEhIfrhhx/UvXt3NWjQQPfcc4+OHz/u0O7QoUMaOHCg6tWrp5YtW2rmzJkOIwZpaWl64YUX1Lp1azVq1EiPPfaYoqOjdfr0afXq1UvS1UAQEhJi/1X97NmzevLJJ3XzzTerefPmGjNmjC5dupSptrVr16pjx46qVauWtmzZoiNHjui2225TXFxcnuvLrq+sfPzxx+rfv7/98eLFi1WlShXNnz9fYWFh6tKli2bOnKk5c+Y41CBJ33zzjdavX5/lL/1r167VI488oqZNm+qZZ57R2rVr7c89/vjjevnll1W1atVs/61ulL+/v0JCQlS/fn317dtXq1evVpcuXTR06FClpKRku1/Hjh0lSd99912B13QtggUAAEABSUq1KT4pVVOX71NWk2sytk1bvl8JyWkFeuzk5GRFRkZq+PDhevrpp/X555/LMAx17drV/mt7XFyc7rjjDrm6uuqrr77SCy+8oHnz5um5556z9xMeHq6PP/5Y4eHh+vrrr3X77bdr2rRpCgoK0qJFiyRdPbH+7bffNH36dFmtVrVv317p6elaunSpPvjgA508eVK9e/e2TzHKqG3MmDH6z3/+o40bN6ply5aZpkLlpb7s+rreiRMn9Ndff6lNmzb2bYmJiapcubIsFot9m5eXl5KTk/Xbb7/Zt/3111968skntWTJErm7u2fqOyUlRW5ubpKkihUr2kcHPvzwQzk5OemBBx7I57/ejXvmmWd06tQpbdq0Kds2Tk5OuuWWW/TLL78Uai0ECwAAgAIy4K0tajJtjc5as183YUiKtiZp4P9+y7aNGXPmzFH37t3VvHlzffTRR4qNjdVnn30mSVq4cKFcXV31/vvvq1mzZurTp4/Cw8M1b948+y/2e/bsUZcuXXTnnXfqpptu0sMPP6wFCxbI2dlZAQEBkqTg4GCFhITIz89P77zzjjw9PfXWW2+pWbNmat68uZYsWaJt27Zp+/btDrW98cYb6tKli0JDQ+0n5tfKS3157evkyZOSpKCgIPu27t2768CBA/r0008lSVarVbNnz5Z0dW2CdHX9xJAhQzRhwgQ1a9Ysy/e4VatWWr58uQzD0FdffaXWrVsrNjZWzz//vBYsWKAXX3xRjRs3Vv/+/RUdHZ3jv9d9991nXz+R8ZdTSLhekyZNJEmHDx/OsV1QUJBOnDiR535vBMECAACgDGnfvr39//fy8lKzZs30559/Srq6cLlt27ZycXGxt+nYsaOSk5Pti5P79++vjz76SMOHD9c333yjuLg4OTllf8q4efNmHT58WLVq1VLNmjVVo0YNNWzYUDabTUePHnVom9XIwrXyUl9e+0pLuzoiVKFCBfu2u+++W2+88YbGjBkjb29vhYaGqnPnznJycrKPrrzwwgtyd3fXuHHjsu171KhRslqt8vLy0ttvv63w8HCNGTNGTz/9tH7//Xd98sknWrJkifz9/R0WYWdlwYIF+u233xz+rh1lyU3G68ttAXyFChXs70lhIVgAAAAUkC+faKsPHs7bSeG0PmGFUoOrq2umxxlTdZKTkzP9up/xOKNN//79tX37dgUHB2vevHkKDAzUK6+8ku3xkpKS1KlTJ23atEm//vqrNm/erC1btujkyZPq16+fQ9usphVdKy/15bWvjJGKmJgYh+1PPvmkYmJiFBERodjYWPXr10/p6emqUaOGJGn58uX6448/FBoaqpCQEPu6ki5dutjDho+PjzZs2KDIyEidOHFCp06d0tGjR/XUU09pzZo1evDBB9WsWTNNnDhRa9asybHOjHUT1/5lNQKTnYw1NKGhoTm2i42NdRi9KQwECwAAgALi7uKsDvX9FeTtLks2bSySgrzd1aKGb6HUsGfPHvv/n5aWpv3796t+/fqSpJtuukm7d+92aP/HH39Ikr2NdHVx9rRp07R+/Xq9//77mjx5shISEuTs7CxJDpdnbdSokXbv3q1q1aplOkH28PDIV+15rS8vGjZsKB8fH+3cuTPL5/38/OxrOby9vdWuXTtJ0po1a7R792776EHGupIlS5ZkunqUl5eXLl++rKeeekrvvPOOnJ2dHcJRxYoVlZqamu3lbAvCokWLVLlyZd155505ttu5c6f9NRYWggUAAEABcnayaOrfoxHXh4uMx1P7hMnZKbvoYc7kyZN1/vx52Ww2vfjii0pISNCQIUMkXb3s6OHDh/Xaa68pPT1dMTExmjx5su6//34FBgZerW3qVG3cuFE2m02GYejUqVPy9PSUu7u7goODJclhWtKIESN08eJFjRw50n4TtlOnTmnMmDH5vvFdXurLKycnJ/Xv31+rVq1y2P7ss88qPj5ekvTDDz9oxowZmj59uipVqiRJCggIcAhHGetKqlWrJl/fzGHwueee03333Wdfj9GqVSutWLFCNptNX331lVq2bOmwWLygxMbG6sUXX1R4eLhmz54tb2/vbNvu3btXZ8+eVd++fQu8jmsRLAAAAApY98ZBWvhASwV6O07XCfR218IHWqp748KbktKzZ081aNBAXl5eevfdd/XZZ5/Z7xNRu3ZtffbZZwoPD5eXl5f95HnBggX2/bt166b//Oc/8vHxkY+Pj95//3198cUXcnZ2VrVq1TRmzBh17NhR1atX18iRI1W7dm2tW7dOe/bsse9zxx13qH79+jme7GYlL/Xlx5gxY/T11187LPwODg5WnTp15Ovrq2HDhmn27NkaPXr0DfW/detW/fDDD5o6dap922OPPaYKFSrIx8dHM2fO1Pz582+o76xkLPSuWrWq6tatq82bN2vVqlV64oknctzv/fff16BBg/IdzvLLYhTm2EwZZLVa5e3trbi4OHl5eRV3OQAAoIAlJSUpIiJCtWvXznUef4a9kXHq/fomfTe6vRpX/+dk2pZuaFvEBcXEJynA01231Pazj1Rkt8+N2rRpkzp06KArV67I3d1d58+fl6+vb7YLr8+dOycPD49spytduXJFNptNlStXzvRcamqqYmNj5e7u7nBzu4SEBKWlpWUKFCkpKYqJiVFISEimfs6ePavg4OBMdWZXX3Z9ZefRRx9VtWrV9PLLL9u3paen6+LFi/Lz88t1NCGjxsDAQIeF4NLVy+NaLJYszwnj4+MzXdr2WjabTVFRUfL398+0puLcuXNycnKyv7cZbSXJYrGoYsWK8vX1zbLv6/uNjo5WkyZNtHPnzmzXYeT0mc/PuS/BIp8IFgAAlG03EixirElasvUvDb21hgK8Cm+fnFwfLHBVcnKy4uLi7FOaypsrV67o8uXL8vf3z7ZNQQWLCjk+CwAAgFwFeLlr7N0NCn0f5J+bm1u5DRXS1QXkFStWLJJjscYCAACgDLjlllt06tQpRitQbAgWAAAAZYCrq2ue1x0AhYFgAQAAAMA0ggUAAEAWuL4NyouC+qwTLAAAAK7h4uIiSUpMTCzmSoCikfFZz/js3yiuCgUAAHANZ2dn+fj4KCYmRpLk4eFRKHdOBoqbYRhKTExUTEyMfHx85OzsbKo/ggUAAMB1Mu5QnBEugLLMx8enQO7KTbAAAAC4jsViUVBQkAICApSamlrc5QCFxsXFxfRIRQaCBQAAQDacnZ0L7KQLKOtYvA0AAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAABACWakphV3CXlSJoLFv/71L02aNKm4ywAAAMUsxpqkuWsPK8aaVNylADfs2s+xdclKHa/VVdYlK4u7rFyViWBhtVp1+fLl4i4DAAAUs5j4ZM1fd0Qx8cnFXUqZZUs3tOXYeX27K1Jbjp2XLd0o7pLKnIzP8fmPVyh27EwpJVWxY2eW+HBRobgLAAAAQOmwem+UXlixX1Fx/4wIBXm7a2qfMHVvHFSMlZU93Q/vlst7q/7ZYOhqyJDkNbRXMVWVsyIZsdiyZYu6deummjVrqm3btnr//fcdnv/44491++23KzQ0VD179tSePXvsz02YMEFVq1ZV1apVddNNN+nBBx/UmTNncj3mRx99pNtuu00hISG64447tGzZMofn7733Xv373//WqFGjVKdOHfXr168gXioAAECZtHpvlEYs3ukQKiQpOi5JIxbv1Oq9UcVUWdnjvGyNJmxclfmJv8NFSR25KPQRiytXrqhHjx4aN26c3nnnHcXExOh///ufmjdvrpYtW2rOnDl68cUXNXfuXN111106dOiQZs6cqSVLlkiSXnjhBfv6ibNnz+rFF19U3759tX37dlksliyPOW/ePM2fP19vvvmmGjdurO3bt+uhhx7SkiVL1KvX1YQXFxen2bNna/r06frpp5/k6+tb2G8FAAAoIkmpNiWmlI4Fr6WBLd3Q1OX7lNWkJ0OSRdK05fvVrl5VOTtlfX6GvElc+r1cpr0m6er7mkkJHrmwGIZRqBPjjh49qvr16ysyMlLBwcH27YZhKCUlRf7+/po+fbrGjBnj8Fx2oSEhIUFeXl76888/1ahRI0lSv379FBISojfeeEMpKSkKCAhwCBGSNGXKFG3fvl2rV6+WJHXp0kU2m00///xzjvUnJycrOfmfeZpWq1WhoaGKi4uTl5dX/t8QAABQaPZGxqn365uKuwzghnQ/vNs+UpFrPLNI/nMnFXq4sFqt8vb2ztO5b6FPhapTp47atm2rTp06acaMGfrtt9+Unp4ui8WiAwcOKD4+Xl26dHHY59pQceLECQ0bNkxhYWEKCAhQzZo1lZ6erpMnT2Z5vAMHDiguLk4PPfSQAgMDVa1aNQUEBGjevHk6duyYQ9vmzZvnWv+MGTPk7e1t/wsNDc3/mwAAAADkwDndpjG/rpGUh1AhXR25mBheoi5FW+hToZycnLR+/XotX75ca9eu1cCBA1WxYkWtWrVKaWlX3wgXF5ds9+/Ro4eaN2+ujz/+WMHBwapQoYKqV6+ulJSULNunpqZKkpYvX6769es7POfs7Ozw2M3NLdf6J0+erHHjxtkfZ4xYAACAkuvLJ9oqLJiZBQVlW8QFPbRoe67tPni4jW6p7VcEFZVNiY2luAmzZRh5HLF4ZbwsLiXnWkxFUomLi4vuvfde3XvvvUpLS1Pr1q21cOFCTZkyRS4uLtq6dasaNGiQab8zZ87o4MGDDiFh37599vCQlQYNGsjFxUW7du1S27ZtTdfu5uaWpwACAABKDncXZ3m4lpwTrtKuQ31/BXm7KzouKct1FhZJgd7u6lDfnzUWJnj8q69cnZ0V8/RM+9qVLBXRNKj8KvSpUDt27NBzzz2nyMhISVJUVJQuXLigoKAgeXp66oknntCzzz6rLVu2yDAMnThxQs8++6wkqUqVKqpUqZL9ik5nzpzRE088kePxvLy8NGrUKD3//PNau3at0tPTdfnyZX3xxReaN29eYb5UAACAMsnZyaKpfcIkZT7ZzXg8tU8YoaIAeA3tpdRpT0lSliGupIYKqQiCRaNGjVSpUiXdeuutqly5sho3bqw+ffpo1KhRkqTw8HANGTJEPXr0kIeHh7p06WIfaXBzc9OHH36o8PBweXh46Oabb9Ydd9whDw+PHI85e/ZsjR49Wg888IA8PDwUEhKir7/+Wn379i3slwsAAFAmdW8cpIUPtFSgt7vD9kBvdy18oCX3sShAtn5dNadDj8xPlOBQIRXBVaGulZiYmG0oMAxDiYmJqlSpUpbPx8fHq1KlSnJyctL58+fl6ekpV1dX+3NOTk5Z7hsfHy9PT89M261WqypUqJBrSMlqv7yujAcAAEUr46pQ341ur8bVvYu7nDLJlm5oW8QFxcQnKcDTXbfU9mOkooBlfI5XhSbK9YXX7Nf0LY5QkZ9z3yKdfJjTSbzFYsk2VEhyCAdVqlTJ9rmc9rsWoQAAgLInwNNNYzrXV4An6yMLi7OTRW3rVsm9IW5Yxue4yq015O7jodiJ4fJ/ZXyJHanIUKQjFmUBIxYAAAAoSkZqWrFd/alE3ccCAAAAwI0rSZeUzQnBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAFDgjNS04i4BAFDECBYAUMrEWJM0d+1hxViTiruULFmXrNTxWl1lXbKy0I5R0t8DACiPCBYAUMrExCdr/rojiolPLvJj29INbTl2Xt/uitSWY+dlSzccnrcuWanYsTOllFTFjp1ZaOGiON8DAEDWKhR3AQCA0mH13ii9sGK/ouL+GSUI8nbX1D5h6t446J9QkZE1DF19LMlraK9iqBgAUJTK1YjF008/rcqVK6ty5cqqWbOmBg4cqJMnTxZ3WQBQ4q3eG6URi3c6hApJio5L0ojFO7X5lSWOoSLD3+GiMKdFAQBKhnI1YjFr1iy99NJLkqSzZ89q2rRp+r//+z/t3LlTTk7lKmMBKAOSUm1KTCn8RdK2dENTl+/LlBmkqzmix+HdCti4KvsO/g4XKTabPAb1LJCaklJtBdIPAKDglKtg4ebmJjc3N0lS5cqV9b///U+enp7av3+/GjdunOU+ycnJSk7+Zw6v1WotkloBIDcD3tpS3CWo++HdGp9TqPibYUiXxs/Wf5bt1eoGzYqgMgBAUStXP9MfPXpUQ4YMUZ06deTl5SV/f3/ZbLYcp0PNmDFD3t7e9r/Q0NAirBgASi7ndJvG/LpGkmTJpW3G82N+XSPndEYbAKAsKlcjFj169NDtt9+uFStWKDg4WBUqVFCVKlWUmpqa7T6TJ0/WuHHj7I+tVivhAkCJ8OUTbRUW7FXox9kWcUEPLdqeabvNyVnz23XVhI2rZCgP4cIi+c8epz0FMB1q/xlriRixAQD8o9wEi8jISB09elSrVq1SvXr1JEl//vlnjqFCcpw+BQAlibuLszxcC/9rvEN9fwV5uys6LinTOovVDZrJIuU+Hcoi+c+dVGBXh3J3cS6QfgAABafcTIXy9/eXp6enli5dKpvNpoiICA0fPry4ywKAEs/ZyaKpfcIkZR6VsOhquIh55onshywKOFQAAEqmchMsXF1dtWTJEr3zzjtyc3NTmzZt1KtXL1WqVKm4SwOAEq974yAtfKClAr3dHbYHertr4QMtdfvEofKfOynL5EGoAIDyodxMhZKkPn36qE+fPkpNTZWLi4skady4cXJ3d89lTwBA98ZBujssUNsiLigmPkkBnu66pbafnJ2upomM8GC/nwWhAgDKlXIVLDJkhApJjFgAKHUCPN00pnN9BXgW/fovZyeL2tatku3z9nAxMVz+r4wvtFBRnO8BACBrFsMwsrrnEbJhtVrl7e2tuLg4eXkV/tVYAKA0MlLTZHEpl79dAUCZkp9z33KzxgIAUHQIFQBQ/hAsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABgGsECAAAAgGkECwAAAACmESyAYmSkphV3CQAAAAWCYAEUoBhrkuauPawYa1Kuba1LVup4ra6yLllZYH0CAAAUF4IFUIBi4pM1f90RxcQn59ju0uLvFPP0TBkpqYp5eqYuLf7OdJ8AAADFiWABFLHNryzRubGzJEmWv7edGztLm19ZUnxFAQAAmFShuAsoanv27NGIESMybW/RooVef/31YqgI5cnmV5YoYPZbkv4JFRZJhqSA2W9ps6TbJw4tpuoAAABuXLkLFjVr1tTMmTPtj+Pj4zV06FA1aNCgGKtCWZOUalNiiuPC7MuffJ8pVGS4NlzEBHiq8pCeDn0BAACUdOUuWHh5eal9+/aSJMMw1K9fPwUHB2v+/PlZtk9OTlZy8j9z261Wa5HUidJtwFtbHB53P7xbEzaukpQ5VGTICBfWZ2br+eV7tbpBs0KtEQAAoCCV6zUWU6ZM0aZNm/Ttt9/K09MzyzYzZsyQt7e3/S80NLSIq0Rp55xu05hf10jKPlRkyHh+zK9r5JzOSAUAACg9yt2IRYYvvvhCs2bN0urVq1W3bt1s202ePFnjxo2zP7ZarYQL5OrLJ9oqLNjL/jixsXRp/GwZyjlcGH//X//Z47Rn0NXpUPvPWDONgAAAAJQ05TJY7N69Ww899JDCw8PVuXPnHNu6ubnJzc2tiCpDWeHu4iwP13/+8/L4V19VcHLSubGzsg0XGaGi6tx/y+eB3g59AQAAlHTlbirUuXPn9H//938aNGiQnnrqqeIuB+WIzwO9FfPME5L+CREZMh7HPPOEQ6gAAAAoLcrdiMW3336rkydPas+ePfZF3BKXm0XRuH3iUG3W1as/ZYxcXBsquNQsAAAorcpdsOjdu7c2btyYabu3t3cxVIPy6PaJQ3Up2Ns+LUq6Ov2pHiMVAACgFCt3waJatWqqVq1acZeBMirA001jOtdXgGfO63J8HugtJ4tFsRPD5f/KeHkN7WW6TwAAgOJkMQzj+uneyIHVapW3t7fi4uLk5eWV+w5ADozUNFlcyl2+BwAApUR+zn3L3eJtoCQhVAAAgLKCYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1ggWJjpKYVdwkAAAAoIAQL3JAYa5Lmrj2sGGvSDe1vXbJSx2t1lXXJykI9DgAAAIpGuQ4Wb731lr766qviLqNUiolP1vx1RxQTn5xrW1u6oS3HzuvbXZHacuy8Li3+TrFjZ0opqYodOzPHcJGf4wAAAKD4VCjuAorTd999p3r16unee+8t7lLKrNV7o/TCiv2Kirs64tD98G5N2LhKkmSRJENXQ4Ykr6G9iqlKAAAAmFVug8XixYu1b98+nT59WqNGjZIkTZkyRdWqVSvmysqO1XujNGLxThl/P84UKjIQLgAAAEq9chssgoKCVKlSJfn6+qphw4aSJDc3t2KuqvRJSrUpMSXzImxbuqGpy/flHioy/B0uUmw2eQzq6dA/AAAASr5yGyw6d+6sWrVqqV69evYRi6wkJycrOfmf+f1Wq7Uoyis1Bry1Jdc2uYaKvxmGdGn8bP1n2V6tbtCsgCoEAABAUSjXi7fzYsaMGfL29rb/hYaGFndJpYpzuk1jfl0jKedQce3zY35dI+d0RioAAABKk3I7YpFXkydP1rhx4+yPrVYr4eIaXz7RVmHBXpm2b4u4oIcWbZfNyVnz23XVhI2rZCgP4cIi+c8epz1/T4faf8aap1ERAAAAFK9yHSwsltxOc6+uu2DtRfbcXZzl4Zr5Y9Shvr+CvN0VHZdkn9aUa7iwSP5zJzks4HZ3cS74ogEAAFDgyvVUKF9fX126dKm4yyiTnJ0smtonTNLVILG6QTPN6dBDkuwLuh1kESoAAABQepTrYNGrVy998cUXeuihhzRq1CidPXu2uEsqU7o3DtLCB1oq0NtdUg7hglABAABQ6pXrqVADBw5UgwYNtGvXLiUkJDDlqRB0bxyku8MCtS3igmLikxTgeZuqbmmq8+NmKWNeFKECAACg9CvXwUKSWrRooRYtWhR3GaVOgKebxnSurwDP3MOYs5NFbetW+WdD3d5yslgUOzFc/q+MzzFU5Oc4AAAAKD4WwzCynPKOrFmtVnl7eysuLk5eXpmvhoS8M1LTZHEp99kWAACgxMrPuW+5XmOB4kWoAAAAKDsIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMA0ggUAAAAA0wgWKPOM1LTiLgEAAKDMK3HB4tSpU4qNjS3uMlACxViTNHftYcVYk/K8j3XJSh2v1VXWJSsLsbL8u5HXAgAAUJIVa7A4ffq0YmJiHLY9/PDDCg8PL5S+UbrFxCdr/rojiolPzlN765KVih07U0pJVezYmXkKF7Z0Q1uOnde3uyK15dh52dINs2VnKb+vBQAAoKSrUJwHf+KJJ1SvXj3NmzevVPWNks8eKjJygaGrjyV5De2V5T6r90bphRX7FRX3zyhCkLe7pvYJU/fGQYVdMgAAQKlWbCMWUVFRSkhI0MWLF3Xw4EEdPHhQKSkpDm0uXryo8+fPZ9tHYmKiTpw4obQ0xzn02fV99uxZ+2OmW5VdmUJFhr/DRVYjF6v3RmnE4p0OoUKSouOSNGLxTq3eG1WIFQMAAJR+xTZi8dprr2n79u3avXu3tm7dKklatWqVJOnw4cO65ZZbdObMGZ0/f14dOnTQsmXL5OHhIUlKSkrSU089pU8++UR+fn46f/68RowYoVmzZsnZ2Tnbvj/88EMtXbpUkhQTEyNfX18tWrRId9xxRzG8A7hRSak2JaZkvSA7cen3ipswO3OoyPB3uEix2eQxqKekq9Ofpi7fl+UuhiSLpGnL96tdvapydrIUxEtQUqqtQPoBAAAoKSyGYRTOJPI86N27d6bpSl26dNHmzZu1bt06tW3bVmfPnlXLli01fvx4jRs3TtLVaU5HjhzRZ599pqpVq+r06dO66667NGrUKI0ZMybbvq9lGIbCw8M1d+5cHT16VBUrVsyyXXJyspKT/5kHb7VaFRoaqri4OHl5eRXMG4E82RsZp96vb8r2+e6Hd2vCxqvhNKfT/4wP/JwOPbS6QbOCK/AGfDe6vRpX9y7WGgAAALJjtVrl7e2dp3PfEndVKEm699571bZtW0lStWrVdPfdd+uPP/6QdPXFvffee3rsscd06dIlHTlyRImJierbt6++/vrrPPV/4cIFHTlyRN27d9fZs2e1f//+bNvOmDFD3t7e9r/Q0FDzLxAFzjndpjG/rpGUc6i49vkxv66RczojBwAAAAWhWBdvZ6d69eoOjytXrqzTp09LujpNKi0tTVOmTJGzs7NDu9xO+n/88Uc9+eSTioqKUkBAgFxcXJSenq7IyEi1atUqy30mT55sHymR/hmxQPH58om2CgvOnJgTGyvnaVDXsFgk/9njtGdQT22LuKCHFm3PdZ8PHm6jW2r73UjJmew/Y9WAt7YUSF8AAAAlQYkMFjlxcXGRJH322Wdq2bJlnvez2Wy67777NGnSJE2YMEHOzs5KTU1VxYoVlZ6enu1+bm5ucnNzM103Co67i7M8XDN/dD3+1Veuzs5ZL9y+lkXynzvJfnWoDvX9FeTtrui4pCx3s0gK9HZXh/r+BbbGwt3FOfdGAAAApUixToVyd3dXampqvvYJCwuTn5+fvvzyy0zPXdvX9X1HRUXp0qVLuvfee+0jHevXr5fNxlSYssRraC/5z52U/Xyo60KFJDk7WTS1T1jG09c3lyRN7RNWYKECAACgLCrWEYuGDRtq+fLl+v3331W5cmXVqVMn131cXFw0e/ZsjRgxQi4uLurVq5cuXryo77//Xh4eHpoxY0aWfdeqVUs1a9bU888/r/Hjx+v48eMaP368LBZOFsuajNCQaeQii1CRoXvjIC18oGWm+1gEch8LAACAPCnWYDF27FhFR0fr8ccfV0JCglatWqUaNWooICDAoV1gYKDD42HDhqlGjRpauHChli1bpuDgYPXu3VvDhw/Pse/vv/9eU6ZM0bBhwxQUFKSFCxfq+eefl6enZ5G8XhSdTOEih1CRoXvjIN0dFqhtERcUE5+kAE933VLbj5EKAACAPCjWy82WRvm55BYKVow1SUu2/qWht9ZQgJd7nvaxLlmp2Inh8n9lfI6hoqjdyGsBAAAoavk59yVY5BPBovQxUtNkcSl11ykAAAAodqX+PhZAQSJUAAAAFD6CBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI0L/OdTxv0ErVZrMVcCAAAAFK6Mc9683FObYJFP8fHxkqTQ0NBirgQAAAAoGvHx8fL29s6xjcXIS/yAXXp6us6cOSNPT09ZLJZ872+1WhUaGqpTp07lelt0lG18FpCBzwIy8FlABj4LyFDcnwXDMBQfH6/g4GA5OeW8ioIRi3xycnJSSEiI6X68vLz4ooAkPgv4B58FZOCzgAx8FpChOD8LuY1UZGDxNgAAAADTCBYAAAAATCNYFDE3NzdNnTpVbm5uxV0KihmfBWTgs4AMfBaQgc8CMpSmzwKLtwEAAACYxogFAAAAANMIFgAAAABMI1gAAAAAMI37WBSCAwcO6ODBgwoNDVWrVq3ydCO9G9kHJd++fft0+PBh1ahRQ61atcqxbUREhLZu3Zpp+4ABA1ShAv+plnYnTpzQ1q1b1aJFCzVo0CBP++zZs0dHjx5VrVq11KJFi0KuEEUlIiJC27ZtU8uWLVW/fv0c2x45ckQ7duzItH3QoEGFVR6KyOXLl7Vz505duXJFTZs2VVBQUJ722717t44fP646deqoWbNmhVwlisLly5e1Y8cOJScnq2nTpgoMDMyx/aFDh/THH384bHN2dtZ9991XmGXmCWcrBcgwDD3++ONaunSp2rZtqz/++EPNmzfXt99+q4oVKxbYPij5DMPQo48+qi+//FK33Xabdu7cqdatW+ubb76Ru7t7lvusX79eTz75pPr27euw/Z577iFYlGL79+/XM888o/379+vMmTOaNWtWrsHCZrPpwQcf1MqVK3XLLbdox44dateunb744gu5uroWUeUoaHv37tXEiRN18OBBnT59Wq+++mquweKHH37Qs88+q549ezpsJ1iUbjNmzNCbb76pOnXqyN3dXZs2bdL48eM1ffr0bPdJS0vT4MGDtW7dOrVp00bbt29X586d9emnn/K/EaXYSy+9pLfeekt169aVq6urfv31V/373//W1KlTs91nxYoVevnll9WtWzf7NldX1xIRLGSgwHz66aeGm5ubsWfPHsMwDCMqKsoIDAw0pk2bVqD7oOT7+OOPjYoVKxr79u0zDMMwIiMjjYCAAOOll17Kdp9FixYZ1atXL6oSUUQ2b95srFixwrDZbEaVKlWMuXPn5rrPO++8Y1SuXNk4fPiwYRiGcfLkScPPz8+YM2dOIVeLwrRp0yZj5cqVhs1mM7y9vY3XX389131ef/1146abbiqC6lCU3nvvPSMuLs7++KeffjIkGevWrct2n9dff93w8fExIiIiDMMwjGPHjhleXl7GG2+8UdjlohC9++67htVqtT9es2aNIclYv359tvvMnj3baNasWRFUl3+ssShAixcvVteuXdW4cWNJUmBgoIYMGaLFixcX6D4o+RYvXqzu3bsrLCxMkhQcHKxBgwbl+u+ampqq1atX64cfftCZM2eKolQUsrZt26p3795ycsr71+3ixYvVp08f+6/ZNWrU0IABA/heKOXatWunnj175uuzIEnJyclatWqV1q5dq+jo6EKqDkVp2LBh8vLysj++66675Ovrq127dmW7z+LFi3XPPfeoVq1akqQ6deqoX79+fC+Uco888og8PT3tj++++255enrm+FmQpCtXruj777/Xjz/+qJiYmEKuMu8IFgVoz5499oCQoUmTJjp69KiuXLlSYPug5Mvu3/XQoUNKSUnJdr/4+HjNnj1bL730kmrXrq3x48cXdqkogbL7/Ozbt08Gtx4qd2JjY/Xqq69q6tSpqlmzpqZMmVLcJaGA7dy5UxcvXsz03/21svte2LNnT2GXhyK0bds2xcfH5/hZkKSoqCjNmzdPU6ZMUY0aNfTSSy8VUYU5Y1JeAYqLi5Ofn5/DtipVqtify2rNxI3sg5Ivu39XwzBktVpVtWrVTPs0a9ZMx48fty/a2rhxozp16qTGjRvr4YcfLpK6UTJk9/lJTU1VQkKCKleuXEyVoajdeuutOnHihP0744cfflDPnj3VtGnTkjGfGqZZrVb9v//3/9S5c2fdfffdWbZJS0tTYmJilt8LCQkJSktLY51FGXDp0iU9+OCD6tq1qzp16pRtuw4dOujEiRP2z8Py5cvVr18/NWvWTH369CmqcrPEiEUBcnNz0+XLlx22ZTzObsHujeyDku9G/l1btGjhcCWIDh06qGvXrlqxYkXhFYoSie8FZGjTpo3DDxHdunVT+/bt+V4oIxISEtSrVy+5urrqiy++yPaKkBUqVJCzs3OW3wsVKlQgVJQBly9fVq9eveTh4aHPPvssx7a33nqrQ8js27ev2rRpUyK+FwgWBahu3br666+/HLadPHlSvr6+8vHxKbB9UPJl9+/q7++fr1+bvby8FBsbW9DloYTL7vMTGhrKCQT4XigjMkKF1WrVjz/+KF9f3xzb16lTJ8vvhdq1axdmmSgCly9fVo8ePXTlyhWtXbv2hs7/Ssr3AsGiAPXs2VPff/+9EhMTJUnp6en68ssv1atXL3ubiIgILV26VKmpqXneB6VPz5499d1339nXydhstkz/rsePH9fSpUuVlpYm6ep8yWtdunRJP//8s9q0aVN0haNYHDlyREuXLrWvn+jZs6eWL1+u5ORkSVenQXz99dd8L5QDhw8f1tKlS+2Pr/9eiImJ0aZNm/heKOUSExPVq1cvXbx4UevWrbNPgb7WoUOH9Pnnn9sf9+zZU8uWLbOfP6SkpGjZsmV8L5RyCQkJ6tmzpxISEvTjjz9mmu4mXb3X2RdffGF/fP33wpkzZ7R169YS8b1gMVgJWGCsVqtat26tatWqaciQIVqzZo02bNigbdu2qW7dupKkDz74QA8//LAuXrwoHx+fPO2D0ufSpUtq3bq1qlevrkGDBmn16tXavHmztm3bZv916d1339Vjjz2m+Ph4Va5cWf369ZOPj49uu+02JSYm6u2335bFYtGGDRsUEBBQzK8IN+rSpUtavXq1JGn48OG655571KNHD4WEhKh9+/aSpDfeeEOjR49WamqqKlSooHPnzql169aqW7euBgwYoBUrVmjnzp36/fffFRISUpwvByZcvHhRP/zwg6SrV4IZOHCgunbtqtDQULVr106SNG/ePI0dO9YeMrt27aoaNWqoTZs2slqtWrhwoTw9PfXLL7/k+gs3Sq6ePXvq559/1pw5cxxCRcOGDdW8eXNJ0pw5czRp0iT7j0/R0dFq3bq1GjVqpH79+umbb77R/v379fvvv+d6QzWUXF27dtWmTZs0Z84ch1ARFhampk2bSpJmzpypadOmKSkpSZLUsWNH3XTTTWrVqpUuXryoBQsWyN/fXz/99JPD1caKAyMWBcjLy0tbt25Vjx499NtvvyksLEx//PGHQ0CoXbu2Bg4caL/JVV72Qenj4+Ojbdu2qWvXrtqyZYuaNGmiP/74w2HIum7duho4cKBcXFwkSV9//bV69uypPXv26MSJE5o4caL+/PNPQkUpFxcXp2XLlmnZsmXq2bOnkpOTtWzZMoe7rDdo0EADBw60X4a0atWq+v3333XnnXfqt99+U+vWrfXHH38QKkq5ixcv2j8Lffr0UWJiopYtW6bt27fb29x0000aOHCg/fGqVat01113affu3YqMjNS0adO0Y8cOQkUpFxISov/7v//Txo0b7Z+JZcuWad++ffY2DRs2dPgsBAYGaseOHWrbtq22bNmi22+/XTt27CBUlHKhoaHq27evNmzYkO1nISwsTPfff7/98Y8//qh27dpp586dio6O1n//+19t3bq12EOFxIgFAAAAgALAiAUAAAAA0wgWAAAAAEwjWAAAAAAwjWABAAAAwDSCBQAAAADTCBYAAAAATCNYAAAAADCNYAEAAADANIIFAAAAANMIFgAAAABMI1gAAAAAMI1gAQAAAMC0/w8POKSMMB0voQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 800x450 with 1 Axes>"
       ]
@@ -8877,42 +1532,42 @@
        "    <tr>\n",
        "      <th>rl_alpha</th>\n",
        "      <td>0.094</td>\n",
-       "      <td>0.062</td>\n",
+       "      <td>0.059</td>\n",
        "      <td>0.136</td>\n",
        "      <td>0.08</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>scaler</th>\n",
-       "      <td>2.158</td>\n",
-       "      <td>1.873</td>\n",
-       "      <td>2.483</td>\n",
+       "      <td>2.153</td>\n",
+       "      <td>1.807</td>\n",
+       "      <td>2.488</td>\n",
        "      <td>2.50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>a</th>\n",
-       "      <td>1.166</td>\n",
-       "      <td>1.024</td>\n",
-       "      <td>1.287</td>\n",
+       "      <td>1.169</td>\n",
+       "      <td>1.045</td>\n",
+       "      <td>1.294</td>\n",
        "      <td>1.20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>z</th>\n",
        "      <td>0.501</td>\n",
        "      <td>0.458</td>\n",
-       "      <td>0.542</td>\n",
+       "      <td>0.537</td>\n",
        "      <td>0.50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>t</th>\n",
        "      <td>0.236</td>\n",
-       "      <td>0.190</td>\n",
-       "      <td>0.286</td>\n",
+       "      <td>0.191</td>\n",
+       "      <td>0.288</td>\n",
        "      <td>0.25</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>theta</th>\n",
-       "      <td>0.403</td>\n",
-       "      <td>0.312</td>\n",
+       "      <td>0.402</td>\n",
+       "      <td>0.303</td>\n",
        "      <td>0.494</td>\n",
        "      <td>0.35</td>\n",
        "    </tr>\n",
@@ -8922,12 +1577,12 @@
       ],
       "text/plain": [
        "           mean  hdi94_lb  hdi94_ub  true\n",
-       "rl_alpha  0.094     0.062     0.136  0.08\n",
-       "scaler    2.158     1.873     2.483  2.50\n",
-       "a         1.166     1.024     1.287  1.20\n",
-       "z         0.501     0.458     0.542  0.50\n",
-       "t         0.236     0.190     0.286  0.25\n",
-       "theta     0.403     0.312     0.494  0.35"
+       "rl_alpha  0.094     0.059     0.136  0.08\n",
+       "scaler    2.153     1.807     2.488  2.50\n",
+       "a         1.169     1.045     1.294  1.20\n",
+       "z         0.501     0.458     0.537  0.50\n",
+       "t         0.236     0.191     0.288  0.25\n",
+       "theta     0.402     0.303     0.494  0.35"
       ]
      },
      "execution_count": 9,
@@ -8999,16 +1654,16 @@
    "id": "ab0cf142",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:49.662968Z",
-     "iopub.status.busy": "2026-07-06T16:28:49.662900Z",
-     "iopub.status.idle": "2026-07-06T16:28:50.790015Z",
-     "shell.execute_reply": "2026-07-06T16:28:50.789612Z"
+     "iopub.execute_input": "2026-08-28T01:43:55.978737Z",
+     "iopub.status.busy": "2026-08-28T01:43:55.978641Z",
+     "iopub.status.idle": "2026-08-28T01:43:57.698500Z",
+     "shell.execute_reply": "2026-08-28T01:43:57.698042Z"
     }
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABecAAAGbCAYAAABONCtsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAu7tJREFUeJzs3Qd0FOXXx/FLgNB77713RAREAQWxggg2RET92wEFK2IBGyKoYBcLFuwgImJDBekgTSnSe++9huQ9v4d31k3YJJuwaZvv55w52Z2yOzub5Jm5c5/7ZImJiYkxAAAAAAAAAACQaiJS760AAAAAAAAAAIAQnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcAAAAAAAAAIJURnAcygYULF1qXLl1s2bJlab0rAAAglcybN++M9n/ixIlu3p49e1JlHwK933fffefmHTlyJFX2Ib79AAAA4eWjjz6ym2++Oa13A0iSbElbHcjc3nzzTZs0aZKNGjXKcubMaRnFtm3bbMyYMfbAAw+k9a6EjZUrV1q/fv18zyMiIqxQoULWtGlTu/HGGy137txJWs/f3Llz7ccff7S1a9daTEyMVahQwc4991y77LLLLGvWrKn0CQEAZ2vnzp12zz33xGoD8ufPbw0aNLCbbrrJChcu7ALU3bt3D+r1/ve//9mll14a9Ptv3br1jPZ/9erVbt6wYcPc+wdrwoQJNnLkSHv//fetYMGCQW8X6P10s0Dz9FqB2sHkSmgfk/u5AQAp5/fff7e3337b9zxbtmxWtGhRu+CCC6xz587uORDXiBEjbPr06fbxxx8HTEwcO3YsBw0ZCpnzQBL89ddf7sIuKioqQx23Ro0a2TfffGO1atVK610JG7t373a/C3ny5LEbbrjBnTwWL17cBUB0vBWQScp6sm/fPrv66qvt/PPPd4F5/bz44ovt0KFD1qNHD6tUqVKqZhkCAM7O4cOHXRtw4sQJ1wYoc7tq1ar2wgsvWO3atW3VqlWWPXt2t8x/2rx5s9vuuuuuizW/WrVqZ/2VXHLJJe6coEiRIknaTjebtU/Hjh1LlfdLjoT2MTX3AwAQHF3z6P92zZo1XTt31VVXuXZRN60vuugi134Ccc2fP9/GjRsX8MDceuutLpkSyEi4DQlkAiVKlHABAYRevXr1fMf2+uuvdwF3BeAHDx5sQ4cODXq9U6dOWYcOHWzx4sU2e/Zsa9iwoW9bdct77LHHXKa9TlBDmWUIAEh51atXj9UOt23b1vWIGjBggLuAjNtGf/nll+7nNddcE/KswcqVK7sptaT2+6X3/QAAnKlly5a+nmHqWabrV/U+/vzzz12SEhAs9U7UBGQkBOeBFLB+/Xr79NNPbfny5RYZGWmtWrWyrl27xrrAvuuuu1xWtSg7oFSpUnbFFVe4TGmPMr+6devmgrKtW7e2d99915YsWWK33XabK6vz6quvusCuMqvVhVuv16xZM7vjjjvc+/p37XruuefcpKwEUTewYLeX48eP24cffmgzZ850XfJ1kqSTpj59+tj999/vuh4GQ+/7/fff26ZNm6x8+fIuK1CBahk/frzrmqYu6fny5fNts27dOnvooYfceymbPO7+HzhwwNWW02tqXzS/d+/eduGFF8Z67/3797uSAJ06dXLfh2fq1KnuzvuWLVusWLFiLmged9tgeSeVqvOblPV04qn9ULdO/8C8R/ul46PfFQBAxtakSRMrUKBAom1FUqgtf+edd1ybr/b5zjvvjLf2us4n1CXcv7yL5v/000+uR5fa5yuvvNKaN2/ulqmN1SQ6R8iRI4d7PHDgQKtTp46rIa+bDJ988onLZvviiy9s7969rm2L7/08f/zxh3311Vfu5nO7du1c5qTK/3g++OADmzx5sjuvitubUTe4Bw0a5HoUJLaP8e2H3lf7OW3aNHfeVaNGDXeOU65cOd86/p9Px1f7op5sOmfTDfQsWbIk81sDAATiXROrnYwbnNf//9GjR7trP5UwU4JT+/btY63zzz//uBvdWkfXUbpWVQ9lz6JFi1z78PTTT7uyoe+9957t2rXLzjnnHNd+BkqGUuk0tZNq38qWLesSrho3bhzwNXPlyuXaHJWX07WuStzFfc3E9jEpnzeupHw+/3XVdiouoHiGrrPVFnrX2mrfVXJVgW9lp6tUq3/5X7WPeh+16b/88ou7btV1d6ByfEl9TbXDOv76/JrUpqsd9k9u8Era6XVVLinueUNS31PxAcUtdE6i70WxGn9KrlOvD50/qAd8lSpV3DmMziOApKKsDRBi6jKtf8gzZsxwGQC6IHziiSdctzz/btYdO3b0dVNXg6WLw8svv9yef/553zoqn+P9w1eDoIa1bt26Loi8ceNGt0wNxiOPPOJK1igz7+GHH7ZbbrklYM15NciepGyv/W7Tpo09/vjjbh01ZE8++aQ7mdBrqPFOjBpAXSwr6K3B2HTCpcZTNym8mnC6maHX040Af2rsNF/7HHf/dbwVuNd+6WRCAYUpU6a4AH1cChboxMa/wbz77rvdvug91eVdr6HggE5QkhsckcSy2+Oup2Opht//pkFcOsmj7iIAZHy6oDt69KjlzZs3JK+nm+vKxFfbpzZaGeK6+F6wYMEZ63q11/3LpKl913mG2iSdk+jGgc4N3nrrLbdcgQXvRrr/+YvKtPnXkNfF7Msvv+xuMnvnPIHez6Ob8W+88YYbh6VkyZIu+UCvq3MGjz5DoNqxXukfL9EhsX0MtB86v1BSgs4jdMwUGNEFv86J9NPjfT5d6L/yyivu5opeVxf1OnYAgNDyrpXitpP9+/d3/7f1v1+90FSqTL3MevXq5VtH/6/VHnjrVKxY0f3/vv32233rbN++3XctfN9997lrSV1n64avbkwrkOtRm6T2RIFmJcjp2nHDhg2uLRg+fPgZr6nA9L333utKktavX9+eeeYZ1y75C2Yfg/28gSTl83nrKhFM1+Ya70w3sZXYprZT273++uvu/ELBfd00V2m+pUuXxrqBoO3V20GBccVBRPENxQ38JfU1dQx++OEHd66gGyNKfFQgPG5ZQF0rx1dzPqnvqaRG3QzQ5zh58qRLWIhb3/7aa691iYFKslQcQdfySjz89ddfE/xugIBiAATtlltu0dVizMGDBwMuX79+fUzOnDndev42bNgQkytXrphnnnkmwdcfOnRoTLZs2WL27t3rnut99H4FChRwr+05evRozBdffOGWtW/fPubUqVO+ZS+//HJMlixZYpYtW+ab99NPP7l1p06d6puXlO1feOEFt+7MmTN987SNttX8Tz/9NNFj9+6777p1R40aFWt+dHR0zI4dO9zjIUOGuHV27twZa50FCxa4+drnuPvfunXrmJMnT/r26fjx4zEPPvhgTPbs2WO2b98e63XOPffcmAYNGvief/DBB+41vvnmm1jrjRw50h2DefPmxft5dCy0rfbZ/7P06dPHzX/rrbeStF6FChViypcvn+hxBABkHGvXrnX/69UuxW3vNf/5558PuF3nzp3dcq99S8zdd98dExkZGbNmzRrfvMOHD8fUqlXrjPb/7bffdvM2btzoa5Py588f89hjj53xulu3bvU9fvXVV912/vM8gwYNcstuvvnmWOcqgd7Pf/3u3bvHep3PP//czddPz3333ReTJ0+eM95z7NixZ5ybJLSPgfbj3nvvjcmaNWvMokWLfPN0zJs1axZTvHjxmCNHjsTa3zvuuCPWa/bq1cud33nnbQCApHnvvffc/1ddr3p0PdehQwd3Peb/P37cuHFuXf0/9zd+/Hg3/9dff3XP27RpE9O2bdsz3su/bZg4caLbpnHjxjHHjh3zzV+6dKlrF/r27eub9+GHHwa85lXbGxEREbNkyZJYr9m0aVP3GTwff/yxmz99+nTfvGD2MdjPG0hSPp+3bsOGDWOtq3b8oosuiilcuHDMrl27fPP3798fU7p06ZgmTZr45in+ofOQAQMGxNqPp5566ozr6qS+pl7Df5/krrvucjGSQO6///4zzhuS+p6Kf/hr165dTKVKlXzPN2/e7I7ZRx99FGu9qKgoX2wDSAoy54EQ+uyzz1ymmLLN/Kk7mO6mKmvbo/V091V31dUlTl2ydGdb2fL+d29Fd8mVEe7RHXuPuvn5d//Wurq7//fffwe1z8Fsr+x03V3WXXuPtombYe91LfOfvMwzlcTRHW7VEPSnruDqxpdc2gcvm1z7pHI8yjjQHW51P/eolrvuhPtnI+huuTIa4tb6VRd1vY4yCBKj99D2yqRQySBlAOoOurIOkrKejp13tx8AEF6UhaU2QNluythSFpjOFR599NGQvL7aaWV1qU3zKAs+bpsbiNph9RpTaTX1tPOnbPakUOZ7oHOV+KjUnD+dDykjXV3iU4PeR+c9yqbz6JxCpfF27Njhsv/i+3yibdUDYsWKFamyvwAQrtR7XO2kBoTVwOm6blM5Mf/rT127qWdX3LJtav9Uzs271lb7o+tplYNNrE1TCVmvDJqo55R6Ufu3Q+rhrOvVuD2c+/bta9HR0fb1118HvJb0byu8jG5PMPsY7OdNSDCfz6NzBv91Dx486ErP6fP4D6auErdqv+fOnesGtveoEoBiG/7Uniq24B0jlc5L6muqJJD/cUuqs31P7zvU4MVejwN9v4o9qJeEjpNHlQ7OJraBzIua80AIqSyLqCSKLnbVEHlds1XLTeVcRP/U1Z1M/8jVILRo0cI1NFpHJVn8u5mJgtrxiTu4mdcYxL3APpvtVfPdO6lIaL/UkMUNaGs7nQCsXLnSV7s2lAIdG5106JjqhoC6qnsnNzrZ8A9U6PvyusOJ931pUmOr7oqJUXdEnURqfZ086XmgmrqJracTBf+yQwCA8KFyamprdONYF+dqf/Q/3//meHLpnEHd3QO1hwpwBEPjnejmdZkyZVw3fXUZ1/gr5513XpL2JaHzlWDW1/HQeYkugFOazsF03FSvPi51/5e4+3G251wAgMDU7qgk2uHDh13Ckup9xy11qrbTvwyo/7Wb1vWu3RTo181w3XjVdaFeW/XCNcUdIyS+tvPnn392bbauFXUtrPXittlqExSMTU5bEcw+Bvt5ExLM54tvXX1uSayd9M41NGZc3MC0rnFVytY7Rkl9TSUaJDVRIK6kvqdq0Guf4/sOFdQvWrSoDRkyxJXx+fbbb12cQ2MEKsnAG+MPSAqC80AIqXFTA6rs6Li1wVV/zJunoLHulCsY75+t5V+T3p//4KhxxR241WvMdRc/GMFsr3WUGRZX3PqxefLkcdl7/rxBchQY18lWQrw79Qry+1NN2PjEd2x000MZbhrAVln/yrzQCZB/QNwbiDdu5ryoYfUfDC4+9erVC7h9Utfzbiborn2wwRQAQMagiz+vDdAg72r7u3fv7i7IvZvIyeW144FqugeaF4gC8ZdddplNmjTJjXOjOqu66NSYOc8++2zQ+5LQ+Uog8e2zf+aeHiuAEFdC5wZJOW6Bzm+88xX//fDfJrnnXACAwFTb2xs4VD2jNSljXNdQumnsXbvpWi6+azdlk4uSoJQYputAJb799ttvbsB01T9X7XL/AH187ZCC7pq8//2B2goFyDWGTHLaimD2MdjPm5BgPl98bXhS20nFMvQZ/W9i6EaC5nvrJfU1k3peEUhS3zPu9xffd6ieExp7Rt+dzp002KzOmXRNr3M8ICkIzgMhpG53GiVcg6gklCWuQczUGGoAEn/qbpUeKYtBZW508uHfiGukc386gYgvAK1jM3nyZJepFl8j6wXDNdhr6dKlffPV1SypdDNEZWOUMa+R7ZWhGHeAHe3TrFmz3Ij3gRrh1KSucxoYTwPpKYMxEH0HuuOf2GCzAID0TV2rdb6gnna6gPMGLU0O9bxTllagtlJlAYKltsXL2tOAcQqSaKA7LzjvJRiEMhCtffa/Ia2Au25Sqxu+/7mBbtprwDr/QESgz5uUfdSFuG6OzJkz54xls2fPdj+9AWYBAKlL10TfffedK4syY8YM37Xb559/7tqnxAZUV3ugQb41qZScphdeeMGVIVNvNv+2xOtF7T9PJei8ILPaApWQURvln1F9tm1FYvuYlM8bn2A+X3y0D+rF4H1Of5qn/dfNE49upP/zzz8uduBRMqKC894xSuprxkfrBXs+Eqr3DERZ9hoYVpOSGrxBZwnOI6moOQ+EkEqm6J+/Aq1xu5mpnpy6PIkaJwW6VYPWo3plgRqM9ECjwStgrgbHo65fqpEfLHX5OnTokKtD53/XWj0IlDEgOjHRiYd/cFonJ8oeSCpl8etERPXtVN+9YsWKdtFFF8VaRydAKjWkz+e/T7rDr/cMtm5/KCgj5JlnnrF3333X/fTvPaD9Ua1D7X/cXgUAgIxJXdrVLurn2VI7pnMI9RLzD8wrkysx+/fvd22Pf+89naOoXfSvzerdQF+/fr2FyhdffOFqu4suslWDP27N2vbt27sAgv+5gW6sT58+/YzXS+o+PvDAAy5w8Oabb/rmqYyAgkI6Jzn33HPP6vMBAJJHZUP69OnjrhO9a+aHH37YtQdKuPKv8y0aI8QL4r/11ltnlAtVhrSCsHHLlajHmP81n9pDBZiV5OXfxqptUk83tY+yd+9e12ap5ErcWvTBCGYfg/28CQnm8yV08//uu++2sWPHuliFR5n+Ot/Q2HUKTntU7mXo0KG+62r91GfQOkpKSM5rxkftvY6JVzY4lJ8jGDpXUMUA7/dB9DuiSb+7QFKROQ8kgxqXuN3ARJnPaijvuOMOF6TXXWM1rqtXr3YZaS+++KJbT0FjnWSoG/mFF17oyybXBbpK4qQ3yqIbPHiw696uQW+V4aeTh6eeesr+/PPPgMciLl3gKvtBDaN6FujY6IREgWcNjCsKAqhB1wmQsvL1XMv1vnqfpNKJzHvvvecaXgW849YYVED8p59+8u1T/fr1XQOrGwJa9tprr1lq0udUrb8nn3zSXn31VbcPyujXCZS6H6p7p246AADCpwu/LpQffPDBWAO/J5WSAtQ9Xu3EsGHD3DmHerMpcOCfhR5fBrnq4A8YMMANKKu2V+2O5vsH+7WvderUsauvvtpl8+n1lfmvecmlQXEvvvhiF9zQTX/VctW5lDL6PMpuf/zxx107rhq5Clzowlfbxg2IJHUfVTJhy5Yt7viPGDHCfXbd5PCyFQEAaUdlQ5RkpWskXY+qRJyutVW+VNduait0HapAqdoK9fYSXVurrKn+p5ctW9a1L+p9pR5rcUvBqJ1Udr6uEzWGi9o/JZX5Zz7rOlbtYc+ePd37qyezrlXVFulaUuOJJVUw+xjs501IMJ8vIepJp+00dprK1er9dfNfvdTjvr+y03Ueout8Jcbp5rduvCso7h+wTsprxkf7/8orr7jrZe+46NjFvfkSyvf0p+9cvSl0bBX30XmXXk/jDShzHkiqLDHeaJUAEqUuYN6AIoH4l0dRKRVv9HV12Q40GMuyZctc4F4lXJRNr5HEFYRWtpYaZQWK1Zipe1TcgUX0+soc02Cr/icEqn2nwL8aRa+ruBr6qVOnWps2bXxZcEnZ3qPX0THQ+irbo5MFZbTppMSrEZiYqKgoW7BggbsA10mGLpjjBvd1oewF53WBrIZ04sSJ7rFOXhLa/7h0Q0Dv6f/Z49K/wcWLF7vvVg26jnVio6zrLr3KECmg7w0kczbrxaWTrjVr1rgTKQVs9F2kdekdAEDS6Mbqjz/+6C7cAnWZVi87lVXRhaX/QGVq39TO6SZ+3BvLCVHGuC6GdRNdwQS128qe928D1baojVWgQxfSHmXxa1tlA6qt1f7GfW+1p9pfva7OUTSAndpLtVnatmPHjrEGl4vv/fzX1+so+0/ZZmrn47uw1uvovEr7pnMmnStoO/Uq8x9PJr59jO9ziz6zzm/Ue0BttX/Jg7j76//5vDZe48b4l+MDAARH11/6/+td/8algKfatksuucRlZse9jlbikq7d4g4aqjZFPbTVlqpNVDvrX1dcdcJ1HalrTN0k1o1ZJY7pGti73oxLbYT2R22GBlBXW+RfGkY9wZQUpuQ7/3J1utYcM2aMC6j73yxObB/9JfZ540rK54tvv/1t3brV3cjXZ9F1bdzXUPa5bqDrGl/lf/R+ai8VM4jb5gb7mvq90OtdeeWV8Z5jqb1XW6ybAAq86/ipp4BuduhGfajeU7+D+u4V+/Av0auB5RVH0O+GEhyScr0P+CM4DyDZnnvuOZc9rxr6GlgVAAAAAID0zD943bZtWws3qf35/IPzAJKOmvMAgqJuWxrkxaM7zuo6r94CBOYBAAAAAACADBicV5dTdX1RN9Sk8B+4CkDKUldy1Y7THfjzzjvPmjZt6rreqbYbAAAAAAAAgAxU1ka1IjX4koJ7KouhkaRbt26d6HZPP/20G7RBtTFV10kDLgRb7xpA8qm+nmqq7d+/39Vj9a+PCwAAAABAehdMnfWMLLU/X2L14QGk4+C8RkxW9vtll13mBooIJjivQLxG654wYYLL3B06dKg988wzLmAYd/BKAAAAAAAAAADSo3QxIKxGpy5XrlxQwfkqVaq4UZdffvll3zyV2ujSpYsL1AMAAAAAAAAAkN6li5rzwdq1a5etWbPGLrjggljz1VVn9uzZabZfAAAAAAAAAAAkRTbLYHWzpGjRorHmq4ZWQsH548ePu8kTHR1te/bssSJFiliWLFlScI8BAEhb6iB38OBBK126tEVEZKh78mdFbb3GtsmXLx9tPQAgrGWUtp62GQCQmcQE2T5nqOC8f6PuLyoqKsELb9W2HzhwYCrsGQAA6dPGjRutbNmyllkoMK+SeQAAZBbpva2nbQYAZEYbE2mfM1RwXncaZPv27Wdk1HvLAunXr5/17dvX93z//v1Wvnx5d3Dy58+fgnsMAEDaOnDggAtSK4M8M/E+L209ACDcZZS2nrYZAJCZHAiyfU73wfmjR4+6zHh9kIIFC1rdunXt999/t2uvvdaXRf/HH3/YnXfeGe9r5MiRw01xKTBPcB4AkBlktjJu3uelrQcAZBbpva2nbQYAZEZZEmmf07Qg3YkTJ2zfvn3uToIcOnTIPT927JhvnV69elnz5s19zx9//HEbOXKkffbZZ25w2Pvuu8/Vk7/nnnvS5DMAAAAAAAAAAJBUaZo5P3r0aLv33nvd4wIFCli3bt3c48cee8xNkjt37ljZ7TfeeKPLph88eLArb1OvXj2XOV+qVKk0+hQAAAAAAAAAACRNlhgNHZvJKFNfNwNUe56yNgCAcJZZ27zM+rkBAJlPRmnzMsp+AgCQmu1empa1AQAAAAAAAAAgMyI4DwAAAAAAAABAKiM4DwAAAAAAAABAKiM4DwAAAAAAAABAKiM4DwAAAAAAAABAKsuW2m8IAAAAAADS1rJly2zGjBmWN29ea9++vRUoUCDRbWbOnGnLly+3XLly2XnnnWcVK1ZMlX0FACBckTmfidxxxx02bNgwCyf9+vWzp59+Oq13AwAAAEAquvzyy+3rr78Oq2PevXt3GzFiRKq818svv2znnHOO/fjjj/bqq69atWrV7J9//ol3/WPHjtlFF11knTp1sj///NM+//xzq1mzpr3yyiupsr8AgPRv8ODBdt9991k4+eCDD+ymm25K0fcgcz6FnDp1yqZOnWpbt261UqVK2QUXXGBZs2a1tLR27VorUqSIhZONGzdazpw503o3AAAAgAzj1YkrUvX9+rSrHvLXXLFihe3Zs8fCyZo1a6x69dAfq7hWrlxpjz76qH322Wd2/fXXW0xMjF199dUumWv27NkBt/n+++9t8uTJtn79eitXrpybN2TIEOvfv7/17NnTIiMjU3y/ASCcVXxsQqq+37oXrwj5ayoGqnYinOzcudNWr16dou9B5nwK+Pbbb133vjZt2ljXrl3dTz3XfAAAAAAA0sro0aOtcOHCdu2117rnWbJksXvvvdfmzJlj69atC7hNtmzZLCIiIlbpm0KFCrkENG0PAACSh8z5EFMAvkuXLi77wN/mzZvdfJ0IXXPNNZYSPv74Yxs1apTLIKlfv77LYqhatWqsdU6ePGnPPvusTZo0yWX3/+9//7Obb77Zt/zff/+1F1980dUfLF26tMueUJdRzy+//GJvv/22bdq0ySpXrmwPPPCAtWjRwrdc6yvb4/jx466LpLo6Xnzxxfbhhx/a77//HmtfnnrqKdu+fbu9++67Qb22julrr71mX331leXLl8+uuOKKM44zAACIY9Kg5B+SNv04nABSna5TdN7/3Xff2ZEjR6xZs2b2xBNPWIkSJWKtd+jQIXv44Ydt1qxZrjdtnz59Yl27aL7KrijgrOsLLVeddM8XX3xhn3zyie3evdtq1KjhSmbWrl3bt1yvpQD2kiVLbMqUKXbJJZdY/vz5bdGiRfbpp5/G2pfbb7/dypcv7yu5mdhrnzhxwl544QV3zVS8eHG74YYbLLUsXbrUXbMp2O6pVauWb1mgOvIdO3a02267zS699FL3eN++fTZ27Fh3DZo9e/aA76NrQk2eAwcOpMjnyRQGJD4eQFgYsD+t9wBAAn799Vd74403XNyuUqVKrg1WGx2XSrSpjdi7d6/rmfXII4/42pxt27bZ888/b/PmzXM3fLt06eLaF+9G78KFC13PLI1vorikYpbezWSvdM6GDRusUaNGLgYaHR3t1r/zzjtd2bWCBQv61lU7rHbKi0cm9tqiuO1bb73lXrdly5bu5nRKI3M+EQr+Hj58OKhJJxu9e/cOGDD25t1///1uvWBeLymB59dff9169erluiWqrvzRo0etefPmZ3T11EmuumM888wzdt1117lf3i+//NJ3gqgsf51w6vV0gvnOO+/4ag/ql/qWW26xDh06uF/UVq1auRNUle/xL52jmwIKuutE+Mknn3Tr6WaATo79bxIoEN+kSZOgX1t1EQcOHGj33HOPPf744y6Y/8033wR9jAAAAACkf7qIf+mll1zdWv1UwLh169buGsKfrgm8C/ULL7zQBQCmT5/u5m3ZssUlCSlp6c0333TXPgoiKFAgSljStUqPHj1coEFJReeee66tWrUqVukcXXsoMUjXKHp8/vnnu3rrSr7y7/Ku6xkvsSiY1+7bt6+NHDnSBe1100DXX8pcTw0HDx6MFbzwsuATC6BrHV3n6WbF4sWL3byESowOGjTIBV68ySuHAwDIeH777Te78sor3U1utW266a3Y3d9//x1rPcXqlFSrtlztm2KDSs71KBiu0jdq3x966CHX9nlxSQ06rrikAu9qu2+88UYXZ/WSer3SOe+9956NHz/exQh1I0BjqGi+Auv+tF3dunWDfu2ffvrJ1ZdXMrBuIOgGu26kp7QsMZkw9VgnHDo52L9/vwtEJ0RBco1enxaUCZInT55E14uKinLZFsrSUPDfyzbRoD7dunVzgXhp27atu7ukO0TeHSmd0OpuljLmdbKobXTCpdfz6CRYd7hUO1+/wP53lfSHpNfTH4X3Htpv/0C86A9AfxA66ZQffvjB3R3THTOd7Cb22toHZcroBO+uu+7yfTc6wVNPhPfff/+sjjUAhKuktHnhJLN+7oDInAeQgWrO6/pAGehKwlGGtihLW/OUhKTsOlEPYWXtTZw40betSooq+K6LawURFKxXINq79lEWnCiBqUyZMjZt2jQXNPfo+kTXJd41i95DyURe0MCjgIRuHDz44IPuuYIUunjXeFh6/8Re2/uMus5p3769W67rtCpVqrhrOvUSSMk2TwEJ3bxQhqFHNxvKli1r48aNcwlTcenmhG4kqIe1Poc3SJ7qzatWvjcvscx5Xb/RNicDmfNA2EvvNed1A7pOnTouMO7fw0w3ab0y3qqAoeVqD1U+TXRDW1U2vPif1levMQ0y7jl58qTrhaUb7YofKuju+eijj9xzJQN776ExU9Ru5sqVy7eeEpZ141jJwaL11V4r+K/2OJjXVpKz2n3vPEAaN27sxlWJG+cMZftMWZswoG6aOglUYNyj2n/6pVuwYEGsdZVx4l8TUH8MKmOjTPsKFSq47ozeYEBerXz9gSg7Qhkhutulu0e6p6NJd5Hi3rxo2rTpGfuoO0+6EfDqq6+6LiH6Q9KdKGVsBPPa3mfUPnl04yLQewEAAADImHRhrYt0/2sbXTPowjrutY3/tYF3beMFtnUxrWsJXXOo27rWLVmypFumQU/Va1glPnVt5F1/KOtO2/kLdL2hmwC6nvGC83qsgLeuwYJ5bZXF0WfUtZlHwXoF51ODErK8HgYeBdi9ZYHoczVo0CBWEF4lbo4dO+bKBAQKzufIkcNNAICMTe2Y/td7CcGedu3auQod/tRWeIF5r21WiTol3yrwfdlll7meaLrJrWV169Z1cUclGc+YMcMF9nWj2Gs/lQCsTHvd7PXalHr16sUKzHtxR91AUMkd3WzWTQGVcNP5QzCvrQC8PqN62fnTPuqGe0oiOJ+I3Llzuy8rGKpD6F/jMD66Q6Q7NsG8dzCUQS5xfzG1vbfME2gd/ULqD6VIkSLupEtdMvXLqrtR6gaqbiFaLqrNFLcGoX6BE9tvZcQrq0KZLRdccIF9//33rjaUBPPa3jqB9h8AAKQQsu4BpDJdv6jXbtygbrDXNt46CgyoPKdqzWpSsFwBf9WC17WFAucaFyvu+8TtuRzoekO9k5VUpN7HXjadMsslmNfWOkpYilurPbWubZQZr9I7un71rktVQ1+Bea/2vHoc6Ljp5oZ6KGj6+eef3fH1PofqBYuWAQDClyp2KICd3LijeOupZ5x6pKmXm3qdFSpUyD1XIF1BdN0A8L9B7/FvMwO1l6p9r5vcaucVYNeNc7XXopvmib22bpprvbSIOxKcT4ROrIIpLSOqka67M+oSGKhakF5Ly7WesipCRd009NrKQNdj/6yTuJkPqtfoT9uoi4UC86IuJrp7pUk3JXSHafjw4a7EjE6Sd+3a5WpMJZXeQyd2+uPQa+hEVc9FfzyJvbZO+PQZtf/+tQq1/wr2AwAAAMj4VEpG5WcU+FZmnOjaSuf9CrAndm3jn32uUp26QNe0Y8cOF3hWgpDq5eo1FYBWndqkUg15ZcHr2kbXNRroVTVsRcGFxF5b+6hAx8qVK91gsaIMdI0NlhqUuahSoSq1ozHIlGWoYIZXqlTUi1klAnT9qmsxJVqp+78Gx1P9fvVqVp1fjVOm4wEACF8KXquHl9pZ/9Jnijuq3fan8mdqx70BYLWNeO2zbk4raK5JbWGnTp3cOC1K4lWbozbJqxOfVF7PNgXgdR6hbHpRwD2x19bNdsUbdW6h7H6Pt/8pieB8CCngrkC2TnK8Lower5SM6iSGMjDvBdT1C6c6SRqgSFkiqvekTIihQ4fGWlcjFCtzXxn+6lqpARhUwsbrXjl58mT3XDWg9MekPxR1B9VrasBW/cHoRFQZ9fp86tqhk0qv9mNC9IenLqWqC6VMei8rPpjXVm0mnQTqM6oGlJ5rsFoN0kRwHgAAAAgPqmer8/vHHnvMxowZ465LdA2lWrXdu3ePta4CygoyK9isYIAGdfNqyeq6R9tcf/31LhCg6xpd3+jaRl3uVeZGGXQKBqi8p5ZNmDDBFygI5tpGNWl1TaNrGU8wr63AgDL89Bk1aJ5eQ/ud0GCsoaZrKV0TTp061QXfNaCff5Bd11tK2PKSv4oWLeoCFspu1DWYjqN6WAfKQAznGs1pZV384+4CQKq4++67XcxT8TwF5OfPn+96WGncFX8a0+Tll192N8bVU6x///6uDJqC40oC1liSSgBWxrxifydPnvSVwdEAsipPp3I53pgsant08/jRRx9NdB+9cTdVVlslbvwTmIN5bSUBeHFdtd+KkaotT86N/KQgOB9iGpxUJyk6GdMdGY9+CXVSqeUpQa+tAL0GH1IWvDI1NMBq3F+gq666yv2B6CRWA79efPHFvlGT9YunYLgyTDRpubL8vZpSej3VVVSmSbFixdzJozJEVEc+GMqU14mnTgDVDdRfMK+tz6hBoTQwrP6Itb8aGRoAAABA+NDF/g033OACwt4YVMqE0zWVP42V5V1fKfFIGXO6zvGC/Mr0VjBBtea1XNdLCtaLrtm0TD2NS5cu7QaJ1bWRAgrB0P7pukqBdy8zzxPMa48cOdLtvz6jbkCox3JyMwWTS9mPgQZ/FQVK4gZc1LU/mKQsAED4UXBbMUO1r2pXFTNUDysl4cYdq0Ula9TmKTapQL5KZ3sZ7KpOovZRicYa8L127dq+QWb1HupJprZaPdMUvNd7KbE4GHpdtacqw+aVm/Pf/8ReWzcNNL6N9lljqSiGqZvqSjJOSVliAtVfCXNJHc0+OVTLSEFonQTqC1X2R6gz5gPRwKr65VbgOm4teA2qqj8EBbfVrVOZGzpZjEvz9YunILn+WOLS4LG68aDPFXcwWP/3CEQjIKvOlP6Y/QemDea1PRqsQfulE0atq64ygT4HACB12rz0KLN+7pDXjT8bbfqlzfsCCBvKvtP1gcalinstpQCBAttK2lFZUV376PolLtXI1XJdgAeqG6ssPl2zqSu7guTxvUcgyiDX5bRXmiYpry3aVtdH3nWXHusaKNDnCIc2LyX2M/Nkzne1TGHA/rTeAwCJ0P9wBeaVHBy3DLh6rKluu0rgKDapEmiBxiVR+6fYntqCwn6Dx/rHJbVc7W/c5f7vEYjaXZVmU4A9UNub0Gv7v4f2UbFJleBW++WfhR/qdo/gfDo+eQEA4GxllAv2UMusnzsggvMAENYySptHcD75CM4DQMYTbLt3ujo/AAAAAAAAAABINQTnAQAAAAAAAABIZQwICwAAUpRqAmpwvJkzZ1rnzp2tdevWiW4zZ84c+/333+3IkSPWsGFDNxCPxhgBAAAAACBccJULAABSzKRJk9zgOd9//72NHDnSFi5cmOg23bp1s969e7safRrg7+GHH7ZWrVq5Qf0AAAAAAAgXZM4DAIAUU6FCBZs/f74VL17cihYtGtQ2jzzyiNWvX9/3/Pbbb7eKFSval19+abfccgvfFgAAAAAgLBCcBwAAKUZZ80nlH5iX0qVLW6FChWzbtm0h3DMAAAAAANIWwXkAAJCuTZgwwXbs2OFK28RHJW/8y96oJA4AAAAAAOkZNecBAEC6tWrVKuvRo4fddddd1qxZs3jXGzRokBUoUMA3lStXLlX3EwAAAACApCJzHgAApEvr1q2ziy++2Fq3bm1vvPFGguv269fP+vbtGytzngD9mWau2X1W30nzykXOansAAAAAwH8IzoeJr776yv766y/3OHv27C4gcdVVV/kCE4kt96xfv95++ukn27Rpkxu4r1GjRgmWEQAAICWoPVJQ/txzz7UvvvjCsmVL+JQlR44cbgIAZHxvv/22rV692j3W/3YNCn7NNddYkSJFglruWbZsmf3666+2fft2N37JeeedZ02aNEmDTwQAQMb2559/2vjx493jrFmzWqlSpVwiVb169YJa7tm9e7crW7py5UrLly+f1a5d2y699NJEr/fCWeb95Clk876jtvfwiXiXF8oTaWUK5gr5+yqgPnXqVLvnnnvs5MmT9sMPP7gMwnHjxln79u0TXS5PPfWUDRkyxK644gpr2LChbdy40a338MMP26xZsywigipIAIDQmzJlin399df22muvubZmw4YNLjCvAMqXX36ZqU/UACBFTBqUuge2Tb8kra7EosOHD9v1119vx44ds48//tgeeughdz2jQcMTW67rnfvuu88+++wz69y5s9WoUcOWL19uo0aNcsGCb7/9NsU+KgAAyTKgQOoeuAH7k7S6En51c3zgwIEWHR1t8+bNc/HCV155xXr16pXocvnkk09c+6yb5S1btrR9+/bZ+++/79rw3377zcqWLWuZEVe7IQ7MXzR0sh2Pio53nRzZIuyPh1qnSIBeWfD6hfa69yvo3r9/f1/wPaHlb775pj3//PP2xx9/nJEpP3/+fMuSJUvI9zdcpdUNGgBIjzZv3uzqwYsCKWPGjHF15Bs0aGB33HGHm//PP/+4dmjYsGEuON+pUyfbsmWLa58eeOAB32upfbr22mvT7LMAAFJPnTp1Yl27KPPumWeesdGjRye6/PHHH3c3d+fOnWu1atWK9bqaBwAAki5Xrly+tleKFy9ujz32mAu4J7ZcmfW33nqru+67++67zyhnmitX5o2TEZwPIQVkEwrMi5ZrvdQIzp5zzjk2YsSIRJfHxMS4wPzNN98csIRN48aNU3hPw0da36ABgPRG5QZq1qzpHqt3lqdMmTK+x2p7Xn/9ddf9UZRZcejQoTNeq0SJEqmyzwCA9EXtg3r2rlixItHlGnNEbYqCAXED80JZGwAAQkNxxSNHjtiOHTsSXf7CCy+4+GLcwLyoPF1mRnA+SEdORMW7LCJLFsuZ/XRAIVSvmzvy7L4aBdynTZtm1atXT3T5mjVrbOvWra6EAMLrBg0ApDWNX9KzZ88E11G2o38twh49eqTCngEAMorjx4/bnDlzrGnTpokuV7d6PefaBgCAlKVycgUKFIg3icp/+fTp0+3ee+/lKwmA4HyQaj/1S7zL2tQoZiNvDXyimJiWgyfZngAlUNa9eEWSX0uDIqn7SFRUlM2YMcMNrqCa8YktV40nKVmyZLI+AwAAAACEksrP6NpFgfbff//dZd6pbE1iy//++2+3nGsbAABCS22t2l7VlF+yZIkrVfPee+/5SmHHt/zEiRN29OhR2uZ4EJwPI5GRke4XPXv27HbBBRe4UZELFiyY6PL169f76gIjdWzce8RKFshpBXNlt2xZ036gXerkAwAAID1R7Vldu6g8Wtu2be2SSy6JVY82vuXeNY1+emXVAADA2VMQXm2vxglTmTgN5qrxLYNZnjdvXuKO8SA4H6Slz5weVDW+sjbJNe3RNhYq/gO+JmV5hQoVrFKlSvbzzz/b7bffHrL9yYxOnkq4pI2n52fz7VSM/nGZFciV3QrnibTCuSPdzyYVC9mdF1bxrTtj1S7LlzO7Fc57ep1ckckroRQf6uQDAAAgvfEf8DUpyxUMyJMnj7u2UTISAAAIjbgDviZlucrNTZw40WXVK3iP/xCcD9LZ1oBP7ddNqoEDB1r37t3t22+/tWuuuSbWMp3YKhOFP56EvTJxhX0yY21QxztXjmx26FiUxcSY7Tty0k1r7PAZN3s0NkD3D+dYVHTMf9tmz3o6mJ8n0lpUKWL9Lv9voKtv52+yPDmyWZH/X64pf87sFhER/w0k6uQDAAAgXCgw/+ijj7qB5zp16mQtWrTwLVNA4JdffrHLLrssTfcRAIDM5sknn7SWLVva888/7x77mzdvnpUtWzbe2vXhLn1EhpHmbr75Ztu7d6/dcsst9uqrr1rDhg3dc9VsLF++vLVvH3/PgczqVHSMZfULeq/eccj2HY1/4GB/X97RzGqWzGf7jp50Yw7sPnTC/dxzRAPF5vStd/TkKatWIp/tOXzcLT95KsbNU7a7prKF/uvaGx0dYw+P/sftlz/tY6Hckda6RjEbem0D3/y3J6+2XNkj7PCJU2d5JAAAAID0o3///q62rTLnL7zwQqtRo4Zt377dFixYYG3atCE4DwBAKtOg7WPGjLE77rjDvv76axeoVy36JUuWuMTUcePGZdrvhOB8CBXKE2k5skXY8aj4S5toudYLtRtuuMH279+f7OXSu3dvlz0/adIk27RpkxUtWtSeeOIJajXGoaD4V3M22NdzN9mo/51nVYvndfPvblXFGpQtYC/8tCyo70y15ovmzeEmKxF/z4qf7r/APdY/q0PHo04H8f9/Kpg7u2/dE6eirVX1Yr5lyog/eDzKBet3HTpuR05ExQrkD/11+RmB/IToBoH2wRvoAwAAABlUm36Wnt1zzz1WoECBZC9Xj19lzt9///02efJk27FjhwvSv/TSS66kJwAA6c6AhGN2aU1laXLnzp3s5XLVVVfZunXrXNu8evVqV4f+nnvucSXpMrMsMYq2ZTIHDhxwJ3MKVufPnz+kr83AmuFJQezJy3fY57M32KTlO8yLad/Tuoo9emnNdFu//XjUKdt7+HR2fmS2CN+NBM1/ZvxS23vkhG3YfcQWbzkQ1Ovlz5nNZfJXLZbXvZammqXyWakCKf9ZAKS/Ni89y6yfO6BJg3wPZ67ZfVYv1bxykbAJ/gFAuMgobV5K7GfFxyZYZrAuZ1fLFNJ5cBIAUqLdI3M+xBRwTY2gK1KHMtU/nLbWvpyzwbbsPxYrONH1vPLWvk7JWOvru1fgXVnr8VHPidT6HcmRLauVLKAp5xnzn+9Uzz1evHm/Xfn6tERfS/nyB45F2bz1e93kuaJ+KXuza2NfRv7bf662KsXyWNXi+axCkdyWPSsDfYSDU6dO2dSpU23r1q1WqlQpu+CCCyxr1tAOTgwAAAAAAJCZEJwHEvoDichiH05f6wZsVQmZLo3L2o3nlbcqxU5noGemGzSj72nuyuys3HHIVu045Grsr9xx0GqXyh+r58CQX5b7nmfPmsUqFsnjy7K/oFoxa1qpcEj2h14qqUcDRatbuMpdeTRYy/Dhw88YQBoAAAAAAADBITgP/L+dB4/b13M32qw1u+3jW5taREQWy5k9qz10SQ3LkyOrXVa3lHueWSnbvlap/G6Kj4pkXdOojAvgr955yI6cOOUea/LKA3nB+R0HjtmjY/7xlcmp8v8B/AK5/qujH5/0Vj4o3APzXbp0ceMN+Nu8ebObP3r0aAL0AAAAAAAAyUBwHpmayrCo/q5qyf+yZJtF/X8xec07v2pR97hbs/AeNKpAzqwWc+qkZckaf1Bcy7VeYsoXyW2vXN/Qd2y3HjjmsuxXbj/ogvXN/GoVr9h+yCYt3+kmf8Xz5bBqJfJa9+YVfWWDvMCwNxitygYlFJgXLdd66Sk4n9Gy/VXKRhnzgYYm8QYHfuCBB6xjx46UuAEAAAAAAEgigvPIlBQg/WbeRheUX7f7iG9+o/IF7abzKljj8oUsM1CA9bfvv7HN7z5qWXPHnxF/6sgBW33F11audeugX1s9D7wSP62qFztjeZXieey5q+u64L03bTtwzHYcPO6mjg3K+Nads3aP3fnpPJdZX614XteTIaPJKNn+e/futfnz59vcuXPtp59+ilXKJtDvz8aNG12A/oYbbrCGDRtanjx5UnV/AQAAkHTR0dH22WefuTGF8ubNa127drUmTZrEu/4PP/xgX375ZcBlb775phvwDgAAJB3BeWRKy7cftBd+XOYe582RzTo1KuMGeE2oZEu4UEB13rx5NmbMGFeyZMWKFW7+qYOxM9jj0kCgoVSqQK4zeiUcOHbS1bJXoN4/y37VzkO2/+jJMwajTczns9dbhSJ5LHdkVleSKFdkVjunQiH33t6Av3sOnbCckRGunn6u7Fkta8Tp7PxQS4/Z/hoxXIF4/T4oGK9p9erVSX6dN954w00RERFWu3ZtO+ecc9zFnaYGDRpYrlzppzcAAAAAzG6++WabMmWKb1yh5s2bu3KF6hEZSKVKlezSSy+NNe/ll1+2AwcOWP784X8NBQBASiE4j7C378gJGzN/s52KjrY7L6zi5p1XqbBdWb+Utaxa1K5qUNry5AjvPwWVJ5k5c6YvIL9hwwbfsuzZs9vJkycTfY2hQ4dalSpVrGnTpim2n/lzZrdG5Qu5yV/nxmWtUblCLkivwP289Xts+qrdib7e53M2njHv7ZsaW6l6p4PFk5btsF5fLIi1PDJrhAviK1D/9FW17bJ6pdz8hRv32Rt/rHKBfi1z6/z/Y83TYLc1Subz/c4t23bQt0w3BjQvLR08ePCMQPzKlSsDrlu5cmUXWC9YsKCNGDEi0dfWxdy6devcDZzFixe76eOPP3bLsmbNanXq1IkVsK9fv77lzJkz5J8RAAAAiZsxY4Z9/vnnNmfOHDv33HN9CTwK1Hfo0MFXStKfzuc0+Sd53Hnnnfbkk08GXB8AAAQnvCOSyLRcdvj6va5szYRFW11Gcv6c2VwdcwVKdQL5RtfGFs4UcP/zzz9dQP67776zbdu2+Zap9Mjll1/uBvJUBky9evXcAJ+Baot7FNg977zzrFOnTvbss8/GOjlPafrOapfO7yZZvHm/Xfn6tES3u6xuSRcgP3rylJs0QG3x/Dl8y6NjYlzwXMu8j37iVLSdOBrtMvVP+R2PzXuP2m//bo/3vV7qnN0XnFcgv8fIvyytHDp0yBYuXOgLwisgv3z58oDfb8WKFV3A3AueN27c2AoXLuy7qfPjjz/G+7uhv6OyZcu67tAKwm/ZssUX/Pd+bt++3f755x83jRw50m2XLVs2q1u3bqyAvX4Hc+T477vJTLX9AQAAUpNK1Ogc0AvMi0oUvvbaay7JQudlifniiy/c9UaPHj1SeG8BAAhvBOcRVhRQ/W7BZheUV+kaj8rV3HReeQt3x44ds4kTJ7rs+O+//9727NnjW6Y6kMqEUUC+ffv2sUqNDB8+3Lp06eKCrf5BWC8L5q233rLZs2fbJ598YmPHjnXB/m7dutmAAQNclnV6dV+bqla3TPz1Lzs2LOMmfWbdwDl64pQdUSD/xCk7dvKUlS303zGqV6aAvdCpngvka9mRE1F29ES0HT2pn6esYtE8sbLvqxTL4+Z7NwUSK2mTXEeOHPEF4r2A+L///hswmF6+fPlYAXEF4osWPT3wcSAKuCf2uzFs2DDfYLClS5d201VXXeWea30F7P1vEujnzp073T5r+uCDD3w9OHQh6H+jQAH8yMjIsKztDwAAkFbWrFljFSrELi/pPdeyYILzOoe78sorrVSp071MAzl+/LibPCqBAwAAYiM4j3QtqRmwb09ebe/8ebpmds7sEXZV/dKulnzDcgXDtrulsqQ1cKcC8sqC0XNPsWLF7Oqrr7bOnTtbmzZt4g10KmCvGpNezUmPsqIVfNXyu+++2x555BHXdVXZ+J9++qnLmLnjjjvcvIROzNM7/W4oO19TfEMBly+S27oWCe4GT4uqRe33B2MPnvvPxn3W4c3pZ7WfR48etb///jtWoHvp0qVuQK+49N15QW791FS8ePEkv2cwvxsJHdcyZcq4yatf6g0iGzfDfvfu3a53hiaPfl9VAsc/YK8eGwrkZ6Ta/kn5X6feCgsWLLBdu3a5GyeNGjVyNz/I9gcAAKGic0oNAusvX758vmWJUY9Inb8NHDgwwfUGDRqU6DoAAGR2BOeRbgWTAZst4nR5mkvrlnTPbzi3nKsjfmPTctapcVkrkCv+IF5Gtm/fPhs/frwLyP/8888uY96jQKgCpgrIt2zZ0pfVnBhtowCqSpSodriC7RdccEGs7WvVquUCtToZf+KJJ+yXX36xt99+2z766CPr1auXC94XKfLfQK4pRYFKZT8nlh2t9dKLiCAHmtXvvbL99Z16Fz5eAHvJkiUueBuXstXjBuJLljz9NxEKwfxuBEsBe2Xwa1KJJC9gv379+lj18PV47969vucelb7RILP+AXsNQqtSOUmh3gynomNSbADgs/9fl9ds5TGzmTPdM7L9kV7MXJP4eB+eWVGnBxz316dd9RDvEQAgqdSjdvXq0wlNHq/HrZYl5v3337dy5cqdMUBsXP369bO+ffvGypzXdgAA4D8E55FuBZMBGxUdYx/PWOcLzqu0yM8PXBCWWfIqBaJyMspa//333y0qKsq3TKVlFIzXpNqRERERyXoPBVtbt46d8R2IAqK6KaCa9o8//rgbVOqll16yd955xx5++GGXZe1l36QEZTyrLEk41hW/55NZlnPROFs5cVSs79hTokQJX1kaLxCv4HxKC/Z3Izn096q6p5r0O+wF7NeuXXtGwF6Dj2nwMk0eDS7bsGFDd0xK1zlP336i73ndu6eD3pHZInwD97aqXsxe7Fzft859n8+3rFmy+Ab11QDAuf//Z/nCue2SOv/dANEYF9mzZvlvsGD3mtlcUD2xGzMZNdsfAABkTCpbM2HCBHeu6SU4LFq0yP1UWcGEqEzNZ5995hJzErvmUFJFqMYUAgAgXBGcR4ZXr8zpQUI94RSYVxkR1XhXQF5Zy/7lS1Tew8uQV+mPtPjcrVq1smnTprlBQ/v37+9KrqjEjQaTUtBepXAUOE0JClJmpEBlgZxZLebUScuSNf7eHDEx0RadJbsdqd/FCmQtYhHzvrQmDevHqhOvQHw4/Y7HR59RN500XXvttW6efv9VB9W/N4HK4CgLa9asWW6KLPGTleoxPOj3OREV7SaNV/HX30tsyJpf3HyV15+wp5b2JOB25bIfsr/zb/A9f29PDTsRE7gnQZlsh+3qAut9z8cfKGcnYyIse5YYy5Yl2qKi9R6J38wK1GsCAAAgqXRupXN3lam89dZb3TmGzt/VM9LLbFeJvQceeMD69OnjzkU9ujZRL97bbruNAw8AQAgQnEeG16FhGQsnCj4qGK9Jg7D604mxgvEKyteoUcPSSxD1iiuusMsuu8y++eYbF5xfuXKlO5F/5ZVX7Omnn7ZbbrklyWVHws2cyb/Y5nfvsay5Y99M8nfq6EFr0fUB21SgnjVpc7mN+3aw5cie9NIx4UrZWVWrVnXTDTfc4AvYr1q1ygXqZ877237aU9TO7G9wpq2fPmRRe7dYlmw5LEv2HBaRPYdtPnnM/tiz+f/XyGJ5G1xiWbLnPL1c60Xm9K3/z871Nm32aN/rlbrtTYvIkev0+tlOv55n1aqV9shXT/iel73/S8ua878BhIOlWvQNyl+c5O0AAAD8qbfiG2+8YT179nRZ8CpbqHGrJk6c6FtHz7WsS5cusYLzGgi2ffv2rkQhAAA4e2keLVMN5REjRtj27dtd9zp1j8ufP/7glWjQS2Xqqh6xTgp0t79mzZqpts9Iecu3HbTjURk7S1QZKMHU6Fb5Dg3qqfrxCsgr+9w/8N2iRQtfQL5ChQqWngOn119/vdvPjz/+2A3+pIE///e//9ngwYPt2WefdVk6yS25kxGtW7fOfa+apk8/PRjsqYM7E9zmngsrWrXmLaxo3hy+wHzUqWiLyJIl6Lr1mYl+n6pXr26rj+ezmWuKW1T240Ft16h+XatRvGkS302v/f+vXzi3WY3u/y2Kmm3+dwVidOMgSzY7lSWrWS6zyO7/rbvn8Dw7dTS7W6Z1th4+ZYdKJ74vymADAAAIhTvvvNMuv/xylwykwWEvvPBCy5Xrv16pxYoVc5n16rnpf92ia+/GjRvzJQAAEA7BeWU66iSga9eu1q5dOxek/+qrr1wt4fhKYTzzzDM2ZMgQVzJDwU4NSKlawwqCqtY2Mi6d7P25Yqd9MG2tTV25y3pfVNUyKgVjVXddZWk8ZcuWteHDh7vgtT6rynEoGK91ly9ffkZtbwXkr776ahfYz0iyZ8/uAvLdunVzNeiff/55l0mvTOdBgwa557oQCNfSLPouvZ4P+o6TSt93k4qFY817ZeIKW7R5v718XQMrni9lygRlZBt2H7GeXyxwA7wWzWm267/xkeOlkks9OqaPLPSPxv1uA2YmvtNFixZNlf0BAACZg65PNAWSJ08edz7vT+fvunYHAABhEpzX6O0XX3yxG+1dFLTUycGHH35o9957b8BtPvnkE9f9TtvKjTfe6OoMK6hPcD5jOnbylI1dsNkF5VftOOTmKUF4874gImzpkILt6v6pALy/zZs3u4D7lVde6QZcWr/+vxrUkZGR7gaVlnfo0MGKFCliGZ1usKlO5e23327Dhg2zoUOHul4B+vznn3++vfDCC+7mXEan71mfy+v5oF4Q/lnd+oz636bvtWXLlu73IO7vhnexo/9/uunob9eh427Q48MnTtllw6ba0OsaWJsaxVPls2UU5Yvktp5tqrrj2qFBKbt46B8J1/Y/ddIubtnK0otGjRqZzZwZ3HoAAAAAACBspFlw/tixYzZp0iRfYF4KFSrkgvU//fRTvMF5lS9QFq5nz549rqt/rVoauA8ZSXR0jA37faWNmrXe9hw+4eblzZHNrj+3nPVoUdEN0Dhm/n+Z5xmllI0y5gMFX715KsskuXPndnXaFZBXzfbEyjllVPny5XN16PU3rfI2r7/+uivxosFkVa9SmfT+dSwzAtU5Vw8fLyCvcQL8ew7o/5gC8h07drTixf8LpKvnhG7cKBDv/zvi9SLQTYy4pY9U3mZcz/Ot1xcL7d+tB+zWkX/Z7S0r2SOX1rAc2TJnPfr1uw/bk+OWWL/LalqtUqf/bvq0q+5b/lTjaLu37wOnn/j/Lf7/cX7rlcFWrkheSy8Clbs6m/UAAAAAAEDGkGbBedWiViDTGw3eo+d//vlnvNspc/6uu+5ywXjV31YG8mOPPZbgaPHHjx93k+fAgQMh+hQ4G6qfvXDjPheYL1Mwl916fkUXmM+X83TGa8S+o5YjW4Qdj4qO9zW0vFCeyDT7Ik6ePOkyoZUFr2ny5MmxStnER+WZHnzwQRegzyzUG+Cll15y2fTPPfecvffee64slSYFrHVM0vNNNm8MAa+GvL53/14Cl156qa9nRMGCBQO+hgL2o0ePDljySIF5LQ+kavF8NvbeFvbiT8vsoxnrXC+TWWt222s3NrIqxdJPkDmlqfb+h9PXujI/x05G2/GTp+yru5qfsd7tN15jhXLYGcdZ7UtCxzmt6H9Yev9fBwAAAAAAwig47wXL4wYnNRiNsurj8/3337vgvYIuVapUsV9//dVl4iogFt+gsKpzrcEpkbZZ8qonP3LGOnupc30rWeB03ewH2laz65uUs/Z1Sli2rLEHClXA/o+HWtvewydcYHTBggWul4TqLqu8g7JIFazSeinlyJEjtmHDBl/wPe6kAK2yqJOqatWqmSow76906dL21ltvuZsTAwYMsM8++8wFrBXw7t69uz399NNWsWJFSw9OnDhhf/zxh9u37777znbu3Bnrf5X+7yggrx4QqssZDC+jPpjBgv3lzJ7VBnSoYy2rFrWHR/9tS7YcsOvfnWXTHm3jloW7pVsO2GPf/mP/bNrvnreoUsQGXVMv5Mc5LaSH/3UAAAAAACD1ZYkJVH8jlTLny5cvbxMmTHCDQ3o0kKTqN//1118BA6UKVqg0Rq9evXzzVUKiQIECLoAWbOa8Mij3798ftqVE0oujJ07Ztws22YfT1trqnYfdvHtbV7FHLg18IyU5g6sml3719+7d6wu0BwrC+wdj46N68fpdVk8OPVZZpsSopJMGfYXZ4sWLXdkbBb+9sjAarFODPpcsWTLVD9HRo0ddNr/K1YwfP979n/AvvaWArwLybdu2jXfg6pS2/cAxe+DLhXZN4zJ2bZPYvY/CcUyK1/9Yae/+ucaiomMsf85s9sQVte3aJmXDdlDhUFObpzYys7V5mfVzBzRpkO/hzDW7U+1tZ5W/84x5/iWoAACZq81Lif2s+NgEywzW5cwkA/EO+O/aCwAyumDbvTTLnFdwtXDhwi4Q7x+cX7hwoTVo0CDgNgqkKnBWrVq1WPP1fP78+fG+V44cOdyE1LPj4DH7dOZ6V09+75GTbl6+/68nf2PT8iEZXFXzlXEdX4BeGe3btm2LN+td06FDpwegTaxmugLv8U0lSpRwA3+Ksl6V9Z3UQT8zs7p169rYsWNt9uzZ9sQTT9hvv/3mesN88MEH7qbMww8/7ILiKf0P88cff3QBef3UjUCPvt9OnTq5gLzq5OvmQVorkT+nffa/87wS6s7cdXssa0QWa1Q+ZY9Vahu3cLO9OWm1e3xZ3ZI2sEMdK54/bW6KAAAAAAAAhFKaBecVpOzWrZsLwClLVsE3lY+YN2+eDR061Lfem2++aStWrHBZ0mXKlHElMb744gs3kKReQwPCKlNZ5SWQfjJd270yxQ3oKmULqZ58JbuuSVlfPflQDK6q779nz57u7pOy6uMG3tU7Q2VJElOsWLEEg++qHx5shq7KTyRn0E+YnXfeeTZx4kT3f0BZ8wrWqyTV22+/bY888oj17t076NIxwdi9e7fLjFdAXuWx/H9X1BNCwXjd+GnevHm6/L40ZoNH5VB6fr7Adh06bn0vqW53X1gl1vKMrMs55ez3f3e4XgKX1i2V1rsDAAAAAACQ8YPzokEhlSlfo0YNVy9+7ty59tRTT8Uq96Hau7NmzfI9V33qm266yW2jDGUF8+vUqWPPPvtsGn0KqJ78X+v22HmVi7iDofrXHRqUtqVbD9j/WlaydrXPrCcfDNWKTmhwVQW+VUu6Xbt28a6jjHbd1Ikv8K4gbKhrvyd30E+cdtFFF9nMmTNd4Lx///6u7I2C9brpoed33nlnrJ4w3kCtwdQVV08Klc9RQF6lhbStp3r16i4gr6lx48YZqmRK1qxZ7NxKhW3831vspZ+X27SVu+zV6xu6DPuMZtKyHfbe1DX2YY9z3f8S9QYY0b1JWu8WAAAAAABA+NSc9+jtFYDfvn27K2+hWvD+FLxXdrwCdh4NGKuAnTJfFWCNbyDYjF6TLyPUkx8zf5N9OH2trdl52L69t4U1/v+SGieioi0yW9ID8v6/Fy+88IIrc5IY1SXX706g4LsC82lVhiQpQWPEfwy//PJLd9NuzZo1bp5uqGgg2ZtvvtkNEJ3YeATqRaHySJqmT58eqzdD/fr1fQH52rVrZ6iAfFz6XKPnbbKnxi2xoydPWaHc2W3otQ3s4lolLCPYfei4PfPDUhu3cIt7/nD7GnZfm6ppvVthIbO2eZn1cwdEzXkACGsZpc2j5nzyUXMeADKeYNu9NA/Op4WMcvKSXmkwyk9mrrPPZm+wfX715J+9uq5d3ajMWQVilTGtrGYFUjVAazAYXDX8nTx50pXAeuaZZ9zNDtGNF9X2j8sLsN94442uJJZ65Phr2rSpr2RN1arhF/xdvfOQ9fp8geu5Ij1aVLQnrqiVrN4rqUFNkALyCszvOXzCVI3n9paVrG+7GpYrkptZoZBZ27zM+rkDIjgPAGEto7R5BOeTj+A8AGQ8KT4g7Lp163zZqsp2V5Yywtv+Iydt4PglNv6fLXby1Ol7OuUK57Lbzq9k1zYpZ3lzZEtW0HXy5MkuGK9BQdWDwpMrVy73U4MAB8LgqpmHej9obIpbbrnFjUOhXhWBAvPi3W/8/PPPfb8n6rWggLwGdo3bOyfcVCmW18be18IG/7Tc9WrZefC4Kw2THm3Zd9T6j11kk5bvdM9rlsxngzvXtwblCqb1rgEAAAAAAKS4JEVTVR5CgTGVmdBgm/4U8Oratavdc889BOrDVJ4cWW322j0uMH9uxUJ2e8vKrp58UgN/KkukgT8VkFdZEpUt8uiOUocOHVxWswb91WC/GlxVGFwVumHz0EMPuVJWV111VaIHpG/fvm4w2RIlMkZpl1DJkS2rPXVVbWtVo5g1LPffgMbHo05ZZNaIdFO+5/kJ/7rAvPap10VV7a5WVc6qHBaA9KXZhhFnzpx0enyaRLXpF/L9AQAAAIAMG5zv16+fvf766672u+qAn3vuub6Al7Kd58yZYz/88IMbnLV3794usxUZ15ETUTZm/mb78Z+t9vFtTV3ATGUxnru6rhXKE+kCfklx6NAhF2hXQF6/J3ruKVasmF199dUus7lNmzYWGRnpW8bgqgjk4MGDQR2YJk2aZLrAvL9W1Yv5Huvm1gNfLrSIiCz2Qqd6ViBX2ozF4K//FbXs4PEoe+rKWla1eL603h0AAAAAAID0GZxXdvPy5ctdnee4SpcubY0aNbK77rrLlZpQXWikP5v3HbW9h0/Eu1xB92wRWezjGevs8zn/1ZP/cdFWXy35NjWLB/1++/bts/Hjx7uA/M8//+wy5j36PVLgXQH5li1bJjhQqtbr2LEjg6vCRwPshnK9zODfrQdt4tLtFhUdYws37LPXbmxo51QonGrvf/JUtL3752rbduCYPXd1PTevdMFc9sltTVNtHwAAAAAAADJkcP7dd98Naj0FXYNdF6kbmL9o6GQ7HhUd7zqqTqPJW6VCkdx2a4uKrnRNsHbu3GnfffedG9T1999/t6ioKN+yypUru2C8JvW8iIgIvnyFgvetW7cOen2EN9WQL1u2rLsZGGhMa8YjOFPt0vlt9D0trPcXC2zDniN23buz7IGLq9m9baqmeE36fzbts0dG/2PLtp3u8XBdk3JWvyx15TOT6Ohod5NWg35ffvnl1rx580S3OXHihGtLVq1aZRUrVnQlzryxSAAAAAAACAfJHhAWGYsy5hMKzEt0zOmpaaXCdnvLSta2VnD15DUwsAZzVRBl6tSpLgjjUZkjL0O+fv366abWNTI23awZPny4C9bpd4rxCIKjclQTere0J75bbOMWbrGXJ66waat22bAbGlqpAqEPeh49ccpe/W2FvT91jfvfUih3dnv6qjpWr0yBkL8X0q/p06db9+7drVq1ajZlyhQrUqRIosH5I0eOuBuyKoF22WWX2dChQ23w4ME2bdo0K1iQGzsAAAAAgEwenF+0aJHNmDHD9u7de8ayxx577Gz3C2nk1esaWqfGZ5YuimvNmjUuGK9p9uzZsZadc845voB8jRo1UnBvkZkxHkHy5MuZ3YZd39AurFbMnhy32A3yfPtHc13QPpQ3z2as2mX9xi6y9buPuOcdGpS2p6+qbUXy5gjZeyBjUDD+t99+s0qVKlnRokWD2kY33zQI/b///muFCxd240zoZu+LL77oJgAAAAAAMm1wXhfNffr0cWVKAmWwEZzPuKqVyBtwvjKTly5d6urHKyD/999/+5YpoNeiRQsXjO/UqZMrPwCkBsYjSB79zXY+p6w1rlDIHvhqofW/vFZIA/PHTp6y+79aaDsPHrdSBXLa853q2kU1M+/AvJldzZo1k7yN2hqNNaLAvOTLl8+uvfZaN5/gPAAAAAAgUwfndWGsC+Srr7469HuEFLFm5+Ekb6OA/Pz5810wXt+3BgSOWwNeAXn9HjDwJtIK4xEkX6Wieey7e1vECsz/vHibVS6Wx6qXyJes/xl6rZzZs9rADnVs5urd9silNVy2PpAUam8UjPensjirV6+2U6dOBRxE/Pjx427yHDhwgIMOAAAAAAi/4Ly6l7dr1y70e4OQ23HwmL3y6wr78q+NQa2vevGqD+wF5FVWwBMZGem+dwXkO3To4EoVAMjY/APzq3Ycsj5fLbTomBh76qra1rVp+aAy6vV/5ulxS+zSuiWtY8PTZbEur1fKTUByHD582PLnzx9rXoECBVwbdfToUcub98xeXoMGDbKBAwdywAEAAAAA4R2cV4D2hx9+sOuvvz70e4SQOXIiytq/OsX2HjkZ9DaXXnqpbV06x/c8d+7cbjA+BeSvuOKKM4IlAMJHgVzZ7dxKhW3Kip3Wf+xim7pil93ftqqdio4/U37Gmt325h+r7MCxKJu3fq8L0OfIdmZWM5AUCr7v378/1rx9+/ZZRESE5coVePDifv36Wd++fWNlzpcrV44DDwAAAAAIr+D866+/7gb9HDt2rFWpUuWMzMrnnnsuVPuHZJaVkNyR2ezaJuXcgI83nlvWHvt2caLb796922UnXnXVVa6ed/v27V2AHkD4K5Yvh33U41z7YNpae+mXZfbzkm1uCkbdMvltcOf6BOYRsjr1K1asiDVPz1XaJlBJG8mRI4ebkL7NXLM7qPVmRcX+/j192lUP8R4BAAAAQAYLzr/00ku2a9cuW7ZsmW3bFlzgBilv/oa99vyEf+3pq2pb/bKnB+p98JLqlj0iwsb+Msmio05YRLbIeLfX8ofvv9eeerCnK2EDIPOJiMhid1xY2c6rXNju+nSebd1/LNFtbm1R0fpfUcuyZY1IlX1E+Jk9e7aNHz/ennnmGZcdr95aQ4YMcecaRYsWdVn033zzjfXo0SOtdxUAAAAAgLQNzn/88cf2448/uqxqpL1Ne4/YSz8vt+//3uKeD/11hX1yW1P32CsvcWLfdtsy4n7Lmjv+sjSnjhywOu8OJzAPwN3gG35DI7vu3ZmJHo3O55QlMI946Sb+G2+84R4fOXLEnT8o6F67dm3r2rWrm//XX3/Z888/bwMGDHDB+V69etn3339vzZs3t0suucQmTZpkxYoVs0ceeYQjDQAAAADI3MF5ZVWff/75od8bJMmh41H21qRV9v60tXYiKtpUzebac8raQ5fUOGNdlaY5dXCnmxJSqhQDOAL4//8bkdSOx9lTqbWcOXO6x48//rhvfvbs2X2PmzVrZs8++6yvZI3qyk+ePNkF6FevXu2C9h07dqRsDQAAAAAgrCQrON+yZUsbM2aM3XLLLaHfIwRFWfLPjF9quw4dd8+bVS5sT1xR2+qWKRCwXEDPnj0TDZ6ULVvWLrjgAr4BAEDIlChRwp544okE12nSpImb/GXLls2NfQIAAAAAQLhKVnBeWdi33Xabffvtt1a1atUzBoQdOnRoqPYP8Th0LMoF5isWyW2PX17L2tUuccb3oMFh33zzTevbt6+dPHnSZcV7YwRomcfbbtiwYfEOtAcAAAAAAAAACJ1kjd63e/dua9eunR0/ftyWLFliixcvjjUh9FbvPGSz1+z2Pb+uSVl7qXN9+7VPK7ukTskzAvMHDx50tXxVt1eB+S5durgBfEePHm1lypSJta4y5jWfDEUAAAAACH87d+60u+66y40B07RpU3vttddiJXDFRz3oNfactrv11ltt69atqbK/AACEq2Rlzv/www+uuzlS3t7DJ2z47ytt1Kz1ViJ/Tvv9wVaWM3tWN/jideeWC7iNbph4wXh9T0OGDLH777/fBfAVgFfd3qlTp7oTKWXTq5QNGfMAAAAAEP5OnTrlAuz58uWzDz/80DZt2uR6xh8+fNj69esX73aDBw+25557zl555RW78MIL7e+//3al6z744INU3X8AAMJJsgeEjY6ODv3ewEcDvH46a7299vtK23/0pJtXq1Q+O3gsygXn4/PZZ5/ZnXfeaUeOHHEZ8l9//bW1aNEi1joKxLdu3ZqjDSBBhfJEWo5sEXY8Kv7/91qu9QAAAJAxaMD1hQsX2oYNG1wvalm7dq0LvKskao4cOc7YZt26dS4QP2LECJcxLzVq1HBJYQAAIJWD88WLF7ft27e7Qd4QWupK+OvS7Tbox39t3e4jbl7NkvncYK8tqxWNd7tjx45Znz597J133nHPVXZIgfpixYrxFQFIljIFc9kfD7V2PXjio8C81gMAAEDGMHnyZKtTp44vMC+XXnqpPfLII7ZgwQJr1qxZwHI22bNnd6VT/UVEJKtSLgAAOJvgvGrTPf744/bGG29YrlwEZULpn0377a5P57nHRfPmsIcuqW7XNilnWSNi15SPm8WgjIV58+a50jVPPfWUPfnkk5SqAXDWFHgn+A4AABA+VMamZMmSseZ5zzdv3hxwmxUrVljNmjVdz2zVp4+KirJzzz3XXXv6B/n9aYw6TZ4DBw6E9HMAAJBpg/NeNzg1zJUqVXJlbvzNnTs3VPuXKRyPOmU5sp0uVdOgXEG7sn4pK184t93bpqrlzZEt0fr/3bt3t71791qRIkVs1KhRLusBAAAAAIC4VKI27hhyyor36tEHcuLECfv333/tk08+sTfffNPN69+/vyuXqtrzefLkOWObQYMG2cCBA/kCAAAIdXD++uuvdxPOztETp+y9qWvsk5nr7cfeLa14/pxu/us3NnIZ8AlRpoKyFHTCI+edd567WVK+fHm+FgAAwtSrE1ckeZtmG3ZbRtNsw4jACyYVSXzjNvEPZggAMCtatKgLqPvbtWuX+xlfWVSVtlUp1Y8++siNbSZ6rKx5lcm54oorzthGg8uqhr1/5ny5cuX4CgAAONvg/GOPPZaczfD/oqNj7Pu/t9jgn5fZ1v3H3Lyv/tpovS6u5h4nFpjftm2b3Xjjje4kSHr37m1Dhgw5owcDAAAAAAD+mjZtap9++qkdOnTI8ubN6+ZNmzbNZdM3bNgw4MFSMpgUKFDAN897fPTo0YDbaGDZQIPLAgCA/zB6Syqbu26PdXpruj3w1UIXmFct59dubGQ9L6oa1PZTpkyxxo0bu8C8TqS++uorGz58OIF5AAAAAECirr32WsuXL5898cQTrkf29u3b7cUXX7QbbrjBChUq5KtLX7FiRfv111/dc2XGV65c2Z555hlXFkeTHitAf8EFF3DUAQBIzcx5WbVqlas9v2HDBteg+9NAsYgtJibG+n79t41dcHqAnTyRWV1N+dtbVrKc2U/Xm09s+6FDh7qugaoDWKdOHRs9erQblAcAAAAAgGAULFjQxo8f78Yu++CDD9ygrVdeeaWvlrzoGn/9+vV25MgR91wZ8N54Z17GfIUKFVxMoESJEhx4AABSMzj/008/WefOnV13uD///NPat2/vatap3Erbtm2Tuy9hTaVqiuSJNFWsub5JOet7SXUrnu90jfnE7Nu3z3r06GHjxo1zz7t162bvvPNOwEF3AAAAAABISLNmzWzFihUuaz537twuk96fasmvXbvW1Zr31KpVy/766y/bvXu367kddxsAAJBKwXl1f3vrrbdcwFhB559//tndbb/zzjstZ87gAs4Z3eZ9R23v4RPxLs+fM5tNXbXLGpQtaHXLnM4sUE35axqXtdql8wf9PgsWLLAuXbrYmjVr3AnQ66+/bnfccUeidekBAAAAAEhIfFnvqj+vsjaBFCkSxODcAAAg5YLz//77rwsYS9asWd0AMLly5XJ16ho0aGDvvvuuhXtg/qKhk+14VHS86yh0HqPBdioVtq/ubOaC6QVyZXdTMFTGRl0Me/bs6W586MRIZWzOOeecEH4SAAAAAAAAAECGGRBWwXhvVPdSpUrZ6tWrT79YRIQdPnzYwp0y5hMKzNv/B+bz5sxml9ctadF6kgSq63frrbe6DHmv/t/8+fMJzAMAAAAAAABAZh8Q1nP55Ze7cjYaGOabb76xFi1ahGbPwsD7NzexZlWS1uVPdf/UK2HRokXuZscLL7xgDz/8sHsMAAAAAAAAAAgPyYr4KgjvGTx4sNWoUcOGDRvmBoR5//33Q7l/GZoy55NCZWuaNGniAvOq/ff777/bo48+SmAeAAAAAAAAAMJMsjLnvXrzUrBgQRs5cmQo9ynTOXHihAvC6waHXHjhhfbll1+6kkEAAAAAAAAAgPBDrZQ0tmnTJmvdurUvMK8gvTLmCcwDAAAAAAAAQPg665rzSL6JEyda165dbdeuXVagQAH75JNPrEOHDhxSAAAAAAAAAAhzBOfTQHR0tD333HM2YMAAi4mJscaNG7s6/pUrV06L3QEAAOnZpEG+h8027E7TXQEAAAAAhA7B+WQolCfScmSLsONR0fGuo+VaLy5lyXfr1s1++eUX9/zOO++04cOHW86cOZOzKwAAAAAAAACADIjgfDKUKZjL/niote09fCLedRSY13r+Zs2aZddee62rM58rVy575513rHv37snZBQAAgExn5prEew7MilqR4PI+7aqHcI8AAAAAIBWC8xUrVgz6RdetW2fhToH3uMH3+Kh0zRtvvGEPPvignTx50qpVq2ZjxoyxevXqpfh+AgAAAAAAAAAycHBe9dE9K1eutCFDhth1111n5557rpv3119/2ddff20PP/xwyuxpBnXw4EH73//+546NdOnSxT744APLnz9/Wu8aAAAAAAAAACC9B+d79Ojhe9yuXTsbOXKk3XTTTbHWueyyy+zjjz8O7R5mYIsXL3bB+OXLl1u2bNls6NCh1rt3b8uSJUta7xoAAAAAAAAAIA1FJGcjZclfddVVZ8zXvDlz5oRivzK8Tz/91Jo2beoC82XLlrUpU6bY/fffT2AeAAAAAAAAAJC84Hzu3Lntl19+OWO+5uXJkydTHdZTp07Z5MmT7YsvvnA/Dx8+bHfffbcb6PXo0aOul8H8+fOtefPmab2rAAAAAAAAAICMVtbG3yOPPOKCzxMnTnQ15zXg6dy5c122+EsvvWSZxbfffuuy4Tdt2uSblz17djfoq0rXPPXUU/bkk09a1qxZ03Q/AQAAAAAAAABhEJx/4IEHrGrVqvbqq6/a+PHj3bzatWvb6NGj7YorrrDMEphXPXndmPCnwLz0798/1iC6AAAAAAAAAACcVXD+t99+syuvvNJNmZFK2ShjPm5g3qOseQ2Mq+A8WfMAAAAAAAAAgJDUnL/00kvjDUxnBlOnTo1VyiYuHZuNGze69QAAAAAAAAAACElwvlKlSrZ8+XLLrLZu3RrS9QAAAAAAAAAAmUuygvOPP/643XLLLTZt2jTbs2ePHTp0KNYU7kqVKhXS9QAAAAAAAAAAmUuyas7fdttt7ucFF1wQcHm4l7zR5y5btqxt3rw54GdVzXktj+/4AAAAAAAAAAAyt2QF52fOnGmZmQZ5HT58uHXp0sUF4v0D9Houw4YNYzBYAAAAAAAAAEDogvPNmjWzzO6aa66x0aNH2/333x9rcFhlzCswr+UAAAAAAAAAAIQsOB9KyjqfO3eubd++3erWrWsVK1YMarsDBw7YnDlzLHfu3Na0aVPLli31P4oC8B07drSpU6e6wV9VY16lbJRZDwAATouOjrZffvnFVq1a5dr5Sy+91LJnz57g4dEYNtpm27ZtVrx4cWvXrp0VLFiQQwoAAAAACBvZkhtQHzVqlH3zzTe2YcMGi4qKirV88eLFQQfYL7/8clu9erXVrFnTBdv79Oljzz33XILbvfPOO/bwww9b/fr1XXB+//799t1331np0qUttSkQ37p161R/XwAAMoLjx4/72vqLL77YlYV7/vnn7bfffrO8efMG3Oaff/6xiy66yKpVq2bnnHOOffXVV/a///3Pfv75Z2vevHmqfwYAAAAAANJNcH7o0KH2yiuv2F133WXjx4+3QYMGucC6AuT33ntv0K/zxBNPuIz5f//912XD/fnnny7QrQtyTYFMmDDB7rvvPhs3bpxdeeWVbt6iRYvs8OHDyfkoAAAgBb355pu2cOFCW7JkiZUsWdL27NnjesrpXGLAgAEBtxkyZIhVqlTJZsyY4RvLRYH9F154wZ13AACA0FDCXI4cOdyUWC+4HTt2nDG/UKFCiW4LAADiF2HJMGLECJc1711UP/bYY/btt9+6Wutr165NUvb97bff7uum3qpVKzv33HPd/Pgo265Dhw6+wLzUq1fPZdcBAID0RecLarcVmJfChQvbtddea19//XW82+giXz3jvMC86HmuXLlSZZ8BAAh38+fPtwYNGrjScfny5bOuXbsmmPC2ZcsWV8ZV194NGzb0TZMmTUrV/QYAINwkKzivAPx5553nHufMmdMOHjzoHt9yyy02ZcqUoF5Dg6ju3bvXlabxp+fqzh7IsWPHXIa+atVu3LjRZdEvWLDA3cVPrEu9MgL8JwAAkPLUO65GjRqx5qmU3YoVK+JtvwcOHOjKxnXu3NndlL/hhhvcOcNLL70U7/vQ1gMAYEkqL9uiRQtXIlal53Sd3atXr0S31XhrGg/Gm3RtDgAAUjk4f+rUKd9AbuXLl7e//vrLPVb9+cQGePPoJMDrBuevSJEitm/fvoDb7N69273377//bi1btnRd5a+66ipXj1bB/vio7E6BAgV8U7ly5YL+rAAAIPl0Az/uQK56rvb8yJEjAbdR0F5Z87oRv3nzZvdTtE18aOsBAAi+V5tueg8ePNj1VtP1cb9+/VwP9viuxT0ab45kNwAA0jg47++2226z66+/3mW1tW/f3q655pqgtvPq0sW9MD906JDLxk9oGw04u3TpUvvxxx9t5cqVrkTOgw8+GO976URDNwO8ybvIBwAAKUvlaOJexKstVvA9vjI1KnmXLVs2mz17tr311ls2ffp0N+j7TTfdFO/70NYDABAcZcmrx3r+/Pl98y688EI7efKkGycmIUqMU6m6EiVKuN5tCtYDAIBUHhB2586dvsePPvqoa5xnzpxpjzzySNADwuruvC68lW3vT88rV64ccJuiRYu6zPcrrrjC8uTJ4+bpwl715z///PN43yuYAW4AAEDoqaSNusv703O19SpdE8i8efPc+YV/zXkNCNuzZ093Q95/voe2HgCA4K/ndW3tr1ixYu5noEFfRdfuL774ot1zzz2uRv0vv/xi1113nevV9tRTT8Vbck6Th4x7AABClDm/ZMmSWI2sas2/88479sADD1hkZGRQr6Hs+DZt2tjo0aNjla1RyZrLLrss1gX6xIkTfc8VmFedWn96XrZs2eR8FAAAkII6duxo33//va+cnXrMqe3v1KmTbx1l6Q0dOtQF3qVKlSoua96fniugHygwDwAAgqe2NG7Gu/c8vhvnSsjTjXNl22t71Zq///777e233473fSg5BwBACmXOq3yNGuRmzZpZ69at3aTHSc1O1533Cy64wG699VZr3ry5vffee1a9enVXKsejxn7WrFmulI08++yzbjDau+66y84//3x3sT5u3Dj7+eefk/NRAABACurTp4+NGTPGdZdXT7dff/3V3ch/7LHHfOtMmzbNHn74YXeT38vM07oaV6Zp06YueK9B4L/66iu+KwAAzlKZMmVceVh/27dvdz9VRi5YVatWdYPCHjt2LGBpWpWc69u3b6zMecZ/AwAgBJnzGiRG9d51of3HH3+4YL0Gd1Mm/MCBA4N+ncaNG7vMeA0K++eff1rnzp3d6O/+Qf4mTZrYJZdc4nuurLkFCxa4bni6wFeZm3/++ce9NwAASF/y5s3rSt8pu07uuOMO1/ZrAHhPo0aN3NgxERGnT0suuugiW7VqlV1++eV24sQJ18YvX77cZeEDAICzo+t49YbfunWrb57K1KjNVpssKlejwLvXY97r3eZPiXLKqE9ozDhl2vtPAAAgtiwxgVrZJNIFs7qsaXR3NeIheMkUpTv2Cuqriz0nCACAcJZZ27yw+tyTBvkezlyzO013JSOYVf7OBJf3aVc91fYFANJjm6eBX5Uop8D6kCFDbNOmTXbzzTe7HmxPP/20W2fdunVWqVIlGzt2rF199dX2zDPPuN7zKkGrIP53331nTzzxhA0bNsyNCZMS+xmMio9NsMxgXc6ulikMOF0GEQDCQbDtXrLK2qjxnjx5sk2aNMn91B13laVRQ64SNwAAIGPbuHEjXc8BAAhD2bNnd73QVUNeY8Ao2K4SNCox51Ht+RIlSviy4h966CEbPny43XfffbZ3716rVq2ajR8/PtZ4cQAAIOmSFZxXnTiVldFI7R999JGrAR/sQLAAACD969Chg7t41zgwN954o7vjDwAAwkOpUqXsk08+SfCaX2VtPLlz53YBfE0AACCNa87fcsstlidPHnv55ZfdAK36qXqycUd8BwAAGdNnn33mBm1XrzhdwHfr1s2NM5PeS9cBAAAAABDWwXlly6sGnQaRUTbdsmXL3E8N7Eq3NgAAMr7atWu7m+8qZadAverkaQD4KlWquBvzKnsDAAAAAABSuayNp3Tp0la1alV3gb5hwwbbvHmz/f7772fzkgAAIB1RaRvVo9X0ww8/uN5zTz31lA0YMMA6duxogwcPdnVngfSi2YYRCa8wqUjCy9tQsgEAAABAOs6cf+6556xt27ZWsGBBu/jii+2XX36xFi1a2I8//mj79u0L/V4CAIA0sWvXLhs2bJjVr1/fBegvvPBCmzBhgk2ZMsWyZMniSt8cPXqUbwcAAAAAgNTInP/555+tVatWbnT3888/3w0OAwAAwod6wr399ts2fvx4q1Chgt1+++3Wo0cPK1GihG8dnQNUrlzZVq9ebXXr1k3T/QUAAAAAIFME56dNmxb6PQEAAOnGE0884QLv6h3XunXreNd78sknrXjx4qm6bwAAAAAAZNqyNnLixAn7888/beTIkb5527dvD9V+AQCANHTFFVfYSy+9FDAw/+KLL7pxZuTWW28lOA8AAAAAQGoF59evX28NGza0yy+/3G677Tbf/Pvuu8/GjRuXnJcEAADpyOjRo23nzp0Bl33xxRe2e/fuVN8nAAAAAAAsswfnH3jgAVdzfv/+/bHmP/TQQy6bDgAAhCdlzG/YsIFseQAAAAAA0qLm/JQpU2zFihWWLVvszTUY3IIFC852nwAAQBpp0qSJLVy40E6dOuUe+4uJibHo6Gi78sorrWTJknxHAAAAAACkdnBe9eY9WbJkiZVNlydPnrPZHwAAkIZee+01O3DggCtV9+CDD7pBYT0REREuKF+vXj2+IwAAAAAA0iI4r8Hh3nrrLXvyySd9wflDhw65i/i2bdue7T4BAIA00qJFC/dz/PjxVqlSJcuVKxffBcLKzDUJj5cwK2pFgsv7tKse4j0CAAAAkFklKzj/8ssv24UXXmgTJkxwXdw7depk06dPd2Vu9BMAAGRstWvXTutdAAAAAAAgrCVrQNjq1avb4sWLrWPHji4wL7169bK///7bZdkBAICMp2HDhq5HnGrOe4/jm7QOAAAAAABI5cz5nj172htvvGH9+vU7i7cGAADpybvvvmsHDx60qlWr+h7HR+sAAAAAAIBUDs5/8MEHrrRNjhw5zuKtAQBAenLeeecFfAwAAAAAANJJWZvmzZvb77//Hvq9AQAA6cLRo0etb9++duLECff866+/toIFC1rp0qXtt99+S+vdAwAAAAAgc2bOt2zZ0m688Ua744473IBxkZGRsZZ369YtVPsHAADSwEsvvWSFCxd2bfypU6fsvvvus4cfftgNBK/2f/Xq1RYRkax7/AAAAAAAILnB+REjRliuXLls1KhRAZcTnAcAIGObPHmyPfPMM+7xX3/95bLm+/fv756rHv3mzZutXLlyabyXAAAAAABksuD8tm3bQr8nAAAg3ciaNavt27fPPf7ll1/s4osvjrU8S5YsabRnAAAAAABk4uB8XHPnzrUmTZqE4qUAAEA60K5dO3vooYdc1vwbb7zhas7L2rVr3YDwZcuWTetdBAAAAAAgQwtJcP7cc891NWgBAEB40GCwhw8ftjlz5tjTTz9tbdu2dfM///xze/HFF9N69wAAAAAAyPBCEpwHAADhJXv27L6a8/68uvMAAAAAAODsRFgmduDAAd/jgwcP2tGjR93jU6dO2f79+y0qKso9P378eKx1Dx06ZEeOHHGPo6Oj3bonT570ravngdZV7wItO3HihHuun3ru9TpQhqKmYNbVa+q1PVqm9xbti55r3wKtq8/iravPqHX1mUXHQMfCf91jx44FtW5Cx1CvkdjxDuYYBnO8gz2G/sfbO4Zx143vGCZ0vPW54h7vYI+h/7recfHWDeYYxne8tT/eukn5nfXWjXtcPEn5ndV6yf2dDbRuevid5X8E/yMyyv+Is6G/ZQ3+umnTpliT9z8EAAAAAACkYXD+2WeftYxo3rx5vsfz58+31atX+wIcU6dO9Q2EpyDEzJkzfesuXLjQVq5c6QtaaN09e/a451u3brXp06f71l28eLEtW7bMF3TRurt27XLPt2/f7p57wculS5e6STRPy7SOaBs994KBek29tkfvqfcW7YvW9YKk2lfts0efRZ9J9Bm1rhfs0THQsfConMH69evdYwWTtK4XjF23bp2rRew/9oBqEXuBKq3rBZU2btxos2fP9q27YMECW7VqlXusAJb/8VYQyP94//3337ZixQr3WMEgrbt7927f4MTTpk3zrbtkyRLf8VbASuvu3LnTPd+xY4d77gXI/v33X7e+R8u8wY71+v7He/ny5fbPP//41p0xY4Zt2bLFPd67d69b1wvE6Xjr83lmzZrlO94KnGldL2C2Zs2aWL+HOp46rv7H2wvixT3e2k7bi15P63qBOb2f3tf/eHu/s97x1n6LPoc+j0efU5/X/3fW/3jruf/x1nEUHVct03EWHXc99wKH+l78j7e+t7jH2wv26fvW9+7R74N+L/x/Z73jrd8j/+Ot3zP9vol+/7Sud7NBv5/6PQ10vPV77X+89Xuv338P/yP4H5GR/0ckh/6W27dvb7ly5XL15cuVKxdr8v97BgAAAAAASZclJhMWi1fwo0CBAi6A5w1opyBetmzZXBBCwUQFO/LkyePmKaCiKX/+/G5dLYuIiLDcuXO7gKS21WOVANB6CnTr9eOuq0Ot99Z7REZGuuC5AjB63SxZsviC3nrfxNZVsFHvnTdvXreNsidz5szpBulTgFPL8+XL59477rp6Xa2nSYElva+WZc2a1b2H5mlbb129v147sXUTOoY6JvoM3jEMtG4wxzCY463jE8wx9D/e3jGMu258xzCh463t9Jn8j3ewx9B/Xe+4eOsGcwzjO95aptfQukn5nfXWjXtcvHWT8jurdbVOcn5nA62bHn5n+R/B/4iM8D9C76+/We2TtywYd911l7vh8Nxzz1mZMmXOWF6pUiX3+dJ7W5/Uz50uTRrkezhzzembpUg5s8rfmeDyPu2qc/gBpCsZpc1Lif2s+NgEywzW5exqmcKA/3ppA0BGF2y7l+zgvDL9lBnoZYz704V8epZRTl4AAEirNu/888+3559/3lq3bp0hv4SwausJzqcqgvMAMpqM0uYRnE8+gvMAkPEE2+4la0DYoUOH2iOPPGL16tWzQoUKnc1+AgCAdKhChQqxatgDAIDwojKUKomnXnjNmzd3vWqD9fvvv7vSfZ06dXI9+AAAQPIkKzg/bNgwGzt2rHXs2DGZbwsAANKz+++/3+69916rWrWq1a5dO613BwAAhNAnn3xi99xzjzVq1Mg3ps6vv/5qlStXTnTbH374wTp37uzK6amMnleqDwAApNKAsKqH265du+RsCgAAMoA+ffq4wcTr1Knjatzrwtt/WrRoUVrvIgAASAaNvXbnnXfaK6+8YtOmTbNly5ZZ+fLl7Y477kh0282bN7ugfr9+/Tj2AACkVeZ8s2bNbPr06QToAQAIU6o3r9p48dFFPAAAyHi+/vpry5Url912223uuQaQf+CBB1zPeAXfAw0EL9HR0datWzd7+OGHrXTp0qm81wAAZPLg/KhRo3yPmzZtajfccIP17NnTdXfPkiVLrHXVYAMAgIyrTZs2ab0LQJpotmFEwitMKhL/sjZkkgJI//755x+rVatWrBrz9evXdz/VMy6+4Pyzzz5rOXLksF69etmYMWMSfZ/jx4+7ycNYNgAAnEVw/qGHHor1XA35u+++G3BdgvMAAISHDRs22PLly+28885LcIR5AACQMahnXKFChWLNK1Lk9I3Hffv2Bdxm6tSp9vbbb7uSd3GT8+IzaNAgGzhwYAj2GACA8BV0cN4bJAYAAIS/qKgo69Gjh3322Wfu+YIFC6xhw4b2yCOPWIkSJezBBx9M610EAADJoOz3uKXrDh065H5qnJlAVALnyiuvdDXqZdasWe7nd999Z40bNw44eLzq0vft2zdW5ny5cuX4zgAAONua8wAAILwNGzbMVqxYYWvWrLFOnTrFutCuWbOmq02bNWvWNN1HAACQdJUrV7a5c+ee0VPOWxZIixYtXFb9l19+6Z6rNr2ovE1kZGTA4LxuAmgCAAAhDs7rgj0+anzVoKtWrRppAACQ8fz666/2zDPPWKVKlWJ1X1c3+Dx58tiqVausRo0aQb1WTEyMy7TTNhUrVrRWrVpZREREotspCDBp0iQ7ceKEXXTRRVasWLGz+kwAAMDssssusxdffNH1imvUqJFvkNiyZcta3bp13fMjR47Yjz/+6ILyGvz1448/jnXoRo8ebddee619+umnljdvXg4rAACpGZz/4IMPbPHixW5UdzXgumjfuHGj6wKvAWI3bdrkurz/+eefVqFCheTuGwAASCPq3p4rVy732D84r0D7nj17gs6EO3nypF1zzTUuQ+/CCy+0GTNmuHMFXfB7rx/IN998Y3fccYfrKq8u8KpZq7FuLrjgghB8OgAAMi+1x507d3bts8rU6fp9+PDh9sUXX/hunu/YscMF38eOHWtXX311Wu8yAABhK/G0tQDUiKuLu7qyrV271nV5V4PeoUMHu+mmm1x9el1M9+nTJ/R7DAAAUpwy5UaNGnVGcH7w4MFWoEABlwEfDAXUNYjcnDlz7KuvvnJB+qVLl9orr7wS7zaLFi1y5xPK6vvjjz9ctt7MmTPJzAMAIERUnkal6mbPnu3qz0+ePNkF4z3qJacAfpkyZQJuryQ9LVfCHgAASL4sMUqBSyJ1cVfmW6lSpWLN37Jli7Vs2dIF6zXpwj49DiSrgWgUWNBJSP78+dN6dwAASHdtnjLmmjVr5i6+ly9f7srKrF692ubPn++y2v3r0CdE5wUqd/fJJ5/45vXs2dP1rlMQPpDbb7/dnWf8+++/llxh1dZPGuR7OHPN7jTdFZg1r1wk/sPQph+HCECqyyhtXkrsZ8XHJlhmsC5nV8sUBsQeqBgAMrJg271kZc4r4K76r3Fp3tatW93jwoULW3R0dHJeHgAApLHixYu7LHeNIaNB3hSYr169uqsdH2xgXpYsWXLGIHF6vmzZsnjPE6ZPn24XX3yxG5xOQf0ffvjBldJJyPHjx93Jj/8EAAAAAEB6lqw+aLpQv+WWW+ztt9+2WrVquXnKbrvrrrtcZp03kFy7du1Cu7cAACDV6Ea7ar2fDQXJCxYsGGueBpXVODUabC7QIHK7du1yY9vofKN58+auhJ7OMzRYXdu2bQO+z6BBg856XwEAAAAASE3Jypx/7733fJlvqkWnSY+zZs3qW3b48GF79dVXQ7u3AAAgxagH3LFjx4Kagq2Kp0FfDx48eEbAXnXsc+bMGe82Knkza9YsV/demfSqa6tyN/FR3Vx1F/QmDVQPAAAAAEDYZc5rUBgNGPP333+7TDZdYNesWdMaNGjgW+fWW28N5X4CAIAU1rRpU9e2B2PBggXWsGHDRNerVq2ay3z3p+caUDa+QeRUPkc3/IsVK+abd+mll9r777/vAu+q2xdXjhw53AQAAAAAQEZxVkOrKxjvH5AHAAAZ16effup6vsnmzZtdCbv//e9/rv67esktXbrUXnnlFWvfvr0LoAejQ4cO9sEHH9iQIUPca6g2/OjRo918/7r0U6dOdeXxdMP/6quvdutrXS/grpsGRYoUCRiYBwAAAAAgrIPz77zzjvt59913+x7HR+sAAICMpV69er7HCpSrhvuDDz7om6dxZa655hqrW7euvfHGG0G9Zt++fV2teG2roPtPP/3k6s0//vjjvnUmTZpkvXr1cjcClE1/55132hdffOF7vzVr1tiHH35oI0aMCPEnBgAAAAAgAwTnhw4d6gu8e4/jQ3AeAICMTdnsXbt2PWN+6dKlXfa6StNUrVo10dfRunPmzLGRI0fa6tWrXYBepe80KKxHwX7dDIiIOD0UjrLlVT5PmfyqPa9yenPnzrU6deqE+FMCAAAAAJABgvOrVq0K+BgAAISfkiVL2kcffWStWrWKNV9Z7lu2bLGiRYsG/Vr58uWz3r17x7u8devWbvIXGRmZ4ACwAAAAAABk6przAAAgPD311FN24YUX2l9//WVt2rSx3Llzu0Hgf/zxRxswYIAVLFgwrXcRAAAAAIDMGZyfNWuWzZgxw/bs2XPGsueee+5s9wsAAKSh+vXr2/Lly2348OE2b948N1Csytio3EzLli35bgAAAAAASIvgvGrOP/LII27gOP+asQAAIHyUKFHCXnjhhbTeDQAAAAAAwlKygvPDhg2zsWPHWseOHUO/RwAAAAAAAAAAhLmI5Gykru3t2rUL/d4AAAAAAAAAAJAJJCs436xZM5s+fXpIdmDEiBFWp04dK1q0qBtwTnVtgzVw4EDLmzevPfrooyHZFwAAAAAAAAAA0lVZm1GjRvkeN23a1G644Qbr2bOnGxwuS5Yssdbt1q1bUK/52WefWe/eve2jjz6y5s2b25AhQ+ziiy+2pUuXWunSpRPc9s8//3T7VLJkSTt+/HiwHwMAAAAAAAAAgIwTnH/ooYdiPc+ePbu9++67AdcNNjg/aNAgu/XWW12gX1577TUbM2aMvf322/bss8/Gu93u3bute/fu9sUXX9i9994b7EcAAAAAAAAAACBjBee3bdsW0jfet2+fLVmyxAYMGOCbFxERYRdddJFNmzYtwW179OjhphYtWoR0nwAAAICEzFyzO95ls6JWJHrw+rSrzgEGAAAAkLTgfKht2bLF/SxevHis+XqeUN35YcOG2c6dO+3JJ58M+r1U9sa/9M2BAweStc8AAAAAAAAAAKTZgLChpGz5uM9jYmICrvv333/bc88952rVZ8sW/H0Flc8pUKCAbypXrtxZ7zcAAAAAAAAAABkuOO9lzCsL3p+ex82m90ydOtWVw2nQoIHlzZvXTYsWLbK33nrLPT516lTA7fr162f79+/3TRs3bkyBTwQAAAAAAAAAQDoPzhctWtSqVq1qU6ZMiTX/zz//tGbNmgXc5q677nLBedW/96Y6derYHXfc4R5nzZo14HY5cuSw/Pnzx5oAAAAAAAAAAMiUZW0eeOAB++CDD1xA/tixY/bss8/ajh077O677/at07NnT2vatKl7nD17dl/GvDepDI43HwAAAAAAAACAsB4QduHChfbxxx/bmjVrbNy4cW7eqFGj7JprrrHcuXMH9Rr33Xef7d692zp16uTKzVSrVs2+//57q1Klim8dBe2PHDmS3N0EAAAAAAAAACA8Mud//vlna9GihW3evNkF0z2rVq2yYcOGJem1nnrqKduzZ48Lwi9btszatWsXa/mbb75pf/31V7zbz5w501566aVkfAoAAAAAAAAAADJQcP6JJ56wkSNH2tdffx1r/o033mjvv/9+snZEpWniqxefK1eueLfTssjIyGS9JwAAAAAAAAAAGSY4v3TpUrvqqqvc4yxZsvjmlylTxjZt2hS6vQMAAAAAAAAAIAwlKzhfoEABXxDePzg/a9YsF6AHAAAAAAAAAAAhHhBW5Wt69+7tStvIyZMn7Y8//rC77rrLunXrlpyXBAAAAAAAqWTixIk2depUy5s3r3Xp0sUqV66c4PoaJ27cuHGuJ32RIkVcb/pKlSrxfQEAkNqZ888//7zlyZPHZclHR0e7xvzSSy+1Jk2a2JNPPnk2+wMAAAAAAFLQAw88YDfccIMdOXLE5s+fb3Xq1LHJkyfHu/7y5cutUaNG9sMPP1i2bNlcr/kaNWrYZ599xvcEAEBqZ85rENYxY8bYv//+a3PnznUB+saNG1u9evXOZl8AAAAAAEAKWrBggQ0fPtx+++03u/jii928W2+91e655x53jR9fadtp06a5jHlPwYIF7YUXXrCbbrqJ7wsAgNQMzsvx48etVq1abtq7d6/r3rZv3z674IILkvuSAAAA4WnSIPdj5prdab0nAIBMTtfu6gXvBealR48e9tFHH7kMeWXEx1WyZMmAZW4UoAcAAKkcnP/888/tp59+sk8//dROnTplrVq1cgPEHjp0yN5991131x0AAAAAAKQvCsDHrS9fpUoV93PFihUBg/MeZdyvW7fO1Z0/evSoffDBBwkm9GnyHDhwICT7DwCAZfaa8y+++KI9/vjj7rEGkDl48KBt2bLF3YF/+eWXQ72PAAAAAAAgBFRnPn/+/GeUrZHDhw8nuK3K2hQrVsxtv3LlSlu1alW86w4aNMi9rjeVK1eO7w8AgFBkzqsB9kZl/+OPP+zqq6+2nDlzWps2bWzNmjXJeUkAAAAAAJDC8ubNa+vXr481TyVqJV++fAlu261bN9/jgQMH2s0332zbtm2zHDlynLFuv379rG/fvrEy5wnQAwAQgsx51afTSO4nT560b775xtq2bevmq4GnsQUAAAAAIH2qXbu2y3qPjo72zVu2bJn7qTHlgtWiRQsX1N+6dWvA5QrYK8PefwIAACEIzj/00EPWoUMHNyhMtmzZrF27dr5a9P530gEAAAAAQPrRuXNn27Vrl3333Xe+eRo7rnHjxr5a9Hv37nXX/UuWLHHP58yZ42rM+9P2KnFTtmzZVP4EAABk8rI2d911l5133nm2YcMGV8omMjLSza9WrZp16tQp1PsIAAAAAABCoGbNmvbMM89Y9+7d7dtvv7XNmzfb33//bRMnTvSts3//fjeeXMuWLa1OnTq2du1a69GjhzVo0MAKFixof/31l23cuNE+/vhjl7AHAACSJ9mtaMOGDd3kj6x5AAAAAADSt/79+9uVV15p06ZNczXor7jiCitatKhveeHChW3IkCFWt25d9/z666935WwnTZrksu6vuuoql6iXK1euNPwUAABk4uC8RnhXGZt///3XYmJiXN26m266icYZAAAAAIB0TlnwmgJRfXiVtfFXpEgR69KlSyrtHQAAmUOyas4vXbrUqlev7hrr2bNnuy5teqx5WgYAAAAAAAAAAEIcnL///vutdevWtmnTJtcNburUqe5xq1at3DIAAAAAAAAAABDisjbTp093A8KoNp1HjzVgTKVKlZLzkgAAAAAAAAAAZBrJypyPjIy0AwcOnDFfI7rnyJEjFPsFAAAAAAAAAEDYSlZwXiOz33zzzbZw4UI3GKymBQsWWLdu3dyI7wAAAAAAAAAAIMTB+eHDh1vhwoWtUaNGlitXLsuZM6c1btzYihYt6pYBAAAAAAAAAIAQ15xXYP7HH3+0xYsX25IlSyxLlixWu3Ztq1u3bnJeDgAAhLlFixbZqlWrrGLFiu7mfrCOHj1q33//vRUrVswuuuiiFN1HAAAAAADSfXDeo2A8AXkAABCfU6dO2S233GITJkywpk2b2rx58+z888+3b775xo1hk5jevXvbJ598Ys2bNyc4j3Sv2YYRia80qUjg+W36hXx/AAAAAIRpcH7WrFk2Y8YM27NnzxnLnnvuubPdLwAAEAZGjhxp48aNs/nz51u1atVsw4YNLnP+9ddftwcffDDBbb/++msXzO/cubNt2bIl1fYZSEkz1+wOOH9W1Iqgtu/TrnqI9wgAAABAhgrODx061B555BGrV6+eFSpUKPR7BQAAwsKoUaPcQPIKzEv58uWtS5cubn5Cwfm1a9fa/fffb3/88YcNHjw4FfcYAAAAAIB0HJwfNmyYjR071jp27Bj6PQIAAGFVa/6SSy6JNU8395VRHxMT48atievkyZN244032pNPPmm1atUK6n2OHz/uJs+BAwdCsPcAAAAAAKSciORsdPjwYWvXrl3o9wYAAISV/fv3u4Hk/RUpUsQF4HU+EcgTTzxhRYsWtXvvvTfo9xk0aJAVKFDAN5UrV+6s9x0AAAAAgHQXnG/WrJlNnz499HsDAADCSo4cOezQoUOx5nnPc+bMecb6S5cutZdfftll23/55ZduUombHTt2uMd79+4N+D79+vVzNwK8aePGjSn0iQAAAAAASOWyNqoN62natKndcMMN1rNnT6tateoZXdK7desWot0DAAAZWZUqVdwgsP7Wr1/vMtuzZTvzNCRr1qyuJr0Gnfdoe2XZf/fdd+4cJNB4N7oJoAkAAAAAgLALzj/00EOxnmfPnt3efffdgOsSnAcAAHL55Ze7jPchQ4a44HlUVJR9++23dsUVV/gO0MqVK23evHl2/fXXW40aNdz6/nr06GHr1q07Yz4AAAAAAJkiOL9t27aU3RMAABB2dHNfQXUF6ZURP378eNuzZ4/179/ft84vv/xivXr1cssDZdMDAAAAABCOklVzHgAAIBga2HXu3LnWqlUrmzVrljVp0sQWLFhgZcuW9a1TvXp1lzUfERH4tOS8886ziy66iAMOAAAAAAgryUpPW7FihX322Wc2cODAWPOffvppV9KmWrVqodo/AAAQBgH6p556Kt7lGvxVU3zuueeeFNozAAAAAAAyWOa8up63bNnyjPnnn3++9e7dOxT7BQAAAAAAAABA2EpWcH7atGnWrFmzM+Y3b97cLQMAAAAAAAAAACEOzhcqVMgWL158xvx//vnH8ufPn5yXBAAAAAAAAAAg00hWcF6Dtt1+++02Y8YMi46OdtP06dPdPC0DAAAAAAAAAAAhHhD2ueees1WrVrka85GRkRYTE2MnT560Dh062PPPP5+clwQAAAAAAAAAINNIVnA+V65cNm7cOFu0aJHNnz/fsmTJYo0aNbJ69eqFfg8BAACAMNdsw4ig1pv5wZnzZpW/M+j36dOuelJ2CwAAAEB6CM4fP37ccuTIEWuegvGBAvKB1gUAAAAAAAAAAEmsOV+zZk374IMP7MiRI/Guc+jQIXvvvffcugAAAAAAAAAA4Cwz5z///HN74IEHrG/fvnbxxRfbOeecYyVKlHD15rdt22Z//fWX/fHHH1anTh374osvgn1ZAAAAAAAAAAAynaCD882bN7fZs2fblClT7Msvv7Svv/7aNm7c6OrNly1b1lq2bGk///yz+wkAAAAAANKnw4cP20svvWRTp061vHnzWrdu3ey6665LcJtffvnFvvrqK1u/fr1VrFjR7rnnHmvSpEmq7TMApEcVH5tgmcG6F69I610IW0keEPbCCy90EwAAAAAAyFjU+/3KK6+0vXv32oABA2zTpk3WvXt327Nnj919990Bt3nhhRdcIF8B/Jtuusl+/fVXa9asmU2YMMHat2+f6p8BAIBMG5x/99137fvvv3cNeseOHe2uu+5KmT0DAAAAAAAhpR7vkydPtpUrV1rVqlXdvF27dtmTTz5p//vf/yxbtjPDBL1797bHH3/c91ylbv/9918bPnw4wXkAAFJjQFh55ZVX7N5777Vjx47Z8ePH3eNXX331bN4fAAAAAACkkt9//91q1qzpC8yLEu8UoP/7778DbqPSN4HmnThxIkX3FQCAcJek4Px7771no0aNco25po8//thGjBiRcnsHAAAAAABCRjXjS5cuHWue91zLgqGs+bFjx9rVV18d7zpK6Dtw4ECsCQAAnEVwfu3atdapUyff886dO7t5AAAAAAAg/Tt58qTlyJEj1rxcuXL5liVmx44d1qFDB2vTpo3rTR+fQYMGWYECBXxTuXLlQrD3AABk4przuvOdM2fOWA245gEAAAAAgPSvcOHCtnTp0ljzdu/e7X4WKVIkwW137tzp6s2XL1/exowZYxER8ef79evXz/r27et7rsx5AvQAkEENKGBhb8D+jDEgbM+ePROd98Ybb5zdXgEAAAAAgJBr3Lixff31124sOS/5bvbs2S7QXr9+/Xi3U016BeaLFi1q48eP92Xbx0fZ+XEz9AEAwFmUtTnnnHNs1qxZsaZA8wAAAAAAQPpz3XXXuUD80KFD3fMjR464x1dddZUVL17czdu6das1a9bMpkyZ4p7v2bPHF5ifMGGC5c6dO00/AwAA4SJJmfNz585NuT0BAAAAAAApSgH4r776yrp3727vv/++7d271+rUqWMjRozwraPytcqmV1BeBgwYYP/884/LrL/ooot865UqVcoNDAsAAFKprA0AAAAAAMi4LrvsMtu8ebP9+++/ljdvXqtSpUqs5Qq6z5w502rUqOGe9+nTx7p27XrG61C2BgCAs0NwHgAAAACATCYyMtIaNGgQcJmC7ipr46lUqZKbAABAmAXndbf+k08+se3bt1u9evXs5ptvdicJ8YmJibEff/zRZsyYYdmyZbOWLVtau3btUnWfAQAAAAAAAABItQFhQ23ZsmUuIK/ucsWKFbMhQ4ZY27ZtLSoqKuD60dHRrsbdO++8Y3ny5LFTp07ZDTfcYLfddluq7zsAAAAAAAAAABkyc/7RRx913ejGjRtnWbJksVtvvdV1lRs1apT16NHjjPW1ztdff221atXyzWvTpo0L6N9///3xdskDAAAAAAAAACA9SbPM+ZMnT9rPP/9sN954owu6S+nSpV2w/fvvvw+4jdbzD8yL93zbtm2psNcAAAAAAAAAAGTgzPn169fbiRMnzhhURs+nT58e9Ou8//77rsTNueeeG+86x48fd5PnwIEDydxrAAAAAAAAAAAycOb80aNH3c98+fLFmp8/f347cuRIUK/xyy+/2LPPPmuvvvqqFS5cON71Bg0aZAUKFPBN5cqVO8u9BwAAAAAAAAAgAwbnFYSXffv2xZq/d+9e37KETJ482a655hobMGCA3XHHHQmu269fP9u/f79v2rhx41nuPQAAAAAAAAAAGbCsjbLXlTW/dOlSu/TSS33z9bxOnToJbjtlyhS78sor7bHHHrP+/fsn+l45cuRwEwAAABBumm0YEfzKk4rEft6mX8j3BwAAAEA6z5yPiIiw6667zkaOHOkrYzNv3jybMWOG3XDDDb71Ro0a5UrXeKZOnWqXX365Pfroo/bkk0+myb4DAAAAAAAAAJAhg/NeLfiYmBhr1KiRC9S3bdvWlai54oorYpWv+eqrr9zjQ4cOuWUaAHbz5s129913+6akDCILAAAAAAAAAECmLGsjxYoVs/nz59tvv/1m27dvd9nw55xzTqx1br75Zrvkkkvc42zZstlLL70U8LWKFInTRRcAAAAAAAAAgHQqTYPzEhkZ6crUxKdVq1a+xzlz5nRZ8gAAAAAAAAAAZGRpWtYGAAAAAAAAAIDMKM0z5wEAAACkjplrdsd6PitqRZJfo0+76iHcIwAAACDzIjgPAAAAZFLNNoxI+kaT/MZ6atMvpPsDAAAAZCaUtQEAAAAAAAAAIJWROQ8AAFLchg0bbPXq1VaxYkWrVKlSoutHRUXZv//+a0eOHLEaNWpYwYIF+ZYAAAAAAGGFzHkAAJBiYmJirGfPnlazZk177LHHrF69enbLLbfYqVOn4t3mvffes6pVq1rXrl2td+/eVqZMGXvhhRf4lgAAAAAAYYXMeQAAkGJGjRplH374oc2ePdsF5leuXGlNmjSxpk2b2n333Rdwm2PHjtnMmTOtVKlS7vmvv/5q7du3d9u0bduWbwsAAAAAEBbInAcAACnm448/tssvv9wF5qVatWrWuXNn++ijj+LdplevXr7AvFxyySVWsmRJmzNnDt8UAAAAACBsEJwHAAApZuHChdaoUaNY8/T8n3/+cSVvgrFq1SrbsWOHqz0fn+PHj9uBAwdiTQAAAAAApGcE5wEAQIrZt2+fFS5cONa8IkWK2IkTJ9xgr4lR0L179+4uoN+xY8d41xs0aJAVKFDAN5UrVy4k+w8AAAAAQEqh5jwAAEgxkZGRdvTo0VjzvKC8liXk5MmTdt1119n27dttypQpli1b/Kct/fr1s759+/qeK3OeAD2Qzk0alPxt2/QL5Z4AAAAAaYLgPAAASDEVK1a0jRs3xpq3adMmK126tGXPnj3BwPz1119vixYtssmTJ1uZMmUSfJ8cOXK4CQAAAACAjIKyNgAAIMVceuml9sMPP1hUVJR7Hh0dbWPHjnXzPRs2bLCff/7ZV4Ne695www2uXr0C8+XLl+cbAgAAAACEHTLnAQBAinn44Yft888/ty5durhM+HHjxrlMegXoPd9//7316tXLZcurdM2tt97qAvqvv/66LV261E1SoUIFq1WrFt8WAAAAACAsEJwHAAApplSpUvbXX3/Zq6++al9++aULsOt55cqVfetoXvv27S0i4r8OfW3atLFvv/021mt16NCB4DwAAAAAIGwQnAcAAClKA7O+8sor8S6/6qqr3OT59NNP+UYAAEhBq1atsvvuu8+mTp1qefPmtW7dutngwYMTHA9G67799ts2ZswYu+CCC+y3337jOwIA4CwRnAcAAAAAIJM4duyYXXLJJdakSRNbs2aNG6hdvdM09ot6ugWyfft2e/zxx+3uu+926+3cuTPV9xsAgHBEcB4AAABA0Gau2e17PCtqRZKPXJ921c/6/ZPzvqF6fyCjGz16tBv/Ze7cuVa4cGErWbKk9e/f3x566CF79tlnXSZ9XCVKlHCZ8zJx4sQ02GsAAMLTf8VdAQAAAABAWJsxY4bVq1fPBeY9F198scuoX7BgQZruGwAAmQ2Z8wAAAACSpdmGEUnfaFIRjjaQhrZt22bFihWLNa948eK+ZaFy/PhxN3kOHDgQstcGACBcEJwHAAAAkCZlcQCkD6ojL1myZAnZaw4aNMgGDhwYstcDACAcUdYGAAAAAIBMQjXm4w7o6j1XbflQ6devn+3fv983qc49AACIjcx5AACAILw6MfkDUDbbQKYwACB9aNGihb333nu2e/duK1LkdJmpP/74w3LmzGmNGjUK2fvkyJHDTQAAIH5kzgMAAAAAkEl07tzZypYta/fcc4+rMT937lx77rnn7O6777a8efO6ddatW+dK3Hz33XdpvbsAAIQ1MucBAAAAAMgkcuXKZb/++qvdd999VqlSJReQv/nmm23w4MEJbqeA/ubNm33PFbzPmjWrRUVFpcJeAwAQngjOAwAAAMg0zqZElfRpVz1k+wKklWrVqrkAfXwqVqzoGyTWs2nTplTYMwAAMheC8wAAAAAyjWYbRiR721nl7wzpvgAAACBzo+Y8AAAAAAAAAACpjOA8AAAAAAAAAACpjOA8AAAAAAAAAACpjJrzAAAAKVynGgAAAACAuMicBwAAAAAAAAAglRGcBwAAAAAAAAAglRGcBwAAAAAAAAAglRGcBwAAAAAAAAAglRGcBwAAAAAAAAAglRGcBwAAAAAAAAAglRGcBwAAAAAAAAAglWVL7TcEAAAAgLPRbMMIDiAAAAAyPDLnAQAAAAAAAABIZWTOAwAAAECQXp244qyPVZ921TneAAAAIHMeAAAAAAAAAIDURlkbAAAAAAAAAABSGcF5AAAAAAAAAABSGcF5AAAAAAAAAABSGQPCAgAAAEAmGpSWAWkBAADSB4LzAAAAAJCBgusAAAAIDwTnAQAAACAIzTaMOKvjNKv8nRxnAAAA+BCcBwAAAIDMdFNhUpHgN27TL+T7AwAAgNMIzgMAAABAmGftAwAAIP2JSOsdAAAAAAAAAAAgsyE4DwAAAAAAAABAKqOsDQAAAAAgsEmDkn9kqFcPAACQ/oPzGzdutO3bt1v16tUtf/78KbYNAABIG7t27bK1a9da+fLlrUSJEim2DQCkZ5mubvzZBPaF4H6KOnbsmC1dutTy5s3rrqtTahsAAJBOy9qoYe/cubPVqFHDbr75ZitZsqS9/vrrId8GAACknccee8zKli1rPXr0sAoVKth9991nMTExId8GAAAE54cffrAyZcrYddddZ+edd56blPwW6m0AAEA6zpwfOHCgzZkzx1avXm2lSpWy7777zjp16mRNmzZ1DX2otgEAAGnjq6++smHDhtnUqVPt3HPPtcWLF1uzZs2sQYMGduedd4ZsGwBA6pm5ZvdZbd+8chFLcZTjiZcC6jfeeKM9/vjj1q9fPzt69Ki1atXK7rjjDvv+++9Dtg0AAEjnwfmRI0faPffc44LscvXVV1vdunXd/PgC7cnZBgAApI0PP/zQLrvsMhdkF7XZuqmu+fEF2pOzDQAgDIP7ax5KsQB/QvswK2pFotv3aZdxS7p8/fXX7mefPn3cz1y5ctmDDz5oXbt2tR07dljx4sVDsg0AAEjHwfktW7a4u+/nnHNOrPnKgF+wYEHItpHjx4+7ybN//37388CBA2f5KQAASN+8ti6tSsKofe7du/cZ7fY333zj9ilLliwh2SY12vrDR/97fQDIyA4cPpbh/x+m5Gc4dvhQotsP+m7+Wb3/fRdVtbRq69XO1qlTx3LmzBmrnY2Ojra///7b2rVrF5JtUqNtjj5+xDKDA1kySWk/YjTIgPg/FEYOhDZOHGz7nGbB+T179rifRYrEznjQc29ZKLaRQYMGuXI4cZUrVy5Z+w4AQEZz8OBBK1CgQKq/r9rnQO22LtaPHDliefLkCck2tPUAgNB5I8UP5uNp2NbH1856y0K1DW1z6KT+GVwaeTHTfFIgw8kUf50vpsynTKx9TrPgfPbs2X0DvPpT7brIyMiQbSOqide3b1/fc93d904uAmXfhQPdndHNh40bN1r+/Pkt3PF5wxvfb3jj+01Zukuvk4HSpUtbWlDbHajdloTa+6Rukxnb+kAy299TUnF8ODb87vC3FY7/d5La1qud1fpJbZuTug1tc2jQdgFIa/wfStn2Oc2C8zpBiYiIsM2bN8ear+fly5cP2TaSI0cON/krWLCgZQY6AcxMF+d83vDG9xve+H5TTlpkzHsqVKgQsN0uWbKk76Z7KLbJzG19IJnt7ympOD4cG353+NsKt/87SWnr1c4uWrQo1jyv3Y3vujo529A2hxZtF4C0xv+hlGmfIyyN5M6d21q0aBFrZPfDhw/bb7/9Fqte3apVq3z15IPdBgAApA9qnydMmOAy2T1qx/3b7a1bt9q0adOStA0AAEh+27x8+XJbseK/gW/HjRtnxYoVswYNGrjnKiWnttkrWRPMNgAAIOnSLDgvzz33nH333Xeuu5suuq+++mo3yvudd97pW+fFF1+0m2++OUnbAACA9OGRRx6xnTt3Wrdu3Wz8+PF2++23uwv7/v37+9YZM2aMXXDBBRYVFRX0NgAAIHkuueQSu+iii6xLly42evRoGzZsmLvu1rV2tmzZfDfO1TZPmTIl6G0AAEAGC863atXKJk2aZOvXr7fhw4e70d91dz5v3ry+dapVq2aNGzdO0jY43YXw6aefPqOLf7ji84Y3vt/wxvcb3lSSbtasWa6d1oW86u7NnDnTatSo4VtHNfjOP/98X234YLZBYJnt7ympOD4cG353+Nvi/4659laJbgq0v/vuu/bnn3/aF198ESvhLWfOnK5t9gZ9DWYb8PcFIDxxDp2yssToihcAAAAAAAAAAGSOzHkAAAAAAAAAADIjgvMAAAAAAAAAAKQygvMAAAAAAAAAAKQyhlUPA3v27HED5FaoUMEKFy4ccJ1jx47Z0qVL3eB61atXt3CwaNEi279/vzVv3tyyZs0aa9nx48dtyZIllidPnrAYQHDHjh22adMmq1mzpuXOnfuM5eH0eQ8cOGBr1qxxg1BVrlzZIiMjz1jnxIkTtnjx4gz5ebdt22arVq2yevXqWYECBQKuo+9a62lA7LNZJz3Yvn27rVy50urWrWsFCxY8Y3l0dLRbrkHGKlWqZNmzZ0/w81atWjXg66Snv9UVK1a4wcoLFSoU73qHDh2yhQsXWsmSJd1nimvz5s22detWq1KlSoKvg8wpKX//+n+6ZcuWWPPUjjRu3NjClc539u3bZy1atAhqfQ2/pG2ioqLc3262bOF7enzq1CmbO3eu5c+f32rVqpXgukePHrV58+adMT+h9isj0+/B2rVr3efW/16dhwT7f987Dy9evLiFK517LV++3PLly2fly5e3iIiEc7x0nqa/Q38aWDSx37uMStday5Ytc38bFStW9A1wnhD9z9Fx0rmujksw2wD+Vq9e7c4XmzVrFtZtF4C0pfZc8SadH+n6FSlAA8IiY5o/f35M27ZtY4oUKRLTsGHDmNy5c8d07do15ujRo7HWGz9+fEzhwoVjqlSpElOwYMGYpk2bxmzbti0mI5s+fXpMZGSkBjOO2bt3b6xlP/74ozsmlStXjilUqFDMOeecE7Nly5aYjGjfvn0xnTt3jsmTJ09MkyZNYsqXLx/zySefhO3nffTRR2Ny5coV06BBg5hKlSrFlChRImbs2LGx1vnll19iihYt6pbr97pRo0YxmzZtiknv5s2bF9OlS5eY4sWLu9/biRMnnrHOsWPH3Do6BrVq/V979wEdRfW2AfwGlCJwRAWliyCSgCigUTTSBQxVQ4cIKGhoSqRIkCJwkCIdNCHAEQIkIUQQpCkEpEloSlMJHhAC0gJIBylyv/O8/2/G2bCbLDEs2cnzOyckMzu77N2dcu87977XT+fJk0dPnDjxrrfJCnbu3KlbtWpllnflypV3bDN69GhdtGhR7evrK98n/l60aJHDNtevX9etW7d2KO/YsWN1VrN7927dpk0b2WdRXpx304LPJkeOHLpz584O62/cuCHncZTTKC8+J6KMHv89evSQc2VAQID5g33MjqKjo7W/v79cC3Pnzu3Wc/bv3y/nIJyrSpYsqYsXL643b96s7ebq1at62LBhUo8oUKCAbtasWbrP2bdvn5zP8Jla95/t27dru/nqq6/kOoQfHFuoL0dERKT7vNDQUNnXKlSoIL+xbDdXrlzRvXv3lvNIpUqVdJEiReQz2rp1a5rPq1u3ri5RooTDvjNgwABtx8/nww8/lLp41apVdeHCheWcsm3btjSft2nTJqn34JjEc7APHThwwGPvm7zb8uXLde3ateW4xHn69OnT9/stEZENHTx4UNqruF6h7epO3YgyhsF5LxYXF6cTEhLM5eTkZDlo+vXrZ65DED5//vx65MiRZuMMjawmTZpob4VgPALRffr0uSM4j4oJGp3Dhw+XZdyoqFatmg4MDNTeCDdfUNE3KlxoAMyaNcuW5V27dq18nz/88IO5DvsybkzcvHlTls+ePasffvhhPWTIEDNQhcZevXr1dFaHmyo4Zo8cOeIyOD9o0CBdrFgx82YDArzYFjej7mabrGDevHk6NjZWHzt2zGVwfuDAgTolJcVcHjVqlAQ3cC4zDB06VAIB+NyMm1E+Pj56/fr1OiuJiYmRn1OnTqUbnI+MjNTVq1fXr7zyyh3B+REjRkiQ8PDhw7K8atUqKe+aNWvueRko68vI8Y/gvDuBWDsYPHiw3rJli54xY4bbwXnc4EWd6NatW7IcEhIin3Hqjg7eDudifD44l+Km/90E548ePart7rPPPjPPu4DrF869iYmJLp8ze/Zs6Riza9cus9MMbpxFRUVpO8E+M378eKmDAupkHTt2lDaHcdy4Cs6j04Xd4fiYOXOm3Fw3Ph/cgC9fvrzL51y+fFnqNgjqAz7HBg0aSBuNyB1jxoyROADqxQzOE9G9gnPM9OnT5bqFuAyD8/cOg/M206VLFwn4GKZMmSLBeWsjc/78+XLXC0EkbxQUFCQBCvSoTh2cDw8Pl4aS0YCAr7/+WhpY3tabHMFHlC+tHnx2Ki8C13jfuIFkwHeMdRhBALgwoKfopUuXzG0WL14sn5MRvM3qTpw44TI4j4AQ9m0rjIqxBnDd2SYrwQ0kV8H51PA9Y9uFCxea69CjLCwszGE7jCJBYCArwvkoreD8L7/8IgENBIFwYyn194Ybj3379nVYhxtu7du3v6fvm7xDRo5/BOffeOMNGb2DXpn//POPtjt3g/MIpuJ4RUDfGmjDdSf1qC07udvg/IYNG+Szunjxos5O0HseQWlXatSoISOmrDCypWbNmtru0Osb+wZGnqQVnO/evbuMtEAd7fbt2zq7MNpfrixYsOCOtti6devkM927d6+H3iXZAerXDM4TkScwOH9vcUJYG8HNFuQGteYv3rlzp+RPtebNfOmllyTP8+7du5W3iYiIkFy7n376qdPHUV7kbLTmZUd58dkgv7M3WbNmjeTmRE595LBGTkrks7RreZs0aSL5gTt27Ki+//57FR8frwYNGqQGDhxo5rZFeZFjHnMnWMsL3lZeZzlrkRf6hRdecFiP8qHc7m7jzbZv3y6/jXMY5tM4cuSIbcqLPMatW7dW48aNk9zEruZbsEt5KXP9l+M/ISFBderUSc6xyBW9bNkyfj3/f00Ba/79EiVKqKJFi/KYs2jbtq0KDg6WOknXrl1lnhu7w1womNfI2Zwg1v0nu56vcb1GnvSSJUumud1XX32lunTpop577jmZq8C4ztsR5q3YsGGDlHns2LFqxIgRLrfFPoLPzjpHgVGfzQ77DxERETnirCE2MmbMGLVv3z4VFRVlrkNwC40pK2MZj3nbBLBDhgxRiYmJLie8sVN5EYQpXLiwatiwoTQSMfEWgjOTJ09WHTp0sF158+bNqz788EP5wX586dIlabQgmGmwU3lTM96/s/IZj7mzjbc6d+6c6tatm2ratKk04u1Y3tDQUFW5cmXVrl07p4/brbyUuTK6f9SrV08NHjxYPfHEE3JjHjc9W7ZsKTfo7TJBfEbhc8PEqKknouYx9z+4EY4bOY0aNZJl7DO1a9eWG+aoc9p54lPczKpSpYrUwVxN5Il6irPjETdaMfFuzpw5lR1hUtihQ4eqvn37St3NlXfffVctXrxY9iPcnMbym2++KUFsO04ojPbX+vXr1YEDB9Szzz5rHjfOOKvP4rPED6/32RPOrzinuIJ2oLuTnBMRkfdhcN4mZs2aJYHrmJgY6ZliQIMz9YUeFWRAjxdvgh7VzZs3VydPnpQfBHBhy5YtqkKFCtIbEOVN3bvcW8uLsiQlJUljZsWKFbJu6tSp0gMJlTP05rJTeZcvX67at2+v1q5dq6pXry7r0PirWbOm3Jx49NFHbVXe1IzgkLPyGWVzZxtvdPnyZWnEorE+Z84cc72dyov9Ojo6WsXFxalNmzbJOgRwTp06JcsYIWOn8lLmy+j+0axZM4fGPXpzRkZGqiVLlqh+/fpl66/K2TUFeMz9O4oAP4bnn39ede/eXc2dO9e2wXkE3du0aSMdJNAL2lVnEATecTw5Ox6x3q6BeYxma9CggXr99dfV8OHD09zWeiMaQedJkyapIkWKyOeK0ZJ2YxwTuLmDESa4kYX6q3X0clrnHox6xXN5vc+e0MZDu8+V3Llzy6hqIiKyJwbnbQDBrJCQEPndokULh8eQOgE9zq2OHTsmvxHM9ibFihWT1C5hYWGybPQsGTZsmASw33vvPSlv6iGz3lre0qVLy29U8A3vv/++6tWrl9yQQHDeTuVF7zz0mDYC89CjRw/5fhG8RI9qlHfjxo22KG9qxYsXl8a8UR4Dlo2yubONNwbmAwMDpZGK1BvW3nQ45tGAtUN5kQYCveZHjRplrktOTpbRMDinfffddxK0QOPLDuWlzJdZxz8Ch4UKFbrjdbIjXFMQDDtz5ox8JoAez7hpxmPOOYzAsOu+g8A8Uvj8/PPPat26dWmmbPHx8ZHHs9P5GoH5WrVqyYiC2NjYu74BgZ7izs5hdoPgOurq6DiFdsuLL77o9Nxz4sQJCchjXwIs4/xj1/2H0jZz5kx+RERE2Rhzzns59F5CUBpDKdHTx9lwdgw/Rc5yA3rLIV0KekB5W/AWQVrjZ+TIkbJ+5cqV8hkY5T148KAMmbWWF72urTllvQF6JoG1EYOeXKjI4/uzW3lRJgRE0Dg2HD161HzMKC8Cmnv27HEob8GCBZW/v7/yZuhZhRsT3377rUMPvNWrV0u53d3Gm1y5ckVSBuA3AvPYb60QmMfICWt5EcTHnATeVl7cgLCev/CDUU6NGzeWvzHsH0EL9LSzlhdBfQTuva28lPncPf5xTUBw0XD16lWH18HjmNsAaReyI9zQPnz4sPxdo0YNCaRZP1OMcsGIw+x4zGFfwfkIudYB5+bUsL/Zcd9BUBQ9vbF/IDBvdJCwQn3sxx9/NJexj6BuinoZ4PfSpUttue9gvidcn9B2WLBgwR2poACdgYxRrbh24TO1Qq9frLPb/uPsOEFqGzBS12DfwLGFkb+AfQTp/KwdTlCfNc7zRERElM3c4wln6R5atGiRzpkzp+7Zs6feuHGj+bN9+3Zzm9u3b+s6deroSpUq6fj4eD1x4kSdK1cuHRkZ6fXfzTfffCOz0587d85hff369XWFChWkvJMnT9a5c+fW4eHh2hu9/fbbunLlynrhwoXyfb/44ova399f37hxw3blPXjwoC5QoIAOCgrSy5cv17GxsdrPz0+//PLL+ubNm+Z2gYGB2tfXVy9YsEBPnTpV58mTR0+ZMkVndSkpKXJ8LlmyRPZbHItYTk5ONrfZtGmTfvDBB3W/fv1kO3y3pUuX1hcuXLirbbKC06dPS/mWLVsm5R03bpwsHz58WB6/deuWrlWrln7sscekHNZz2PHjx83XSUxMlHNWnz59ZDt8/6VKlbrjuL/fzpw5I+995cqVUt4xY8bI8qFDh1w+JyAgQHfu3Nlh3bZt2+QYDg0N1d9++61u1KiRLlGihD579qwHSkFZnTvHf0hIiC5fvrx5nOE8iuPvu+++0zNnztRlypTRVatW1deuXdN2k5SUJMdd//795bxhnFMuXrxoblO8eHE5nxgGDx6sCxYsqGfMmKGjo6PleOvQoYO2I5xP8Xng3Fu9enX5G+sMe/fulfPX6tWrZRmfY5cuXeR6i/NRcHCwfK44z9kN6luoT8ydO9fhemQ9h48dO1bq3dZ6C/Yd7C/4fPAaWMZ6O8H17emnn5a619q1ax0+n/Pnz5vb1axZUzdr1kz+PnDggJxnUB/9/vvvpc6D6/1bb72l7ebLL7/UrVq10vPmzdOrVq2S822hQoV0x44dzW1wvsWxFRERYa5r27atnL9jYmL09OnTpQ48fPjw+1QK8jY4N+EYxP6GfQv1bSzjeCUiyiyoQxvX/Lx58+q+ffvK36hzU+bywT/3+wYBZcy4ceNkoqXUihYtquLj4x16dIwfP156Z6B35ttvv62CgoK8/mNHeQYMGCC9SlEua8+vCRMmSE7Lhx56SPKYY/I7b4Re5BERETI6AHlPq1WrJkNl8+XLZ8vyojenkXMRvYdQXqS2sX6/6CmK8mLSLZQXQ9Ctk8ZmVatWrXKanxVzKRgjPwATHn/xxRfSuwq9y5DyBMe0lTvb3G/oIffpp5/esT44OFhSNeF7dNW7sHfv3g7nqK1bt8p+gSHfFStWVP3795cUH1kJelpios3UsH9iH3YGuZsxtB3lsULPzSlTpshIGT8/P/l+rXmfKXtL7/hH3WDnzp0yxwFgOxw/6E2PUUbolYlzjrOer94O85RgFE5q06dPl7lpAOeWunXrmsclqsGzZ89WCxculGsuRq317NnTlp8PRvCknoeoQIECUseAQ4cOSR0RucGRigOfDdKXoDc45sgoX768fG5ly5ZVdoNRTOfPn0/zHD5//nw1bdo0Od8bUF/BMYf6S5kyZWSSVF9fX2UnGJ2JtIrO4NyCNDfwwQcfyP5kjGzFqN3w8HDpTY+0bdj/UF8z0rjYCY4hzCmD6zau15j4Fnn1jbIifVadOnVkng9jHhCsw+eH+iFG8GBeLUxETOSOL7/8Us7PqWFeGaSfIiK6l3UAzD2DejdlHgbniYiIiIiIiIiIiIg8jDnniYiIiIiIiIiIiIg8jMF5IiIiIiIiIiIiIiIPY3CeiIiIiIiIiIiIiMjDGJwnIiIiIiIiIiIiIvIwBueJiIiIiIiIiIiIiDyMwXkiIiIiIiIiIiIiIg9jcJ6IiIiIiIiIiIiIyMMYnCcijzh27JhauHDhPX8OERERZT0JCQnq6NGj6W63YcMG9ccff3jkPRERERER3W8+Wmt9v98EEXmPrVu3qkOHDqW5TevWrZWPj4/DusWLF6vg4GB1+fJlt/+vjDyHiIiI7t6ePXvUb7/9Jn/nzJlTFS9eXFWuXFk99NBDsi4+Pl79888/Lp9fsmRJFRAQ4PK1GzRooH7//XdVoECBNN9HdHS0mjp1qkpMTLyjLkFEREREZDcP3O83QETe5eeff1br1683l+Pi4pS/v78qU6aMua5Vq1Z3NKhLlCihWrRo4dH3SkRERO6JiYlR4eHhqmHDhhKE37t3rzp//rwE5atXr66WLl2qbty4IdseOXJEgufNmzdXDzzwv+ZEtWrVXAbnP/nkE9W9e/d0A/PQtm1bNXDgQLlB/9Zbb/HrIyIiIiJbY895IvpvJxEfHzVjxgzVpUsXWU5OTla7du1SjRs3ll72SE2Dhj4a+Fu2bJGGPJw9e1atXr1a/s6TJ48qV66cqlixosNrs+c8ERGRZ4SFhcl1NykpSZZv376tmjRpog4fPqx+/fVXh23nz58vQfRLly6p/Pnzp/m6GG339NNPy+9SpUo5rMfrPv7446pKlSrqwQcfNB9DcB51CKTCISIisgNcXzt16iQ3widPniwp3MaOHSs3tw8ePKgmTJgg18UiRYqoNm3aqDfffNN8LtrSeBzXRlx3mzVrpjp06CCPRUZGqt27d6u6deuqBQsWqDNnzqhGjRqp0NBQlSPHv5mst23bpqZMmSI32HE97tWrl3SyMxivExgYqGJjY+V16tSpo/r06WNeo9N6H5BeOYjIOfacJ6JMtXHjRtWjRw/1/PPPq1u3bsmFv1atWmr79u2qY8eOZnD+3LlzEgSAa9euSQ88VEwWLVpk9sIjIiKi+wMNeqSi+eijj6THfK5cuTL0OsuXL5fRddbA/ODBgyVAgB75aOijHoDr/5NPPimPIxjw+eefS/Dfnd72REREWR1StSKoHRQUJNfBrl27Kj8/P0kph+thSEiIrEfwvFu3bur48eMy6gzQjsb18uOPP5ab5998842McnvnnXdkPpdZs2bJaw8ZMkS269evn0pJSVGjR4+W5+/YsUP+D7TTEUxfuXKleu2119TmzZvVCy+8INsYr4MUdLj24/0igP/333+roUOHpvs+3CkHETnHCBgRZbqLFy9KpQN3611BLzr0vLM+p2rVqioqKkp17tyZ3woREdF9hh5wDz/8cIYD80Y6vAoVKpjLV69eVaNGjVI//PCDNOJh3759EqA3VKpUSW7wYySesQ0REZEdoLd8y5YtzWUEy9u3b69GjhxprsubN6+0pY2g9o8//iiBc/SIB4xss143cc1ExzfM/wLo1Y652xCkf+yxxyRoj5Ht6NUO9evXlxFsCKKvWLHC4f9dsmSJypcvnyyjdz964xvB+bTex4ABA9ItBxE5x+A8EWU6TCTnzgUYd9l/+uknSX1z/fp16VWH4XYMzhMREXkeeqrjxjmuzxjaPn36dLMhn1EYFv/oo4861BEwPB457dFrD+nx0HPQ6pFHHjGfS0REZCevvvqqwzJuViMFDK6JWmv5Qa/1U6dOSS/1ggULyogy9FY/efKk/F22bFkJfBvKly9vBuaN4Dt6vCO9TI0aNWQUuzVoDkg9O2jQIId1uB4bgXlj3jj8n4a03oc75SAi5xicJ6JMh7vz6fWyQ288VBpw0UaPOtzd//PPP6WHHhEREd2f4Dx63t28eVOGx2OoO3re/Re4vl+5csVczp07t5o7d67q27evGjZsmKpZs6Zq166dQ05aY3umtCEiIruxBr+Nax7mcUGud1fbRkdHqzlz5kiquP79+0sgHstIJevsNREwR3o6jE4HBMlTzxGDZVz3razzvwBuoKO9bkjrfbhTDiJyjsF5Isp0uIinBw3yZ599VobNGTBhDO7wExERkecVK1bMTDmHBntAQIBM+B4XF5fh13zmmWfUsmXLHNa1aNFCfvbv3y8NfAzpR15cY9QdhtobzyUiIrIz9D7/66+/ZP41VxA0x+hy/GAemNatW0vKmlWrVpnpZ5Daxpi7DXnjkRMec74AfiOFnBWW8X/fjbTehzvlICLn/p26mYjIgzAUDsPvDBjqtmbNGn4HREREWQB6rYeHh0uu2XXr1mX4derWrSspctBrD/D7woUL8jfqAb1795Zedlu2bDGfg5y2CMxbJ5ElIiKyo549e6oZM2aohIQEcx3Svhpp5ZBqDh3bjOsoAuR58uRx6OWONHDG9gjSI5f8Sy+9ZM75gmA6UtVh9DocOHBARUZG3lU62fTeR3rlICLX2HOeiO4LDF8PCwuTFDgYUjdt2jSpSBAREVHWgLyxTZs2lfyymBMmo69Rrlw59fXXX6tOnTpJYB6pbFAPqFixokpOTpae9TExMeZz0FMfPfaJiIjs7oMPPpCOarguFi5cWNLRIBCOEWXGXC1ILfPkk0+qokWLyrZIBRsfH2++Bq6nS5culTY1gudII4Nl6/+xZ88eGbn+1FNPyQg1jFpHQN1d6b2P9MpBRK75aGsCKSKiu4SLekhIiKpdu7Ysb9q0Sc2bN08qBlY7duxQX3zxhZo9e7ZD4xt31nGhR/55NNgxFK5Pnz4un0NERESZLzY2Vq6748ePd1iflJSkhg4dKj++vr6yLjExUU2ePFlFRUVJDvn0IPA+btw4mQQeqe9wrce1/ZdffpGb9C1btpQefrBz507pSY+UN5yHhoiI7AI52TEZur+/v7R/U0N6V6Sjwci10qVL35EqFvPB4HEE3hEgNx7HpK5og2OU2/Hjx6UXPXrMGylurFJSUtTRo0dlZBoC6FaY/w056o3e9oDXOnLkiKpatWq678PdchDRnRicJyIiIiKieyo0NFRu5vv5+aW5XUREhHriiSdUUFAQvxEiIqJ0WIPzROSdmNaGiIiIiIjuqUmTJrm1Xbdu3fhNEBEREVG2wZ7zREREREREREREXsZZOhoi8i4MzhMREREREREREREReVgOT/+HRERERERERERERETZHYPzREREREREREREREQexuA8EREREREREREREZGHMThPRERERERERERERORhDM4TEREREREREREREXkYg/NERERERERERERERB7G4DwRERERERERERERkYcxOE9ERERERERERERE5GEMzhMRERERERERERERKc/6P4WrOncuKLkxAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABecAAAGbCAYAAABONCtsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvctoD+AAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2MVJREFUeJzs3XdYFNcaBvB3d+koRRRFOmIvWMAWsfcuYO+9ixobdk3UGDVq1Fhi70bA3mKs2EXFGrEhCCIi0jvL3D+4TFxpC9J9f8/Dc9k5Z858s3Izu9+c+Y5EEAQBRERERERERERERESUb6QFHQARERERERERERER0feGyXkiIiIiIiIiIiIionzG5DwRERERERERERERUT5jcp6IiIiIiIiIiIiIKJ8xOU9ERERERERERERElM+YnCciIiIiIiIiIiIiymdMzhMRERERERERERER5TMm54mIiIiIiIiIiIiI8hmT80TfAS8vLzg5OeH58+cFHQoRERHlk3v37qW5/p8/fx5OTk74/PlzvsSQ3vGOHj0KJycnxMTE5EsMGcVBRERExcvOnTsxcODAgg6DKFtUCjoAoqJkw4YNuHTpEvbu3QsNDY2CDkdpHz58gJubGyZPnlzQoRQbL1++hIuLi/haKpVCX18f9evXR9++faGlpZWtfl/y9PTE6dOn4ePjA0EQYG5uDjs7O3To0AEymSzvT46IiHJFcHAwxo4dK76WSqXQ0dGBjY0N+vfvj1KlSiEmJgaDBg1SarwRI0agffv2Sh8/MDAwzfX/9evXcHNzw5o1a1CqVCmlxzp16hR27NiBrVu3Qk9PT+n90jve8+fP4ebmhq1bt6Z7HcypzGLM6XkTEVHeuXDhAjZu3Ci+VlFRQenSpWFvbw9HR0eoqDBlRWlt2bIF169fx65du9K0eXl54ciRIwUQFVHOceY8UTbcvXsXbm5uSEpKKuhQsqVOnTo4fPgwqlatWtChFBshISFwc3ODtrY2+vTpA0dHRxgaGmLy5MmoU6cOgoODs9UPAMLCwtC9e3f88MMP8PHxwQ8//IBWrVohKioKQ4YMgaWlZb7OMiQiom8THR0NNzc3JCQkoE+fPnBycoK1tTWWLl2KatWq4dWrV1BVVUWfPn0UfgICAuDm5oZevXopbK9YseI3x9S2bVscPnwYBgYG2drv5cuXcHNzQ1xcXL4cLycyizE/4yAiIuX4+PjAzc0NVapUQZ8+fdClSxeoqqpi0KBBaNmyJRISEgo6RCqE7t+/j2PHjqXbNnToUOzduzefIyL6NrwNSfQdKFu2LJycnAo6jGKpZs2a4nvbu3dv1KlTB46Ojli+fDlWrlypdD+5XI6uXbviyZMnuH37NmrXri3uO3DgQMyaNQt9+/ZFQkJCrs4yJCKivFepUiWF63Dr1q1hZ2eHhQsXYu/evWmu0QcPHgQAODg45PqsQSsrK1hZWeXqmIXpeIU9DiIiSqtJkybik2H9+/dH2bJl4eLigv3792PIkCEFGxwVKTY2NrCxsSnoMIiyhcl5ojzg6+uLPXv2wNvbG2pqamjWrBn69eun8AV79OjRCAkJAQCoqqrCyMgInTp1QqtWrcQ+cXFxGDBgAPr27YvmzZtj8+bNePr0KYYNGwYNDQ2sXr0aK1euRFRUFLZu3YqQkBA0bNgQI0eOhJqamjiOl5cXfv75Z/z888+oUqUKAOD69etK7w8A8fHx2L59O27evAkdHR0MGTIEZcuWxZQpU+Ds7Ax7e3ul3pvr16/j+PHj8Pf3h5mZGXr16oU6deoAAE6cOIFdu3Zhx44dKFmypLjP27dvMW3aNEyZMgU//PBDmvgjIiKwc+dO+Pv7w9nZGatXr8akSZPQtGlThWOHh4djxIgR6NGjB/r16ydu9/DwwLFjx/D+/XuUKVMGjo6OafZVVuqHynv37mWr3/79++Hh4YGNGzcqJOZTlSlTBidOnICqqmqO4iIiosLD1tYWurq6WV4rsiMqKgqbNm2Cl5cXypYti1GjRqXb7/z589i8eTO2bNmiUN7l/PnzOHPmDIKDg2FmZobOnTujUaNGAFLqt+7cuRMAMHLkSKirqwMAFi1ahOrVq+Po0aPYu3cvdu/ejfv37+PAgQMIDQ3F/v37MzxeqosXL+LQoUNISEhAmzZt0KdPH0il/z3cu23bNly+fBl79uxR2O/u3btYvnw5li1bhooVK2YZY0ZxJCQkYP/+/bh27Rri4uJQuXJlDBkyBKampmKfL8/Py8sLe/bsQUxMDFq1aoWBAwdCIpEo+89ERERKSP1OfO/evTTJ+bt378LV1RX+/v7Q09ND165d0a5dO4U+jx49wsGDB+Hv748yZcrA3t4e3bt3F9sfP36MRYsWYcGCBZDJZPjzzz/x6dMn1KtXD6NGjUp3MtSpU6dw5swZhIaGwsTEBL1790bdunXTHVNTUxObN29GYGAg6tSpg7Fjx6YZM6sYs3O+X8vO+X3ZV11dHVu3boWvry9WrlwJU1NT8bv2/fv3IQgCbGxsMHToUOjr64tjbNiwAV5eXvjzzz9x6NAhnDt3DqqqqujRo0e65fiyO+bRo0dx6tQp6OnpQU9PD+fPn0dMTIzC5IbUknY7d+7EhQsX0nxuyO4xjx07huPHj0MqlaJ79+7o1KmTwnhyuRxubm64du0awsLCUKFCBfTp0weVK1fO9N+GKD0sa0OUyw4fPozKlSvjxo0baNKkCapXr465c+eiZcuWCo9Zd+vWTXxMvX379khISEDHjh2xZMkSsU9SUpL4H/zu3btDJpOhRo0aeP/+Pd69ewc3NzccP34cM2bMQNWqVVGpUiVMnz4dgwcPVogpteb8p0+fxG3Z2T8uLg4tWrTA7NmzUalSJdjY2GDevHk4ePAg3Nzc4Ovrm+X7IggCRo4ciaZNm+Lz589o1aoV9PT0MHr0aLEmnLe3N9zc3BAfH6+wb1hYGNzc3PDu3bs08R8+fBjTpk1DpUqVoK6uDjMzM1y9ehWrV69OE8OBAwfg6uqqcMEcM2YMWrVqhfj4eLRt2xbq6upo06YNFi1alOU5pScqKgoAspzd/nW/gwcPQiqVKtw0+JqmpibrLhIRFQNyuRyxsbEoUaJErowXEhICOzs7rF69GjY2NrCyssKoUaPw4MGDNH1Ta69/WSZt9uzZ6N69O7S0tNC+fXvo6upixowZ+OOPPwCklMdLvZH+5ecXQ0NDAP/VkP/zzz+xatUq1K5dW/zMk97xUu3YsQPr169H/fr1Ua5cOQwbNgx9+vSBIAhinwcPHqRbOza19E/qRIesYkwvjrCwMDRs2BDTpk2DlZUV7O3tcf78eVStWhXnz58X+6We3549e/Dbb7/B1tYWhoaGGDp0KGbPnq3MPxEREWVD6nelr6+Tc+bMQcOGDRESEoLWrVvDwMAADg4OmDhxotjHzc0NderUEftYWFhgz549GD58uNgnKChI/C48fvx4VKpUCTVq1MCyZcvQqFEjREREiH0FQUCfPn3Qo0cPaGhooFWrVvDz84OtrS3Wrl2bZsxz585h3LhxsLS0RK1atbB48WJ069ZN4TyUiVHZ801Pds4vte+JEycwevRomJubo1SpUggPD8fr169Ro0YNrFu3DjY2NqhXrx62bduGatWq4dmzZ+IYd+/exYkTJ+Di4oILFy6gSZMmAICOHTti3rx5CrFld8w5c+bg5MmTqF+/PkJDQ9GsWTNUqFAhTVlATU1NAOnXnM/uMX/++WecOnUKTZo0QWJiIjp37pymvn3Pnj3h7OwMIyMjtG3bFlKpFL169cLff/+d6b8NUboEIlLa4MGDBQBCZGRkuu2+vr6ChoaGMHjwYIXtfn5+gqamprB48eJMx1+5cqWgoqIihIaGCoIgCJGRkQIAQVdXV/D19RX7xcbGCgcOHBAACO3atRPkcrnYtmrVKkEikQjPnz8Xt505c0YAIHh4eIjbsrP/0qVLBQDCzZs3xW1yuVxo166dAEDYs2dPpuclCIKwefNmAYCwd+9ehe3JycnCx48fBUEQhBUrVggAhODgYIU+Dx48EAAIBw4cSBN/8+bNhcTERDGm+Ph44ccffxRUVVWFoKAghXHs7OwEGxsb8fW2bdsEAMLhw4cV+u3YsUOQSCTCvXv3MjyfmzdvCgCEFStWKJzLlClTBADCH3/8ka1+5ubmgpmZWYbHIyKiosfHx0cAIPz4448K21euXCkAEJYsWZLufo6OjgIA8fqWlTFjxghqamrCmzdvxG3R0dFC1apV01z/N27cKAAQ3r17JwhCyjVJR0dHmDVrVppxAwMDxd9Xr14tAFDYlmrZsmUCAGHgwIHittjY2HSP92X/QYMGKYyzf/9+AYCwf/9+cdv48eMFbW3tNMc8cuRIms8mmcWYXhzjxo0TZDKZ8PjxY3FbYmKi0LBhQ8HQ0FCIiYlRiHfkyJEKY06cOFHQ1NQUP7cREVH2/PnnnwIA4cyZM+K2+Ph4oWvXroJEIlH4b/yxY8cEAMLGjRsVxjhx4oQAQPj7778FQRCEFi1aCK1bt05zrC+vDefPnxcACHXr1hXi4uLE7c+ePRNkMpkwdepUcdv27dvT/c47ZswYQSqVCk+fPlUYs379+kJ8fLzYb9euXQIA4fr16+I2ZWJU9nzTk53zS+1bu3Zthb6xsbFCy5YthVKlSgmfPn0St4eHhwvly5cXbG1txW2DBw8W1NTUhIULFyrEMX/+/DTfq7M75vz58xViEgRBGD16tKCrq5vuuTs7O6f53JDdYy5dulRh/zZt2giWlpbi64CAAAGAsHPnToV+SUlJYm6DKDs4c54oF+3btw9xcXGYMWOGwnZTU1O0bdsWrq6u4ra4uDjs2rUL48aNQ+/eveHk5ITjx48jKSlJ4e4tkFKb1szMTHytoaEh/j5kyBCFx79bt24NQRDw8OFDpWJWZv/Dhw+jXr16aNiwobhNKpWmmWGf+mjZlz+pM8+2b9+OChUqoH///gr7SCQSlClTRqlY0zN48GBxNrlUKoWamhqGDx+OxMRE7N69W+z35MkT3L17V2E2wrZt22BpaZmm1u/AgQOhpqYGNze3LI+/e/duODk5oUePHqhSpQrWr18PZ2dnjB49Olv9YmJixLv9RERUvJw4cQJOTk5wcHCAjY0N5syZgxkzZmDmzJm5Mv7hw4fRuXNnWFpaitu0tLTSXHPTI5FIoK6uDg8PD3z48EGhrVy5ctmKY9iwYeLvX35WyciIESMUXvfu3RuGhoY4dOhQto6bU4cOHULr1q1Ro0YNcZuKigomTZqEjx8/4sKFCwr9vzw/IOUzU2xsLF68eJEv8RIRFVdLliyBk5MTunTpAmtra9y9exd79+5V+P65bds26Orqpinb1rlzZ5QtW1b8rq2hoYFnz57h6dOnCv3Su6YNGDBALIMGAFWrVkWbNm0UrkMHDx5EmTJl0jzhPHXqVCQnJ+Ovv/5S2J76XTJV69atAaTM6E6lTIzKnm9mlDm/VP3791foGxkZiYsXL2LgwIEKi6nr6OhgxIgR8PT0xKtXr8TtCQkJGDdunMKYkyZNgiAI4nsUHByc7THHjh0rvlbms8XXvvWYQMq/oY+Pj/jEgZqaGqRSKc6dO4fIyEixn0wm+6bcBn2/WB+BKBd5e3sDSKlvKpFIIAiC+Gj248eP8fnzZwAp9c4aNWqEyMhIjBgxAo0bN4aGhgYeP36Mq1evKjxmBgAVKlTI8JhfL26WejH4+gv2t+z/9u1b8UNFZnElJCSkSWi3bt0abdq0wcuXL8XatbkpvfematWqaNy4MbZv345p06YBSPlwo66urpCo8Pb2Fh+HAyD+ewmCAKlUCj8/vyyPX6dOHXTp0gVSqRS6urqoU6dOujV1s+pnYGCgUHaIiIiKj8qVK6NPnz5ITEyEl5cXvL298enTJ4Wb4zkVERGBkJCQdK+H1tbWSo2xceNGDB8+HMbGxrC1tUWzZs3g6OiIBg0aZCuWzD6vKNNfKpXCysoKPj4+2RonJyIjIxESEoKKFSumaatUqRIApInjWz9zERFR+po1a4batWsjOjoampqaOHbsWJpSp97e3gplQL/87hYfHy9+d1uyZAkcHBxQo0YNVK1aFc2aNUOnTp3QqVOnNGuEZHTtPHv2LBITE6Gqqoq3b9+iQoUKaa7ZVlZWkMlkObpWKBOjsuebGWXOL6O+b9++BYAsr5OpnzVKliyZJjFtYGAAPT098T3K7phaWlrZnijwteweU19fH3p6egr9vvw31NHRQenSpbFixQq4uLjA3d0djRo1QvPmzdG7d29xjT+i7GBynigXqaqqQiqVokePHmlqg/fq1Uvctn37djx79gyPHz9WmK31ZU36L325OOrXvl64NfVinpycrFTMyuyvpqaG2NjYNPt+XT9WW1sbhw8fVtiWukiOuro6oqOjM40l9U59QkKCwvawsLAM98novRkxYgSGDRuGmzdvol69eti7dy8cHBwUEuKpC/F+PXMeSJm99+VicBmpWbNmuvtnt1/qzYRXr14pnUwhIqKioVKlSuI1oG/fvqhRowYGDRqEqlWrijeRcyr1Op5eTff0tqXH0dERHTp0wKVLl3Dt2jWcOnUKK1aswNy5c/HTTz8pHUtmn1fSk1HMX87cU1dXR2JiYpp+mX02UEbq+5be55vUzytfxvHlPqmy+5mLiIjS16RJE3Hh0MGDB2Pw4MEYNWoUatasCVtbWwAp391KlSqV4Xe3smXLAkiZFPXy5UvcvHkTV69exT///INNmzahY8eOOHnypEKCPqPrkEwmg0wmA5Dxd+H4+HjI5fIcXSuUiVHZ882MMueX6utreHavk3FxcUhOTla4iSEIAuLi4sR+2R0zu58r0pPdY3797wek/284depUDB06FP/88w+uXbuGnTt34qeffsL27dsxaNCgb46bvi9MzhPlooYNG2Lr1q0wNzfPdJZ4QEAAZDIZqlWrprD94sWLeR1ijtSuXRsPHz6EXC5XuIjfv39foZ+qqmqGCeiGDRvi8uXLiIyMzPAim5oMf/fuHcqXLy9u9/T0zHbMvXr1grOzM7Zt2wZ/f398+vQpzQI7DRs2xK1bt9C1a9d0L8L5aezYsdixYwdWrVqFjRs3ptvn4cOHqFixYpaLzRIRUeE2cOBAbN26FYsWLcKgQYPERUtzQkNDA1WqVEn3Wnn37l2lx9HS0hJn7S1btgzt27fH2rVrxeR86gSD3ExEe3p6KtyQDgsLw6tXrzBgwABxm6mpKRISEhAUFKSQiEjvfLMTo7q6OqpWrYo7d+6kabt9+zYAiAvMEhFR/lq1ahWOHj2KSZMm4caNGwBSvrvt378f7du3z3JBdRUVFdjb28Pe3h5z5szBnDlzsHTpUrx48QKVK1cW+3l6eopPUX+5zcbGRkwy16lTB66urggLC1OYUf2t14qsYszO+WZEmfPLSOXKlaGpqSme55du374NFRUV1KxZU9yWmJiIR48eoXbt2uK2x48fIy4uTnyPsjtmRlRUVJT+PJJbx0yPvr4+evbsiZ49e2LFihXiorNMzlN2seY8US7q378/KleujLFjx6Z5zOzp06dwd3cHkHIBl8vlOHHihNh+7ty5dC8YhcHEiRPx7t07rFixQtzm4+OD48ePKz2Gi4sLoqKiMG7cOIW71s+ePcPNmzcBAPb29ihRooRCcvrFixc4efJktmPW1tZGnz598Ndff2H9+vWwsLBAy5YtFfrMmTMHnz9/xsSJExViEgQBJ0+eVLpuf26wtbXF4sWLsXnzZixevFjh6QFBEHDw4EG0bNkyzVMFRERUNC1ZsgRRUVFYsmTJN481ceJE3L59G3v37hW33b17F9euXcty3/DwcGzevFnh6T25XI7Y2FiF2qypN9B9fX2/Od5UBw4cwMePHwGkJNRnzpyZpmZtu3btIJVKFT4b3Lp1C9evX08zXnZjnDx5Mh4/fowNGzaI27y9vbFq1SrY29vDzs4uR+dFRETfpnTp0pgyZQpu3rwpfmeePn06pFIphg8frlDnGwAuXLggJvH/+OOPNOVCo6OjoaKikqZcyaVLlxS+823evBmPHj2Cs7OzuG3ixIlISEjAtGnTIJfLAQChoaGYOXMmypUrl6YWvTKUiVHZ882MMueXEQ0NDYwZMwZHjhzBuXPnxO1Xr17F3r17MWTIEOjr64vbdXR0sHLlSvF7dWxsLKZPnw59fX0MHDgwR2NmxNTUFJGRkWLZ4Nw8D2V4e3vj8OHD4t8DkPL0f0JCAkqXLp2tsYgAzpwnypGBAwemeQwMAHbs2IELFy5g5MiRqFy5MmrXrg09PT28fv0aWlpa+OWXXwAAffr0wYkTJ+Do6IimTZuKs8mXLFmCHj165PfpZKlTp05Yvnw55s6di3379sHQ0BDR0dGYP38+rly5ku578TU7OzscPXoUY8aMgbm5OWrXro1Pnz5BEATs2rULQEpNupUrV2LixIm4f/8+DAwMIAgC5s6diytXrmQ77uHDh+PPP//E1atXsXjx4jQ1Bm1tbXHmzBkxplq1akEul+PFixewtbXF77//nu1jfou5c+eiQoUKmDdvHlavXg1bW1uoqanh0aNHiImJweDBg6GtrZ2vMRERUd5IfYR/8+bN+PHHHxUWfs+usWPH4uXLlxg8eDDWrFkDLS0tqKqqYubMmQqz0NOjrq4OLy8vLFy4EJaWljAwMMCjR4+grq6ukOxv3749qlevju7du6Nhw4ZQVVXFokWLUL169RzHPWPGDLRq1QrlypWDj48PPnz4gB07dsDGxkbsU7VqVcyePRuLFy/G2bNnoaKigtKlS2PGjBlpEiLZjXHUqFF4//49fvzxR2zZsgUGBga4ffu2OFuRiIgKztSpU7F+/XrMnTsXnTp1QqVKlXDhwgWMGDEC5ubmsLGxgUwmg7e3N6pWrYq1a9cCSFlTpF69ejAwMICJiQl8fHwQFBSErVu3pikFM3PmTEyaNAkSiQQRERF49OgRXFxcFGY+29nZYe/evZgwYQIuXLiAihUr4v79+yhdujTOnDkDXV3dbJ+bMjEqe76ZUeb8MrNs2TJERESgS5cuqFu3LmQyGe7evYtevXqlOb6mpiYGDx6M2rVrw8LCAo8fP0ZycjKOHDmikLDOzpgZGTRoEH777TfY2tqK78vWrVvT3HzJzWN+SVdXF66urpg0aRIqV64MLS0t3L17F1ZWVli3bl22xyOSCKmrVRJRljw9PcUFRdLzZXkUf39/cfV1a2vrdBdjef78OV6/fo3y5cujTp06CA4OxpUrV2Bvb4+yZctCLpfjyJEjqFGjRpqFRfz9/XHr1i20adNG4QNBfHw8Tpw4gdq1a4uPigcFBcHDwwMtWrQQZ8FlZ/9UQUFB8PT0hK6uLho1aoQLFy6gXbt2OHPmjFgjMCtJSUl48OABPnz4AHNzc1SvXj1Ncv/9+/dicr5hw4aIiIjA+fPn0bBhQ5iYmGQa/9eOHj2KpKQkhXP/miAIePLkCd6+fQs9PT1UqVIly1XWP3/+jIsXL6JWrVriQjLf0u9r3t7eePPmDSQSCczMzGBtbV3gpXeIiCh7YmJicPr0aVSuXDndR6b9/Pxw584d2NjYKCxUduvWLfj7+8PR0THNjeXM+Pr64vHjxzA0NISdnR2CgoJw7do1hWvgmzdvcP/+fXTq1AmamprivlFRUXj8+DFCQ0NhYmKCmjVrpjl2UlIS7ty5g6CgIMjlcjRr1gxlypSBt7c3Hj9+jG7duiksLpfR8b7sL5fLcePGDSQkJKBhw4YZfrF+8+YNnj59ChMTE9SpUwfv37/HjRs30LJlS4X1ZDKKMaPzBlJmQHp6eiIuLg6VKlVSKHnwdbxfnl/qNb5x48YK5fiIiEg5b9++haenp/j992t3796Fr68v2rZtCx0dHXF76vdobW1tVKlSJc2ioQkJCXj27Bn8/f1haGgIGxsbhbri//zzD9q0aYPz58+jVatWuH37Nj59+oTatWuL3ze/FhcXh7t37yI0NBTGxsaoU6eOQmmYjx8/4urVq2jatKlCuTpBEODm5oaqVasq3CzOKsYvZXW+X8vO+WUU95cCAwPh5eUFQRBQq1atNGMMGTIEZ8+exYcPHxAWFobbt29DVVUVjRo1SnPNVXZMT09PfPjwAZ07d053/5iYGNy5cwefP39GcnIyunTpAnV1dTx8+BA+Pj7o3r17rh3T19cXd+/eRbt27RRK9IaEhODJkyeIi4uDpaVltr7vE32JyXkiyrGff/4Z8+fPR0BAAIyMjAo6HCIiIiIiIqJMfZm8bt26dUGHk+vy+/y+TM4TUfax5jwRKcXV1RWJiYniay8vL6xZswZdu3ZlYp6IiIiIiIiIiCibCkVyXi6XIywsDElJSdna78uFq4gobz19+hQWFhZo06YNGjRogPr168PGxgZbt24t6NCIiIiIiIiIiIiKnAIta/P+/Xts2bIFW7duRUBAAC5duoTmzZtnud+CBQuwdu1aREVFwdLSEuvWrVO63jUR5VxoaCiePHmC8PBwVK5cWaE+LhEREREREVFhp0yd9aIsv88vq/rwRJS5Ak3OL1u2DHFxcejQoQMaNWqkVHJ+3bp1mDt3Lk6dOoX69etj5cqVWLx4MZ48eZJm8UoiIiIiIiIiIiIiosKoUCwI6+/vD1NTU6WS8xUqVED37t2xatUqcZuFhQWcnJywcuXKPI6UiIiIiIiIiIiIiOjbFYqa88r69OkT3rx5A3t7e4XtTZs2xe3btwsoKiIiIiIiIiIiIiKi7FEp6ACy4+PHjwCA0qVLK2w3NDTMNDkfHx+P+Ph48XVycjI+f/4MAwMDSCSSvAmWiIioEBAEAZGRkShfvjyk0iJ1T/6bJCcn4/379yhZsiSv9UREVKwVlWs9r81ERPQ9Ufb6XKSS86mSk5MVXiclJWV6cV+2bBkWLVqU12EREREVWu/evYOJiUlBh5Fv3r9/D1NT04IOg4iIKN8U9ms9r81ERPQ9yur6XKSS8+XLlwcABAUFKWz/+PGj2JYeFxcXTJ06VXwdHh4OMzMzvHv3Djo6OnkTLBERUSEQEREBU1NTlCxZsqBDyVep58trPRERFXdF5VrPazMREX1PlL0+F/rkfGxsLJKSklCyZEno6emhRo0auHDhAnr27AkgZRb9xYsXMWrUqAzHUFdXh7q6eprtOjo6/FBARETfhe/t8fHU8+W1noiIvheF/VrPazMREX2Psro+F2hBuoSEBISFhSEiIgIAEBUVhbCwMMTFxYl9Jk6ciEaNGomvZ8+ejR07dmDfvn148+YNxo8fj/j4eIwdOzbf4yciIiIiIiIiIiIiyokCnTnv6uqKcePGAQB0dXUxYMAAAMCsWbMwa9YsAICWlpbCXfW+ffsiNjYWy5cvR1BQEGrWrImLFy/CyMgo/0+AiIiIiIiIiIiIiCgHJIIgCAUdRH6LiIiArq4uwsPD+TgdEREVa9/rNe97PW8iIvr+FJVrXlGJk4iIKDcoe90r0LI2RERERERERERERETfIybniYiIiIiIiIiIiIjyGZPzRERERERERERERET5jMl5IiIiIiIiIiIiIqJ8xuQ8EREREREREREREVE+UynoAIiIiIiIiIgofz1//hw3btxAiRIl0K5dO+jq6ma5z82bN+Ht7Q1NTU00aNAAFhYWeR8oERFRMcaZ89+RkSNHYs2aNQUdRq5ycXHBggULCjoMIiIiIiLKRx07dsRff/1V0GHkqkGDBmHLli35cqxVq1ahXr16OH36NFavXo2KFSvi0aNHGfaPi4tDy5Yt0aNHD1y5cgX79+9HlSpV8Ntvv+VLvEREVPgtX74c48ePL+gwctW2bdvQv3//PD0GZ87nEblcDg8PDwQGBsLIyAj29vaQyWQFGpOPjw8MDAwKNIbc9u7dO2hoaBR0GERERERERcbq8y/y9XhT2lTK9TFfvHiBz58/5/q4BenNmzeoVCn336uvvXz5EjNnzsS+ffvQu3dvCIKA7t27Y+TIkbh9+3a6+xw/fhyXL1+Gr68vTE1NAQArVqzAnDlzMGHCBKipqeV53ERExZnFrFP5ery3v3TK9TEDAwPh6+ub6+MWpODgYLx+/TpPj8GZ83nA3d0dFhYWaNGiBfr164cWLVrAwsIC7u7uBR0aERERERERfcdcXV1RqlQp9OzZEwAgkUgwbtw43LlzB2/fvk13HxUVFUilUoXSN/r6+pDJZJBIJPkRNhERUbHEmfO5zN3dHU5OThAEQWF7QEAAnJyc4OrqCgcHhzw59q5du7B37158/vwZtWrVwpw5c2Btba3QJzExET/99BMuXboEuVyOESNGYODAgWL7v//+i19++QXPnz9H+fLlMXLkSHTs2FFsP3fuHDZu3Ah/f39YWVlh8uTJaNy4sdg+cuRIVKpUCfHx8Th9+jSqVKmCVq1aYfv27bhw4YJCLPPnz0dQUBA2b96s1NiCIOD333/HoUOHULJkSXTq1CnN+0xERERfubQs5/u2cMm9OIiIlCSXy/H777/j6NGjiImJQcOGDTF37lyULVtWoV9UVBSmT5+OW7duQUNDA1OmTFH47nLr1i389ttvePv2LaysrDBlyhQ0aNBAbD9w4AB2796NkJAQVK5cGS4uLqhWrZrY3rFjR/Ts2RNPnz7F1atX0bZtW+jo6ODx48fYs2ePQizDhw+HmZmZWHIzq7ETEhKwdOlSnD59GoaGhujTp0+uvoeZefbsGSpVqgSp9L+5elWrVhXb0qsj361bNwwbNgzt27dHt27dEBYWhiNHjmDXrl1QVVVN9zjx8fGIj48XX0dEROTuiXxPFma9HkCxsDC8oCMgokz8/fffWL9+Pfz9/WFpaYnp06ejYcOGafpt2bIFR44cQWhoKLp3744ZM2aI15wPHz5gyZIluHfvHnR1deHk5IRhw4aJN3q9vLywYsUKeHt7o3z58hg4cKB4MxlIKZ3j5+eHOnXqYO/evUhOTsaKFSswatQoXLlyBXp6emLf3bt3Y9euXWI+MquxgZQb2H/88QeSk5PRpEkTqKjkfeqcM+ezIAgCoqOjlfqJiIjApEmT0k0Yp25zdnZGRESEUuNlJ/G8bt06TJw4Eb1798aaNWsQGxuLRo0apXnU8/fff8fr16+xePFi9OrVC6NGjcLBgwcBpHxAbNGiBXR0dLBu3ToMHz4cmzZtEmsP7t69G4MHD0bXrl3xxx9/oFmzZmjbti08PDzE8X18fDBnzhwEBQXht99+w7x589CsWTNcunQJt27dEvslJiZi48aNsLW1VXrsVatWYdGiRRg7dixmz56Nc+fO4fDhw0q/R0REREREVPjNmDEDv/76K8aPH49ff/0Vz549Q/PmzZGYmKjQb/bs2QBSvqg3bdoU3bt3x/Xr1wEA79+/R6tWrVCrVi1s2LABvXr1wvTp0xEaGgoA+OmnnzBv3jwMGTIE69evR5UqVWBnZ4dXr16J47948QJjx45FyZIl8ccff2Ds2LH44YcfsH//fgQEBIj9goODsXv3bnFikTJjT506FTt27ICLiwumTJmCdevW4c6dO3nzhn4lMjJSIXkBpMyCBzJPoOvr6yMoKAhPnz7FkydPACDTEqPLli2Drq6u+JNaDoeIiIqef/75B507d0aDBg2wfv16WFlZoVmzZnj48KFCv3PnzuHQoUOYMWMGpkyZgt9++w3z588X23v27AlfX1/8+uuvmDZtGu7cuSPmJW/evIkWLVqgTp062LBhA/r27YtJkyaJk3qBlNI5f/75J06cOIFFixZhy5YtqFevHgIDA+Hq6qoQy+bNm1GjRg2lxz5z5gz69++PTp06YcmSJQgJCcHSpUtz/b38mkT4DqceR0REQFdXF+Hh4dDR0cm0b3R0NEqUKJFPkSmKioqCtrZ2lv2SkpJgaGiIBQsWwNnZGUDKbJOKFStiwIABWLx4MQCgdevW8PPzg7e3t3hHavbs2Thy5Aj+/fdfvHr1ChUrVkRQUBAMDQ3F8RMTEyGVSmFkZIQNGzYo3FWaNm0avL29ceLECfEYUVFRCol4AGjRogVq1KiBdevWAQBOnjwJJycnfPjwASVLlsxy7MTERJQtWxbLli3D6NGjAaT825iamsLBwQFbt27N9vtLRPQ9yM41rzj5Xs87XZw5T0RfKcw15z98+AAzMzMcPnwY3bp1AwCEhYXBzMwMa9aswbBhwwAA1tbWsLS0xPnz58V9+/Xrh9DQUJw5cwb//PMPunfvjsjISPG7T3JyMgDg8+fPMDY2xrVr12BnZyfu7+TkBCMjI/E7i7W1NWxtbcWkQSorKyuMHz8eP/74IwBg/fr1WLp0Kd69e4fQ0NAsx049xxMnTqBdu3YAAD8/P1SoUAELFizA3LlzlX6/gOxf8/r27Yv379/jypUr4raAgACYmJjg2LFj6Nq1a5p9/vjjD7i4uOD58+cwMjICkLJI3oQJE/DmzRtx25fSmzlvamrKa3NOcOY8UbFX2GvON27cGNWrV8eff/4pbuvYsSM0NDTEMt6TJ0/Gn3/+iXfv3qFUqVIAgP3792PkyJFi/k9DQwOnT59Gy5YtxXESExOhqqqKpk2bokWLFli0aJHYtnPnTixatAg+Pj7iMfbt2wc/Pz9oamqK/SZOnIgnT57g0qVLAFImD1tZWeHOnTuws7NTauxGjRrB1tZW/BwAAHXr1oWamlqaPKcylL0+s6xNMfD27VuEhoaidevW4jaZTIYWLVrgwYMHCn2bN2+uUBOwZcuW+OWXXxAbGwtzc3NUrVpVXAwotVa+qqoqnj59iuDgYMyfPx9LliyBIAgQBAEhISFpbl7Ur18/TYz9+/fH7NmzsXr1aqioqGDfvn3o1KkT9PT0lBo79RxbtGghjqmtrZ3usYiIiIiIqGh68uQJEhMTFb7b6Onpwc7OLs13my+/GwAp321SE9t169ZFiRIl0KlTJwwcOBAtWrRAuXLlAAC3b99GQkICRowYAYlEIn7/CAwMRN26dRXGTO/7Rr9+/bBv3z4xOb9v3z707dsXMplMqbEfP36MxMRENG/eXBzTzMwMFSpUyOG7lj0VK1YUnzBI9ebNG7EtPbdv34aNjY1CEr59+/aIi4uDl5dXusl5dXV1qKur52LkRERUEARBgJeXlzghOFWbNm3w+++/K2yzsbERE/NAyrU5JiYG3t7esLW1RYcOHTB27FiMHz8eLVu2RI0aNaCqqgq5XI4bN27g3bt3OHbsmHj9jIqKgq+vL+Lj48VrSs2aNRUS80BK3rFx48bw9/eHiYkJ9u/fj0qVKsHOzk6psdXU1ODl5YXp06crjNuyZUtcu3YtN9/ONJicz4KWlhaioqKU6nv16lWFGocZOX36NJo2barUsZURHR0NAGn+MLW0tMS2VOn1EQQBMTExMDAwwO3bt7F7924cO3YMkydPRq1ateDq6oqYmBgAwIoVK9LUIFRTU8sy7p49e2LChAk4f/487O3tcfz4cezduxcAlBo7tU968RMRERERUfEQHR0NqVSaJqmr7Heb1D6lSpXCo0ePsGvXLuzatQsjRoxA69atceDAAcTExEAikWD79u1pjvP1k8vpfd8YMGAAlixZgn///VecTffHH38AgFJjx8TEQEVFJU2t9vz6btO1a1f89NNPuHr1qvi9dM+ePahYsaJYez4yMhK7du1Cp06dYGlpCUtLS5w9exbR0dHiedy7dw8AYGlpmS9xExFRwUhKSkJ8fHyO847Af7nLw4cP4+DBgzhz5gyWLl0KfX19HDx4EJUqVYJcLoezs7PCDfpUX14z07teNmzYEBUqVMCBAwcwffp07Nu3DwMGDACQUsY7q7ETExORkJBQIHlHJuezIJFIlCotAwBt27aFiYkJAgIC0q0XL5FIYGJigrZt20Imk+VajFZWVpBIJHj69CmsrKzE7U+ePEkz8+HZs2cKr58+fQpdXV0YGBgAAEqWLInx48dj/PjxiIqKgp2dHdauXYtp06ZBKpXi06dP6Ny5c7Zj1NXVRadOnbBv3z58+vQJ6urq6NQp5RGaChUqZDm2paUlJBIJnj17plCr8OnTp7C3t892PEREREREVPhYW1sjOTkZ//77L2rWrAkgZcbe06dPMWLECIW+6X23+XL2uaGhIaZPn47p06fj48ePqFq1Kvbu3YsGDRpAEARERkaiXr162Y6xSpUqqFu3Lvbt2wd1dXVUq1YNderUAQBUqlQpy7ErVKiApKQkvHz5EpUrVwYAxMXF4fXr19mOJSdsbW0xevRoODk5YdSoUfD398eBAwfEUqUAEBISgokTJ8LExASWlpaYMGECdu7ciSZNmqBXr14IDQ3Fli1bMHz4cFSpUiVf4iYiooKhqqoKMzMzPH36VKH02ZMnT2Btba3Q9/nz50hOThYXgH369CkAiNdnFRUVDBgwAAMGDEBSUhJ69OiBefPm4fjx4zAxMYG/v79YJz67Up9sa926Nf7991/0798fQMoNg6zGVlNTg6mpKZ49e4YOHTqI21Pjz0tMzucimUyGtWvXwsnJSXyEMVVqKZk1a9bkamIeSEmo9+/fH4sWLcIPP/yAUqVKwd3dHVevXsXKlSsV+l64cAGnT59Gx44dERgYiF9//RUjR44EkPJ45eXLlzFy5EhoaGggOTkZSUlJKFGiBEqVKoXBgwdj3rx5qFu3LmrVqgVBEHDt2jW8fPlSrP2YmQEDBmDgwIHw8/NDz549xVnxyoyto6ODXr16YdGiRWjUqBF0dHSwadMmvHjxgsl5IiIiIqJionr16rC3t8esWbPg5uYGDQ0NrFmzBh8+fMCgQYMU+h44cACjR4+Gra0tnj9/js2bN4u1ZC9cuIAPHz6gd+/eUFFRQVJSEpKTk1GiRAnY2NigRYsWcHZ2xvHjx2Fubo7k5GScOnVKTBRkZcCAAVi3bh3U1NQwePBgcbsyY9eoUQMNGzbErFmzcOjQIaipqWHRokWZLsaa2zZt2oSOHTvCw8MDlpaWePjwoUKSXUdHB+PHjxcnf5UuXRrPnj3DwYMH8eLFC5QoUQKurq7pzkDMT/ldo7mgvM143V0ionwxZswYrF27Fj179oS1tTXu37+PXbt2Yf369Qr93r9/j1WrVmH69OmIiYnBnDlz0L59e5iYmCAqKgrLli3DtGnToK+vD0EQkJiYKJbBmTJlCubOnYs2bdqIa7I8e/YMJ06cwMyZM7OMMXXdzdmzZ6Nx48YKE5iVGXvEiBFiXtfc3ByXL1/G8ePHc3QjPzuYnM9lDg4OcHV1hbOzM/z9/cXtJiYmWLNmDRwcHPLkuGvWrEH//v1hbGwMAwMDREZGYsOGDWn+gLp06YLp06dj9OjRCAoKQqtWrcRVk83NzfHy5UsYGhrC0NAQQUFBaNu2rVhTasOGDfjxxx/RoEEDlClTBhEREahTpw5Wr16tVIydOnWCmpoaPDw8sGTJEoU2ZcZes2YNunXrhrJly0JfXx/m5uZo1qzZt7xtRERERERUyOzatQt9+vRB6dKlxTWo9u3bBxMTE4V+3bt3F79fBQYGol+/fhg9ejSAlCT/zp07MWbMGJQrVw6BgYHo378/evfuDQBwdXXFmDFjULFiRZQvXx6fP39Gq1atsGrVKqVi7NOnD6ZPn47k5GRxZl4qZcbesWMHunfvjtKlS0NDQwN2dnY5nimYU127dk138VcgZQLV1wkXLS0tpSZlERFR8TNlyhS8fPkS1atXR7ly5RAUFISJEydi4MCBCv3q16+PM2fOYNWqVYiMjIS1tTWOHTsGIGUGu7a2NipWrIiSJUsiLCwM1apVExeZnTJlCuLi4tC7d2+oq6tDEASUK1cOv/76q1IxVqxYEXZ2djh79qxYbu7L+LMae9q0aXjw4AGsra1hZGQENTU19OjRA35+ft/y1mVJIqRXf6WYy+5q9jkhl8vh4eGBwMBAGBkZwd7ePtdnzKcnODgYYWFhMDc3T1ML/u3bt9DU1ETZsmXx8eNHJCUloXz58mnGSEpKgp+fH8qUKYOSJUumaY+NjYW/vz+MjIzSLAb75THS4+Pjg+joaFSvXl1hYVplxk7l6+uLkiVLolSpUvD394dUKk33PIiIKH+ueYXR93re6bq0LOf7tnDJvTiIiLLp/fv3iI2NhYWFRZrvUi9fvkTp0qWhr6+PgIAAqKmpoUyZMmnGiI+PR0BAAMqVK5du3dioqCgEBgbC1NQUGhqK05O/PEZ6Xrx4AUEQxNI02RkbSCnX4+PjI37v8vHxQYkSJdI9j8wUlWteXsT5/cyc71fQIeSPheEFHQERZSE8PBxBQUEwNjZOUwb8w4cPSEhIgJmZGcLCwhAaGpruuiSCIMDX1xc6OjoKi8emSkpKgq+vL/T19dO0f3mM9AQGBiIkJATW1tbpXnszG/vLYwiCACMjI3z69AkREREKs/CVpex1j8n5QvzhhYiI6Ft9r9e87/W808XkPBFRsVZUrnlMzucck/NEREWPstc9aT7GREREREREREREREREYHKeiIiIiIiIiIiIiCjfMTlPRERERERERERERJTPmJwnIiIiIiIiIiIiIspnTM4TEREREREREREREeUzJueJiIiIiIiIiIiIiPIZk/NERERERERERERERPmMyXkiIiIiIiIiIiIionymUtABEBEREVEhdWlZzvdt4ZJ7cRARERERERVDTM4XE4cOHcLdu3cBAKqqqjA1NUWXLl1gamqqVHsqX19fnDlzBv7+/ihdujTq1KmDZs2a5e/JEBERERHRd2vjxo14/fo1AEBdXR0WFhZwcHCAgYGBUu2pnj9/jr///htBQUEoX748GjRoAFtb2/w9GSIiomLgypUrOHHiBABAJpPByMgIrVq1Qs2aNZVqTxUSEoJTp07h5cuXKFmyJKpVq4b27dtDReX7TVF/v2eeRwLCYhEanZBhu762Goz1NHP9uGfOnIGHhwfGjh2LxMREnDx5ElOnTsWxY8fQrl27LNsBYP78+VixYgU6deqE2rVr4927dzh58iSmT5+OW7duQSplFSQiIiIioiLvW56KyYlsPklz6NAhREdHo3fv3oiLi8OuXbswbdo0eHh4oFatWlm2JyYmYvz48di3bx8cHR1RuXJleHt7Y+/evTAyMoK7u3senSgREVEOLdTN5+OFZ6v73bt3sXHjRixatAjJycm4d+8epk+fjt9++w0TJ07Msh0Adu/ejfHjx6NBgwZo0qQJwsLCsHXrVkybNg3//PMPTExM8uJMCz0m53NRQFgsWq68jPik5Az7qKtIcXFa8zxJ0JuammLatGkAABcXF7Rr1w5z5swRk++ZtW/YsAFLlizBxYsX08yUv3//PiQSSa7HW1wV1A0aIqLCLC4uDt7e3ihfvjzKlCmj1D7BwcGIiYmBqakpbxATEX1nqlevrvDdpWbNmli8eDFcXV2zbJ89ezYOHjwIT09PVK1aVWFcT0/P/D0RIiKiYkJTU1O89gKAoaEhZs2ahfHjx2fZfuXKFQwdOhQbNmzAmDFjFMZ9+/YtNDW/3zwZk/O5KDQ6IdPEPADEJyUjNDohX5Kz9erVw5YtW7JsFwQBS5YswcCBA9MtYVO3bt28DLNYKegbNEREhc379++xatUqHDhwAB8/fsTKlSsxefLkTPc5cuQIFi5ciMDAQGhqaiI6OhrLly/H8OHD8ydoIiIqVGQyGWrXro0XL15k2R4REYF169Zh1qxZaRLzAFjWhoiIKJfUq1cPMTEx+PjxY5btS5cuRd26ddMk5gHAwsIijyMt3DgNTUkxCUkZ/sQlynN93G8lCAKuXbuGSpUqZdn+5s0bBAYGonnz5t983O9ddm7QEBF9Dx4+fAgjIyM8fvwYenp6Su3j5eWFvXv34uPHj/D19cWaNWswcuRI3LhxI2+DJSKiQik+Ph537tzJ8LvNl+13795FfHw8v9sQERHlMQ8PD+jq6qJs2bJZtl+/fp1rWmaAM+eVVG3+uQzbWlQugx1D6+do3CbLL+FzOonat790yvZYr1+/xrRp05CUlIQbN27g5cuXOHnyZJbtYWFhAIBy5crl6ByIiIgy0qFDB3To0CFb+yxatEjh9YABAzBt2jRcuXIFjRs3zs3wiIiokPL09MS0adMQHx+PCxcuICYmBosXL86y/eHDhwD43YaIiCi3xcTEYNq0aUhOTsbTp09x5coV/Pnnn2Ip7IzaExISEBsby2tzBpicL0bU1NRQrlw5qKqqwt7eHq1atVKYpZhRu6+vLwAgICCggCL//rwLjUE5XQ3oaapCRVbwD7CwTj4RFWYBAQEICQmBubl5QYdCRET5RFNTE+XKlYO6ujpat26Ntm3bKtSjzag99TtNQEAAqlSpUlDhExERFTsSiQTlypWDVCqFra0ttm7dClNTU6XaS5QowbxjBpicV9Kzxe0ybJN+w2Kp12a2yPG+X/tywdfstJubm8PS0hJnz55lPd9vlCjPvKRNqgn77kMuABIJoKupilLaaiilpYZS2mqwtdDHqKYVxL43Xn1CSQ1VlCqR0kdTTZarMbNOPhEVZnK5HCNGjECFChXg4OCQYb/4+HjEx8eLryMiIvIjPCIiyiNfLvianXZbW1toa2vj7NmzaNWqVV6GSERE9F35esHX7LQ3b94c58+fR3JyMqTSgp+kWpgwOa8kLbW8eavyatzsWrRoEQYNGgR3d/c0yY+zZ8+ibdu2/D9PFn47/wK7b/go1VdTXQVRcUkQBCAsJhFhMYl4g2gAijd7BEHAoO13kJQs/Levqiwlma+thsYVDODS8b+Frtzv+0NbXQUG/28vpa0GHQ1VSKUZ30AqbAsZExGlEgQBI0eOxIMHD3DlyhVoaGhk2HfZsmVpyuEQEdH3R1tbGzNnzsTSpUvRo0cPhXJoycnJOHfuXLbLrREREdG3mTdvHpo0aYIlS5Zg3rx5Cm337t2DiYlJhrXri7vCkRmmAjdw4ECEhoZi8ODBWL16NWrXro3Q0FA8fPgQZmZmaNcu4ycHvlfyZAGyL5Lerz9GISxWucV8D45siCrlSiIsNhGfoxMQEpWAz9EJ+ByTAGO9/5JPsYlyVCxbEp+j4/E5OgGJcgGxiXIEhMUiICwWJvr/JcuTkwVMd30E+ReJfACQSSXQ11JD88plsLKnjbh94+XX0FSVIjoh5wsaExHlFUEQMHr0aJw6dQqXLl1C5cqVM+3v4uKCqVOniq8jIiIUHrGkFDffhHzT/o2sDHIpEiKivDNnzhzExsaiVatWaNq0KSpXroygoCA8ePAALVq0YHKeiIgon9WvXx9ubm4YOXIk/vrrLzRp0gQJCQl4+vQpBEHAsWPHCjrEAsPkfC7S11aDuoo0y/Ig+tpquX7sPn36IDw8PMftADBp0iQMGjQIly5dgr+/P0qXLo25c+eyVuNXAsJiceiOH/7y9MfeEQ1gbVgCADCmWQXYmOhi6ZnnSo2jIpOidAl1lC6hDmRwc1BLTQVnnO0BpCSqouKTUpL4///R01IV+ybIk9GsUhmxLTQ6AZHxSZAnC/gUFY+YhP9uHCQnC1j5t3eaRH5mPkfHQxAEcaEPIqLc8unTJ/j7+6N27doAUv57N2bMGBw7dgwXL15EtWrVshxDXV0d6urqeRwpEVEx0cKloCPI1NixY6Grq5vjdqlUiqVLl8LZ2RmXL1/Gx48f0bRpU/z6669cv4SIiAqnhZnn7Apa8+bNoaWlleN2AOjSpQvevn2Ly5cv4/Xr1yhRogTGjh0LW1vb3A63SJEIgqB8dq6YiIiIgK6uLsLDw6Gjo5OrY3NhzeJJnizgsvdH7L/th0veH5Ga0x7bvAJmtv/v5kVhq98enyRHaHTK7Hw1Fal4IyE+SY7FJ54hNCYBfiExePJeudrMOhoqqFi2JKzLlIC1YcpPFaOSMNLl3zRRYZWX1zxlxMbGwtvbGwDQokULjBgxAv3794euri4sLS0BAOvXr8fEiRORmJgIFRUVODs7Y9OmTdi+fTuqV68ujlWmTBkYGxsrddyCPu9C5dIy8dd8nTlfyJN/RETFRVG55uVFnBazTuXKOIXdW41+BR1C/ijkyUkiouxQ9rrHmfO5zFhPk8n3YiQqPgnbr/ng4B0/vA+PE7c3sjJAvwZmaFe9nEJ/Yz1NXJzWvNDcoFFXkaGcrgzldDXSbF/SoyYA4ElAODqvu5blWBIAEXFJuOcbinu+oeL2TrWMsKFfXQApM/I3XnmNCmW0YW1YEuYGWlCVca2C4kAul8PDwwOBgYEwMjKCvb09ZLLcXZyYiic/Pz8MGTIEQMoC5OfPn8f58+fRokULrF69GkBK0t3GxkZ8Muf58+eoWrUqVqxYoTBWnz59MGvWrHyNn4iIiIiIiCivMDlPlAkVqQTbr/sgLCYRelqqcKprgr4NzFChTIkM9ymuN2hcxzaClpoKXn6MwquPUXj9MQovP0aimtF/d/8CwmKx4py3+FpVJoGFgbY4y96+YhnUtyyVK/HwKZX84+7uDmdnZ/j7+4vbTExMsHbt2jQLSBN9rXLlyvDy8sq0T+/evdG7d2/x9blz5/I4KiIiIiIiIqKCx+Q80f8FR8bjL893uPUmBLuG1odUKoGGqgzT2laGtroMHWoYQUP1+50prK4iQ1UjHVQ1yvhRHEEAHOoY4+XHKLwOjkJMghwvP0bh5ccoACnlgVKT8x8j4jDT7ZFYJqfC/xP4upqqGY6fqrCVDyrO3N3d4eTkhK8roAUEBMDJyQmurq5M0BMRERERERER5QCT8/RdS04WcPNNCPbf9sO5px+Q9P9i8jffhOAH69IAgAENi/eiUboaMgjyREhkGSfFBXkidDWyvjFhZqCF33rXBpDy3gZGxOHVxyi8DIrE6+AoNPyiVvGLoChc8g7GJe9ghTEMS6qjYtkSGNTIQiwblJoYTi15ERqdkGliHgDik5IRGp1QqJLzRW22v1wuh7Ozc5rEPABxceDJkyejW7duLHFDRERERERERJRNTM7Tdyk0OgGH773D/tt+eBsSI26vY6aH/g3MUddMvwCjyz+CIOCf44cRsHkmZFoZz4iXx0Tgdae/YNq8udJjS6USscRPs0pl0rRXMNTGz91r4NX/y+S8+hiFDxFx+BgZj4+R8ehm89+ij3d8PmPUnnuwNiyBioYloK1e9BLBRWW2f2hoKO7fvw9PT0+cOXNGoZTN1wRBwLt37zB58mT06dMHtWvXhra2dj5GS0REREQ5kZycjH379sHDwwMlSpRAv379YGtrm2H/kydP4uDBg+m2bdiwAbq6unkVKhERUbHG5Dx9l7yDIrH09HMAQAl1FfSoY4x+DcwyLdlSXAiCgHv37sHNzQ3u7u548eIFAEAeGZzpfoGBgbkah5GuZpqnEiLiEvH6/4n6L2fZvwqOQnhsYprFaLOy/7YvzA20oaUmg4aqDJpqMtQz14eRbkryOyo+CZ+jEqChJoWWmgo0VWWQSSW5c4JfKYyz/cPDw3H//n3cu3cPnp6e8PT0xOvXr7M9zvr167F+/XpIpVJUq1YN9erVg62tLWxtbWFjYwNNzcLzNAARERERAQMHDsTVq1fFdYUaNWoEV1dXdOvWLd3+lpaWaN++vcK2VatWISIiAjo6xf87FBERUV5hcp6KvbCYBLjdD4A8ORmjmlYAADSwLIXOtYzQxLo0utiUh7Z68f6/glwux82bN8WEvJ+fn9imqqqKxMTELMdYuXIlKlSogPr16+dZnDoaqqhjpo86Xz254FjXBHVM9fEqOCVxf8/3M66/CslyvP133qXZtrF/XRjVTEkWX3r+ERMPPFBoV5NJoakmg6aqDAu6VEOHmkYAAK93YVh/8RW0/t+mqSYT+2mpyWBfsQwqlysJIOVv7vmHSLFNQ1WGsJiMy9nkh8jIyDSJ+JcvX6bb18rKCra2ttDT08OWLVuyHLtRo0Z4+/YtAgMD8eTJEzx58gS7du0CAMhkMlSvXl0hYV+rVi1oaGjk6vkRERERkXJu3LiB/fv3486dO7CzswOQMoHH2dkZXbt2FUtJfql69eqoXr26+Do8PByjRo3CvHnz0u1PREREyineGUn6bgmCgHu+odh/2w+nHgciPikZOhoqGNTIAhqqMkgkEqzvV7egw8xTiYmJuHLlCtzc3HD06FF8+PBBbNPW1kbHjh3h4OCA9u3bo2bNmggICEi3tniq+/fvo0GDBujRowd++uknhQ/neU1DVYZq5XVQrXzKrJwnAeHovO5alvt1qFEOmqoyxCbKEZsoR0yCHIY66mJ7siBASy2lPfXUE+TJSIhNRnhsIuRfvB8BobH459+gDI/1q6OqmJz3eheGITvu5uRUc0VUVBS8vLzEJPy9e/fg7e2d7r+vhYUFbG1txeR53bp1UapUyqK9crkcp0+fzvBvQyKRwMTEBB4eHpDJZHj//r2Y/E/936CgIDx69AiPHj3Cjh07AAAqKiqoUaOGQsK+Zs2aUFdXT3OMnChqtf2JiIiI8tPJkydhYWEhJuYBoE+fPvj999/x5MkT1KxZM8sxDhw4gMTERAwZMiQPIyUiIir+mJynYiU8NhFHHwRg/20/eAdFiturGumgfwOzAowsf8TFxeH8+fNwd3fH8ePH8fnzZ7FNV1cXXbt2hYODA9q1a6dQamTt2rVwcnKCRCJRSMKmzoL5448/cPv2bezevRtHjhzB0aNHMWDAACxcuBBWVlb5d4LZNL6FNWoYZ1z/slttY3SrbQxBEBCflIzYBDliEuWITZAjLlEOE/3/3qOaxrpY2qMmYhNT2mISkhCbkIzYxCTEJshhUfq/WutqMikqlNFGbMJ/NwWyKmmTUzExMWIiPjUh/u+//6abTDczM1NIiNetWxelS5fOcGyZTJbl38aaNWvExWDLly+P8uXLo0uXLgBSbpK9f/9e4SaBp6cngoOD4eXlBS8vL2zbtg1AyhMcNWvWVLhRUKNGDaipqWXr/Sgqtf2JiIiICsqbN29gbq5YXjL19Zs3b5RKzm/btg2dO3eGkZFRhn3i4+MRHx8vvo6IiMhhxERERMUXk/NUqGV3BuzGy6+x6UpKzWwNVSm61CqPfg3MUNtUr9g+bhkVFYUzZ87A3d0dJ0+eRFRUlNhWpkwZdO/eHY6OjmjRokWGiU4HBwe4urqKNSdTmZiYYM2aNXBwcMCYMWMwY8YMzJs3D25ubtizZw8OHDiAkSNHYt68eZl+MC/sJBIJNFRTys9ktBSwmYEW+hkod4OnsXVpXPixucK2R+/C0HXD9W+KMzY2Fg8fPlRIdD979gzJyWkT0SYmJmKSu169eqhXrx4MDQ2zfUxl/jYyIpFIYGxsDGNjY7F+aeoisl/PsA8JCcH9+/dx//59cX81NTXUqlVLIWFfvXp1qKqqZnjMwljbXxmp/62Ty+V48OABPn36hNKlS6NOnTqQyWSc7U9ERES5JjY2FiVKlFDYVrJkSbEtK48ePYKnpycWLVqUab9ly5Zl2YeIiOh7x+Q8FVrKzIBVkaaUp2lfoxwAoI+dKS49/4i+9U3Ro64JdDUzTuIVZWFhYThx4gTc3d1x9uxZxMXFiW3GxsZwcHCAo6MjmjRpIs5qzoqDgwO6desGDw8PBAYGwsjICPb29gr7V61aFa6urvD09MTcuXNx7tw5bNy4ETt37sTEiRMxY8YMGBgYZHKU3KGvrQZ1FWmWs6P1tbM36zovSZVcaDYgLBY1jHURFxcnfvFJTWA/ffoUcrk8zT7ly5dPk4gvV65crsWuzN+GsiQSCczMzGBmZoYePXoASEnY+/r6KtTDv3fvHkJDQ8XXqdTV1WFjY6OQsK9WrRpUVLJ3OYtJkEOeLOTZAsDZkf5/60oAL+OAmzcBcLY/ERER5R5dXV28fv1aYVvqE7e6uhk/dZpq69atMDU1TbNA7NdcXFwwdepU8XVERARMTU1zEDEREVHxxeQ8FVrKzIBNShaw68ZbMTlvUVobZyfbF8tZ8sHBwTh69Cjc3Nxw4cIFJCUliW1WVlZwdHSEo6Mj7OzsIJVKc3QMmUyG5s2bZ9nP1tYWZ8+exZUrVzB79mzcuHEDv/76KzZt2oTp06fD2dlZnH2TF4z1NHFxWvNiWVd87O5b0Hh8DC/P71X4N05VtmxZsSxNaiK+fPnyeR6Xsn8bOSGRSGBhYQELCws4OjoCSEnY+/j4pEnYh4eH486dO7hz5464v4aGBmrXrg1bW1uUr94AyPD5h//02pyS9FZTkYoL9zarVAa/ONYS+4zffx8yiURc1FdTTQat//+vWSkttK3+3w2Qe76hUJVJ/lssWFUGLTUVqKtIs7wxU1Rn+xMREVHRVLNmTZw6dQpJSUniBIfHjx8DAGrUqJHpvvHx8di3bx8mTpyY5XcOdXX1XFtTiIiIqLhicp6KvJrGOgqvi1Ni3t/fH0eOHIGbmxs8PDwUypdUr15dnCFfq1atAjnvZs2a4dq1azh9+jTmzJmDhw8fYt68efj9998xe/ZsjBkzBhoaGnlybGM9zSKVqNTVkEGQJ0Iiy/hpDkFIRrJEFTG1nKArM4D03kHY1q6lUCe+fPnyxepvPCMSiQRWVlawsrJCz549AQDJycl48+aNwtME9+/fR0REBG7duoVbt25BrewZGA1Zq/RxEpKSkZCUsgDw3YdPseLNOQCAIACnPlcFkP57baoahYc6fuLrPz9XRoKQ/pMExirR6K7rK74+EWGKREEKVYkAFUkykpIlALK+mZXeUxNERERE2dWzZ0/MmTMHe/bswdChQyGXy/H777/D3t5enNn+6dMnTJ48GVOmTEG9evXEfY8cOYKwsDAMGzasoMInIiIqVpicpyKva23jgg4hV7158wZubm5wc3PD7du3Fdrq1asHR0dHODg4oHLlygUUoSKJRIJOnTqhQ4cOOHz4MObNm4eXL19iypQp+O2337BgwQIMHjw422VHips7l88hYPNYyLR0Muwjj41E436T4a9bE7YtOuKY+3Koq2a/dExxJZVKYW1tDWtra/Tp0wdASsL+1atX8PT0xM17D3Hmc2mkfd4grcA905AU+h4SFXVIVNUhVVVHQGIcLn4O+H8PCUrYtIVEVSOlXUUdEjUNsf+jYF9cu+0qjmc0bAOk6pop/VVSxkv16tVLzDg0V3xt4nwQMo3/FhBW1oMHD2Bj1irb+xERERF9ycLCAuvXr8eECROwb98+BAYGIioqCufPnxf7REVFYd++fXByclJIzm/btg3t2rWDmZlyazERERFR5go8W/b06VNs2bIFQUFBqFmzJiZOnAgdnYyTVwBw8uRJnD59GqGhoTAzM8PQoUNRpUqVfIqY8oP3h0jEJxXtWaJyuVypGt2CIODZs2dwd3eHm5sbHj58KLZJJBI0btxYTMibm5vn5ylki1QqRe/eveHg4IBdu3Zh0aJFePfuHUaMGIHly5fjp59+Qs+ePXNccqcoevv2Ldzd3eHu7o7r11MWg5VHBme6z9imFqjYqDFKl1AXE/NJ8mRIJRKl69Z/T6RSKSpVqoTX8SVx840hklTjldqvTq0aqGxYP5tHi///D4BSWkDlQf81Jd3Gl3cFBADJEhXIJTJAE1Ab9F/fz9H3II9VhVwiQ7JEBYHRckSVzzqWT58+ZTNeIiIiovSNGjUKHTt2xO3bt1GiRAk0bdoUmpr/PZVapkwZ7NmzB7a2tuI2QRAwdOhQ1K1btyBCJiIiKpYKNDnv6emJpk2bol+/fmjTpg22bNmCQ4cO4c6dOxmWwli8eDFWrFiB2bNnw97eHufOnUPt2rXh4eEBOzu7fD4Dyk2CIODKi2Bsu+YDj5efMKmldUGHlGPu7u5wdnaGv7+/uM3ExARr166Fg4MDBEHA/fv34ebmBnd3d3h7e4v9Umt7Ozo6onv37jAyMiqIU8gxVVVVjBgxAgMGDMCmTZuwZMkSvHz5En369MGyZcuwZMkSdOzYsdiWZvH29haffLh//3629zcyMoKtRSmFbb+df4HHAeFY1csGhiXzpkxQUeYXEoMJBx5AniygtAbwKS7rfcaMGYMh3QrHLPSdxy5g4c2sgy5dunQ+RENERETfCxMTE5iYmKTbpq2tjQEDBihsk0gk6NevX36ERkRE9N0o0OS8i4sLWrVqha1btwIAHBwcYGJigu3bt2PcuHHp7rN7925MmDABLi4uAIC+ffvi1q1bOHToEJPzRVRcohxHHgRg2zUfvPoYBQCQSoCAMCUybIWQu7s7nJycIAiCwvaAgAA4Ojqic+fOePz4MXx9/6tBraamhjZt2sDR0RFdu3aFgYFBfoed6zQ0NDB58mQMHz4ca9aswcqVK/Hw4UN07twZP/zwA5YuXYqmTZsWdJjfTBAEPHz4UHzy4dmzZ2KbVCpF06ZN4eDggK5du6JJkyYICAhI87cBpHzZMTExgb29vcL2T1Hx2HXjLaIT5OiwxgMre9mgRWXDPD+vosTMQAsTWlhDEAR0tTFCq5UXM6/tL09EqybN8jHCzNWpUwe4eVO5fkRERERERERUbBRYcj4uLg6XLl0SE/MAoK+vj1atWuHMmTMZJucrVaqEly9fiq8/f/6MT58+oWrVqnkeM+Wu5GQBay68xN5bvvgcnQAAKKGugt52phjS2ALhsYlwu++fxSiFi1wuh7Ozc7rJ19RtJ0+eBABoaWmhQ4cOcHR0RKdOnbIs51RUlSxZEvPmzcO4ceOwfPlyrFu3DtevX0ezZs3Qrl07LFmyRKGOZVGQnJyMO3fuiAn5N2/eiG2qqqpo1aoVHBwc0K1bNxga/pdIX7t2LZycnCCRSBT+RlKfIlizZk2a0kelS6jj2IQfMPGAF/4NjMDQHXcxvIklZrSvDHWV77MevW9INOYdewqXDlVQ1Sjl/zdT2lQS2+fXTca4qZNTXnz5/8X/v89//LYcpgYl8ivcLKVX7upb+hERERERERFR0VBgyfl3795BLpeLq8GnMjU1xZUrVzLcb/fu3Rg9ejSqVq0Kc3NzPH78GLNmzcp0tfj4+HjEx/9XhzgiIuLbT4C+mVQqgde7MHyOToCxniaG/mCB3namKKmRMuNVGhYLdRUp4pOSMxxDXUUKfW21/Ao5jcTERAQEBMDX1xe+vr64fPmyQimbjCxevBg//vgjtLS08iHKwsHAwAC//vorJk+ejJ9//hl//vknzp07h3PnzsHJyQmLFy8u1DfZUtcQSK0hHxAQILZpaGigffv24pMRenp66Y7h4OAAV1fXdEserVmzBg4ODunuZ21YEkfGNcYvZ55j54232HbNB7fehOD3vnVQoUzhSTLntSR5MrZf98Fv518gLjEZ8YlyHBrdKE2/4X0doK+ONO+zqalppu9zQdHXViv0/60jIiIiIiIiotxXYMn51GT518nJEiVKIC4u43Imx48fx5UrV+Ds7IwKFSrg77//xrp169C5c+cMF4VdtmwZFi1alHvBU7YlJ6fUk99x4y1+dayFcropdbMnt66I3ramaFe9LFRkiguFGutp4uK05giNToBcLseDBw/w6dMnlC5dGnXq1IFMJoO+thqM9TTTO2SuiImJgZ+fn5h8//onICAAyckZJ9QyYm1t/V0l5r9Uvnx5/PHHH/jxxx+xcOFC7Nu3D66urnB3d8egQYOwYMECWFhYFHSYAICEhARcvHgR7u7uOHr0KIKD/1vMtUSJEujcuTMcHR3RoUMHaGtrKzVm6ox6ZRYL/pKGqgwLu1ZHE+vSmO76EE/fR6D35lu4NrMFNFSL/4zqZ+8jMMv9ER75hwMAGlcwwDKHmhn2z+n7XBAKw3/riJR1802I0n1vJb1Is+3Lp1yIiIiIiIi+dxIhvfob+eDdu3cwMzPDqVOn0LFjR3H7iBEj8PDhQ9y9ezfNPjExMShdujSWL1+OiRMnittbtWoFXV1duLu7p3us9GbOm5qaIjw8vNiWEiksYhPkcH/gj+3XfPA6OBoAMK55Bcxon/6NlPRktbhqTgmCgNDQUDHRnl4S/stkbEbU1NRgZmYGc3NzqKmp4cyZM1nuc+nSJTRv3jzHsRcnT548wbx583D06FEAKWVhxowZg9mzZ6NcuXL5Hk9sbCzOnTsHNzc3nDhxAuHh4WKbvr4+unXrBkdHR7Ru3TrDhavzWlBEHCYf9IJDXWP0tDXNeociLC5RjnUXX2LzlTdIShago6GCuZ2qoaetSbFdVDi3RUREQFdX97u75n2v552uS8vEX7OTXP9Wt8xGpdnG5DwRUe4rKte8vIjTYtapXBmnsHur8Z0sxLswPOs+RERFhLLXvQKbOW9iYoJSpUrh4cOHCsl5Ly8v2NjYpLtPaGgoYmNjUbFiRYXtFStWxP379zM8lrq6OtTV1XMncFLKx8g47Lnpi723fBEakwgAKPn/evJ965spPU5mi6s6OTnB1dU1wwR9cnIyPnz4kOGsd19fX0RFRWUZQ8mSJWFubp7hT9myZSGVpsz6l8vlsLCwyPain9+zGjVq4MiRI7h9+zbmzp2Lf/75B+vWrcO2bdvg7OyM6dOnQ19fP09jiIiIwOnTp+Hm5obTp08jJiZGbCtbtix69OgBR0dHNGvWDKqqGS80ml/K6mhg34gG+DI37fn2M2RSCeqY5e17ld+OeQVgw6XXAIAONcphUdfqMNQpmJsiRERERERERES5qcCS8xKJBAMGDMC2bdswZswY6Ovr4+LFi7h37x5Wrlwp9tuwYQNevHiBtWvXwtjYGOXLl8eBAwfQrl07SCQSfP78GWfOnEHnzp0L6lToK3GJcrT57SrCY1OS8ib6mhj6gyV62ZqI9eSVkdXiqhKJBBMmTICOjg78/f3TJN7fvXuHhISELI9TpkyZTJPvenp6Ss/QlclkOVr0k4AGDRrg/PnzuHjxImbPno3bt29j2bJl2LhxI2bMmIFJkyYpXTpGGSEhIThx4gTc3Nzw999/K/ytmJmZwdHREQ4ODmjUqFGh/PeSSv/7mwyNTsCE/Q/wKSoeU9tWwpimFRTaizKneqa48O9HONQ1RvsaRgUdDhERERERERFRrimw5DwA/Pzzz/Dy8kLlypVRpUoVeHp6Yv78+QrlPh48eIBbt26Jr/ft24f+/fujcuXKsLCwwL1791C9enX89NNPBXAGBKTUk7/79jMaWBkASKmN3dWmPJ4FRmBEE0u0qZa2nrwyPDw8Ml1cVRAEBAYGok2bNhn2kUqlMDY2zjDxbmZmluu133O66CelaNmyJW7evIkTJ05gzpw5ePLkCWbPno21a9dizpw5GDVqlMKTMKkLtSpTV/zDhw84evQo3NzccOnSJcjlcrGtUqVKcHR0hKOjI+rWrVukSqbIZBLYWZbCiYfv8etZb1x7+Qmre9dG2SI4w/zS84/40+MNtg+xg4aqDDKpBFsG2RZ0WEREREREREREua7Aas6nEgQBDx48QFBQEGrUqAFTU8X6yV5eXvj8+TNatmwpbouLi8OTJ08QEhICc3PzDBeCzUhRqclX2MUmyOF23x/br/vgTXA03Mc1Rt3/l9RISEqGmkr2E/KpBEHA0qVLMXfu3Cz7litXDjVq1Eg3+W5sbFxgZUiykzSm9Mnlchw8eBDz58/HmzdvAKTMal+4cCEGDhyI48ePZ7kega+vL9zd3eHu7o7r168rPM1Qq1YtMSFfrVq1IpWQ/5ogCHC954/5x54iNlEOfS1VrOxpg1ZVyxZ0aEoJiYrH4pPPcMzrPQBgervKGN/CuoCjKh6+12ve93re6WLNeSKiYq2oXPNYcz7nWHOeiKjoUfa6V+DJ+YJQVD68FFZBEXHYffMt9t32Q9gX9eR/6l4D3esY53hcuVyOmzdvws3NDe7u7vDz81NqPy6uWvwlJiZi27ZtWLx4MQIDAwEAxsbGCAgISNM3NcHet29fvHjxAp6engrt9evXF0vWWFsXv+Tv6+AoTNz/AM8CIwAAQxpbYG6nqjl6eiU/CIKAY17vsfjkM3yOToBUAgxvYompbSpDU403s3LD93rN+17PO11MzhMRFWtF5ZrH5HzOMTlPRFT05PmCsG/fvhVnq5qamsLc3DynQ1ERER6TiEUnnuLEo/dIlKfc0zEtpYlhP1iip60pSqhn/88pMTERly9fhru7O44cOYKgoCCxTVNTEwAQGxub7r5cXPX7oaqqijFjxmDw4MHYsGEDli5dmm5iHoA4M37//v0AUv5O7O3t4ejoiB49eqR5Oqe4qVCmBI6Mb4zlZ7yx/boPgiPjISuk9effh8VizpHHuOQdDACoUq4kljvWgo2pXsEGRkRERERERESUD7KVTfX19cWGDRtw8OBBvHv3TqHN1NQU/fr1w9ixY5moL6a01WW47fMZiXIBdhb6GN7ECm2qlc124i8uLg7nz5+Hu7s7jh8/js+fP4tturq66Nq1KxwcHNCuXTucOXMGTk5OAMDFVQmampqYNm0aqlSpgi5dumTZf+rUqZgxYwbKli0apV1yi7qKDPO7VEOzymVQ2/S/BY3jk+RQk0kLTfmeJaf+xSXvYKjJpJjY0hqjm1X4pnJYRERERERERERFidLJeRcXF6xbtw4tW7bE3LlzYWdnJya8goKCcOfOHZw8eRLVq1fHpEmTsHTp0jwLmvJeTEIS3O4H4PSjQOwaVh9qKlKoyKT4uXsN6GuroXY2Z7ZGRUXhzJkzcHd3x8mTJxEVFSW2lSlTBt27d4ejoyNatGgBNTU1sY2Lq1J6IiMjlepna2v73SXmv9SsUhnxd0EQMPmgF6RSCZb2qAldzYJZi+FLczpVRWR8EuZ3rgprw5IFHQ4RERERERERUb5SOjn/+fNneHt7w9g4bU3x8uXLo06dOhg9ejQCAgKwePHiXA2SckdAWCxCoxMybNfXVoOKVIJdN95i/53/6smffhwo1pJvUcVQ6eOFhYXhxIkTcHd3x9mzZxEXFye2GRsbw8HBAY6OjmjSpEmms98dHBzQrVs3Lq5KIiMjo1zt9z34NzAS558FISlZgJdfGH7vWxv1zEvl2/ET5cnYfOU1PkTE4efuNQEA5fU0sXtY/XyLgYjyV0O/LWk3XjJQbucWLrkbDBERERERUSGkdHJ+8+bNSvUzNjZWui/ln4CwWLRceRnxSckZ9pFKUn5Su5gbaGFoYwu0qab8zOPg4GAcPXoUbm5uuHDhApKSksQ2KysrODo6wtHREXZ2dpBKlS9fIZPJuOgriezt7WFiYoKAgACkt6Y11yNIq1p5HbiObYxJBx7A73MMem2+hcmtKmJcC+s8r0n/yD8MM1wf4fmHlCceetmaopaJXp4ek4iIiIiIiIiosMvxgrBUtIRGJ2SamAeAZCHlp75lKQxvYonWVZWrJ+/v748jR47Azc0NHh4eSE7+7zjVq1cXZ8jXqlWr0NS6pqJNJpNh7dq1cHJygkQi4XoESqptqodTk5pg7tEnOOb1HqvOv8C1V5+wpk9tGOlq5vrxYhPkWP3PC2z1eINkAdDXUsWCLtVR01g3149FRERERERERFTU5Dg5//jxY9y4cQOhoaFp2mbNmvVNQVHBWd2rNnrUTVu66Gtv3ryBm5sb3NzccPv2bYW2evXqiQn5ypUr51Wo9J3jegQ5U1JDFWt610bTimUw79gT3Pb5jOE7PXFqUpNcvXl249UnuBx5DN+QGABAV5vyWNClGgxKqOfaMYiIiIiIiIiIirIcJefXrl2LKVOmwMrKCnp6emnamZwvuiqWLZHudkEQ8OzZM7i7u8PNzQ0PHz4U2yQSCRo3bgxHR0f06NEDFhYW+RQtfe+4HkHOSCQSONYzQV1zfUw+5IU5HavmamI+LlEO50NeCI6Mh5GuBpb0qIGWVb7fhXmJiIiIiIiIiNKTo+T8L7/8And3d3Tv3j2Xw6G88iY4Otv7CIKA+/fvw83NDe7u7vD29hbbUmvAOzo6onv37lx4kwoM1yPIOcvS2jg6rrFCYv7skw+wKqONSmVLZns8QRAgkUigoSrDoq7VcfN1CGa0r4ySGqq5GTYRERERERERUbGQo+R8ZGQk2rRpk9uxUB74GBmH3/5+gYN33ynVPzk5GdevXxcT8r6+vmKbmpoa2rRpA0dHR3Tt2hUGBgZ5FTYR5ZMvE/OvPkZhyiEvJAsC5nephn71zZSaUf8xMg4Ljj1F+xrl0K12SlmsjjWN0LEmb9oREREREREREWUkR8n5Nm3a4OTJk+jdu3dux0O5KCYhCe1WX0VoTKLS+7Rv3x6Bz+6Ir7W0tNChQwc4OjqiU6dO0NHRyYtQiagQ0NVUhZ1lKVx9EYw5R57A48UnOLe2hjyDtaQFQcCNNyHYcPEVIuKScM83FO1rlIO6CssKERERERERERFlJUfJ+XXr1qFevXo4cuQIKlSokGZm5c8//5wrwVH2pZaVAAAtNRX0tDXFbZ/P6GtnglnuT7LcPyQkBLq6uujSpQscHBzQrl07aGlp5XXYRFQIlCmpjp1D7LDtmg9+PfccZ59+wNmnH5Tat4axDpY71mJinoiIiIiIiIhISTlKzv/666/49OkTnj9/jg8flEvcUN677xeKJaf+xYIu1VDLRA8A8GPbSlCVSnHk3CUkJyVAqqKW4f7JSQmY7jwO83+cADW1jPsRUfEllUowsqkVGliVwug99xAYHpflPkMbW2BOp6pQkUnzIUIqij59+oTt27fj5s2bGDZsGLp06ZLlPh8+fMC6devw6tUrWFhYYPz48TAzM8uHaImIiIiIiIjyR46S87t27cLp06fRrl273I6HcsA/NAa/nvXG8YfvAQAr/36B3cPqA4A4izUhLAjvtzhDppVxWRp5TASqb17LxDwRoZaJHtb2qYNem29m2dexngkT85ShkydPYsyYMejTpw8uXLiAZs2aZbnPx48fYWtri5o1a6JXr144fvw46tWrB09PT5ibm+dD1ERERERERER5L0fJeTU1Nfzwww+5HQtlU1R8Ev649Apbr/kgISkZEgnQs54JprWtnKavlpYW5JHBkEcGZzqmkREXcCSiFFpqLFFD387Ozg6vX7+Guro6du7cqdQ+K1asgLq6Oo4fPw5VVVUMGjQINjY2WLJkCbZs2ZK3ARMRERERERHlkxwl55s0aQI3NzcMHjw4t+MhJR1/+B6LTzzDp6h4AEBDq1KY26kaahjrpul7+/ZtTJgwIdPxJBIJTExMYG9vnyfxEhHR96ls2bLZ3ufMmTPo0qULVFVVAQAymQwODg7YsWNHbodHREREREREVGBylJzX0tLCsGHD4O7uDmtr6zQLwq5cuTJXgqOMRcUl4VNUPCwMtDC7Y1W0qVY2zb+DIAjYsGEDpk6disTERBgZGYlrBAiCIPZL3W/NmjWQyThTloiICpaPjw9MTU0VtpmamsLf3x+JiYli0v5L8fHxiI+PF19HRETkeZxERERERERE3yJHRYJDQkLQpk0bxMfH4+nTp3jy5InCD+W+18FRuP0mRHzdy9YEvzrWwt9TmqFt9XJpEvORkZHo168fJk6ciMTERDg5OeH58+dwdXWFsbGxQl8TExO4urrCwcEhX86FiIgoM/Hx8dDS0lLYVqJECbEtPcuWLYOurq7483Vyn4iIiP4THByM0aNHo1q1aqhfvz5+//13hQlcGXFzc0O7du1QrVo1DB06FIGBgfkQLRERUfGVo5nzJ0+ehIpKjnalbAqNTsDaCy+x95Yvyupo4MKPzaChKoOKTIpeduknHp4+fSom41VUVLBixQo4OztDIpHAwcEB3bp1g4eHBwIDA2FkZAR7e3vOmCciokJDV1cXoaGhCttCQkKgqqoKbW3tdPdxcXHB1KlTxdcRERFM0BdCN7+YaJCZW0kvMmyb0qZSboVDRPRdksvlaNeuHUqWLInt27fD398fw4YNQ3R0NFxcXDLcb/ny5fj555/x22+/oWnTpnj48CHmzp2Lbdu25WP0RERExUuOF4RNTk7O7VjoCwlJydhzyxe/X3iJ8NhEAEBVo5KIjEuChmrGifR9+/Zh1KhRiImJgbGxMf766y80btxYoY9MJkPz5s3zMnwiKgb0tdWgriJFfFLG/71XV5FCX1stH6Oi74GNjQ0ePnyosM3Lyws1a9ZM86RYKnV1dairq+dHeEREREXa8ePH4eXlBT8/P5iYmABIKSn3888/Y+rUqeleT9++fYu5c+diy5YtGDp0KACgcuXKcHJyytfYiYiIipscJecNDQ0RFBSUo0XeKHOCIODvZ0FYdvpfvA2JAQBUKVcScztVQ5OKpTPcLy4uDlOmTMGmTZsAAG3atMG+fftQpkyZfImbiIofYz1NXJzWHKHRCRn20ddWg7GeZj5GRcXR6dOnsWXLFri7u0MqlWLgwIGYOHEi/v33X1StWhU+Pj5wc3PDggULCjpUIiKiIu/y5cuoXr26mJgHgPbt22PGjBl48OABGjZsmGYfNzc3qKqqol+/fgrbpdIcVcolIiKi/8tRcn706NGYPXs21q9fD01NJmVy0yP/cIzecw8AULqEOqa1rYSetqaQSdOfKQikzGJwcnLCvXv3IJFIMH/+fMybN4+laojomxnraTL5Tt/Ex8cHU6ZMAZCyHsq2bdtw+fJlNGjQQHx0/s2bNzh27BiSk5MhlUoxePBgXLt2DfXr10fdunXx8OFDtG3bFhMmTCjIUyEiIioW/P39Ua5cOYVtqa8DAgLS3efFixeoUqUK/vrrL/z+++9ISkqCnZ0d5s+fr5Dk/xIXayciIspajpLzqY/B/fXXX7C0tISammJJA09Pz1wJ7nsRnySHukpKIt3GVA+daxnBrJQWxrWwRgn1zP+JTp48iUGDBiE0NBQGBgbYu3cv2rdvnx9hExERZalUqVIYMmQIAIj/CwBGRkbi7506dYKJiYl4U1kqlWLbtm2YOXMmXr9+DXNzc1SrVi0/wyYiIiq2kpOT06whp6qqCiClHn16EhIS8O+//2L37t3YsGEDAGDOnDlo3rw5Hj58mO6aMMuWLcOiRYtyOXoiIqLiJUfJ+d69e6N37965Hct3JzZBjj893mD3TV+cntQEhjoaAIB1fetkWFM3VVJSEubPn49ly5YBABo0aIC//voLZmZmeR43ERGRsnR1ddG9e/dM+1haWsLS0jLN9kqVKqFSJS7+SURElJtKly6dZm2XT58+AUCGZVENDQ0RFxeHnTt3wtjYGACwc+dOmJiY4PLly+jUqVOafbhYOxERUdZylJyfNWtWbsfxXUlOFnD84XssP/scgeFxAIBDd99hYquKAJBlYv7Dhw/o27cvLl++DACYNGkSVqxYkeYJBiIiIiIiIqIv1a9fH3v27EFUVBRKlCgBALh27RpUVFRQu3btdPdp0KABgJSb7qlSf4+NjU13Hy7WTkRElDWu3pLPPN9+Ro8/rmPyIS8EhsfBWE8Tv/etgwktrZXa/+rVq6hbty4uX76MEiVK4NChQ1i7di0T80RERERERJSlnj17omTJkpg7dy6SkpIQFBSEX375BX369IG+vj6AlLr0FhYW+PvvvwGklKCzsrLC4sWLkZycjOTkZCxevBi6urqwt7cvyNMhIiIq0nI0cx4AXr16hePHj8PPzw9JSUkKbevXr//mwIobQRAw9a+HOPIgZYEdbTUZxrWwxvAmltBQzXrhVkEQsHLlSri4uEAul6N69epwdXVFlSpV8jp0IiIiIiIiKib09PRw4sQJDBo0CNu2bUN8fDw6d+4s1pIHUsqo+vr6IiYmBkDKLPjU9c5SZ8ybm5vj+PHjKFu2bIGcBxERUXGQo+T8mTNn4OjoiPr16+PKlSto164dHj58iA8fPqB169a5HWOxIJFIYKCtBokE6G1riqltK8GwpIZS+4aFhWHIkCE4duwYAGDAgAHYtGlTuovuEBEREREREWWmYcOGePHiBYKCgqClpYWSJUsqtJuYmMDHxweGhobitqpVq+Lu3bsICQmBmppamn2IiIgo+3KUnJ87dy7++OMPDBkyBBKJBGfPnkV8fDxGjRoFDQ3lEs5FXUBYLEKjEzJs19FQgcerT7Ax0UMN45SZBRNbVYRDXRNUK6+j9HEePHgAJycnvHnzBmpqali3bh1GjhyZZV16IiIiIiIiosxkNOtdRUUFFhYW6bYZGBjkYURERETflxwl5//99184OTkBAGQyGWJjY6GpqYlffvkFNjY22Lx5c64GWdgEhMWi5crLiE9KzrCPBIAAoL5lKRwa1RASiQS6mqrQ1VRV6hiCIGDbtm2YMGEC4uPjYWFhAVdXV9SrVy93ToKIiIiIiIiIiIiICkyOkvOxsbHiqu5GRkZ4/fo1atSoAalUiujo6FwNsDAKjU7INDEPpCTmS2iooGONckgWAFk2JrrHxMRg3Lhx2LVrFwCgc+fO2L17t7g4DxEREX2fVp9/ke19GvqF5EEkRERERERE9K1yvCBsqo4dO2LUqFEYNGgQDh8+jMaNG+dGXMXC1oG2aFghe4/8vXjxAk5OTnj8+DGkUimWLl2K6dOnQyqV5lGURERERERERERERJTfcpTxPXz4sPj78uXLUblyZaxZswYlS5bE1q1bcy24oq6ERvbufbi6usLW1haPHz9G2bJlceHCBcycOZOJeSIiIiIiIiIiIqJiJkcz51PrzQOAnp4eduzYkWsBfY8SEhIwc+ZMrFmzBgDQtGlTHDx4EEZGRgUbGBERERERERERERHlCU7JLmD+/v5o3ry5mJifOXMmLly4wMQ8ERERERERERERUTH2zTXnKefOnz+Pfv364dOnT9DV1cXu3bvRtWvXgg6LiIiIiIiIiIiIiPIYZ84XgOTkZCxevBjt2rXDp0+fULduXdy/f5+JeSIiIiIiIiIiIqLvBGfO54C+thrUVaSIT0rOsI+6ihT62mpptn/69AkDBgzAuXPnAACjRo3C2rVroaGhkWfxEhERERUlDf22ZNx4ySDznVu45G4wREREREREeYTJ+Rww1tPExWnNERqdkGEffW01GOtpKmy7desWevbsCX9/f2hqamLTpk0YNGhQXodLRERERERERERERIWM0sl5CwsLpQd9+/ZtDkIpWoz1NNMk3zMiCALWr1+PH3/8EYmJiahYsSLc3NxQs2bNPI6SiIiIiIiIiIiIiAojpZPzCxcuFH9/+fIlVqxYgV69esHOzg4AcPfuXfz111+YPn16rgdZlEVGRmLEiBH466+/AABOTk7Ytm0bdHR0CjgyIiIiIiIiIiIiIiooSifnhwwZIv7epk0b7NixA/3791fo06FDB+zatSvXgivqnjx5AicnJ3h7e0NFRQUrV67EpEmTIJFICjo0IiIiIiIiIiIiIipA0pzsdPfuXXTp0iXN9i5duuDOnTvfHFRxsGfPHtSvXx/e3t4wMTHB1atX4ezszMQ8EREREREREREREeUsOa+lpYVz586l2X7u3Dloa2t/c1BFiVwux+XLl3HgwAFcvnwZ0dHRGDNmDAYNGoTY2Fi0adMG9+/fR6NGjQo6VCIiIiIiIiIiIiIqJJQua/OlGTNmYNCgQTh//jzs7OwgCAI8PT2xZ88e/Prrr7kdY6Hl7u4OZ2dn+Pv7i9tUVVWRmJgIiUSC+fPnY968eZDJZAUYJREREREREREREREVNjlKzk+ePBnW1tZYvXo1Tpw4AQCoVq0aXF1d0alTp1wNsLByd3eHk5MTBEFQ2J6YmAgAmDNnjsIiukRERET07W6+Ccm0/VbSi0zbp7SplJvhEBERERER5ViOkvP//PMPOnfujM6dO+d2PEWCXC6Hs7NzmsR8KolEgl27dmHhwoWcNU9EREREREREREREaeSo5nz79u0zTEx/Dzw8PBRK2XxNEAS8e/cOHh4e+RgVERERERERERERERUVOZo5b2lpCW9vb1SpUiW34ykSAgMDc7UfERERUYYuLRN/beiXeUkXIiIiIiIiKjpyNHN+9uzZGDx4MK5du4bPnz8jKipK4ae4MzIyytV+RERERERERERERPR9ydHM+WHDhgEA7O3t020v7iVv7O3tYWJigoCAgHTPVSKRwMTEJMP3h4iIiIiIiIiIiIi+bzlKzt+8eTO34yhSZDIZ1q5dCycnJ0gkEoUEvUQiAQCsWbOGi8ESERERERERERERUbpylJxv2LBhbsdR5Dg4OMDV1RXOzs4Ki8OamJhgzZo1cHBwKMDoiIiIiIiIiIiIiKgwy1FyPjcJggBPT08EBQWhRo0asLCwUGq/iIgI3LlzB1paWqhfvz5UVPL/VBwcHNCtWzd4eHggMDAQRkZGsLe354x5IiIiIiIiIiIiIspUjjLagiBg7969OHz4MPz8/JCUlKTQ/uTJE6XGiYiIQMeOHfH69WtUqVIFd+7cwZQpU/Dzzz9nut+mTZswffp01KpVC1paWggPD8fRo0dRvnz5nJzON5HJZGjevHm+H5eIiIiIiIiIiIiIiq4cJedXrlyJ3377DaNHj8aJEyewbNky3LlzB0ePHsW4ceOUHmfu3LkICgrCv//+Cz09PVy5cgXNmzdHy5Yt0bJly3T3OXXqFMaPH49jx46hc+fOAIDHjx8jOjo6J6dCRERERERE9F2KiIiAuro61NXVM+2XnJyMjx8/ptmur6+f5b5ERESUMWlOdtqyZQsOHz6MhQsXAgBmzZoFd3d3rFmzBj4+PkqNkTr7fvjw4dDT0wMANGvWDHZ2dti7d2+G+y1ZsgRdu3YVE/MAULNmTVSsWDEnp0JERERERET0Xbl//z5sbGxgaGiIkiVLol+/fplOeHv//j2MjIxQs2ZN1K5dW/y5dOlSPkZNRERU/OQoOe/j44MGDRoAADQ0NBAZGQkAGDx4MK5evarUGP7+/ggNDUWtWrUUtteqVQuPHj1Kd5+4uDjcuXMH7du3x7t373Dq1Ck8ePAAycnJmR4rPj4eERERCj9ERERERERE35vU8rKNGzdGeHg4Xr9+jTt37mDixIlZ7uvh4YEPHz6IP+3bt8+HiImIiIqvHCXn5XI5VFVVAQBmZma4e/cuAMDPz0/cnpXw8HAAKY/BfcnAwABhYWHp7hMSEgK5XI4LFy6gSZMm2LBhA7p06YJ69erB398/w2MtW7YMurq64o+pqalSMRIREREREREVJ4cPH0ZoaCiWL18OdXV1mJqawsXFBXv37s3wu3iqpKQkTnYjIiLKRTlKzn9p2LBh6N27N/r06YN27drBwcFBqf1S69LFxMQobI+KioKGhkam+zx58gTPnj3D6dOn8fLlSwiCgB9//DHDY7m4uCA8PFz8effunVIxEhERUe4IDw/H48ePERoaqvQ+ISEhePr0KYKDg/MwMiIiou/LnTt3UKtWLejo6IjbmjZtisTERHh5eWW6b7169VCuXDmULVsWS5YsQVJSUh5HS0REVLzlKDn/5ZfkmTNnYuXKldDT08OMGTPwxx9/KDWGqakpVFRU4Ofnp7Ddz88PVlZW6e5TunRp6OrqolOnTtDW1gYAaGpqonPnzuLs/fSoq6tDR0dH4YeIiIjyx8KFC1G2bFl0794d5cqVy/SGOgCEhoaiffv2MDc3R+/evWFlZYVmzZrhw4cP+RQxERFR8RUcHIzSpUsrbCtTpgwApLvoKwCoqKjgl19+QXBwMKKjo7Fr1y4sX74cS5cuzfA4LC9LRESUtRwl558+fYr4+Hjx9eDBg7Fp0yZMnjwZampqSo2hoaGBFi1awNXVVdwWEhKCCxcuoEOHDuK2e/fu4fz58+LrTp064cWLFwpjvXjxAiYmJjk5FSIiIspD7u7uWLZsGS5cuIDXr1/j1q1b2LRpE7Zv357hPgsWLIC3tzd8fX3x5MkT+Pv7Izg4GDNmzMjHyImIiIoniUSSZsZ76muZTJbuPuXKlcPMmTOho6MDiUSC9u3bw9nZGRs3bszwOCwvS0RElDWVnOzUrl07SCQSNGzYEM2bN0fz5s3RsGFDseyMsn755RfY29tj6NChaNSoEf78809UqlQJw4YNE/ts3LgRt27dwpMnTwAAP/30Exo0aIDRo0fjhx9+wO3bt3Hs2DGcPXs2J6dCREREeejPP/9Eu3bt8MMPPwAA6tSpg+7du2Pr1q0K1/svBQYGombNmjAwMAAA6Orqol69eggMDMy3uImIiIorY2NjvHz5UmFbUFAQAKB8+fJKj2NtbY0PHz4gLi4u3dK0Li4umDp1qvg6IiKCCXoiIqKv5GjmfFhYGE6fPo2mTZvi4sWLaNeuHfT09NCiRQssWrRI6XHq1q2Le/fuQV9fH1euXIGjoyM8PDwUkvy2trZo27at+NrKygoPHjxA6dKl8ffff0NXVxePHj1CixYtcnIqRERElIfu378POzs7hW0NGjTAgwcPIAhCuvtMnToVt27dwu+//47r169j06ZNOHfuHFxcXPIjZCIiomKtadOmePr0qcJN73PnzqFEiRKoU6cOAEAul+PDhw/iE/PpXbNv376NcuXKZbpmHMvLEhERZS5HM+dTS9KkJsS9vb2xbNky7N27F5cvX8aCBQuUHqtKlSr47bffMmwfM2ZMmm0mJiZYsmRJ9gMnIiKifBUSEiLOgE9VunRpxMXFISYmRlxD5ku2trYYMmQIZs+eDTMzM7x79w6DBg1C48aNMzxOfHy8Qsk91rUlIiJKX7du3VCtWjUMGjQIK1asgL+/P3766SdMmzZNTLS/e/cOlpaWOHLkCLp3746ffvoJEokEHTp0QIkSJXD06FFs2bIFa9asKdiTISIiKuJyNHPe398fe/fuxfDhw1GhQgXUqVMH7969w4IFC3D16tXcjpGIiIjy2bt373JlHFVVVYWkOQDExsaKbekZP348Tp48CR8fHzx79gx+fn64c+cOhgwZkuFxWNeWiIhIOaqqqvj7779hZGSEHj16wMXFBS4uLpg/f77YRyaToWzZsmKyftq0aVBRUcH48ePRtWtXeHh44MSJE5gwYUJBnQYREVGxkKOZ86ampihdujTGjh2LnTt3okGDBkovBEtERESFX9euXaGqqophw4ahb9++0NXVzdE4ZmZmeP/+vcK29+/fo2zZshl+djhy5AimTJmCMmXKAAD09fUxdOhQTJ06FYIgQCKRpNmHdW2JiIiUZ2RkhN27d2fYbmpqig8fPoivtbS0xCQ+ERER5Z4czZwfPHgwtLW1sWrVKvz0009YtWoVbt68mWbFdyIiIiqa9u3bB3t7eyxYsABGRkYYMGAALl68mGGd+Iy0atUKZ86cUdjv5MmTaNWqlfg6ODgYnp6e4msDAwOFhACQskisvr5+uol5gHVtiYiIiIiIqOjJUXJ+586dePv2LZ4+fYq+ffvi+fPn6Nu3L/T19dGhQ4fcjpGIiIjyWbVq1bBq1Sr4+/tj3759CA8PR7t27VChQgX89NNPSpe9mTFjBgICAjBs2DCcP38e48aNw9OnTzFnzhyxz6FDh2BnZyfe5B83bhy2bNmCVatWwcPDA+vWrcPq1asxbty4PDlXIiIiIiIiooKQo+R8qvLly8Pa2hoVKlSApaUl4uLicOHChdyKjYiIiAqYqqoqevTogRMnTuDIkSMIDw/H/PnzYWFhAQcHB7x8+TLT/S0sLHDjxg3I5XIsXLgQYWFh8PDwQLVq1cQ+hoaGqFevnjgrftKkSThw4ADu3LmD2bNn48qVK/jzzz8xd+7cPD1XIiIiIiIiovyUo5rzP//8My5fvowbN24gKSkJdnZ2aN68OWbPno0ffvght2MkIiKiAvLp0yfs3bsX27dvx7///ovOnTtj5MiR0NXVxW+//QZ7e3v4+PhAU1MzwzGqVq2aaV3bXr16oVevXgrbevTogR49euTaeRAREREREREVNjlKzp89exbNmjXDzJkz8cMPP0BLSyu34yIiIqICdOHCBWzcuBEnTpyAubk5hg8fjiFDhqBs2bJinx9++AFWVlZ4/fo1atSoUYDREhERERERERU9OUrOX7t2LbfjICIiokJk7ty5sLKywrlz59C8efMM+82bNw+Ghob5FxgRERERERFRMZHjmvMJCQm4cuUKduzYIW4LCgrKlaCIiIioYHXq1Am//vpruon5X375BQEBAQCAoUOHMjlPRERERERElAM5Ss77+vqidu3a6NixI4YNGyZuHz9+PI4dO5ZrwREREVHBcHV1RXBwcLptBw4cQEhISD5HRERERERERFS85Cg5P3nyZDRr1gzh4eEK26dNm4ZffvklVwIjIiKiwicgIAB+fn6cLU9ERERERET0jXJUc/7q1at48eIFVFQUd69RowYePHiQK4ERERFR/rO1tYWXlxfkcjlsbW0V2gRBQHJyMjp37oxy5coVUIRERERERERExUOOkvMJCQni7xKJRPw9ICAA2tra3x4VERERFYjff/8dERERGD9+PH788UdYWVmJbVKpFOXKlUPNmjULMEIiIiIiIiKi4iFHyfnmzZvjjz/+wLx588TkfFRUFH788Ue0bt06VwMkIiKi/NO4cWMAwIkTJ2BpaQlNTc0CjoiIiIiIiIioeMpRcn7VqlVo2rQpTp06BUEQ0KNHD1y/fh0qKiq4fv16bsdIRERE+axatWoFHQJRjjT025J5h0sGmbe3cMm9YIiIiIiIiDKRowVhK1WqhCdPnqBbt27o0aMHAGDixIl4+PAhLC0tczVAIiIiyh+1a9eGRCKBl5eX+HtGP15eXgUdLhEREREREVGRlqOZ8xMmTMD69evh4sKZRURERMXF5s2bERkZCWtra/H3jFhbW+djZERERERERETFT46S89u2bcOqVaugrq6e2/EQERFRAWnQoEG6vxMRERERERFR7stRWZtGjRrhwoULuR0LERERFRKxsbGYOnUqEhISAAB//fUX9PT0UL58efzzzz8FHB0RERERERFR0ZejmfNNmjRB3759MXLkSFSrVg1qamoK7QMGDMiV4IiIiKhg/PrrryhVqhTU1NQgl8sxfvx4TJ8+HYIgYOTIkXj9+jWk0hzd4ycqUDffhGTafivpRabtU9pUys1wiIiIiIjoO5aj5PyWLVugqamJvXv3ptvO5DwREVHRdvnyZSxevBgAcPfuXejp6WHOnDkAUmrTBwQEwNTUtCBDJCIiIiIiIirScpSc//DhQ27HQURERIWITCZDWFgYAODcuXNo1aqVQrtEIimAqIiIiIiIiIiKjxwl57/m6ekJW1vb3BiKiIiICoE2bdpg2rRpuHv3LtavX4+//voLAODj4wN1dXWYmJgUcIRERERERERERVuuJOft7OwgCEJuDEVERESFwNSpUxEdHY07d+5gwYIFaN26NQBg//79+OV/7d15eEzn///xV0I2CUHsW2y1hVpaxNIqqqqWUqqUotUWXRTVqqqWVks/tKU7n276UWvVVrppaSeIWlK1b4mQxB5JZBe5f3/4Od9OkxAxmch4Pq5rrivnPu/7zPs+ZubEO/fcZ9q0As4OAAAAAIDCzyHFeQAA4Fo8PDysNef/6fK68wAAAAAA4Pq4F3QCBSkhIcH6+fz580pJSZEkXbx4UfHx8crIyJAkpaWl2cUmJiYqOTlZkpSZman4+HhduHDBio2Pj8821hij+Ph4paenS5LS09MVHx9vfesgKSlJSUlJuYpNTk5WYmKi9Tzx8fFKS0uTJF24cEHx8fHKzMzMNjYhIcGKzcjIUHx8vC5evChJSklJ0fnz5+1iU1NTcxV7pXOYmpp61fOdm3OYm/Od23P4z/N9+Rz+Ozanc3il852SkpLlfOf2HP4z9vJ5uRybm3OY0/lOTEy0Yq/lNXs59t/n5bJrec0mJSXl+TWbXeyN8JrlM4LPiMLyGXE90tPTFR0draioKLvH5XMMAAAAAADyxiHF+TfeeMMRh3G6bdu2WT9v375dhw8flnSpwGGz2awb4UVFRWnTpk1W7F9//aWDBw9KulS0sNlsio2NlSQdP35cGzZssGJ37dqlffv2SbpUdLHZbDpz5owk6eTJk7LZbFYhaM+ePdqzZ4+kS0Ujm82mkydPSpLOnDkjm81mFbL27dunXbt2Wc+zYcMGHT9+XJIUGxsrm81mFZEOHjyov/76y4rdtGmToqKiJElxcXGy2WxWsefw4cPavn27Ffvnn38qMjJS0qWils1ms4pVR44c0ZYtW6zYrVu3KiIiQtKlQpXNZrOKSseOHdPmzZut2LCwMB06dEjSpeLZP893dHS03fnesWOHDhw4IOlSkctms+ns2bOSLt2cOCQkxIrdvXu3db4vXrwom82m06dPS5JOnTolm81mFcj27t2r3bt3W31tNpt1s+OzZ8/ane/9+/fr77//tmI3btyomJgYSdK5c+dks9msQtzBgwcVFhZmxYaGhlrnOyEhQTabzSqYhYeH270Ot2zZoiNHjtid78tFvH+f723btik8PFzSpQKezWazCnNRUVEKDQ21O9+XX7OXz/e5c+ckSTExMdq4caMV+/fff2v//v2S/u81+8/zbbPZ7M733r17JV0qitpsNp06dUqSdPr0adlsNqtwuG/fPrvzHRISkuV8Xy72HThwQDt27LBiN23apOjoaEn/95q9fL4PHTpkd743b96sY8eOSbpUnLTZbFbhNiIiQlu3bs32fCclJdmd78jISP35559WLJ8RfEYU5s+IvDh16pQ6d+4sHx8fValSRVWrVrV7/PPcAAAAAACAa+dmbsLF4hMSEuTv769jx45ZN7Q7f/68ihYtKh8fH128eFGJiYny9fVV0aJFlZaWprS0NJUoUULSpYKIu7u7ihUrpszMTJ0/f17FihWTh4eH0tLSlJqaKn9//yyxxhglJCTIx8dHnp6eSk9PV0pKikqUKCE3NzeroOXr63vV2OTkZGVmZsrPz0/SpVma3t7e8vLy0oULF5ScnKzixYvL3d09S2xCQoK8vLzk5eWljIwMJSUlyc/PT0WKFFFKSooyMjJUvHhxK9bT01Pe3t5Xjb3SOUxNTVV6erp1DrOLzc05zM35dnNzy9U5/Of5vnwO/x2b0zm80vlOSUnRxYsX7c53bs/hP2Mvn5fLsbk5hzmd78TERBUpUkQ+Pj7X9Jq9HPvv83I59lpes0lJSTLG5Ok1m13sjfCa5TOCz4jC8Blx4cIF+fv7Kz4+3tqXG8OGDdPff/+tKVOmqHLlyln216hRQ15eXrk+nrNdvtZf67hvSOumWj9uCj9bgIncHEKrPXnF/aM71XFSJgCQO4XlmpcfeVZ/abVDjnOjO+L9cEGn4ByT4q8eAwCFRG6ve3kuzoeGhmrjxo3WbNB/mjJlSl4O6TSF5ZcXAACuV16veW3atNGbb76pu+66K/+Sy0cuda2nOO9UFOcBFDaF5ZpHcT7vKM4DQOGT2+tenm4IO2PGDL344otq1KiRSpUqleckAQDAjSkwMNBuDXsAAOBaTp8+rS1btsjPz0+tWrWSh4dHrvv++uuvOnfunHr16qUiRYrkY5YAALi2PBXnZ86cqWXLlun+++93dD4AAOAG8Nxzz+mpp55S7dq11aBBg4JOBwAAONDXX3+tESNGqGnTptY9dX7++WfVrFnzqn2///579e7dW+np6Tp//ry1VB8AALh2ebohbFJSkjp16uToXAAAwA1i9OjR+uuvvxQUFCRvb2/5+fnZPXbu3FnQKQIAgDw4duyYnnzySb377rsKCQnRvn37VK1aNT3xxBNX7RsdHa0RI0Zo/PjxTsgUAADXl6eZ88HBwdqwYQMFegAAXNSbb76p+Pic1/2sVq2aE7MBAACOsnjxYvn4+Oixxx6TJBUtWlSjRo3S/fffr+jo6GxvBC9JmZmZGjhwoF544QVVqlTJmSkDAOCycl2cnzdvnvVzixYt1K9fPz3zzDOqXbu23Nzc7GIHDhzouAwBAIDTtW/fvqBTAAAA+eDvv/9W/fr17daYv/XWWyVJO3fuzLE4/8Ybb8jLy0vPPvusli5detXnSUtLU1pamrXNvWwAAMgq18X5sWPH2m17eHho9uzZ2cZSnAcAwDUcPXpU+/fvV8uWLa94h3kAAFA4xMfHq1SpUnZtAQEBkqS4uLhs+9hsNn3yySf666+/skzOy8nUqVM1efLk68oVAABXl+vi/OWbxAAAANeXkZGhIUOG6JtvvpEkhYWFqUmTJnrxxRdVvnx5Pf/88wWcIQAAyAsvL68sS9clJiZKkry9vbPt89hjj6lbt24KCQmRJIWGhkqSli9frmbNmmV78/jx48drzJgx1nZCQoKqVq3qkDEAAOAq8rTmPAAAcG0zZ87UgQMHFB4erl69elnt48ePV7169TRq1CgVKVKkADME8kfw0TlXDlgXkPO+9twgEcCNr2bNmtq6datd29GjR6192WndurXi4uK0cOFCSZduDCtJS5culaenZ7bFeS8vL3l5eTkydQAAXE6eivMzZ87McZ+Xl5dq1qyp9u3by9PTM695AQCAAvTzzz/r9ddfV40aNey+vl6qVCn5+vrq0KFDqlu3bgFmCAAA8qJLly6aNm2awsLC1LRpU0mXbhJbpUoVNWzYUJKUnJysNWvWqHXr1qpUqZLmzp1rd4xvv/1WDz74oP73v//Jz8/P6WMAAMBV5Kk4//nnn2vXrl0qWrSoqlSpIjc3Nx07dkwZGRmqXbu2oqKiVL58ef3+++8KDAx0dM4AACCfJSYmysfHR5LsivPGGMXGxjITDgCAQurOO+9U79699cADD+j5559XVFSUZs2apQULFsjd3V2SdOrUKT344INatmyZevbsWbAJAwDgwtzz0umBBx5Qr169FB0drYiICIWHhysqKko9evTQgAEDdOLECTVr1kyjR492dL4AAMAJWrdurXnz5kmyL86//fbb8vf3V/Xq1QsoMwAAcL0WLlyo8ePHa/PmzYqPj9f69ev14IMPWvt9fX3Vu3dvVa5cOdv+VapUUe/evVW0KCvlAgBwPdyMMeZaO9WoUUMbN25UxYoV7dpjYmLUtm1bhYeHKzw8XK1bt74hbySbkJAgf39/xcfHq0SJEgWdDgAA+Sav17xTp04pODhYVapU0f79+9WhQwcdPnxY27dv15IlS+zWob8RudS1ft1U68dN4WcLMBFIUquarDkP4MZSWK55+ZFn9ZdWO+Q4N7oj3g8XdArOMSn+6jEAUEjk9rqXp5nzJ06cUHp6epb29PR0HT9+XJJUunRpZWZm5uXwAACggJUrV05bt25V+/bt1aBBAx0+fFh16tRRSEjIDV+YBwAAAACgMMjTd9Dat2+vwYMH65NPPlH9+vUlSXv37tWwYcPUoUMHSZduJNepUyfHZQoAAJyqdOnSmjx58nUfJyYmRrNmzdKhQ4dUvXp1Pfvss7laFmfVqlVavny50tPT1bt3b9a8BQAAAAC4lDzNnP/vf/8rSWrQoIF8fX3l6+urBg0aqEiRIta+pKQkvffee47LFAAA5Kv09HSlpqbm6pHbVfFOnDih5s2ba/fu3erZs6ciIyN1++2368iRI1fs98QTT2jo0KEKCgpSjx49NH/+fM2dO9cBowQAAAAA4MaQp5nzlStX1vr167Vjxw7t3btXbm5uqlevnho3bmzFPProow5LEgAA5L8WLVpox44duYoNCwtTkyZNrho3ffp0+fj4aNmyZfLw8NCAAQPUpEkTTZkyRZ999lm2fb777jt98cUX2rJli5o1ayZJevDBBxUXF5fboQAAAAAAcMO7rlurN27c2K4gDwAACq///e9/SkpKkiRFR0dr8ODBevzxx9WxY0f5+vpqz549evfdd9W5c2fVqVMnV8f88ccf1b17d3l4eEiS3N3d1atXL33++ec59vniiy/Url07qzB/WcmSJfM2MAAAAAAAbkC5Ls5/+umnkqThw4dbP+dk+PDh15cVAABwukaNGlk/Dxs2TJMnT9bzzz9vtXXo0EEPPPCAGjZsqA8//DBXx4yIiFCVKlXs2qpWraro6GhduHDBKtr/099//62HH35YX331ldasWaPSpUurW7du6tatW47Pk5aWprS0NGs7ISEhV/kBAAAAAFBQcl2cnzFjhqRLhffLP+eE4jwAAIXb7t279fDDD2dpr1Spkvz9/RUREaHatWtf9Tjp6ekqVqyYXdvl7fT09GyL88nJyZo7d65atWqlvn37Kjw8XP3799eLL76oiRMnZvs8U6dOdcjNawEAAAAAcJZcF+cPHTqU7c8AAMD1VKhQQV999ZXatWtn175u3TrFxMSoTJkyuTpOyZIlFRsba9d29uxZeXp6ZinaX1aqVClJ0rfffit390v3ri9atKhef/11TZgwwWr7p/Hjx2vMmDHWdkJCgqpWrZqrHAEAAAAAKAjXteY8AABwTa+++qruvPNObdmyRe3bt1exYsW0d+9erVmzRpMmTcr1+u+NGzfOcpPZv/76S40aNZKbm1u2fZo0aaK4uDi7InzNmjWVlJSkxMRElShRIksfLy8veXl55X6AAAAAAAAUsDwX50NDQ7Vx48Yss+EkacqUKdeVFAAAKFi33nqr9u/fr1mzZmnbtm1KSkpS7dq1tX79erVt2zbXxxk0aJCeeuop7d69W0FBQTp8+LCWLl2q119/3YpZvXq1PvnkE61cuVLu7u567LHH1LdvXx06dEi1a9fWxYsXtXDhQt16663ZFuYBAAAAACiM8lScnzFjhl588UU1atTI+uo5AABwLeXLl9dbb711XccYNGiQNm7cqJYtW6px48bauXOnunXrpqeeesqKiYiI0OrVq5WZmSl3d3d16dJFY8aMUbNmzXTbbbcpMjJSnp6eWrJkyfUOCQAAAACAG0aeivMzZ87UsmXLdP/99zs6HwAA4ELc3Nw0e/ZsjRs3TocPH1ZgYKDq1KljF9OtWzdVr15dRYoUsdomT56s4cOHa/fu3SpXrpwaNGigokVZjQ8AAAAA4Dry9L/cpKQkderUydG5AAAAF1WzZk3VrFkz233Vq1dX9erVs7RXrFhRFStWzOfMAAAAAAAoGO5XD8kqODhYGzZscEgCc+bMUVBQkMqUKaP27dtr27Ztue47efJk+fn5ady4cQ7JBQAAAAAAAAAAZ8j1zPl58+ZZP7do0UL9+vXTM888o9q1a8vNzc0uduDAgbk65jfffKORI0fqq6++UqtWrTR9+nR17NhRe/bsUaVKla7Y9/fff9e8efNUoUIFpaWl5XYYAAAAAAAAAAAUuFwX58eOHWu37eHhodmzZ2cbm9vi/NSpU/Xoo4+qX79+kqT3339fS5cu1SeffKI33ngjx35nz57VoEGDtGDBArsbygEAAAAAAAAAUBjkujh/4sQJhz5xXFycdu/erUmTJllt7u7u6tChg0JCQq7Yd8iQIRoyZIhat27t0JwAAAAAAAAAAHCGPN0Q1hFiYmIkSeXKlbNrL1eu3BXXnZ85c6ZOnz6tiRMn5vq50tLS7Ja+SUhIuMZsAQAAAAAAAABwnDzdENahCbi7Z9k2xmQbu2PHDk2ZMkXffPONihbN/d8Vpk6dKn9/f+tRtWrV68oZAAAAAAAAAIDrUWDF+csz5k+fPm3Xfvr06Syz6S+z2WyKi4tT48aN5efnJz8/P+3cuVMff/yx/Pz8dPHixWz7jR8/XvHx8dbj2LFjjh0MAAAAAAAAAADXoMCWtSlTpoxq166tP/74Q7169bLaf//9d/Xt2zfbPsOGDdOQIUPs2lq3bq077rhDb7/9tooUKZJtPy8vL3l5eTksdwAAANycNoWfzXFfaMaBq/Yf3amOI9MBAAAAUIgV6LI2o0aN0ueff67ff/9dqampeuONN3Tq1CkNHz7cinnmmWfUokULSZKHh4c1Y/7yw93d3WoHAAAAAAAAAKAwyPPM+b/++ktz585VeHi4VqxYIUmaN2+eHnjgARUrVixXx3j66ad19uxZ9erVS/Hx8brlllu0cuVK1apVy4pJTU1VcnJyXtMEAAAAAAAAAOCGk6eZ8z/++KNat26t6OhorVy50mo/dOiQZs6ceU3HevXVVxUbG6vU1FTt27dPnTp1stv/0UcfacuWLTn237Rpk/7zn/9c03MCAAAAAAAAAFCQ8lScf+WVV/Tll19q8eLFdu39+/fXZ599lqdEPDw8sm338vKSj49Pjv18fHzk6emZp+cEAAAAAAAAAKAg5Kk4v2fPHnXv3l2S5ObmZrVXrlxZUVFRjskMAAAAAAAAAAAXlafivL+/v1WE/2dxPjQ0VJUrV3ZMZgAAAAAAAAAAuKg83RC2f//+GjlypL788ktJ0oULF/Tbb79p2LBhGjhwoEMTBAAAAAAAjvXLL7/IZrPJz89Pffr0Uc2aNa8Yn5qaqhUrVmjPnj0KCAhQ9+7dVaNGDSdlCwCAa8rTzPk333xTvr6+qly5sjIzM+Xn56d7771Xt99+uyZOnOjoHAEAAAAAgIOMGjVK/fr1U3JysrZv366goCCtX78+x/j9+/eradOm+v7771W0aFGFhoaqbt26+uabb5yXNAAALihPM+d9fHy0dOlS7d27V1u3blVmZqaaNWumRo0aOTo/AAAAAADgIGFhYZo1a5bWrl2rjh07SpIeffRRjRgxQnv37s22j7+/v0JCQhQQEGC1lSxZUm+99ZYGDBjglLwBAHBFeZo5L0lpaWmqX7++HnnkEfXo0UPbtm2TzWZzZG4AAAAAAMCBVqxYocqVK1uFeUkaMmSI9u3bp/3792fbp0KFCnaFeenSMjclS5bMz1QBAHB5eZo5P3/+fP3www/63//+p4sXL6pdu3aKiopSYmKiZs+erUcffdTReQIAAAAAgOu0f//+LOvL16pVS5J04MAB1a1bN8e+s2bN0pEjR7Rnzx6lpKTo888/zzE2LS1NaWlp1nZCQsJ1Zg4AgOvJ08z5adOm6eWXX5Yk2Ww2nT9/XjExMVqxYoXeeecdhyYIAAAAAAAcIzk5WSVKlLBr8/f3lyQlJSVdsW9AQIDKli2rEiVK6ODBgzp06FCOsVOnTpW/v7/1qFq16vUnDwCAi8nTzPlDhw5Zd2X/7bff1LNnT3l7e6t9+/YKDw93aIIAAAAAAMAx/Pz8FBkZadcWFxcnSSpevPgV+w4cOND6efLkyXrkkUd04sQJeXl5ZYkdP368xowZY20nJCRQoAcA4F/yVJyvXLmy1q9fr44dO2rJkiWaMWOGJCkyMpKLLQAAwL+tmypJ2hR+toATAQDc7Bo0aKC1a9cqMzNT7u6Xvky/b98+SVL9+vVzfZzWrVtr0qRJOn78uKpXr55lv5eXV7ZFewAA8H/ytKzN2LFj1aNHD1WoUEFFixZVp06dJF1ai/6ff0kHAAAAAAA3jt69e+vMmTNavny51TZ79mw1a9bMWov+3LlzGjt2rHbv3i1J+vPPP5WSkmJ3nOXLl6ts2bKqUqWK03IHAMDV5Gnm/LBhw9SyZUsdPXpU7du3l6enpyTplltuUa9evRyaIAAAAAAAcIx69erp9ddf16BBg/Tdd98pOjpaO3bs0C+//GLFxMfH65133lHbtm0VFBSkiIgIDRkyRI0bN1bJkiW1ZcsWHTt2THPnzlXRonkqKwAAAOWxOC9JTZo0UZMmTezamDUPAAAAAMCNbcKECerWrZtCQkLk5+enrl27qkyZMtb+0qVLa/r06WrYsKEk6aGHHtLdd9+tdevW6cyZM+revbvat28vHx+fghoCAAAuIc/F+eTkZM2fP1979+6VMUYNGjTQgAEDuDgDAAAAAHCDa9y4sRo3bpztvhIlSmjs2LF2bQEBAerTp48zUgMA4KaRpzXn9+zZozp16mjs2LHavHmztmzZorFjx6pOnTras2ePo3MEAAAAAAAAAMCl5Kk4/9xzz+muu+5SVFSUQkJCZLPZFBUVpXbt2um5555zdI4AAAAAAAAAALiUPC1rs2HDBkVERMjPz89q8/Pz0zvvvKMaNWo4LDkAAAAAAAAAAFxRnmbOe3p6KiEhIUt7fHy8vLy8rjspAAAAAAAAAABcWZ6K8927d9cjjzyiv/76S8YYGWMUFhamgQMHqlu3bo7OEQAAAAAAAAAAl5Kn4vysWbNUunRpNW3aVD4+PvL29lazZs1UpkwZzZo1y9E5AgAAAAAAAADgUvK05nzp0qW1Zs0a7dq1S7t375abm5saNGighg0bOjo/AAAAAAAAAABcTp6K85c1bNiQgjwAAAAAAAAAANcoz8X50NBQbdy4UbGxsVn2TZky5bqSAgAAAAAAAADAleWpOD9jxgy9+OKLatSokUqVKuXonAAAgIs5d+6cjhw5oqpVq6pMmTK57nfx4kVt3bpVxYsXV4MGDfIxQwAAAAAAnCtPxfmZM2dq2bJluv/++x2dDwAAcDGvvPKKZsyYocDAQB05ckTDhw/XzJkz5ebmdtW+kyZN0ptvvqk777xT69evz/9kgesQfHTO1YPWBWTf3n68Y5MBAAAAcMPLU3E+KSlJnTp1cnQuAADAxXz77beaMWOG1q9fr+DgYP39999q3bq1GjVqpMcff/yKfdetW6eFCxeqV69eOnv2rJMyBvLXpvDsX8uhGQdy1X90pzqOTAcAAABAAXLPS6fg4GBt2LDB0bkAAAAX89lnn6lz584KDg6WJN16663q2bOnPv/88yv2O3PmjAYPHqy5c+eqePHizkgVAAAAAACnyvXM+Xnz5lk/t2jRQv369dMzzzyj2rVrZ/la+sCBAx2XIQAAKLS2b9+ukSNH2rW1bNlSS5culTEm26VtjDEaPHiwHn30UbVu3Vpz5uRiqRAAAAAAAAqZXBfnx44da7ft4eGh2bNnZxtLcR4AAEhSbGysSpcubdcWEBCg1NRUJScny9fXN0uf9957T7GxsZo4cWKunyctLU1paWnWdkJCQt6TBgAAAADACXJdnD9x4kR+5gEAAFyQh4eHXdFcklJSUqx9/xYeHq4JEybos88+09atWyVJp0+fVkJCgkJDQ9WoUaNsC/pTp07V5MmT82EEAAAAAADkjzzdEBYAACA3AgMDFRMTY9cWExOjChUqyNPTM0t8YmKiGjdurA8++MBqO3z4sNLS0jRq1Ch99dVXqlevXpZ+48eP15gxY6zthIQEVa1a1YEjAQAAAADAsfJ0Q9gDBw7otddey9L+2muv6eDBg9edFAAAcA0dO3bU6tWrZYyx2lauXKmOHTta2ydPnlRoaKikSzeMDQ0NtXt07dpVzZo1U2hoaLaFeUny8vJSiRIl7B4AAAAAANzI8lScf/bZZ9W2bdss7W3atMly0zcAAHDzevHFF3XixAkNHjxYP/zwg5588knt27dPEyZMsGKWLFmiVq1aKSMjowAzBQAAAADAufJUnA8JCVFwcHCW9latWikkJOS6kwIAAK4hMDBQmzZtUtGiRTVt2jSlpqZqw4YNql+/vhVToUIFtWzZUm5ubtkeo1atWmrQoIGzUgYAAAAAwCnytOZ8qVKltGvXLrVq1cqu/e+//+Zr5AAAwE7dunX1xRdf5Li/T58+6tOnT477J06cmB9pAQAAAABQoPI0c/6hhx7S0KFDtXHjRmVmZiozM1MbNmzQ0KFD9dBDDzk6RwAAAAAAAAAAXEqeZs5PmTJFhw4dUps2beTp6SljjC5cuKAePXrozTffdHSOAAAAAAAAAAC4lDwV5318fLRixQrt3LlT27dvl5ubm5o2bapGjRo5Oj8AAAAAAAAAAFxOrovzaWlp8vLysmtr1KhRtgX57GIBAAAAAAAAAMAluS7O16tXT6+88or69++vYsWKZRuTmJioBQsW6K233lJERITDkgQAAABcWfDRObmK2/R51rbQak/m+nlGd6qT61gAAAAA+SvXxfn58+dr1KhRGjNmjDp27KjbbrtN5cuXlzFGJ06c0JYtW/Tbb78pKChICxYsyM+cAQAAAAAAAAAo1HJdnG/VqpU2b96sP/74QwsXLtTixYt17Ngxubm5qUqVKmrbtq1+/PFHtW3bNj/zBQAAAAAA1yEpKUn/+c9/ZLPZ5Ofnp4EDB6pv375X7PPTTz9p0aJFioyMVPXq1TVixAjdfvvtTsoYAG5M1V9aXdApOMWRaV0LOgWXdc03hL3zzjt155135kcuAAAAAAAgHxlj1K1bN507d06TJk1SVFSUBg0apNjYWA0fPjzbPm+99ZZsNpv69u2rAQMG6Oeff1ZwcLBWr16tzp07O3kEAAC4jmsuzs+ePVsrV66UMUb333+/hg0blh95AQAAAAAAB/vxxx+1fv16HTx4ULVr15YknTlzRhMnTtTjjz+uokWzlglGjhypl19+2dru2LGj9u7dq1mzZlGcBwDgOrhfS/C7776rp556SqmpqUpLS9NTTz2l9957L79yAwAAAAAADvTrr7+qXr16VmFeku6//36dOXNGO3bsyLaPn59ftm3p6en5licAADeDayrO//e//9W8efP066+/6tdff9XcuXM1Z86c/MoNAAAAAAA4UGRkpCpVqmTXdnk7MjIyV8fYu3evli1bpp49e+YYk5aWpoSEBLsHAACwd03F+YiICPXq1cva7t27tyIiIhyeFAAAAAAAcLwLFy7Iy8vLrs3Hx8fadzWnTp1Sjx491L59ez311FM5xk2dOlX+/v7Wo2rVqteXOAAALuia1pxPS0uTt7e3te3j46O0tDSHJwUAAAAAAByvdOnS2rNnj13b2bNnJUkBAQFX7Hv69Gl17NhR1apV09KlS+XunvN8v/Hjx2vMmDHWdkJCAgV6ACisJvkXdAb5b1J8gTztNd8Q9plnnrlq24cffpj3jAAAAAAAQL5o1qyZFi9erNTUVGvy3ebNm+Xu7q5bb701x35nzpxRx44dVaZMGa1atcqabZ8TLy+vLDP0AQCAvWta1ua2225TaGio3SO7NgAAAAAAcOPp27ev3N3dNWPGDElScnKyZsyYoe7du6tcuXKSpOPHjys4OFh//PGHJCk2NtYqzK9evVrFihUrsPwBAHAl1zRzfuvWrfmVBwAAAAAAyGflypXTokWLNGjQIH322Wc6d+6cgoKCNGfOHCsmLS1NmzdvVmxsrCRp0qRJ+vvvv3XrrbeqQ4cOVlzFihW1bNkyp48BAABXcc3L2gAAAAAAgMKrS5cuio6O1t69e+Xn56datWrZ7a9YsaI2bdqkunXrSpJGjx6thx9+OMtxWLYGAIDrQ3EeAAAAAICbjKenpxo3bpztPi8vLwUHB1vbNWrUUI0aNZyVGgAAN40CL85HR0fr66+/1smTJ9WoUSM98sgj8vT0zDHeGKM1a9Zo48aNKlq0qNq2batOnTo5MWMAAAAAAAAAAK7PNd0Q1tH27dunRo0aadOmTSpbtqymT5+uu+++WxkZGdnGZ2Zm6tZbb9Wnn34qX19fXbx4Uf369dNjjz3m5MwBAAAAAAAAAMi7Ap05P27cODVu3FgrVqyQm5ubHn30UdWoUUPz5s3TkCFDssS7ublp8eLFql+/vtXWvn173X333Xruuedy/EoeAAAAAAAAAAA3kgKbOX/hwgX9+OOP6t+/v9zc3CRJlSpVUvv27bVy5cps+7i5udkV5iVZ2ydOnMjfhAEAAAAAAAAAcJACmzkfGRmp9PT0LDeVqVGjhjZs2JDr43z22Wfy9fVV8+bNc4xJS0tTWlqatZ2QkHDtCQMAAAAAAAAA4CAFNnM+JSVFklS8eHG79hIlSig5OTlXx/jpp5/0xhtv6L333lPp0qVzjJs6dar8/f2tR9WqVfOeOAAAAAAAAAAA16nAivMlSpSQJMXFxdm1nzt3ztp3JevXr9cDDzygSZMm6Yknnrhi7Pjx4xUfH289jh07lue8AQAAAAAAAAC4XgVWnK9ataqKFy+uPXv22LXv2bNHQUFBV+z7xx9/qFu3bnrppZc0YcKEqz6Xl5eXSpQoYfcAAAAAAAAAAKCgFNia8+7u7urbt6++/PJLDR8+XMWKFdO2bdu0ceNGjR8/3oqbN2+eIiIiNHHiREmSzWbTfffdp3HjxlltAAAAwM0q+Oic3AevC7Dfbj8++zgAAAAA+a7AZs5Ll9aCN8aoadOm6tu3r+6++2498cQT6tq1qxWzfv16LVq0SJKUmJiorl27ytfXV9HR0Ro+fLj1uJabyAIAAAAAAAAAUJAKbOa8JJUtW1bbt2/X2rVrdfLkSY0bN0633XabXcwjjzyie+65R5JUtGhR/ec//8n2WAEBAdm2AwAAAAAAAABwoynQ4rwkeXp66r777stxf7t27ayfvb29NXz4cGekBQAAAAAAAABAvinQZW0AAAAAAAAAALgZUZwHAAAAAAAAAMDJCnxZGwAAAADOsSn8rN12aMaBaz7G6E51HJUOAAAAcFNj5jwAAAAAAAAAAE5GcR4AAAAAAAAAACejOA8AAAAAAAAAgJOx5jwAAMhXx44d08yZM3Xo0CFVr15dI0eOVK1atXKMv3jxohYvXqy1a9cqOTlZTZo00YgRI1SiRAknZg3cHIKPzrn2TusC/u/n9uMdlwwAAABwk2HmPAAAyDfHjx9XixYtdPjwYfXr108nT55U8+bNFR4enmOfe++9V99//71at26tHj16aMWKFbrtttsUFxfnvMQBAAAAAMhnzJwHAAD5Zvr06fLz89O3336rokWL6qGHHlLTpk315ptv6vPPP8+2z4IFC1SmTBlru2vXrqpQoYIWLVqkYcOGOSt1AAAAAADyFTPnAQBAvvnxxx/VrVs3FS16aT6Au7u7evXqpR9//DHHPv8szEuSn5+ffHx8lJiYmK+5AgAAAADgTMycBwAA+ebIkSOqWrWqXVuVKlUUExOjCxcuyMPD46rH+OqrrxQXF6d77703x5i0tDSlpaVZ2wkJCXlPGgAAAAAAJ6A4DwAA8k16erp8fHzs2ooVK2btu1pxftOmTXrmmWf0xhtvKCgoKMe4qVOnavLkydefMADnWTc17325ES0AAABcAMvaAACAfFOyZEnFxsbatZ09e1aenp5WkT4nW7ZsUZcuXfT000/r5ZdfvmLs+PHjFR8fbz2OHTt23bkDAAAAAJCfmDkPAADyTZMmTRQWFmbXFhYWpltvvVVubm459tu2bZvuueceDR06VNOnT7/q83h5ecnLy+u68wUAAAAAwFmYOQ8AAPLN4MGDtWbNGu3cuVOSdPDgQS1dulSDBw+2YlatWqV7771XmZmZki4V7zt16qShQ4fqnXfeKZC8AQAAAADIbxTnAQBAvhk4cKAeffRRtWzZUi1btlTTpk11//33a8SIEVZMZGSkfvrpJ6s4/9BDDykpKUm7du3Svffeaz0+/vjjghoGAAAu5dChQ+rcubOKFSumcuXKacyYMbpw4cIV+9hsNj388MPy8vLS3Xff7aRMAQBwbSxrAwAA8o2bm5s++ugjjRs3TocPH1ZgYKBq1qxpF9OjRw/Vrl1bRYoUkSTNmTNHqampWY4VGBjolJwBAHBlqampuueee3T77bcrPDxcUVFR6tGjh4wxeu+997Ltc/LkSb388ssaPny4jDE6ffq0k7MGAMA1UZwHAAD5rlq1aqpWrVqu9t11111OygoAgJvPt99+q2PHjmnr1q0qXbq0KlSooAkTJmjs2LF644035Ofnl6VP+fLlZbPZJEm//PKLs1MGAMBlsawNAAAAAAA3iY0bN6pRo0YqXbq01daxY0elpqZmuYk7AADIX8ycBwAAAJBrm8LP/t9G+Nhr7t+qZsB1P39oxoE89x/dqc51PT9Q2J04cUJly5a1aytXrpy1z1HS0tKUlpZmbSckJDjs2AAAuApmzgMAAAAAcBMzxki6dK8YR5k6dar8/f2tR9WqVR12bAAAXAUz5wEAAAA4jd3MewBOV6FCBYWGhtq1Xb7Ba/ny5R32POPHj9eYMWOs7YSEBAr0AAD8CzPnAQAAAAC4SbRu3Vo7d+7U2bP/94ey3377Td7e3mratKnDnsfLy0slSpSwewAAAHvMnAcAAMiF937J+xrXwUeZKQwAuDH07t1bEydO1IgRI/T+++8rKipKU6ZM0fDhw+Xn5ydJOnLkiGrUqKFly5apZ8+eBZswAAAujOI8AAAAAAA3CR8fH/388896+umnVaNGDfn5+emRRx7R22+/fcV+VapUUXR0tLXt5uamIkWKKCMjI79TBgDAZVGcBwAAAADgJnLLLbfo559/znF/9erVrZvEXhYVFZXfaQEAcNOhOA8AAADgpnE9S1RJ0uhOdRyUCQAAAG523BAWAAAAAAAAAAAnozgPAAAAAAAAAICTUZwHAAAAAAAAAMDJWHMeAAAAwE0j+OicPPcNrfakAzMBAADAzY7iPAAAQC5cT0EPAAAAAIB/Y1kbAAAAAAAAAACcjOI8AAAAAAAAAABORnEeAAAAAAAAAAAnozgPAAAAAAAAAICTUZwHAAAAAAAAAMDJihZ0AgAAAABwLYKPzinoFAAAAIDrxsx5AAAAAAAAAACcjOI8AAAAAAAAAABORnEeAAAAAAAAAAAnY815AAAAAMil9345cN3HGN2pjgMyAQAAQGHHzHkAAAAAAAAAAJyM4jwAAAAAAAAAAE5GcR4AAAAAAAAAACejOA8AAAAAAAAAgJNxQ1gAAAAAyIXgo3Ouq39otScdksf13pSWG9ICAADcGCjOAwAAAIATXW9xHQAAAK6BZW0AAAAAAAAAAHAyZs4DAAAAgAvLshzPuoDcd24/3rHJAAAAwEJxHgAAAABucNe73j0AAABuPCxrAwAAAAAAAACAkzFzHgAAAACQvXVT896XJXEAAACu6IaYOX/s2DFt3bpVCQkJ+doHAAAUjDNnzmjLli06efJkvvYBAAC5k5qaqu3bt+vAgQP52gcAAOSsQGfOp6amasCAAfrhhx8UGBioyMhIvf3223r22Wcd2gcAABScl156STNnzlStWrV0+PBhDR06VB9++KHc3Nwc2gcAbnQ33brx1zPrXmLmfT76/vvvNXjwYJUqVUpnz55VnTp1tHLlSpUvX96hfQAAwJUVaHF+8uTJ+vPPP3X48GFVrFhRy5cvV69evdSiRQu1bNnSYX0AAEDBWLRokWbOnCmbzabmzZtr165dCg4OVuPGjfXkk086rA8AwHk2hZ+9rv6tagY4KJMrYDmeHJ08eVL9+/fXyy+/rPHjxyslJUXt2rXTE088oZUrVzqsDwAAuLoCLc5/+eWXGjFihCpWrChJ6tmzpxo2bKgvv/wyx0J7XvoAAICC8cUXX6hLly5q3ry5JKlhw4bq1auXvvjiixwL7XnpAwAoPHJd3A8fm+Ou6y3wXymH0IyrL9kyulOd63r+grR48WJJ0ujRoyVJPj4+ev755/Xwww/r1KlTKleunEP6AACAqyuw4nxMTIxOnjyp2267za69RYsWCgsLc1gfSUpLS1NaWpq1HR8fL0msVw8AcHmXr3XGmAJ5/rCwMI0cOdKurUWLFlqyZImMMdkuU5OXPs641ielpF09CAAKgYSk1OvqfyN8HubnGFKTEq/af+ry7df1/E93qH1d/f/pWq/1YWFhCgoKkre3t9XWokULZWZmaseOHerUqZND+jjj2pyZluywY93IEtwK5vc4p6NGg0KIzyEX4uDPoNxenwusOB8bGytJCgiwn/EQEBBg7XNEH0maOnWqJk+enKW9atWq15QzAACF1fnz5+Xv7+/0542Njc32up2Wlqbk5GT5+vo6pA/XegCA43yY78/wcj4cM7fX+pyus5f3OaoP12bHcf5vcAVk2k0zUqDQuSnenfn0GXS163OBFec9PDwkXbrB6z+lpKTI09PTYX0kafz48RozZoy1nZmZaf1y4ao3lktISFDVqlV17NgxlShRoqDTyXeM17UxXtfGePOXMUbnz59XpUqV8v25suPh4ZHtdVvSFa/319rnZrzWZ+dmez9dK85Pzjg3V8b5uTLOT86ccW6u9Vrv4eGh8+fP27Xl5tp8rX24NjsG7y8ABY3PobzJ7fW5wIrzVatWlbu7u6Kjo+3ao6OjVa1aNYf1kSQvLy95eXnZtZUsWTJviRcyJUqUuKneOIzXtTFe18Z4809BzJi/LDAwMNvrdoUKFaw/ujuiz818rc/OzfZ+ulacn5xxbq6M83NlnJ+c5fe5uZZrfWBgoHbu3GnXdvm6m9P/q/PSh2uzY/H+AlDQ+By6drm5Prs7IY9sFStWTK1bt7a7s3tSUpLWrl1rt17doUOHrPXkc9sHAADcGDp16qTVq1crMzPTalu5cqXddfv48eMKCQm5pj4AACBvOnXqpP379+vAgf+78e2KFStUtmxZNW7cWNKl9eJDQkKsJWty0wcAAFy7AivOS9KUKVO0fPlyjR8/XitXrlTPnj1Vrlw5Pfnkk1bMtGnT9Mgjj1xTHwAAcGN48cUXdfr0aQ0cOFCrVq3S0KFDdeDAAU2YMMGKWbp0qe644w5lZGTkug8AAMibe+65Rx06dFCfPn307bffaubMmZo2bZqmTJmiokUvfbn++PHjuuOOO/THH3/kug8AALh2BVqcb9eundatW6fIyEjNmjVLQUFBCgkJkZ+fnxVzyy23qFmzZtfUB5e+Qvjaa69l+Rqhq2K8ro3xujbG69qqVq2q0NBQ+fn5aebMmTLGaNOmTapbt64VU6lSJbVp08ZafzY3fZC9m+31da04Pznj3FwZ5+fKOD85uxHPjZubm1auXKk+ffpo9uzZ+v3337VgwQK7CW/e3t5q06aNddPX3PRB/rgRX0MAbi58DuUvN2OMKegkAAAAAAAAAAC4mRTozHkAAAAAAAAAAG5GFOcBAAAAAAAAAHAyivMAAAAAAAAAADgZt1V3AbGxsYqMjFRgYKBKly6dbUxqaqr27NkjPz8/1alTx8kZ5o+dO3cqPj5erVq1UpEiRez2paWlaffu3fL19XWJGwieOnVKUVFRqlevnooVK5ZlvyuNNyEhQeHh4fL29lbNmjXl6emZJSY9PV27du0qlOM9ceKEDh06pEaNGsnf3z/bmKioKJ04cUK33HLLdcXcCE6ePKmDBw+qYcOGKlmyZJb9mZmZOnjwoNzc3FSjRg15eHhke5zL461du3a2x7lRnDp1SgcOHFBQUJBKlSqVY1xiYqL++usvVahQQbVr186yPzo6WsePH1etWrWueBzcnI4fP66oqCjVqlUrx+v+ZUePHtXRo0ft2jw9PdWiRYv8TLFAHThwQKdOnbK7yfDV7Nu3TykpKQoKCsr2uuMqLl68qG3btsnX11dBQUFXjE1LS9OWLVuytF/t862wMsboyJEjSk5OVq1ateTt7Z2rfqdPn9aRI0cUGBiocuXK5XOWBSc9PV379++Xn5+fAgMD5e5+5Tleu3fv1rlz5+zaSpcurQYNGuRnmgUmNTVV+/btk7+/v6pXr56rz56MjAzt2rVLnp6eql+/fq4/r4DLDh8+rOPHjys4OFhFi1LaAZA/4uLitHv3btWqVUsVKlQo6HRck0GhtX37dnP33XebgIAA06RJE1OsWDHz8MMPm5SUFLu4VatWmdKlS5tatWqZkiVLmhYtWpgTJ04UUNaOsWHDBuPp6WkkmXPnztntW7NmjQkICDA1a9Y0pUqVMrfddpuJiYkpmESvU1xcnOndu7fx9fU1t99+u6lWrZr5+uuv7WJcabzjxo0zPj4+pnHjxqZGjRqmfPnyZtmyZXYxP/30kylTpoypUaOGKV26tGnatKmJiooqmISvwbZt20yfPn1MuXLljCTzyy+/ZIlJTU01ffr0MT4+PqZ+/frG29vbvPfee9cccyMICwszffv2tcb7ww8/ZImZNm2aqVixoqlXr56pUaOGqVixovnuu+/sYtLS0sxDDz1kN97p06c7axi5tmPHDtOvXz9Tvnx5I8msWrXqivF9+/Y17u7uZujQoXbt6enp5uGHHzbe3t7WeKdNm5afqaMQycjIMEOGDDHe3t6mQYMGxsvLy0yePPmKfSZMmGBKlChh2rRpYz169OjhpIyda9myZaZt27amVKlSRlKW34eyc/ToUdO4cWMTEBBgatSoYcqWLWvWrl3rhGydKzU11UyZMsVUr17dlChRwnTu3PmqfSIiIowkc9ttt9m9fjZs2OCEjJ1r7ty5platWqZGjRqmfv36xt/f33z44YdX7Td27Fjj5eVlvR+fffZZk5mZ6YSMnSc5OdmMHTvWlC5d2jRq1MhUrFjR1K1b12zatOmK/Tp37mwqV65s99p58cUXnZS18yQlJZmRI0eagIAA06xZM1O2bFlTr1498+eff16xX0hIiKlYsaKpVq2aKVu2rGnQoIE5dOiQk7JGYbd69WrTvn17U7p0aSPJnD59uqBTAuCCDh8+bIYOHWoqVqxo3N3dzSeffFLQKbksivOF2KJFi+z+AxkZGWkqVqxoXnjhBavtxIkTxs/Pz7z11lvGmEu/YDdv3tx0797d6fk6yrlz50zNmjXN888/n6U4f/r0aVO8eHHz+uuvG2OMSUlJMcHBwaZLly4FlO31ufvuu02zZs2sX7iSkpLMl19+ae13pfH+9ttvRpJZt26d1fbCCy8YX19fc+HCBWOMMWfPnjX+/v7m1VdfNcZcKja0adPGdOrUqSBSviZff/21WbRokTl69GiOxflXXnnFVKpUyfpjw6pVq4wku0JIbmJuBPPmzTMLFiww0dHRORbnJ0yYYE6dOmVtT5061Xh5eZnIyEirbdKkSaZChQrm6NGjxphLf4xyc3Mzv//+e/4P4hrMnz/fzJ8/35w8efKqxfnZs2ebO+64w7Rq1SpLcX7KlCmmXLly5siRI8YYY37++Wfj5uZmfv3113zNH4XDjBkzTOnSpa0Czvr1602RIkXM6tWrc+wzYcIE065dOydlWLCmTJlifv/9d7NkyZJcF+fvuusuc9ddd5m0tDRjzKU/EpcqVSrLH/4Lu9OnT5uXX37ZHDlyxAwYMOCaivMHDx50QoYF66233jIRERHW9uLFi42bm5sJCQnJsc+8efOMj4+P2bZtmzHm0h9pixUrZj7//PP8TtepoqOjzfTp001iYqIx5tIfCR977DFTrlw5k56enmO/zp07m+eff95ZaRaYY8eOmc8++8w6FxcuXDB9+/Y1devWzbFPYmKiqVChghk5cqQx5tI57dy5s2nevLlTckbh9/bbb5u1a9eaNWvWUJwHkG/WrFlj5syZYxITE42vry/F+XxEcd7FPP7446ZVq1bW9vvvv2/8/Pzs/oO6cOFC4+7ubk6ePFkQKV63Bx54wLzyyitm2bJlWYrzH3/8sSlWrJhJSkqy2r799lvj5uZW6GaT//7770aS2bhxY44xrjTeRYsWGTc3N5OcnGy1LVu2zLi5uZm4uDhjjDFz5swx3t7e5vz581bM8uXLjSSreHujO378eI7F+UqVKplXXnnFrq1JkyZ2BdzcxNxITp8+nWNx/t/i4uKMJLN06VKrrVq1auall16yi7v99tvN4MGDHZ2qQ5w7d+6Kxfldu3aZihUrmiNHjpg2bdpk+XerWbOmGTt2rF1bcHCwGTBgQL7ljMKjQYMG5plnnrFru+uuu0zv3r1z7DNhwgTTunVrExYWZvbv32/9sdOV5bY4Hx4ebiSZH3/80Wo7d+6c8fDwsPtDuKu51uL8L7/8YrZv324SEhKckN2No0yZMubtt9/OcX+HDh1Mnz597Nr69etn2rRpk9+pFbjQ0FAjyezevTvHmM6dO5thw4aZLVu2mMjISJf7RsGVXP7/V04WL16c5f9i69evN5LMzp07nZEiXMQPP/xAcR6AU1Ccz1/cENaFGGO0bds2u/WLw8LCFBQUZLduZosWLZSZmakdO3YURJrX5ZNPPlFUVJRee+21bPeHhYWpfv36duuyt2jRQsYY/fXXX07K0jF+/fVXBQQEqFWrVjpw4IB27dql1NRUuxhXGm/37t3VunVrDR48WD/99JOWLFmiV155RRMmTLDWVA8LC1PdunXl5+dn9bu8bnJhG++/nTp1SjExMbrtttvs2lu0aKGwsLBcxxRml9c2vvwZFhsbq6NHj7rMeFNSUvTQQw9pxowZCgwMzLL/8v0WXGW8cKzU1FTt3bs3T6+P0NBQDRw4UHfddZcqVaqkRYsW5Weqhcbl8/bPc1qyZEndcsstvOf+YdCgQRo4cKACAgL0+OOPKzk5uaBTynfh4eGKjY3N9p4gl4WFhd20n9dbtmyRh4eHqlWrdsW4r776So8//rgaN26soKAgbd682UkZOt+ePXv0xx9/6IsvvtD06dM1ZcqUHGPDwsJUtWpVu3sUXP599mZ4/QAAAHvcNcSFvP3229q7d6/mzp1rtcXGxiogIMAu7vJ2bGysU/O7Xjt37tSrr76qTZs25XjDG1cab0xMjMqWLav77rtPBw8elLu7u06dOqVZs2Zp0KBBklxrvD4+Pho5cqRGjhypvXv36vz58ypXrpweeughK8aVxvtvl/PPbnyX9+UmprA6d+6cRowYoR49eujWW2+V5HrjHTVqlJo0aaKHH3442/2uNl44VlxcnIwx1/z6aN26tSIjI1WlShUZY/T2229r4MCBqlOnjpo2bZrfad/QLp+3f99Ul/fcJT4+Plq2bJl69uwp6dINPtu3by9fX1/NmjWrYJPLRxcuXNCQIUN06623qnv37tnGGGMUFxeX7fsxOTlZaWlp8vLycka6Tnfw4EFNnDhRo0ePtpss8W+DBw/WkiVLVLx4caWmpurxxx9Xz549tWfPHpe8ofDcuXP1+++/69ChQ2rYsKG6du2aY2x2v8/6+PjIx8eHz56b1I4dO3T+/Pkc97u7u6t169ZOzAgA4EwU513El19+qVdffVXz589Xo0aNrHYPD48sF/qUlBRJkqenp1NzvF6DBw9W7969deLECZ04cUJ79+6VdGlGYIMGDVStWjV5eHhkmV1eWMfr4eGhffv26bHHHtOaNWskSR988IEef/xxtW7dWrVr13ap8a5evVoDBgzQb7/9pjvuuEOSNGnSJLVr104HDx5U6dKlXWq8/+bh4SFJ2Y7v8thyE1MYJSYmqmvXrvL399fXX39ttbvSeH/77Td98803WrRokUJCQiRdmil/8uRJhYSEqFWrVi41XjheXl8f9913n/Wzm5ubXnrpJc2ePVvffvvtTV+cv3xO09LS5OPjY7XznrukfPnyVmFekoKCgjRy5Eh98MEHLlucv3jxoh5++GFFRkbqjz/+sF4j/+bm5qaiRYvm+DtJTv0Ku6ioKHXu3Fnt2rXTm2++ecXY/v37Wz97e3tr5syZKlu2rNavX69evXrld6pO9/bbb0uS0tPTNXz4cLVv314HDx60+/byZdn9PmuMUXp6Op89N6kPPvhA+/bty3G/l5eXfv31VydmBABwJorzLuDrr7/WsGHD9PXXX6tPnz52+wIDA7Vz5067tujoaEm66ldRbzSVKlXSrl279NJLL0n6vxlvkydP1mOPPaYnnnhCgYGB1tIYlxXW8VavXl2SNHz4cKvtySef1HPPPafQ0FDVrl3bpcb7/fff69Zbb7UK85L09NNPa/LkyQoJCVGPHj0UGBgom81m16+wjvffKleurCJFiljjuSw6OtoaW25iCpvExER16dJFqampWrt2rbWEkXTpPe/h4eES401LS1OTJk00depUqy0yMlKnTp3SSy+9pB9//FEVKlSQl5eXS4wXjle6dGkVL17cIa+PcuXKZTnOzejy8lLR0dF2y5fExMSoW7duBZXWDa18+fI6deqUMjIycvwWY2F18eJFDRgwQJs3b9b69euzXX7sn6pVq5bt+7FKlSpyd3e9lUOjoqJ01113qWHDhlq8ePE1//tfnmTh6p89np6eeu655/Tll19q165duv3227PEBAYG6vjx4zLGyM3NTZJ0/PhxXbx4kev9Teqzzz4r6BQAAAXI9X5zvMn873//0xNPPKG5c+eqX79+WfZ36tRJ+/fv14EDB6y2FStWqGzZsmrcuLEzU71u33//vUJCQqzHW2+9JUn64Ycf9MQTT0i6NN7Dhw9rz549Vr8VK1aodOnSatasWYHknVedO3eWJLv/xMTExMgYo7Jly0pyrfGWLVtWJ0+eVEZGhtV27Ngxa590abyRkZH6+++/rZgVK1aoZMmSat68uXMTdjBvb2/dcccdWrlypdWWkpKiX375RZ06dcp1TGGSlJSk++67T0lJSVq7dm2WpSU8PDzUrl07u/Gmpqbqp59+KnTj7dKli93nV0hIiBo1aqRu3bopJCREfn5+KlKkiNq3b2833rS0NP3444+FbrxwPDc3N3Xs2NHu9XHhwgWtWbPG7vURGRmpP//809pOSkqyO87x48e1a9cuNWzYMP+TvgGFhYXp0KFDkqSWLVuqePHidud0y5YtiomJuSnfc6mpqQoJCdG5c+ckZX3tSNLPP/+sunXrumRhfuDAgdq4caPWr1+vmjVrZomJiYmxvvkkXfqd5Pvvv5cxRtKlmc8rV650yddOdHS02rdvr/r16+vbb7/Ndnb3rl27rN9H09LS7H6fk6R169bpwoULLvfZk9375PJnzOWla4wxCgkJ0YkTJyRdeu2cO3fObsLJihUrrN/zAADATaZg7kMLR/juu+9MkSJFzDPPPGNsNpv12LJlixWTmZlpOnToYBo1amSWLFli3nvvPePp6Wlmz55dgJk7xrJly4wkc+7cObv2e+65xzRo0MAsWbLEzJo1y3h5eZmPP/64YJK8To888ohp0qSJWbp0qfnuu+/M7bffbpo3b27S09OtGFcZ7+HDh03x4sXNAw88YFavXm0WLFhg6tevb1q2bGkuXLhgxXXp0sXUq1fPLF682HzwwQfG29vbvP/++wWYee6cOnXK2Gw2s2LFCiPJvPfee8Zms5nIyEgrJiQkxHh4eJgXXnjBrFixwtxzzz2mevXqJj4+/ppibgSnT582NpvNfP/990aSmTFjhrHZbObIkSPGGGMyMjLMXXfdZQICAsyKFSvsPsNiYmKs42zatMl4enqa559/3qxYscJ06dLFVKtWLcv7vqCdOXPG2Gw288MPPxhJ5u233zY2m81ERETk2KdNmzZm6NChdm1//vmn8fLyMqNGjTIrV640Xbt2NVWqVDFnz57N5xGgMAgLCzM+Pj7m6aefNitXrjQ9e/Y0FSpUMCdPnrRixo0bZ8qXL29tN2nSxEydOtWsWbPGfPXVV6Z+/fqmXr16Ji4uriCGkK8OHTpkbDabeeONN4wk8+uvvxqbzWb3eREUFGT3vnvnnXdMsWLFzEcffWQWLVpkbrnlFtOjR48CyD7/bd682dhsNnPPPfeYli1bGpvNZjZs2GDtP3jwoJFkVq1aZYwx5tVXXzVDhgwxCxcuNKtWrTJDhgwxHh4eZvny5QU1hHzz6KOPGi8vLzN37ly761F4eLgV895775l//tcpIiLClCpVygwYMMCsXLnSDB482JQoUcIcPHiwIIaQb2JjY02dOnVMnTp1rPfU5cc/P0c6duxounbtaoy5dG6aNm1qPvroI/PTTz+ZmTNnmjJlyrjke+ujjz4yffv2NfPmzTM///yzmTFjhilTpowZPHiwFZOSkmIkmU8++cRq69+/v6levbqZP3++mTNnjilevLh5/fXXC2AEKIwiIiKMzWYzM2bMMJLM999/b2w2mzlz5kxBpwbAhSQkJFjXfB8fHzN27Fhjs9nMvn37Cjo1l+NmzP+f7oFCZ8aMGVq+fHmW9ooVK2rJkiXWdlJSkt555x3ZbDb5+fnpkUce0QMPPODETPOHzWbT+PHj9eOPP9rdkCo5OVnvvvuu/vjjDxUrVkwDBgzQgw8+WICZ5l1GRoY++eQT/fDDDypatKiCg4P13HPPydfX14pxpfGGh4dbay56e3srODhYTz/9tN2/b0pKit599139/vvvKlasmPr3729309gb1c8//6zXX389S/vgwYOtb35I0qZNm/Thhx/qxIkTatiwoV566SVVrFjRrk9uYgrar7/+qtdeey1L+8CBAzV8+HClpKTkOLtwzJgxdp9Rmzdv1gcffKDjx48rKChI48aNU+XKlfMt97xYv369XnnllSzt/fv319NPP51tn6eeekqBgYEaN26cXfuWLVv0/vvvKyYmRvXr19dLL72kKlWq5EveKHzCwsI0c+ZMRUVFqW7duho3bpzd8huffvqpfvjhB61YsUKSdPbsWX3wwQfasmWL/Pz8FBwcrBEjRmS7DnJhl9PvRe+8845atmwpSRo0aJD1OXLZggULtHDhQqWkpKh9+/YaPXq0S56f+++/X2fPnrVr++c6xtHR0XrooYf0n//8R61bt5YxRosXL9aKFSsUFxenOnXqaMSIEapbt25BpJ+vsjs3ktS3b1+NHDlSkrRkyRLNmjXLbvb8gQMHNH36dB0+fFg1atTQ2LFjVb9+fafl7Qz79+/X0KFDs903c+ZMa9mW0aNHy9PT01p7/eDBg/r444+1Z88elS9fXvfee6/69+9vLePiSn744QctWrRIMTExqlKlinr27Knu3btbY01PT1eHDh30wgsv6P7777faPvjgA/3888/y9PRU7969NWTIkAIcBQqTjz76SAsWLMjSPmXKFN11113OTwiAS9qzZ4+efPLJLO133323Jk2a5PyEXBjFeQAAAAAAAAAAnIw15wEAAAAAAAAAcDKK8wAAAAAAAAAAOBnFeQAAAAAAAAAAnIziPAAAAAAAAAAATkZxHgAAAAAAAAAAJ6M4DwAAAAAAAACAk1GcBwAAAAAAAADAySjOA3CK6OhoLV26NN/7AACAG8/atWt17Nixq8b98ccfCg8Pd0JGAAAAQMFzM8aYgk4CQOGxefNmRUREXDHmoYcekpubm13b8uXLNXDgQCUmJub6ufLSBwAAXLu///5be/bskSQVKVJElStXVpMmTVSsWDFJ0pIlS3Tx4sUc+1etWlVt2rTJ8didO3fWgQMHVLx48Svm8c033+iDDz7Qpk2bsvwuAQAAALiaogWdAIDCZfv27fr999+t7UWLFql58+aqWbOm1da3b98s/6GuUqWK+vTp47Q8AQBA7s2fP18ff/yx7rvvPl28eFE7d+5UXFyclixZojvuuEOrVq1Senq6JOno0aPatGmTevfuraJFL/13Ijg4OMfi/Msvv6ynnnrqqoV5Serfv78mTJig5cuXq1evXo4bIAAAAHADYuY8gOvi5uam//73v3r88cclSZGRkfrrr7/UrVs3bd68WdHR0brvvvsUFxen0NBQ9e7dW5J09uxZ/fLLL5Ikb29v3XLLLQoKCrI7NjPnAQBwjpdeeknLly/Xvn37JEmZmZnq3r27jhw5ot27d9vFLly4UP3799f58+fl5+d3xeNGRESodu3aioiIULVq1ezad+/erXLlyqlp06by8PCw9k2YMEGbN2/W2rVrHThCAAAKzr59+zRkyBB9/PHHmjVrlsLDwzV9+nQFBwfr8OHDevfdd7V7925VqFBB/fr1U8+ePa2+cXFxevfdd7V582b5+fnp/vvv16BBgyRJs2fP1o4dO9SxY0ctXrxYZ86cUdeuXTVq1Ci5u//fStZ//vmn3n//fR09elTVqlXTc889p+bNm1v7Lx+nS5cuWrBggc6cOaMOHTro+eeft67RV8pD0lXHASB7zJwH4FA2m01PP/20GjdurIyMDFWrVk133XWXtmzZosGDB1vF+XPnzmn58uWSpJSUFG3atEnBwcH67rvvrFl4AACgYLi7u6tz584aPXq00tPT5enpmafjrF69WjVr1rQrzE+cOFHvv/++7rjjDsXFxSklJUXfffedAgMDJUkdOnTQf/7zH50/fz5Xs+0BALjRJSYmavPmzXrggQc0ceJEDR8+XPXr19eePXt0xx13aNiwYZo4caKOHj2qESNGKCYmRk899ZQkafDgwYqLi9OLL76ozMxMLVu2TBcvXtSjjz6qY8eO6csvv9TmzZv16quvKi4uTi+88IJOnTqladOmSZK2bt2qO+64Q08//bQGDRqkH374QW3bttXGjRt12223SZJ1nAMHDmj06NFKTEzUc889p9TUVE2aNOmqeeRmHACyRwUMgMMlJCTogQce0KhRo3KMqV27thYuXGjXp1mzZpo7d66GDh3qhCwBAMCVHD58WP7+/nkuzEuXlsNr0KCBtZ2cnKypU6dq3bp1uuOOOyRJe/fuVUpKihXTqFEjZWRk6K+//rJiAABwBdOnT9eDDz5obQ8aNEgDBgzQW2+9ZbX5+Pho1KhRVlF7w4YN+vLLL9W1a1dJUvfu3e2umxkZGVq+fLmqVq0qSfLz89PAgQP1wgsvKCAgQK+++qq6deumd999V5J0zz33KCIiQhMnTtSaNWvsnnfFihXy9fWVJIWHh2vx4sVWcf5KeYwfP/6q4wCQPYrzAByuSJEiuboAX7x4Udu2bVN0dLTS0tJUrVo1/fnnnxTnAQAoAOfPn9fChQt18eJF7dixQ3PmzLH+I59XZ86cUenSpa3tIkWKyMPDQzt37lTbtm3l5uam+vXr2/UpVaqU1RcAAFfSunVru+1169apQoUKatu2rYwxMsYoMTFRJ0+eVFxcnEqWLKkOHTroxRdf1IkTJ9ShQwfVqlVLPj4+1jHq1q1rFealS8X31NRU7d69W3feeae2bNliVzSXpPvuu0+vvPKKXVv9+vWtwrx06b5xJ06csLavlEduxgEgexTnAThcQEDAVWfZHT58WPfcc4+MMWrQoIH8/PwUFRUlf39/J2UJAAD+6fz581q+fLkuXLigzZs367bbbtPAgQOv65h+fn5KSkqytr28vPS///1PY8eO1eTJk9WuXTs9/PDDdmvSXo5nSRsAgKv5Z/FbunTN69+/v7p06ZJj7DfffKOvv/5aq1ev1rhx41S1alV9/fXXaty4cbbH9PHxkbu7uxISEiRdWlLn3/eI8fPz0/nz5+3a/nn/F+nS/eX+eZvKK+WRm3EAyB7FeQAO5+bmdtWYyZMnq2HDhlqxYoXV1q9fP6WmpuZnagAAIAeVKlWylpw7f/682rRpo8cff1yLFi3K8zHr1Kmj77//3q6tT58+6tOnj/bv36/Vq1dr0KBBmjZtmvWtu4iICKsvAACurFatWoqNjVVwcHCOMR4eHho6dKiGDh2q9PR0PfTQQ3rhhRf0888/S7q0/ExGRoZ177YDBw4oMzNTNWvWlCTVrFlTe/futTvm3r17VatWrWvK9Up55GYcALLnfvUQAHC8EydOqG7dutZ2XFycfv311wLMCAAAXFa8eHF9/PHHWrx4sdavX5/n43Ts2FE7duxQYmKipEuz9+Lj4yVd+hr+mDFj1KVLF4WGhlp9NmzYoDp16tjdRBYAAFf0zDPP6L///a/Wrl1rtUVHR1vLyl28eFGTJ0+2rqMeHh7y9va2m+V+5swZKz4jI0MTJ05UixYtrHu+DB06VHPmzNHhw4clSYcOHdLs2bOvaTnZq+VxtXEAyBkz5wEUiJ49e+qll15SQECA/Pz89OmnnyojI6Og0wIAAP9f27Zt1aNHD7344ov6888/83yMW265Rd9++62GDBmi+Ph4tWvXTj179lRQUJAiIyP1/fffa/78+VafRYsW6fHHH3fUMAAAuGE9++yziouLU8+ePVW2bFm5u7vr4sWLmjZtmqRL92oxxigwMFAVK1ZUXFyc/P39tWTJEusYQUFBWrVqlT799FMlJibK19dXq1atsnuOv//+Ww0bNlSNGjUUERGhfv366Zlnnsl1nlfL42rjAJAzN/PPBaQA4Br169dPw4YNU/v27SVJISEhmjdvnj799FO7uK1bt+rDDz/UV199ZbUtWrRIa9euVZEiRXTPPfcoPj5esbGxev7553PsAwAAHG/BggXaunWr3nnnHbv2ffv2adKkSZo0aZLq1asnSdq0aZNmzZqluXPnysvL66rHnj9/vmbMmKFt27bJzc1NsbGx+uqrr7Rr1y4FBATowQcfVIsWLSRJYWFh6tKli/bv3899aAAALiMpKUk7d+5U8+bNVaRIkSz7U1NTdeDAARUvXlzVq1fPslTshQsXdODAAfn6+iowMNDa/8orrygkJETr169XTEyMzpw5owYNGlhL3PzTqVOndOzYMVWrVk1ly5a12xcVFaWEhARrtr10aUb+0aNH1axZs6vmkdtxAMiK4jwAAACAfDVq1CgNGzZM9evXv2LcJ598ovLly+uBBx5wUmYAABRe/yzOAyicWNYGAAAAQL6aOXNmruJGjBiRv4kAAAAANxBmzgMAAAAAAACFTHbL0QAoXCjOAwAAAAAAAADgZO4FnQAAAAAAAAAAADcbivMAAAAAAAAAADgZxXkAAAAAAAAAAJyM4jwAAAAAAAAAAE5GcR4AAAAAAAAAACejOA8AAAAAAAAAgJNRnAcAAAAAAAAAwMkozgMAAAAAAAAA4GQU5wEAAAAAAAAAcLL/Bw6aBCTjEf50AAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1500x400 with 3 Axes>"
       ]
@@ -9115,10 +1770,10 @@
    "id": "dual-alpha-rule",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:50.791301Z",
-     "iopub.status.busy": "2026-07-06T16:28:50.791214Z",
-     "iopub.status.idle": "2026-07-06T16:28:50.793493Z",
-     "shell.execute_reply": "2026-07-06T16:28:50.793124Z"
+     "iopub.execute_input": "2026-08-28T01:43:57.699499Z",
+     "iopub.status.busy": "2026-08-28T01:43:57.699404Z",
+     "iopub.status.idle": "2026-08-28T01:43:57.701777Z",
+     "shell.execute_reply": "2026-08-28T01:43:57.701515Z"
     }
    },
    "outputs": [],
@@ -9163,10 +1818,10 @@
    "id": "dual-alpha-register",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:50.794582Z",
-     "iopub.status.busy": "2026-07-06T16:28:50.794504Z",
-     "iopub.status.idle": "2026-07-06T16:28:50.797754Z",
-     "shell.execute_reply": "2026-07-06T16:28:50.797345Z"
+     "iopub.execute_input": "2026-08-28T01:43:57.702618Z",
+     "iopub.status.busy": "2026-08-28T01:43:57.702535Z",
+     "iopub.status.idle": "2026-08-28T01:43:57.706403Z",
+     "shell.execute_reply": "2026-08-28T01:43:57.706149Z"
     }
    },
    "outputs": [
@@ -9225,10 +1880,10 @@
    "id": "dual-alpha-sim",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:50.798896Z",
-     "iopub.status.busy": "2026-07-06T16:28:50.798818Z",
-     "iopub.status.idle": "2026-07-06T16:28:51.039619Z",
-     "shell.execute_reply": "2026-07-06T16:28:51.039272Z"
+     "iopub.execute_input": "2026-08-28T01:43:57.707350Z",
+     "iopub.status.busy": "2026-08-28T01:43:57.707265Z",
+     "iopub.status.idle": "2026-08-28T01:43:58.081470Z",
+     "shell.execute_reply": "2026-08-28T01:43:58.081133Z"
     }
    },
    "outputs": [
@@ -9303,10 +1958,10 @@
    "id": "dual-alpha-fit",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:51.040951Z",
-     "iopub.status.busy": "2026-07-06T16:28:51.040879Z",
-     "iopub.status.idle": "2026-07-06T16:28:54.647979Z",
-     "shell.execute_reply": "2026-07-06T16:28:54.647293Z"
+     "iopub.execute_input": "2026-08-28T01:43:58.082652Z",
+     "iopub.status.busy": "2026-08-28T01:43:58.082555Z",
+     "iopub.status.idle": "2026-08-28T01:44:01.592067Z",
+     "shell.execute_reply": "2026-08-28T01:44:01.591658Z"
     }
    },
    "outputs": [
@@ -9343,143 +1998,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "  0%|                                                  | 0/600 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:   5%| | 30/600 [00:00<00:09, 63.20it/s, 7 steps of size 1.10e-01. acc. "
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  11%| | 68/600 [00:00<00:03, 135.44it/s, 7 steps of size 1.83e-01. acc."
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  17%|▏| 103/600 [00:00<00:02, 188.10it/s, 7 steps of size 5.00e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  23%|▏| 138/600 [00:00<00:02, 228.82it/s, 5 steps of size 1.15e+00. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  31%|▎| 184/600 [00:00<00:01, 289.79it/s, 7 steps of size 9.72e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  37%|▎| 223/600 [00:00<00:01, 315.25it/s, 7 steps of size 7.76e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "warmup:  45%|▍| 268/600 [00:01<00:00, 351.59it/s, 9 steps of size 4.45e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  50%|▌| 302/600 [00:01<00:00, 346.94it/s, 3 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  58%|▌| 348/600 [00:01<00:00, 376.67it/s, 7 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  66%|▋| 396/600 [00:01<00:00, 402.99it/s, 7 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  72%|▋| 433/600 [00:01<00:00, 393.13it/s, 7 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  79%|▊| 474/600 [00:01<00:00, 397.28it/s, 3 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  85%|▊| 512/600 [00:01<00:00, 391.25it/s, 7 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  93%|▉| 557/600 [00:01<00:00, 408.25it/s, 1 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample:  99%|▉| 596/600 [00:01<00:00, 401.09it/s, 3 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "sample: 100%|█| 600/600 [00:01<00:00, 314.31it/s, 7 steps of size 6.94e-01. acc"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
       "Only one chain was sampled, this makes it impossible to run some convergence checks\n"
      ]
     }
@@ -9518,10 +2036,10 @@
    "id": "dual-alpha-summary",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:54.649667Z",
-     "iopub.status.busy": "2026-07-06T16:28:54.649411Z",
-     "iopub.status.idle": "2026-07-06T16:28:54.715953Z",
-     "shell.execute_reply": "2026-07-06T16:28:54.715449Z"
+     "iopub.execute_input": "2026-08-28T01:44:01.593721Z",
+     "iopub.status.busy": "2026-08-28T01:44:01.593418Z",
+     "iopub.status.idle": "2026-08-28T01:44:01.685439Z",
+     "shell.execute_reply": "2026-08-28T01:44:01.685005Z"
     }
    },
    "outputs": [
@@ -9555,14 +2073,14 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>rl_alpha</th>\n",
-       "      <td>0.434</td>\n",
-       "      <td>0.314</td>\n",
-       "      <td>0.578</td>\n",
+       "      <td>0.444</td>\n",
+       "      <td>0.311</td>\n",
+       "      <td>0.581</td>\n",
        "      <td>0.35</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>rl_alpha_neg</th>\n",
-       "      <td>0.107</td>\n",
+       "      <td>0.106</td>\n",
        "      <td>0.080</td>\n",
        "      <td>0.136</td>\n",
        "      <td>0.10</td>\n",
@@ -9573,8 +2091,8 @@
       ],
       "text/plain": [
        "               mean  hdi94_lb  hdi94_ub  true\n",
-       "rl_alpha      0.434     0.314     0.578  0.35\n",
-       "rl_alpha_neg  0.107     0.080     0.136  0.10"
+       "rl_alpha      0.444     0.311     0.581  0.35\n",
+       "rl_alpha_neg  0.106     0.080     0.136  0.10"
       ]
      },
      "execution_count": 15,
@@ -9617,10 +2135,10 @@
    "id": "bea36762",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T16:28:54.717124Z",
-     "iopub.status.busy": "2026-07-06T16:28:54.717039Z",
-     "iopub.status.idle": "2026-07-06T16:28:54.724832Z",
-     "shell.execute_reply": "2026-07-06T16:28:54.724451Z"
+     "iopub.execute_input": "2026-08-28T01:44:01.686515Z",
+     "iopub.status.busy": "2026-08-28T01:44:01.686418Z",
+     "iopub.status.idle": "2026-08-28T01:44:01.688975Z",
+     "shell.execute_reply": "2026-08-28T01:44:01.688614Z"
     }
    },
    "outputs": [
@@ -9685,7 +2203,735 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.15"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "03c3569b0ec145f694eeaeb375a8497d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_983100af473e41ca9f17d37c2cf6a90e",
+        "IPY_MODEL_34d29e25544a4bc8b90a692ab0fa261a",
+        "IPY_MODEL_9aa7884099e44078bbd159acd40ad3dd"
+       ],
+       "layout": "IPY_MODEL_6cb70512413b43b7ba681222b852e62d",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "0b768326aa4943a7923416dc922fe115": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "34d29e25544a4bc8b90a692ab0fa261a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_c4988e09b5844270a37285c8cd6010ca",
+       "max": 85342.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_ca7fdfc9581f41c59d57530a24e0ae5d",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 82001.0
+      }
+     },
+     "360552b0edd64ec18ff26b192704d575": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_e15c10cd70804497b1d2b95d5f4f2c5e",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0b768326aa4943a7923416dc922fe115",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "angle.onnx: reconstructing file: 100%"
+      }
+     },
+     "388c0058cd70430ab0a9406a8bde15c9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "395b675cb51b474384882da70ab70259": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "4b23179f741841e5b0fa27906d15fde6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "6cb70512413b43b7ba681222b852e62d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "983100af473e41ca9f17d37c2cf6a90e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_b8875269e7d84eefa7e4f5129e8ab467",
+       "placeholder": "​",
+       "style": "IPY_MODEL_ae043e9a55624f5cae78cef89182cb96",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "angle.onnx: downloading bytes: "
+      }
+     },
+     "9aa7884099e44078bbd159acd40ad3dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_d8f545acb98c429aaabe183deb65a12b",
+       "placeholder": "​",
+       "style": "IPY_MODEL_b2862f120b3443959e8c10f4d37b99d7",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 82.0kB, 8.09kB/s  "
+      }
+     },
+     "9e533ecc1cfe46ed9891dfb13752f1a5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_395b675cb51b474384882da70ab70259",
+       "max": 85342.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_fbfb4077cfdc411aa617f28ec68db411",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 85342.0
+      }
+     },
+     "ae043e9a55624f5cae78cef89182cb96": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "b2862f120b3443959e8c10f4d37b99d7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "b8875269e7d84eefa7e4f5129e8ab467": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "be5d61cc32ce4b01ba559f484e295770": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_360552b0edd64ec18ff26b192704d575",
+        "IPY_MODEL_9e533ecc1cfe46ed9891dfb13752f1a5",
+        "IPY_MODEL_d1c8cc5d46154b0fa90e038fe63794d0"
+       ],
+       "layout": "IPY_MODEL_388c0058cd70430ab0a9406a8bde15c9",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "c4988e09b5844270a37285c8cd6010ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ca7fdfc9581f41c59d57530a24e0ae5d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "d0536bea3d384a4d8ce3a048d1228a92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d1c8cc5d46154b0fa90e038fe63794d0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_4b23179f741841e5b0fa27906d15fde6",
+       "placeholder": "​",
+       "style": "IPY_MODEL_d0536bea3d384a4d8ce3a048d1228a92",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 85.3kB / 85.3kB, 8.42kB/s  "
+      }
+     },
+     "d8f545acb98c429aaabe183deb65a12b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "e15c10cd70804497b1d2b95d5f4f2c5e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "fbfb4077cfdc411aa617f28ec68db411": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/rlssm_hssm_custom_models.ipynb
+++ b/docs/tutorials/rlssm_hssm_custom_models.ipynb
@@ -1465,8 +1465,10 @@
    "source": [
     "## 7. Group-level recovery\n",
     "\n",
-    "A light check that the fit found the truth: the group intercept (posterior mean + 94% HDI)\n",
-    "against each true group mean. For a full **per-participant** recovery treatment see the\n",
+    "An illustrative group-level check compares each posterior intercept (mean + 94% HDI)\n",
+    "with its generating value. This deliberately short two-chain fit retains modest sampler\n",
+    "warnings, so treat the figure as a wiring demonstration rather than a formal recovery\n",
+    "result. For a full **per-participant** recovery treatment see the\n",
     "[Basic](../rlssm_basic/) and [Advanced](../rlssm_advanced/) tutorials — we keep this one\n",
     "short on purpose."
    ]
@@ -1866,8 +1868,9 @@
    "source": [
     "### Simulate matched data\n",
     "\n",
-    "`ssm-simulators` already includes `RescorlaWagnerDualAlphaRule`, so we use that\n",
-    "tested implementation to generate a small matched dataset. We still wrote the\n",
+    "`ssm-simulators` already includes `RescorlaWagnerDualAlphaDrift`, whose drift\n",
+    "specialization computes `v`, so we use that tested implementation to generate a small\n",
+    "matched dataset. We still wrote the\n",
     "HSSM-side function independently above because the purpose here is to show how users\n",
     "can introduce different custom learning rules into the registry. If a new rule also\n",
     "needs simulation or posterior predictive checks, implementing its matching\n",


### PR DESCRIPTION
- Use `RescorlaWagnerDualAlphaDrift` for the tutorial's matched simulator configuration.
- Align simulator ownership with the HSSM-side learner: `v` is computed from Q-value differences and `scaler`, while `rl_alpha`, `rl_alpha_neg`, and `scaler` remain free parameters.
- Avoid requiring a nonexistent sampled `v` in the simulator `theta` contract.
- Add an opt-in `full_run` input for targeted notebook runs so refreshed committed outputs come from the notebook's documented full-scale mode; sharded checks keep their existing reduced scale.
- Correct the matching simulator name in the narrative and qualify the short recovery plot as a wiring demonstration rather than a formal recovery study.

The generic `RescorlaWagnerDualAlphaRule` updates Q values but intentionally emits no decision-process parameter. The drift specialization is the matching authority for this tutorial; no library contract changes are needed.

Refs #1243

Verification:
- Instantiated the current `ssms.rl.ModelConfig` and asserted `required_params == ["rl_alpha", "rl_alpha_neg", "scaler", "a", "z", "t", "theta"]` with computed SSM params `{"v"}`.
- Full-scale targeted hosted execution [33133461276](https://github.com/lnccbrown/HSSM/actions/runs/33133461276) passed at `fcf3dab7` and records `FULL_RUN=True`.
- The imported artifact has 32 executed cells, no error outputs, no machine-local paths, and two visually inspected figures.
- Executable cell sources are identical to the source-fix commit; versus the PR base, the only executable source change is `RescorlaWagnerDualAlphaRule` to `RescorlaWagnerDualAlphaDrift`.
- The refreshed short fit reports 18/800 divergences versus 19 previously, with improved maximum R-hat and no ESS warning. The page now explicitly treats it as an integration/wiring demonstration, not formal recovery evidence.
- `python3 scripts/check_docs_notebook_paths.py`
- `./scripts/docs.sh build` (strict; Python 3.12)
