### PR TITLE
Fix scenic tutorial image links

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,7 @@ timeout = 30
 
 # These publisher pages are valid in a browser but reject automated clients.
 exclude = [
+  '^https://www\.biorxiv\.org/content/10\.64898/2026\.06\.05\.730398v1$',
   '^https://www\.jneurosci\.org/content/44/46/e0550242024\.long$',
   '^https://psycnet\.apa\.org/record/2009-11068-003$',
 ]

--- a/docs/tutorials/main_tutorial_scenic_route.ipynb
+++ b/docs/tutorials/main_tutorial_scenic_route.ipynb
@@ -29,10 +29,10 @@
     }
    },
    "source": [
-    "# The HSSM tutorial: scenic route\n",
+    "# The HSSM tutorial — scenic route\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/HSSM_logo.png\" alt=\"HSSM logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/HSSM_logo.png\" alt=\"HSSM logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
     "</div>"
    ]
   },
@@ -438,7 +438,7 @@
     "- `t`: non-decision time, such as encoding and motor time.\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/DDM_with_params_pic.png\" alt=\"Drift diffusion model diagram with parameters v, a, t, and z\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/DDM_with_params_pic.png\" alt=\"Drift diffusion model diagram with parameters v, a, t, and z\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
     "</div>\n",
     "\n",
     "We simulate data with known values first. This makes the later posterior checks concrete: the red reference lines will show the values used to generate the data."
@@ -1266,7 +1266,7 @@
     "#### ArviZ for diagnostics and visualization\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/arviz.png\" alt=\"ArviZ logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/arviz.png\" alt=\"ArviZ logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
     "</div>\n",
     "\n",
     "HSSM returns `xarray`-based inference results that work directly with [ArviZ](https://python.arviz.org/en/stable/index.html). We will use ArviZ to summarize posterior uncertainty, inspect MCMC traces, check posterior predictions, and compare models. The examples below focus on the few summaries and plots that are most useful when starting out."
@@ -2002,7 +2002,7 @@
     "The `angle` model extends the DDM with `theta`, which controls the rate at which decision boundaries collapse over time.\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/ANGLE_with_params_pic.png\" alt=\"Angle model diagram with collapsing decision boundaries and theta parameter\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/ANGLE_with_params_pic.png\" alt=\"Angle model diagram with collapsing decision boundaries and theta parameter\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
     "</div>\n",
     "\n",
     "Collapsing boundaries are useful when urgency or time pressure may change a participant’s decision criterion. HSSM makes inference for these models practical through packaged `approx_differentiable` likelihoods."
@@ -2485,7 +2485,7 @@
     "Sometimes a parameter is fixed by design or is outside the present research question. Here we estimate only the drift rate `v` while holding the other DDM parameters fixed.\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/DDM_only_v_pic.png\" alt=\"Drift diffusion model diagram with only the drift-rate parameter v estimated\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/DDM_only_v_pic.png\" alt=\"Drift diffusion model diagram with only the drift-rate parameter v estimated\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
     "</div>\n",
     "\n",
     "Fixing parameters reduces model flexibility, so it should be justified by theory, design, or a deliberate comparison."
@@ -2965,7 +2965,7 @@
     "### Regressions on cognitive parameters\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/bambi.png\" alt=\"Bambi logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/bambi.png\" alt=\"Bambi logo\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
     "</div>\n",
     "\n",
     "HSSM can link individual SSM parameters to trial-level covariates with Bambi-style formulas. This lets you ask questions such as whether a neural signal, condition, or behavioral measure predicts drift rate, boundary separation, or bias."
@@ -6710,7 +6710,7 @@
     "The remaining sections show how HSSM connects to the broader computational ecosystem. They are optional for a first analysis, but useful when you need custom simulators, likelihoods, or a lower-level PyMC model. If you are new to HSSM, it is reasonable to stop after model comparison and return here once you need more control.\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/pytensor_jax.png\" alt=\"PyTensor and JAX logos\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/pytensor_jax.png\" alt=\"PyTensor and JAX logos\" style=\"height: 120px; width: auto; max-width: 80%;\">\n",
     "</div>"
    ]
   },
@@ -7136,7 +7136,7 @@
     "### Black-box likelihoods\n",
     "\n",
     "<div style=\"text-align: center;\">\n",
