### PR TITLE
chore: ignore generated .cursor/ and .agents/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ pre-commit
 uv.lock
 
 .claude/CLAUDE.local.md
+
+# Generated per-checkout by HSSMSpine's cross-editor sync
+# (scripts/sync_agent_config.py materializes these from .claude/).
+.cursor/
+.agents/


### PR DESCRIPTION
- HSSMSpine's `sync_agent_config.py` materializes `.cursor/` and `.agents/` into every ecosystem repo on each launch, but only the spine gitignored them
- That left every repo one `git add -A` away from committing generated editor config. It just happened on [HSSM #1248](https://github.com/lnccbrown/HSSM/pull/1248), where the swept-in files also leaked local worktree paths into the diff
- No repo tracks these paths today (`git ls-files .cursor .agents` is empty in all five), so this only affects future accidents — nothing needs untracking
- Verified with `git check-ignore` on paths inside both directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)