### PR TITLE
Link list_data from the reference index

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@ This section records the public HSSM interfaces and project metadata. Use the
 
 ## Functions and specialized modules
 
+- [`hssm.list_data`](../api/list_data.md) lists package-supplied datasets.
 - [`hssm.load_data`](../api/load_data.md) loads package-supplied datasets.
 - [`hssm.simulate_data`](../api/simulate_data.md) simulates supported models.
 - [`hssm.show_defaults`](../api/show_defaults.md) inspects model defaults.

--- a/tests/test_docs_public_reference.py
+++ b/tests/test_docs_public_reference.py
@@ -10,6 +10,7 @@ from hssm.modelconfig import get_default_model_config, list_models
 
 ROOT = Path(__file__).parent.parent
 MODEL_REFERENCE = ROOT / "docs/reference/models-and-likelihoods.md"
+REFERENCE_INDEX = ROOT / "docs/reference/index.md"
 
 
 def _code_values(cell: str) -> tuple[str, ...]:
@@ -68,6 +69,13 @@ def test_previously_missing_top_level_apis_are_documented() -> None:
     for relative_path, names in expectations.items():
         contents = (ROOT / relative_path).read_text()
         assert all(name in contents for name in names)
+
+
+def test_dataset_helpers_are_linked_from_reference_index() -> None:
+    """Keep both dataset discovery and loading reachable from the index."""
+    contents = REFERENCE_INDEX.read_text()
+    for target in ("../api/list_data.md", "../api/load_data.md"):
+        assert f"]({target})" in contents
 
 
 def test_onnx_reference_states_the_enforced_contract() -> None:


### PR DESCRIPTION
## Summary

- link `hssm.list_data` from the reference index alongside `hssm.load_data`
- add a focused regression check that keeps both dataset helpers reachable from that index
- keep this follow-up independent of #1290

## Validation

- `pytest -p no:rerunfailures -o addopts='' -q tests/test_docs_public_reference.py` (4 passed)
- `ruff check tests/test_docs_public_reference.py`
- `ruff format --check tests/test_docs_public_reference.py`
- `mkdocs build --strict`

No dependency or version changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `hssm.list_data` to the API reference index.

- **Tests**
  - Added coverage to verify that both dataset helper APIs are linked from the reference index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->