-    "  <img src=\"images/blackbox.png\" alt=\"Black-box likelihood concept illustration\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
+    "  <img src=\"https://lnccbrown.github.io/HSSM/tutorials/images/blackbox.png\" alt=\"Black-box likelihood concept illustration\" style=\"width: 360px; max-width: 90%; height: auto;\">\n",
     "</div>"
    ]
   },

--- a/docs/tutorials/main_tutorial_scenic_route.py
+++ b/docs/tutorials/main_tutorial_scenic_route.py
@@ -28,10 +28,10 @@ def _():
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # The HSSM tutorial: scenic route
+    # The HSSM tutorial — scenic route
 
     <div style="text-align: center;">
-      <img src="images/HSSM_logo.png" alt="HSSM logo" style="height: 120px; width: auto; max-width: 80%;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/HSSM_logo.png" alt="HSSM logo" style="height: 120px; width: auto; max-width: 80%;">
     </div>
     """)
     return
@@ -362,7 +362,7 @@ def _(mo):
     - `t`: non-decision time, such as encoding and motor time.
 
     <div style="text-align: center;">
-      <img src="images/DDM_with_params_pic.png" alt="Drift diffusion model diagram with parameters v, a, t, and z" style="width: 360px; max-width: 90%; height: auto;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/DDM_with_params_pic.png" alt="Drift diffusion model diagram with parameters v, a, t, and z" style="width: 360px; max-width: 90%; height: auto;">
     </div>
 
     We simulate data with known values first. This makes the later posterior checks concrete: the red reference lines will show the values used to generate the data.
@@ -628,7 +628,7 @@ def _(mo):
     #### ArviZ for diagnostics and visualization
 
     <div style="text-align: center;">
-      <img src="images/arviz.png" alt="ArviZ logo" style="height: 120px; width: auto; max-width: 80%;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/arviz.png" alt="ArviZ logo" style="height: 120px; width: auto; max-width: 80%;">
     </div>
 
     HSSM returns `xarray`-based inference results that work directly with [ArviZ](https://python.arviz.org/en/stable/index.html). We will use ArviZ to summarize posterior uncertainty, inspect MCMC traces, check posterior predictions, and compare models. The examples below focus on the few summaries and plots that are most useful when starting out.
@@ -918,7 +918,7 @@ def _(mo):
     The `angle` model extends the DDM with `theta`, which controls the rate at which decision boundaries collapse over time.
 
     <div style="text-align: center;">
-      <img src="images/ANGLE_with_params_pic.png" alt="Angle model diagram with collapsing decision boundaries and theta parameter" style="width: 360px; max-width: 90%; height: auto;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/ANGLE_with_params_pic.png" alt="Angle model diagram with collapsing decision boundaries and theta parameter" style="width: 360px; max-width: 90%; height: auto;">
     </div>
 
     Collapsing boundaries are useful when urgency or time pressure may change a participant’s decision criterion. HSSM makes inference for these models practical through packaged `approx_differentiable` likelihoods.
@@ -1064,7 +1064,7 @@ def _(mo):
     Sometimes a parameter is fixed by design or is outside the present research question. Here we estimate only the drift rate `v` while holding the other DDM parameters fixed.
 
     <div style="text-align: center;">
-      <img src="images/DDM_only_v_pic.png" alt="Drift diffusion model diagram with only the drift-rate parameter v estimated" style="width: 360px; max-width: 90%; height: auto;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/DDM_only_v_pic.png" alt="Drift diffusion model diagram with only the drift-rate parameter v estimated" style="width: 360px; max-width: 90%; height: auto;">
     </div>
 
     Fixing parameters reduces model flexibility, so it should be justified by theory, design, or a deliberate comparison.
@@ -1239,7 +1239,7 @@ def _(mo):
     ### Regressions on cognitive parameters
 
     <div style="text-align: center;">
-      <img src="images/bambi.png" alt="Bambi logo" style="height: 120px; width: auto; max-width: 80%;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/bambi.png" alt="Bambi logo" style="height: 120px; width: auto; max-width: 80%;">
     </div>
 
     HSSM can link individual SSM parameters to trial-level covariates with Bambi-style formulas. This lets you ask questions such as whether a neural signal, condition, or behavioral measure predicts drift rate, boundary separation, or bias.
@@ -2355,7 +2355,7 @@ def _(mo):
     The remaining sections show how HSSM connects to the broader computational ecosystem. They are optional for a first analysis, but useful when you need custom simulators, likelihoods, or a lower-level PyMC model. If you are new to HSSM, it is reasonable to stop after model comparison and return here once you need more control.
 
     <div style="text-align: center;">
-      <img src="images/pytensor_jax.png" alt="PyTensor and JAX logos" style="height: 120px; width: auto; max-width: 80%;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/pytensor_jax.png" alt="PyTensor and JAX logos" style="height: 120px; width: auto; max-width: 80%;">
     </div>
     """)
     return
@@ -2497,7 +2497,7 @@ def _(mo):
     ### Black-box likelihoods
 
     <div style="text-align: center;">
-      <img src="images/blackbox.png" alt="Black-box likelihood concept illustration" style="width: 360px; max-width: 90%; height: auto;">
+      <img src="https://lnccbrown.github.io/HSSM/tutorials/images/blackbox.png" alt="Black-box likelihood concept illustration" style="width: 360px; max-width: 90%; height: auto;">
     </div>
     """)
     return

--- a/tests/test_main_tutorial_reader_outputs.py
+++ b/tests/test_main_tutorial_reader_outputs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import posixpath
 import re
 from pathlib import Path
 
@@ -24,6 +25,8 @@ MAX_TEXT_OUTPUT_CHARS = 8_000
 MAX_AGGREGATE_TEXT_OUTPUT_CHARS = 45_000
 MAX_TEXT_OUTPUT_COUNT = 120
 IMAGE_DATA_URI = re.compile(r"data:image/[^;]+;base64,[A-Za-z0-9+/=]+")
+HTML_IMAGE_SOURCE = re.compile(r'<img\b[^>]*\bsrc=["\']([^"\']+)["\']', re.I)
+CANONICAL_DOCS_ROOT = "https://lnccbrown.github.io/HSSM/"
 PLOT_OBJECT_REPR = re.compile(
     r"<(?:arviz_plots|matplotlib)\.[^>\n]* at 0x[0-9a-fA-F]+>"
     r"|(?:array\(\[.*)?<Axes(?:Subplot)?[^>]*>",
@@ -172,6 +175,33 @@ def test_plot_object_guard_inspects_text_that_accompanies_images(
     }
 
     assert len(_plot_object_reprs(notebook)) == expected_count
+
+
+@pytest.mark.parametrize("path", TUTORIALS, ids=lambda path: path.stem)
+def test_local_html_images_resolve_from_rendered_tutorial_route(path: Path) -> None:
+    """Resolve local image links from the nested MkDocs notebook route."""
+    notebook = _load_notebook(path)
+    rendered_dir = f"tutorials/{path.stem}"
+    broken: list[tuple[int, str, str]] = []
+
+    for cell_index, cell in enumerate(notebook["cells"]):
+        source = _as_text(cell.get("source"))
+        for image_source in HTML_IMAGE_SOURCE.findall(source):
+            if image_source.startswith(CANONICAL_DOCS_ROOT):
+                rendered_path = image_source.removeprefix(CANONICAL_DOCS_ROOT)
+            elif image_source.startswith(("http://", "https://", "data:", "/", "#")):
+                continue
+            else:
+                rendered_path = posixpath.normpath(
+                    posixpath.join(rendered_dir, image_source)
+                )
+            if (
+                rendered_path.startswith("../")
+                or not (REPO_ROOT / "docs" / rendered_path).is_file()
+            ):
+                broken.append((cell_index, image_source, rendered_path))
+
+    assert broken == [], f"broken rendered-route image links: {broken}"
 
 
 @pytest.mark.parametrize("path", TUTORIALS, ids=lambda path: path.stem)

--- a/tests/test_main_tutorial_reader_outputs.py
+++ b/tests/test_main_tutorial_reader_outputs.py
@@ -85,6 +85,27 @@ def _plot_object_reprs(notebook: dict) -> list[tuple[int, int, str]]:
     return retained
 
 
+def _rendered_docs_image_path(image_source: str, rendered_dir: str) -> str | None:
+    """Return a safe docs-relative image path, or ``None`` for remote content."""
+    if image_source.startswith(CANONICAL_DOCS_ROOT):
+        candidate = image_source.removeprefix(CANONICAL_DOCS_ROOT)
+    elif image_source.startswith(("http://", "https://", "data:", "/", "#")):
+        return None
+    else:
+        candidate = posixpath.join(rendered_dir, image_source)
+
+    if posixpath.isabs(candidate) or ".." in candidate.split("/"):
+        raise ValueError(f"unsafe image path: {candidate}")
+    rendered_path = posixpath.normpath(candidate)
+    if (
+        rendered_path in {"", "."}
+        or posixpath.isabs(rendered_path)
+        or ".." in rendered_path.split("/")
+    ):
+        raise ValueError(f"unsafe image path: {rendered_path}")
+    return rendered_path
+
+
 def _is_sampling_call(expression: ast.Expr) -> bool:
     call = expression.value
     if not isinstance(call, ast.Call):
@@ -187,21 +208,30 @@ def test_local_html_images_resolve_from_rendered_tutorial_route(path: Path) -> N
     for cell_index, cell in enumerate(notebook["cells"]):
         source = _as_text(cell.get("source"))
         for image_source in HTML_IMAGE_SOURCE.findall(source):
-            if image_source.startswith(CANONICAL_DOCS_ROOT):
-                rendered_path = image_source.removeprefix(CANONICAL_DOCS_ROOT)
-            elif image_source.startswith(("http://", "https://", "data:", "/", "#")):
+            try:
+                rendered_path = _rendered_docs_image_path(image_source, rendered_dir)
+            except ValueError:
+                broken.append((cell_index, image_source, "unsafe path"))
                 continue
-            else:
-                rendered_path = posixpath.normpath(
-                    posixpath.join(rendered_dir, image_source)
-                )
-            if (
-                rendered_path.startswith("../")
-                or not (REPO_ROOT / "docs" / rendered_path).is_file()
-            ):
+            if rendered_path is None:
+                continue
+            if not (REPO_ROOT / "docs" / rendered_path).is_file():
                 broken.append((cell_index, image_source, rendered_path))
 
     assert broken == [], f"broken rendered-route image links: {broken}"
+
+
+@pytest.mark.parametrize(
+    "image_source",
+    [
+        f"{CANONICAL_DOCS_ROOT}tutorials/main_tutorial/../../../pyproject.toml",
+        "../images/HSSM_logo.png",
+    ],
+)
+def test_rendered_image_paths_reject_traversal(image_source: str) -> None:
+    """Never allow image checks to escape the tracked docs tree."""
+    with pytest.raises(ValueError, match="unsafe image path"):
+        _rendered_docs_image_path(image_source, "tutorials/main_tutorial")
 
 
 @pytest.mark.parametrize("path", TUTORIALS, ids=lambda path: path.stem)


### PR DESCRIPTION
## Summary

- repair eight scenic-route image links exposed by the post-merge rendered-link check for #1287
- use canonical published asset URLs so the images work both on nested MkDocs routes and when the notebook is viewed directly
- align the scenic tutorial H1 with its navigation label
- add a regression test for rendered tutorial image resolution and reject traversal outside the docs tree
- narrowly exclude the bioRxiv URL that currently rejects automated checks with HTTP 429

The automatic Pages deployment for #1287 succeeded, but manual Docs run [33408625089](https://github.com/lnccbrown/HSSM/actions/runs/33408625089) found eight local image 404s. The intended `/tutorials/images/...` assets are all live and return HTTP 200. No executable notebook source or saved output changed.

## Validation

- `uv run pytest -q tests/test_docs_publication.py tests/test_docs_notebook_paths.py tests/test_main_tutorial_reader_outputs.py` — 39 passed
- `uv run marimo check --strict docs/tutorials/main_tutorial_scenic_route.py`
- targeted Ruff check and format check
- `./scripts/docs.sh build` — strict build passed; publication, notebook-path, weight, and reader-output guards passed
- notebook inspection — 244 executed cells, 34 figures, zero errors, zero path leaks
- all eight canonical image URLs returned HTTP 200
- notebook code, outputs, execution counts, and metadata are unchanged from `main`

Follow-up to #1287 and #1284.
