### PR TITLE
Research: isolate hierarchical TruncatedNormal density and parameterization effects

### DIFF
--- a/scripts/truncated_hierarchy_causal_models.py
+++ b/scripts/truncated_hierarchy_causal_models.py
@@ -1,0 +1,552 @@
+"""Same-model parameterizations for the TruncatedNormal causal experiment.
+
+The builders in this module all define the same natural-scale hierarchy::
+
+    group_location ~ TruncatedNormal(base_mean, location_sigma, bounds)
+    group_scale ~ Weibull(1.5, 0.3)
+    group_effect[g] ~ TruncatedNormal(group_location, group_scale, bounds)
+    y[i] ~ Normal(group_effect[group_index[i]], observation_sigma)
+
+Only the coordinates used to represent the two truncated variables change.  This
+lets the #1282 experiment distinguish a density implementation problem from a
+centered-coordinate geometry problem without changing the statistical model.
+
+``manual_centered`` codes the truncated density and bounded-coordinate Jacobian
+explicitly.  The two inverse-CDF parameterizations map standard-Normal offsets
+through ``Phi`` to Uniform quantiles, then use an independent Acklam
+normal-quantile implementation composed only of PyTensor primitives that lower
+to JAX.  No builder samples.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Literal
+
+import numpy as np
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+
+from scripts.truncated_hierarchy_models import (
+    SCALE_PRIOR_ALPHA,
+    SCALE_PRIOR_BETA,
+    Bounds,
+    GeometryContractError,
+    NativeTruncatedPrior,
+    SyntheticHierarchyData,
+)
+
+Parameterization = Literal[
+    "native_centered",
+    "manual_centered",
+    "group_icdf_noncentered",
+    "full_icdf_noncentered",
+]
+
+_LOG_2PI = math.log(2.0 * math.pi)
+_SQRT_2 = math.sqrt(2.0)
+
+# Peter J. Acklam's inverse-normal rational approximation.  Keeping the
+# coefficients here, rather than calling either PyMC's Normal or
+# TruncatedNormal ``icdf``, gives the causal experiment an independent path.
+_ACKLAM_A = (
+    -3.969683028665376e01,
+    2.209460984245205e02,
+    -2.759285104469687e02,
+    1.383577518672690e02,
+    -3.066479806614716e01,
+    2.506628277459239e00,
+)
+_ACKLAM_B = (
+    -5.447609879822406e01,
+    1.615858368580409e02,
+    -1.556989798598866e02,
+    6.680131188771972e01,
+    -1.328068155288572e01,
+)
+_ACKLAM_C = (
+    -7.784894002430293e-03,
+    -3.223964580411365e-01,
+    -2.400758277161838e00,
+    -2.549732539343734e00,
+    4.374664141464968e00,
+    2.938163982698783e00,
+)
+_ACKLAM_D = (
+    7.784695709041462e-03,
+    3.224671290700398e-01,
+    2.445134137142996e00,
+    3.754408661907416e00,
+)
+_ACKLAM_LOW = 0.02425
+
+
+class CausalModelContractError(GeometryContractError):
+    """Raised when an input would make the four models non-isomorphic."""
+
+
+def _constant(value: float) -> Any:
+    """Return a scalar in the active PyTensor floating-point dtype."""
+    return pt.as_tensor_variable(np.asarray(value, dtype=pytensor.config.floatX))
+
+
+def _polyval(coefficients: tuple[float, ...], value: Any) -> Any:
+    result = _constant(coefficients[0])
+    for coefficient in coefficients[1:]:
+        result = result * value + _constant(coefficient)
+    return result
+
+
+def _standard_normal_lower_icdf(
+    probability: Any | None = None,
+    *,
+    log_probability: Any | None = None,
+) -> Any:
+    """Approximate ``Phi^-1(p)`` from ``p`` or ``log(p)`` for ``p <= 0.5``.
+
+    Acklam's tail and central rational approximations avoid ``erfinv`` and
+    ``erfcinv``.  The latter currently lacks a native PyTensor-to-JAX lowering.
+    The log-probability path remains finite when an ordinary probability would
+    underflow.  A Newton step on ``log(Phi(x))`` retains that stability.
+    """
+    if (probability is None) == (log_probability is None):
+        raise CausalModelContractError(
+            "provide exactly one of probability or log_probability"
+        )
+    if log_probability is None:
+        if probability is None:  # pragma: no cover - guarded above
+            raise AssertionError("unreachable missing probability")
+        p = pt.as_tensor_variable(probability)
+        log_p = pt.log(p)
+    else:
+        log_p = pt.as_tensor_variable(log_probability)
+        p = pt.exp(log_p)
+    log_p = pt.minimum(log_p, _constant(math.log(0.5)))
+
+    tail_argument = pt.sqrt(-_constant(2.0) * log_p)
+    tail = _polyval(_ACKLAM_C, tail_argument) / (
+        _polyval(_ACKLAM_D, tail_argument) * tail_argument + _constant(1.0)
+    )
+
+    centered = p - _constant(0.5)
+    squared = centered * centered
+    central = (
+        _polyval(_ACKLAM_A, squared)
+        * centered
+        / (_polyval(_ACKLAM_B, squared) * squared + _constant(1.0))
+    )
+    approximation = pt.switch(
+        pt.lt(log_p, _constant(math.log(_ACKLAM_LOW))), tail, central
+    )
+    # One Newton step brings Acklam's ~1e-9 approximation to floating-point
+    # precision.  Solving in log-CDF space avoids underflow in the far tail.
+    approximation_logcdf = _normal_logcdf(approximation)
+    approximation_logpdf = -_constant(0.5) * approximation * approximation - _constant(
+        0.5 * _LOG_2PI
+    )
+    logcdf_derivative = pt.exp(approximation_logpdf - approximation_logcdf)
+    return approximation - (approximation_logcdf - log_p) / logcdf_derivative
+
+
+def _standard_normal_logcdf_and_logsurvival(value: Any) -> tuple[Any, Any]:
+    """Return log-CDF and log-survival without ordinary-probability underflow."""
+    value = pt.as_tensor_variable(value)
+    return _normal_logcdf(value), _normal_logcdf(-value)
+
+
+def truncated_normal_icdf(
+    quantile: Any,
+    *,
+    mu: Any,
+    sigma: Any,
+    bounds: Bounds,
+    quantile_survival: Any | None = None,
+    log_quantile: Any | None = None,
+    log_quantile_survival: Any | None = None,
+) -> Any:
+    """Map Uniform quantiles to an exact truncated Normal natural variable.
+
+    Both the target CDF and target survival probability are interpolated
+    directly.  Selecting the smaller one before applying the symmetric
+    inverse-normal approximation avoids cancellation in either tail.  ``upper``
+    may be infinite; the causal study deliberately requires a finite lower bound.
+    """
+    if bounds.lower is None:
+        raise CausalModelContractError(
+            "causal TruncatedNormal models require a finite lower bound"
+        )
+    quantile = pt.as_tensor_variable(quantile)
+    mu = pt.as_tensor_variable(mu)
+    sigma = pt.as_tensor_variable(sigma)
+    lower_standard = (_constant(bounds.lower) - mu) / sigma
+    lower_logcdf, lower_logsurvival = _standard_normal_logcdf_and_logsurvival(
+        lower_standard
+    )
+
+    if bounds.upper is None:
+        upper_logcdf = _constant(0.0)
+        upper_logsurvival = _constant(-np.inf)
+    else:
+        upper_standard = (_constant(bounds.upper) - mu) / sigma
+        upper_logcdf, upper_logsurvival = _standard_normal_logcdf_and_logsurvival(
+            upper_standard
+        )
+
+    complement = (
+        _constant(1.0) - quantile
+        if quantile_survival is None
+        else pt.as_tensor_variable(quantile_survival)
+    )
+    log_q = pt.log(quantile) if log_quantile is None else log_quantile
+    log_complement = (
+        pt.log(complement) if log_quantile_survival is None else log_quantile_survival
+    )
+    target_logcdf = pt.logaddexp(
+        log_complement + lower_logcdf,
+        log_q + upper_logcdf,
+    )
+    target_logsurvival = pt.logaddexp(
+        log_complement + lower_logsurvival,
+        log_q + upper_logsurvival,
+    )
+    from_lower = _standard_normal_lower_icdf(log_probability=target_logcdf)
+    from_upper = -_standard_normal_lower_icdf(log_probability=target_logsurvival)
+    standard_value = pt.switch(
+        pt.le(target_logcdf, target_logsurvival), from_lower, from_upper
+    )
+    return mu + sigma * standard_value
+
+
+def _truncated_normal_from_standard_normal(
+    offset: Any,
+    *,
+    mu: Any,
+    sigma: Any,
+    bounds: Bounds,
+) -> Any:
+    """Map a standard-Normal offset through its Uniform CDF to the TN inverse."""
+    log_quantile, log_quantile_survival = _standard_normal_logcdf_and_logsurvival(
+        offset
+    )
+    quantile = pt.exp(log_quantile)
+    quantile_survival = pt.exp(log_quantile_survival)
+    return truncated_normal_icdf(
+        quantile,
+        mu=mu,
+        sigma=sigma,
+        bounds=bounds,
+        quantile_survival=quantile_survival,
+        log_quantile=log_quantile,
+        log_quantile_survival=log_quantile_survival,
+    )
+
+
+def bounded_from_unconstrained(coordinate: Any, bounds: Bounds) -> Any:
+    """Apply the same lower/interval mapping used by PyMC's Interval transform."""
+    if bounds.lower is None:
+        raise CausalModelContractError(
+            "causal TruncatedNormal models require a finite lower bound"
+        )
+    coordinate = pt.as_tensor_variable(coordinate)
+    if bounds.upper is None:
+        return _constant(bounds.lower) + pt.exp(coordinate)
+    width = bounds.width
+    if width is None:  # pragma: no cover - narrowed by the finite upper bound
+        raise CausalModelContractError("finite bounds must have a finite width")
+    return _constant(bounds.lower) + _constant(width) * pt.sigmoid(coordinate)
+
+
+def bounded_log_jacobian(coordinate: Any, bounds: Bounds) -> Any:
+    """Return ``log(abs(dx/dz))`` for :func:`bounded_from_unconstrained`."""
+    if bounds.lower is None:
+        raise CausalModelContractError(
+            "causal TruncatedNormal models require a finite lower bound"
+        )
+    coordinate = pt.as_tensor_variable(coordinate)
+    if bounds.upper is None:
+        return coordinate
+    width = bounds.width
+    if width is None:  # pragma: no cover - narrowed by the finite upper bound
+        raise CausalModelContractError("finite bounds must have a finite width")
+    return (
+        _constant(math.log(width)) - pt.softplus(-coordinate) - pt.softplus(coordinate)
+    )
+
+
+def _normal_logcdf(value: Any) -> Any:
+    """Compute a standard-normal log-CDF without tail underflow."""
+    value = pt.as_tensor_variable(value)
+    scaled = value / _constant(_SQRT_2)
+    # Keep each inactive branch in its numerically safe half-plane.  This also
+    # prevents an overflowing erfcx value from contaminating autodiff through
+    # an elementwise switch.  Explicit switches preserve the selected branch's
+    # one-sided derivative at zero; ``maximum(x, 0)`` would give JAX's 1/2
+    # subgradient there and corrupt the non-centered transform.
+    negative = pt.lt(value, _constant(0.0))
+    tail_argument = pt.switch(negative, -scaled, _constant(0.0))
+    central_argument = pt.switch(negative, _constant(0.0), scaled)
+    tail = (
+        _constant(math.log(0.5))
+        - _constant(0.5) * value * value
+        + pt.log(pt.erfcx(tail_argument))
+    )
+    central = pt.log1p(-_constant(0.5) * pt.erfc(central_argument))
+    return pt.switch(negative, tail, central)
+
+
+def _logdiffexp(log_big: Any, log_small: Any) -> Any:
+    """Compute ``log(exp(big) - exp(small))`` without cancellation."""
+    return log_big + pt.log1mexp(log_small - log_big)
+
+
+def manual_truncated_normal_logp(
+    value: Any,
+    *,
+    mu: Any,
+    sigma: Any,
+    bounds: Bounds,
+) -> Any:
+    """Independently code the normalized truncated-Normal natural log-density."""
+    if bounds.lower is None:
+        raise CausalModelContractError(
+            "causal TruncatedNormal models require a finite lower bound"
+        )
+    value = pt.as_tensor_variable(value)
+    mu = pt.as_tensor_variable(mu)
+    sigma = pt.as_tensor_variable(sigma)
+    lower_standard = (_constant(bounds.lower) - mu) / sigma
+    log_survival_lower = _normal_logcdf(-lower_standard)
+    in_support = pt.gt(value, _constant(bounds.lower))
+
+    if bounds.upper is None:
+        log_normalizer = log_survival_lower
+    else:
+        upper_standard = (_constant(bounds.upper) - mu) / sigma
+        log_cdf_lower = _normal_logcdf(lower_standard)
+        log_cdf_upper = _normal_logcdf(upper_standard)
+        log_survival_upper = _normal_logcdf(-upper_standard)
+        from_cdf = _logdiffexp(log_cdf_upper, log_cdf_lower)
+        from_survival = _logdiffexp(log_survival_lower, log_survival_upper)
+        log_normalizer = pt.switch(
+            pt.ge(lower_standard, _constant(0.0)), from_survival, from_cdf
+        )
+        in_support = in_support & pt.lt(value, _constant(bounds.upper))
+
+    standardized = (value - mu) / sigma
+    logp = (
+        -_constant(0.5) * standardized * standardized
+        - pt.log(sigma)
+        - _constant(0.5 * _LOG_2PI)
+        - log_normalizer
+    )
+    valid = in_support & pt.gt(sigma, _constant(0.0))
+    return pt.switch(valid, logp, _constant(-np.inf))
+
+
+def _validate_inputs(prior: NativeTruncatedPrior, data: SyntheticHierarchyData) -> None:
+    if prior.bounds != data.spec.bounds:
+        raise CausalModelContractError("prior and data bounds must be identical")
+    if prior.bounds.lower is None:
+        raise CausalModelContractError(
+            "causal TruncatedNormal models require a finite lower bound"
+        )
+    if not math.isclose(prior.scale_prior_alpha, SCALE_PRIOR_ALPHA):
+        raise CausalModelContractError(
+            f"group_scale alpha must remain frozen at {SCALE_PRIOR_ALPHA}"
+        )
+    if not math.isclose(prior.scale_prior_beta, SCALE_PRIOR_BETA):
+        raise CausalModelContractError(
+            f"group_scale beta must remain frozen at {SCALE_PRIOR_BETA}"
+        )
+
+
+def _add_group_scale(floatx: str) -> Any:
+    scale_rv = pm.Weibull(
+        "group_scale_rv",
+        alpha=np.asarray(SCALE_PRIOR_ALPHA, dtype=floatx),
+        beta=np.asarray(SCALE_PRIOR_BETA, dtype=floatx),
+    )
+    return pm.Deterministic("group_scale", scale_rv)
+
+
+def _add_likelihood(group_effect: Any, data: SyntheticHierarchyData) -> None:
+    if not data.y.size:
+        return
+    pm.Normal(
+        "y",
+        mu=group_effect[data.group_index],
+        sigma=np.asarray(data.spec.observation_sigma, dtype=data.spec.floatx),
+        observed=data.y,
+        dims="observation",
+    )
+
+
+def _model_coords(data: SyntheticHierarchyData) -> dict[str, Any]:
+    coords: dict[str, Any] = {"group": data.group_labels}
+    if data.y.size:
+        coords["observation"] = np.arange(data.y.size)
+    return coords
+
+
+def build_native_centered(
+    prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> pm.Model:
+    """Build the native centered PyMC reference model."""
+    _validate_inputs(prior, data)
+    lower, upper = prior.bounds.pymc_limits()
+    with pytensor.config.change_flags(floatX=data.spec.floatx):
+        with pm.Model(coords=_model_coords(data)) as model:
+            location_rv = pm.TruncatedNormal(
+                "group_location_rv",
+                mu=np.asarray(prior.location_base_mean, dtype=data.spec.floatx),
+                sigma=np.asarray(prior.location_prior_sigma, dtype=data.spec.floatx),
+                lower=lower,
+                upper=upper,
+            )
+            location = pm.Deterministic("group_location", location_rv)
+            scale = _add_group_scale(data.spec.floatx)
+            effect_rv = pm.TruncatedNormal(
+                "group_effect_rv",
+                mu=location,
+                sigma=scale,
+                lower=lower,
+                upper=upper,
+                dims="group",
+            )
+            effect = pm.Deterministic("group_effect", effect_rv, dims="group")
+            _add_likelihood(effect, data)
+    return model
+
+
+def build_manual_centered(
+    prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> pm.Model:
+    """Build the centered model from Flat coordinates and explicit log-density."""
+    _validate_inputs(prior, data)
+    with pytensor.config.change_flags(floatX=data.spec.floatx):
+        with pm.Model(coords=_model_coords(data)) as model:
+            location_coordinate = pm.Flat("group_location_coordinate")
+            location = pm.Deterministic(
+                "group_location",
+                bounded_from_unconstrained(location_coordinate, prior.bounds),
+            )
+            pm.Potential(
+                "group_location_density",
+                manual_truncated_normal_logp(
+                    location,
+                    mu=np.asarray(prior.location_base_mean, dtype=data.spec.floatx),
+                    sigma=np.asarray(
+                        prior.location_prior_sigma, dtype=data.spec.floatx
+                    ),
+                    bounds=prior.bounds,
+                )
+                + bounded_log_jacobian(location_coordinate, prior.bounds),
+            )
+            scale = _add_group_scale(data.spec.floatx)
+            effect_coordinate = pm.Flat("group_effect_coordinate", dims="group")
+            effect = pm.Deterministic(
+                "group_effect",
+                bounded_from_unconstrained(effect_coordinate, prior.bounds),
+                dims="group",
+            )
+            pm.Potential(
+                "group_effect_density",
+                pt.sum(
+                    manual_truncated_normal_logp(
+                        effect,
+                        mu=location,
+                        sigma=scale,
+                        bounds=prior.bounds,
+                    )
+                    + bounded_log_jacobian(effect_coordinate, prior.bounds)
+                ),
+            )
+            _add_likelihood(effect, data)
+    return model
+
+
+def build_group_icdf_noncentered(
+    prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> pm.Model:
+    """Keep the location centered and inverse-CDF non-center group effects."""
+    _validate_inputs(prior, data)
+    lower, upper = prior.bounds.pymc_limits()
+    with pytensor.config.change_flags(floatX=data.spec.floatx):
+        with pm.Model(coords=_model_coords(data)) as model:
+            location_rv = pm.TruncatedNormal(
+                "group_location_rv",
+                mu=np.asarray(prior.location_base_mean, dtype=data.spec.floatx),
+                sigma=np.asarray(prior.location_prior_sigma, dtype=data.spec.floatx),
+                lower=lower,
+                upper=upper,
+            )
+            location = pm.Deterministic("group_location", location_rv)
+            scale = _add_group_scale(data.spec.floatx)
+            effect_offset = pm.Normal(
+                "group_effect_offset", mu=0.0, sigma=1.0, dims="group"
+            )
+            effect = pm.Deterministic(
+                "group_effect",
+                _truncated_normal_from_standard_normal(
+                    effect_offset,
+                    mu=location,
+                    sigma=scale,
+                    bounds=prior.bounds,
+                ),
+                dims="group",
+            )
+            _add_likelihood(effect, data)
+    return model
+
+
+def build_full_icdf_noncentered(
+    prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> pm.Model:
+    """Inverse-CDF non-center both the location and the group effects."""
+    _validate_inputs(prior, data)
+    with pytensor.config.change_flags(floatX=data.spec.floatx):
+        with pm.Model(coords=_model_coords(data)) as model:
+            location_offset = pm.Normal("group_location_offset", mu=0.0, sigma=1.0)
+            location = pm.Deterministic(
+                "group_location",
+                _truncated_normal_from_standard_normal(
+                    location_offset,
+                    mu=np.asarray(prior.location_base_mean, dtype=data.spec.floatx),
+                    sigma=np.asarray(
+                        prior.location_prior_sigma, dtype=data.spec.floatx
+                    ),
+                    bounds=prior.bounds,
+                ),
+            )
+            scale = _add_group_scale(data.spec.floatx)
+            effect_offset = pm.Normal(
+                "group_effect_offset", mu=0.0, sigma=1.0, dims="group"
+            )
+            effect = pm.Deterministic(
+                "group_effect",
+                _truncated_normal_from_standard_normal(
+                    effect_offset,
+                    mu=location,
+                    sigma=scale,
+                    bounds=prior.bounds,
+                ),
+                dims="group",
+            )
+            _add_likelihood(effect, data)
+    return model
+
+
+def build_causal_model(
+    parameterization: Parameterization,
+    prior: NativeTruncatedPrior,
+    data: SyntheticHierarchyData,
+) -> pm.Model:
+    """Dispatch to one of the four frozen same-natural-model builders."""
+    builders = {
+        "native_centered": build_native_centered,
+        "manual_centered": build_manual_centered,
+        "group_icdf_noncentered": build_group_icdf_noncentered,
+        "full_icdf_noncentered": build_full_icdf_noncentered,
+    }
+    return builders[parameterization](prior, data)

--- a/scripts/truncated_hierarchy_causal_models.py
+++ b/scripts/truncated_hierarchy_causal_models.py
@@ -12,7 +12,7 @@ lets the #1282 experiment distinguish a density implementation problem from a
 centered-coordinate geometry problem without changing the statistical model.
 
 ``manual_centered`` codes the truncated density and bounded-coordinate Jacobian
-explicitly.  The two inverse-CDF parameterizations map standard-Normal offsets
+explicitly.  The three inverse-CDF parameterizations map standard-Normal offsets
 through ``Phi`` to Uniform quantiles, then use an independent Acklam
 normal-quantile implementation composed only of PyTensor primitives that lower
 to JAX.  No builder samples.
@@ -40,6 +40,7 @@ from scripts.truncated_hierarchy_models import (
 Parameterization = Literal[
     "native_centered",
     "manual_centered",
+    "location_icdf_noncentered",
     "group_icdf_noncentered",
     "full_icdf_noncentered",
 ]
@@ -83,7 +84,7 @@ _ACKLAM_LOW = 0.02425
 
 
 class CausalModelContractError(GeometryContractError):
-    """Raised when an input would make the four models non-isomorphic."""
+    """Raised when an input would make the five models non-isomorphic."""
 
 
 def _constant(value: float) -> Any:
@@ -500,6 +501,40 @@ def build_group_icdf_noncentered(
     return model
 
 
+def build_location_icdf_noncentered(
+    prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> pm.Model:
+    """Inverse-CDF non-center the location and keep group effects centered."""
+    _validate_inputs(prior, data)
+    lower, upper = prior.bounds.pymc_limits()
+    with pytensor.config.change_flags(floatX=data.spec.floatx):
+        with pm.Model(coords=_model_coords(data)) as model:
+            location_offset = pm.Normal("group_location_offset", mu=0.0, sigma=1.0)
+            location = pm.Deterministic(
+                "group_location",
+                _truncated_normal_from_standard_normal(
+                    location_offset,
+                    mu=np.asarray(prior.location_base_mean, dtype=data.spec.floatx),
+                    sigma=np.asarray(
+                        prior.location_prior_sigma, dtype=data.spec.floatx
+                    ),
+                    bounds=prior.bounds,
+                ),
+            )
+            scale = _add_group_scale(data.spec.floatx)
+            effect_rv = pm.TruncatedNormal(
+                "group_effect_rv",
+                mu=location,
+                sigma=scale,
+                lower=lower,
+                upper=upper,
+                dims="group",
+            )
+            effect = pm.Deterministic("group_effect", effect_rv, dims="group")
+            _add_likelihood(effect, data)
+    return model
+
+
 def build_full_icdf_noncentered(
     prior: NativeTruncatedPrior, data: SyntheticHierarchyData
 ) -> pm.Model:
@@ -542,10 +577,11 @@ def build_causal_model(
     prior: NativeTruncatedPrior,
     data: SyntheticHierarchyData,
 ) -> pm.Model:
-    """Dispatch to one of the four frozen same-natural-model builders."""
+    """Dispatch to one of the five same-natural-model builders."""
     builders = {
         "native_centered": build_native_centered,
         "manual_centered": build_manual_centered,
+        "location_icdf_noncentered": build_location_icdf_noncentered,
         "group_icdf_noncentered": build_group_icdf_noncentered,
         "full_icdf_noncentered": build_full_icdf_noncentered,
     }

--- a/scripts/truncated_hierarchy_causal_oracle.py
+++ b/scripts/truncated_hierarchy_causal_oracle.py
@@ -1,0 +1,763 @@
+"""Independent second-order oracle for truncated-hierarchy log densities.
+
+This module is deliberately isolated from PyMC, PyTensor, JAX, Bambi, and the
+qualification model builders.  It implements a tiny forward-mode, second-order
+``Jet2`` scalar and uses only :mod:`numpy` and :mod:`scipy` special functions.
+That makes it suitable as an independent reference when deciding whether a
+transformed PyMC graph has the same value, gradient, and curvature as the
+mathematical hierarchical TruncatedNormal posterior.
+
+The canonical coordinate order is always location, log scale, then group
+effects.  The centered variant uses bounded coordinates for location and group
+effects.  Group inverse-CDF non-centering replaces the group coordinates with
+standard-Normal offsets; full inverse-CDF non-centering replaces the location
+coordinate as well.  Every actual constrained free-variable transform includes
+its log absolute Jacobian in the returned posterior.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+import numpy as np
+from scipy.special import expit, log_ndtr, ndtr, ndtri, ndtri_exp
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, NDArray
+
+LOG_2PI = math.log(2.0 * math.pi)
+LOG_SQRT_2PI = 0.5 * LOG_2PI
+
+type CausalParameterization = Literal[
+    "centered",
+    "group_icdf_noncentered",
+    "full_icdf_noncentered",
+]
+
+
+class OracleDomainError(ValueError):
+    """Raised when the oracle is evaluated outside its mathematical domain."""
+
+
+@dataclass(frozen=True, slots=True)
+class Jet2:
+    """Value, gradient, and Hessian of one scalar expression.
+
+    ``Jet2`` is intentionally small rather than a general automatic
+    differentiation system.  Its arithmetic is sufficient for the probability
+    densities and transforms in this module, and keeping it local makes the
+    reference independent of the differentiation stacks under investigation.
+    """
+
+    value: float
+    gradient: NDArray[np.float64]
+    hessian: NDArray[np.float64]
+
+    __array_priority__: ClassVar[float] = 1000.0
+
+    def __post_init__(self) -> None:
+        """Validate and detach derivative arrays from caller-owned storage."""
+        value = float(self.value)
+        gradient = np.array(self.gradient, dtype=np.float64, copy=True)
+        hessian = np.array(self.hessian, dtype=np.float64, copy=True)
+        if gradient.ndim != 1:
+            raise ValueError("a Jet2 gradient must be one-dimensional")
+        expected_shape = (gradient.size, gradient.size)
+        if hessian.shape != expected_shape:
+            raise ValueError(
+                f"a Jet2 Hessian must have shape {expected_shape}, got {hessian.shape}"
+            )
+        gradient.setflags(write=False)
+        hessian.setflags(write=False)
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "gradient", gradient)
+        object.__setattr__(self, "hessian", hessian)
+
+    @property
+    def dimension(self) -> int:
+        """Return the number of independent coordinates represented."""
+        return self.gradient.size
+
+    @classmethod
+    def constant(cls, value: float, dimension: int) -> Jet2:
+        """Construct a constant in a derivative space of ``dimension``."""
+        if isinstance(dimension, bool) or not isinstance(dimension, int):
+            raise TypeError("dimension must be an integer")
+        if dimension < 0:
+            raise ValueError("dimension must be non-negative")
+        return cls(
+            float(value),
+            np.zeros(dimension, dtype=np.float64),
+            np.zeros((dimension, dimension), dtype=np.float64),
+        )
+
+    @classmethod
+    def variable(cls, value: float, index: int, dimension: int) -> Jet2:
+        """Construct one independent variable in a derivative space."""
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise TypeError("index must be an integer")
+        if index < 0 or index >= dimension:
+            raise ValueError("variable index must lie inside the derivative space")
+        gradient = np.zeros(dimension, dtype=np.float64)
+        gradient[index] = 1.0
+        return cls(
+            float(value),
+            gradient,
+            np.zeros((dimension, dimension), dtype=np.float64),
+        )
+
+    def _coerce(self, other: float | Jet2) -> Jet2:
+        """Promote a numeric constant and enforce compatible jet dimensions."""
+        if isinstance(other, Jet2):
+            if other.dimension != self.dimension:
+                raise ValueError("Jet2 operands have different dimensions")
+            return other
+        return Jet2.constant(float(other), self.dimension)
+
+    def compose(self, value: float, first: float, second: float) -> Jet2:
+        """Apply a scalar unary function from its first two derivatives."""
+        gradient = first * self.gradient
+        hessian = first * self.hessian + second * np.outer(self.gradient, self.gradient)
+        return Jet2(value, gradient, hessian)
+
+    def __neg__(self) -> Jet2:
+        """Negate value and derivatives."""
+        return Jet2(-self.value, -self.gradient, -self.hessian)
+
+    def __add__(self, other: float | Jet2) -> Jet2:
+        """Add a scalar or compatible jet."""
+        right = self._coerce(other)
+        return Jet2(
+            self.value + right.value,
+            self.gradient + right.gradient,
+            self.hessian + right.hessian,
+        )
+
+    def __radd__(self, other: float | Jet2) -> Jet2:
+        """Add this jet to a left-hand scalar or compatible jet."""
+        return self + other
+
+    def __sub__(self, other: float | Jet2) -> Jet2:
+        """Subtract a scalar or compatible jet."""
+        return self + (-self._coerce(other))
+
+    def __rsub__(self, other: float | Jet2) -> Jet2:
+        """Subtract this jet from a left-hand scalar or compatible jet."""
+        return self._coerce(other) - self
+
+    def __mul__(self, other: float | Jet2) -> Jet2:
+        """Multiply by a scalar or compatible jet."""
+        right = self._coerce(other)
+        hessian = (
+            right.value * self.hessian
+            + self.value * right.hessian
+            + np.outer(self.gradient, right.gradient)
+            + np.outer(right.gradient, self.gradient)
+        )
+        return Jet2(
+            self.value * right.value,
+            right.value * self.gradient + self.value * right.gradient,
+            hessian,
+        )
+
+    def __rmul__(self, other: float | Jet2) -> Jet2:
+        """Multiply this jet by a left-hand scalar or compatible jet."""
+        return self * other
+
+    def reciprocal(self) -> Jet2:
+        """Return the multiplicative inverse."""
+        if self.value == 0.0:
+            raise OracleDomainError("cannot divide by zero")
+        inverse = 1.0 / self.value
+        return self.compose(inverse, -(inverse**2), 2.0 * inverse**3)
+
+    def __truediv__(self, other: float | Jet2) -> Jet2:
+        """Divide by a scalar or compatible jet."""
+        return self * self._coerce(other).reciprocal()
+
+    def __rtruediv__(self, other: float | Jet2) -> Jet2:
+        """Divide a left-hand scalar or compatible jet by this jet."""
+        return self._coerce(other) * self.reciprocal()
+
+    def __pow__(self, exponent: float) -> Jet2:
+        """Raise this jet to a constant real power."""
+        if not isinstance(exponent, (int, float)) or isinstance(exponent, bool):
+            raise TypeError("Jet2 only supports constant real exponents")
+        power = float(exponent)
+        if self.value == 0.0 and power < 0.0:
+            raise OracleDomainError("a negative power requires a nonzero base")
+        if self.value <= 0.0 and not power.is_integer():
+            raise OracleDomainError("a non-integer Jet2 power requires a positive base")
+        value = self.value**power
+        if power == 0.0:
+            return Jet2.constant(1.0, self.dimension)
+        if power == 1.0:
+            return self
+        first = power * self.value ** (power - 1.0)
+        second = power * (power - 1.0) * self.value ** (power - 2.0)
+        return self.compose(value, first, second)
+
+
+def seed_jets(values: ArrayLike) -> tuple[Jet2, ...]:
+    """Seed one independent ``Jet2`` for each value in a one-dimensional vector."""
+    point = np.asarray(values, dtype=np.float64)
+    if point.ndim != 1:
+        raise ValueError("jet seed values must be one-dimensional")
+    if not np.all(np.isfinite(point)):
+        raise ValueError("jet seed values must all be finite")
+    return tuple(
+        Jet2.variable(float(value), index, point.size)
+        for index, value in enumerate(point)
+    )
+
+
+def _promote(*values: float | Jet2) -> tuple[Jet2, ...]:
+    """Promote scalars into the single derivative space present in ``values``."""
+    dimensions = {value.dimension for value in values if isinstance(value, Jet2)}
+    if len(dimensions) > 1:
+        raise ValueError("Jet2 operands have different dimensions")
+    dimension = next(iter(dimensions), 0)
+    return tuple(
+        value if isinstance(value, Jet2) else Jet2.constant(float(value), dimension)
+        for value in values
+    )
+
+
+def jet_exp(value: Jet2) -> Jet2:
+    """Exponentiate a jet."""
+    result = math.exp(value.value)
+    return value.compose(result, result, result)
+
+
+def jet_log(value: Jet2) -> Jet2:
+    """Take a natural logarithm of a positive jet."""
+    if value.value <= 0.0:
+        raise OracleDomainError("logarithm requires a positive value")
+    inverse = 1.0 / value.value
+    return value.compose(math.log(value.value), inverse, -(inverse**2))
+
+
+def jet_sigmoid(value: Jet2) -> Jet2:
+    """Evaluate a numerically stable logistic sigmoid."""
+    result = float(expit(value.value))
+    first = result * (1.0 - result)
+    second = first * (1.0 - 2.0 * result)
+    return value.compose(result, first, second)
+
+
+def jet_softplus(value: Jet2) -> Jet2:
+    """Evaluate ``log(1 + exp(value))`` without overflow."""
+    result = float(np.logaddexp(0.0, value.value))
+    first = float(expit(value.value))
+    return value.compose(result, first, first * (1.0 - first))
+
+
+def jet_log_ndtr(value: Jet2) -> Jet2:
+    """Evaluate the standard-normal log CDF and its first two derivatives."""
+    result = float(log_ndtr(value.value))
+    log_density = -0.5 * value.value**2 - LOG_SQRT_2PI
+    inverse_mills = math.exp(log_density - result)
+    second = -inverse_mills * (value.value + inverse_mills)
+    return value.compose(result, inverse_mills, second)
+
+
+def jet_ndtr(value: Jet2) -> Jet2:
+    """Evaluate the standard-normal CDF and its first two derivatives."""
+    result = float(ndtr(value.value))
+    density = math.exp(-0.5 * value.value**2 - LOG_SQRT_2PI)
+    return value.compose(result, density, -value.value * density)
+
+
+def jet_ndtri(value: Jet2) -> Jet2:
+    """Evaluate the standard-normal quantile and its first two derivatives."""
+    if not 0.0 < value.value < 1.0:
+        raise OracleDomainError("normal quantile requires a probability in (0, 1)")
+    result = float(ndtri(value.value))
+    inverse_density = math.exp(0.5 * result**2 + LOG_SQRT_2PI)
+    return value.compose(
+        result,
+        inverse_density,
+        result * inverse_density**2,
+    )
+
+
+def jet_ndtri_exp(log_probability: Jet2) -> Jet2:
+    """Invert a standard-normal log CDF without exponentiating its value."""
+    if not log_probability.value < 0.0:
+        raise OracleDomainError("normal log-quantile requires a value below zero")
+    result = float(ndtri_exp(log_probability.value))
+    log_density = -0.5 * result**2 - LOG_SQRT_2PI
+    first = math.exp(log_probability.value - log_density)
+    second = first * (1.0 + result * first)
+    return log_probability.compose(result, first, second)
+
+
+def jet_log1mexp(value: Jet2) -> Jet2:
+    """Evaluate ``log(1 - exp(value))`` stably for a negative jet."""
+    if value.value >= 0.0:
+        raise OracleDomainError("log1mexp requires a strictly negative value")
+    if value.value < -math.log(2.0):
+        result = math.log1p(-math.exp(value.value))
+    else:
+        result = math.log(-math.expm1(value.value))
+    exponential = math.exp(value.value)
+    denominator = -math.expm1(value.value)
+    first = -exponential / denominator
+    second = -exponential / denominator**2
+    return value.compose(result, first, second)
+
+
+def jet_logdiffexp(larger: Jet2, smaller: Jet2) -> Jet2:
+    """Return ``log(exp(larger) - exp(smaller))`` without cancellation."""
+    if larger.dimension != smaller.dimension:
+        raise ValueError("Jet2 operands have different dimensions")
+    if not larger.value > smaller.value:
+        raise OracleDomainError("logdiffexp requires larger > smaller")
+    return larger + jet_log1mexp(smaller - larger)
+
+
+def jet_logaddexp(left: Jet2, right: Jet2) -> Jet2:
+    """Return ``log(exp(left) + exp(right))`` without overflow."""
+    if left.dimension != right.dimension:
+        raise ValueError("Jet2 operands have different dimensions")
+    if left.value >= right.value:
+        return left + jet_softplus(right - left)
+    return right + jet_softplus(left - right)
+
+
+@dataclass(frozen=True, slots=True)
+class TruncationBounds:
+    """One- or two-sided open support used by a TruncatedNormal."""
+
+    lower: float | None
+    upper: float | None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize support limits."""
+        lower = None if self.lower is None else float(self.lower)
+        upper = None if self.upper is None else float(self.upper)
+        if lower is not None and not math.isfinite(lower):
+            raise ValueError("lower must be finite or None")
+        if upper is not None and not math.isfinite(upper):
+            raise ValueError("upper must be finite or None")
+        if lower is None and upper is None:
+            raise ValueError("at least one truncation bound is required")
+        if lower is not None and upper is not None and not lower < upper:
+            raise ValueError("finite bounds must satisfy lower < upper")
+        object.__setattr__(self, "lower", lower)
+        object.__setattr__(self, "upper", upper)
+
+    def contains(self, value: float) -> bool:
+        """Return whether ``value`` lies strictly within the open support."""
+        if not math.isfinite(value):
+            return False
+        if self.lower is not None and value <= self.lower:
+            return False
+        return self.upper is None or value < self.upper
+
+
+@dataclass(frozen=True, slots=True)
+class TransformedValue:
+    """Natural value and log absolute Jacobian of a scalar transform."""
+
+    natural: Jet2
+    log_abs_det_jacobian: Jet2
+
+
+def support_transform(
+    unconstrained: Jet2, bounds: TruncationBounds
+) -> TransformedValue:
+    """Map an unconstrained jet into lower, upper, or finite support."""
+    lower = bounds.lower
+    upper = bounds.upper
+    if lower is not None and upper is None:
+        distance = jet_exp(unconstrained)
+        return TransformedValue(lower + distance, unconstrained)
+    if lower is None and upper is not None:
+        distance = jet_exp(unconstrained)
+        return TransformedValue(upper - distance, unconstrained)
+    if lower is None or upper is None:  # pragma: no cover - validated bounds
+        raise AssertionError("unreachable invalid bounds")
+    width = upper - lower
+    fraction = jet_sigmoid(unconstrained)
+    log_jacobian = (
+        math.log(width) - jet_softplus(-unconstrained) - jet_softplus(unconstrained)
+    )
+    return TransformedValue(lower + width * fraction, log_jacobian)
+
+
+def support_inverse(natural: float, bounds: TruncationBounds) -> float:
+    """Map an interior natural value back to its unconstrained coordinate."""
+    value = float(natural)
+    if not bounds.contains(value):
+        raise OracleDomainError("natural value must lie strictly inside support")
+    if bounds.lower is not None and bounds.upper is None:
+        return math.log(value - bounds.lower)
+    if bounds.lower is None and bounds.upper is not None:
+        return math.log(bounds.upper - value)
+    if bounds.lower is None or bounds.upper is None:  # pragma: no cover
+        raise AssertionError("unreachable invalid bounds")
+    return math.log(value - bounds.lower) - math.log(bounds.upper - value)
+
+
+def positive_transform(unconstrained: Jet2) -> TransformedValue:
+    """Map an unconstrained jet to the positive reals with an exponential."""
+    return TransformedValue(jet_exp(unconstrained), unconstrained)
+
+
+def positive_inverse(natural: float) -> float:
+    """Map a positive natural value back to its log coordinate."""
+    value = float(natural)
+    if not math.isfinite(value) or value <= 0.0:
+        raise OracleDomainError("positive inverse requires a positive finite value")
+    return math.log(value)
+
+
+def normal_logpdf(
+    value: float | Jet2,
+    location: float | Jet2,
+    scale: float | Jet2,
+) -> Jet2:
+    """Return a Normal log density including its normalization constant."""
+    value_jet, location_jet, scale_jet = _promote(value, location, scale)
+    if scale_jet.value <= 0.0:
+        raise OracleDomainError("Normal scale must be positive")
+    standardized = (value_jet - location_jet) / scale_jet
+    return -0.5 * standardized**2 - jet_log(scale_jet) - LOG_SQRT_2PI
+
+
+def weibull_logpdf(
+    value: float | Jet2,
+    shape: float,
+    scale: float,
+) -> Jet2:
+    """Return the Weibull log density in SciPy/PyMC shape-scale form."""
+    value_jet = _promote(value)[0]
+    shape_value = float(shape)
+    scale_value = float(scale)
+    if value_jet.value <= 0.0:
+        raise OracleDomainError("Weibull value must be positive")
+    if not math.isfinite(shape_value) or shape_value <= 0.0:
+        raise OracleDomainError("Weibull shape must be positive and finite")
+    if not math.isfinite(scale_value) or scale_value <= 0.0:
+        raise OracleDomainError("Weibull scale must be positive and finite")
+    ratio = value_jet / scale_value
+    return (
+        math.log(shape_value)
+        - math.log(scale_value)
+        + (shape_value - 1.0) * jet_log(ratio)
+        - jet_exp(shape_value * jet_log(ratio))
+    )
+
+
+def truncated_normal_log_normalizer(
+    location: float | Jet2,
+    scale: float | Jet2,
+    bounds: TruncationBounds,
+) -> Jet2:
+    """Return ``log(Phi(beta) - Phi(alpha))`` with tail-stable branches."""
+    location_jet, scale_jet = _promote(location, scale)
+    if scale_jet.value <= 0.0:
+        raise OracleDomainError("TruncatedNormal scale must be positive")
+    alpha = None if bounds.lower is None else (bounds.lower - location_jet) / scale_jet
+    beta = None if bounds.upper is None else (bounds.upper - location_jet) / scale_jet
+    if alpha is None:
+        if beta is None:  # pragma: no cover - validated bounds
+            raise AssertionError("unreachable invalid bounds")
+        return jet_log_ndtr(beta)
+    if beta is None:
+        return jet_log_ndtr(-alpha)
+
+    # In the positive tail, subtract survival probabilities.  Elsewhere,
+    # subtract CDFs.  This avoids the catastrophic 1 - Phi(x) cancellation.
+    if alpha.value >= 0.0:
+        return jet_logdiffexp(jet_log_ndtr(-alpha), jet_log_ndtr(-beta))
+    return jet_logdiffexp(jet_log_ndtr(beta), jet_log_ndtr(alpha))
+
+
+def truncated_normal_logpdf(
+    value: float | Jet2,
+    location: float | Jet2,
+    scale: float | Jet2,
+    bounds: TruncationBounds,
+) -> Jet2:
+    """Return a normalized TruncatedNormal log density on open support."""
+    value_jet, location_jet, scale_jet = _promote(value, location, scale)
+    if not bounds.contains(value_jet.value):
+        raise OracleDomainError("TruncatedNormal value lies outside open support")
+    return normal_logpdf(value_jet, location_jet, scale_jet) - (
+        truncated_normal_log_normalizer(location_jet, scale_jet, bounds)
+    )
+
+
+def truncated_normal_from_standard_normal(
+    offset: float | Jet2,
+    location: float | Jet2,
+    scale: float | Jet2,
+    bounds: TruncationBounds,
+) -> Jet2:
+    """Map a standard-Normal offset through the exact TN inverse CDF.
+
+    The target log CDF and log survival probability are formed independently,
+    and the smaller probability is inverted directly from log space.  This
+    avoids both ``1 - Phi(x)`` cancellation and ordinary-probability underflow
+    while retaining exact second-order dependence on location, scale, and
+    offset.
+    """
+    offset_jet, location_jet, scale_jet = _promote(offset, location, scale)
+    if scale_jet.value <= 0.0:
+        raise OracleDomainError("TruncatedNormal scale must be positive")
+
+    alpha = None if bounds.lower is None else (bounds.lower - location_jet) / scale_jet
+    beta = None if bounds.upper is None else (bounds.upper - location_jet) / scale_jet
+    log_quantile = jet_log_ndtr(offset_jet)
+    log_quantile_survival = jet_log_ndtr(-offset_jet)
+
+    if alpha is None:
+        if beta is None:  # pragma: no cover - validated bounds
+            raise AssertionError("unreachable invalid bounds")
+        log_target_cdf = log_quantile + jet_log_ndtr(beta)
+        log_target_survival = jet_logaddexp(
+            log_quantile_survival,
+            log_quantile + jet_log_ndtr(-beta),
+        )
+    elif beta is None:
+        log_target_cdf = jet_logaddexp(
+            log_quantile_survival + jet_log_ndtr(alpha),
+            log_quantile,
+        )
+        log_target_survival = log_quantile_survival + jet_log_ndtr(-alpha)
+    else:
+        log_target_cdf = jet_logaddexp(
+            log_quantile_survival + jet_log_ndtr(alpha),
+            log_quantile + jet_log_ndtr(beta),
+        )
+        log_target_survival = jet_logaddexp(
+            log_quantile_survival + jet_log_ndtr(-alpha),
+            log_quantile + jet_log_ndtr(-beta),
+        )
+
+    if log_target_cdf.value <= log_target_survival.value:
+        standardized = jet_ndtri_exp(log_target_cdf)
+    else:
+        standardized = -jet_ndtri_exp(log_target_survival)
+    natural = location_jet + scale_jet * standardized
+    if not bounds.contains(natural.value):
+        raise OracleDomainError(
+            "finite precision put the TN inverse-CDF value on its boundary"
+        )
+    return natural
+
+
+@dataclass(frozen=True, slots=True)
+class HierarchicalPosteriorSpec:
+    """Natural-scale constants for the centered hierarchical posterior."""
+
+    bounds: TruncationBounds
+    location_base_mean: float
+    location_prior_scale: float
+    scale_prior_shape: float
+    scale_prior_scale: float
+    n_groups: int
+    group_index: NDArray[np.int64]
+    observations: NDArray[np.float64]
+    observation_scale: float
+
+    def __post_init__(self) -> None:
+        """Validate and detach the complete posterior specification."""
+        if isinstance(self.n_groups, bool) or not isinstance(self.n_groups, int):
+            raise TypeError("n_groups must be an integer")
+        if self.n_groups <= 0:
+            raise ValueError("n_groups must be positive")
+        numeric_constants = {
+            "location_base_mean": self.location_base_mean,
+            "location_prior_scale": self.location_prior_scale,
+            "scale_prior_shape": self.scale_prior_shape,
+            "scale_prior_scale": self.scale_prior_scale,
+            "observation_scale": self.observation_scale,
+        }
+        for name, raw_value in numeric_constants.items():
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+            if name != "location_base_mean" and value <= 0.0:
+                raise ValueError(f"{name} must be positive")
+            object.__setattr__(self, name, value)
+
+        raw_index = np.asarray(self.group_index)
+        if raw_index.ndim != 1 or not np.issubdtype(raw_index.dtype, np.integer):
+            raise ValueError("group_index must be a one-dimensional integer array")
+        group_index = np.array(raw_index, dtype=np.int64, copy=True)
+        observations = np.array(self.observations, dtype=np.float64, copy=True)
+        if observations.ndim != 1:
+            raise ValueError("observations must be one-dimensional")
+        if group_index.size != observations.size:
+            raise ValueError("group_index and observations must have equal length")
+        if np.any(group_index < 0) or np.any(group_index >= self.n_groups):
+            raise ValueError("group_index contains an out-of-range group")
+        if not np.all(np.isfinite(observations)):
+            raise ValueError("observations must all be finite")
+        group_index.setflags(write=False)
+        observations.setflags(write=False)
+        object.__setattr__(self, "group_index", group_index)
+        object.__setattr__(self, "observations", observations)
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorComponents:
+    """Separate transformed-space terms and their summed log posterior."""
+
+    location_prior: Jet2
+    scale_prior: Jet2
+    group_prior: Jet2
+    likelihood: Jet2
+    transform_log_jacobian: Jet2
+
+    @property
+    def total(self) -> Jet2:
+        """Return the complete transformed-coordinate log posterior."""
+        return (
+            self.location_prior
+            + self.scale_prior
+            + self.group_prior
+            + self.likelihood
+            + self.transform_log_jacobian
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NaturalHierarchy:
+    """Natural variables induced by one causal parameterization."""
+
+    parameterization: CausalParameterization
+    location: Jet2
+    scale: Jet2
+    group_effect: tuple[Jet2, ...]
+    free_rv_log_jacobian: Jet2
+
+
+def hierarchical_natural_values(
+    transformed_point: ArrayLike,
+    spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization = "centered",
+) -> NaturalHierarchy:
+    """Map a frozen causal-coordinate vector to the common natural hierarchy."""
+    point = np.asarray(transformed_point, dtype=np.float64)
+    expected_dimension = spec.n_groups + 2
+    if point.shape != (expected_dimension,):
+        raise ValueError(
+            f"transformed_point must have shape ({expected_dimension},), "
+            f"got {point.shape}"
+        )
+    if parameterization not in {
+        "centered",
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }:
+        raise ValueError(f"unknown causal parameterization {parameterization!r}")
+
+    coordinates = seed_jets(point)
+    scale_transform = positive_transform(coordinates[1])
+    free_rv_log_jacobian = scale_transform.log_abs_det_jacobian
+
+    if parameterization == "full_icdf_noncentered":
+        location = truncated_normal_from_standard_normal(
+            coordinates[0],
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            spec.bounds,
+        )
+    else:
+        location_transform = support_transform(coordinates[0], spec.bounds)
+        location = location_transform.natural
+        free_rv_log_jacobian += location_transform.log_abs_det_jacobian
+
+    if parameterization == "centered":
+        group_transforms = tuple(
+            support_transform(coordinate, spec.bounds) for coordinate in coordinates[2:]
+        )
+        group_effect = tuple(item.natural for item in group_transforms)
+        for transformed_group in group_transforms:
+            free_rv_log_jacobian += transformed_group.log_abs_det_jacobian
+    else:
+        group_effect = tuple(
+            truncated_normal_from_standard_normal(
+                offset,
+                location,
+                scale_transform.natural,
+                spec.bounds,
+            )
+            for offset in coordinates[2:]
+        )
+
+    return NaturalHierarchy(
+        parameterization=parameterization,
+        location=location,
+        scale=scale_transform.natural,
+        group_effect=group_effect,
+        free_rv_log_jacobian=free_rv_log_jacobian,
+    )
+
+
+def hierarchical_posterior_components(
+    transformed_point: ArrayLike,
+    spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization = "centered",
+) -> PosteriorComponents:
+    """Evaluate one same-model hierarchy in sampler-visible coordinates.
+
+    Coordinate order is always location, log scale, then one coordinate per
+    group.  Centered coordinates use the bounded support transform.  Group-NC
+    replaces group coordinates with standard-Normal offsets; full-NC also
+    replaces the location coordinate.  The return value keeps probability terms
+    separate so a mismatch can be localized before inspecting the total.
+    """
+    point = np.asarray(transformed_point, dtype=np.float64)
+    natural = hierarchical_natural_values(point, spec, parameterization)
+    expected_dimension = point.size
+    coordinates = seed_jets(point)
+
+    if parameterization == "full_icdf_noncentered":
+        location_prior = normal_logpdf(coordinates[0], 0.0, 1.0)
+    else:
+        location_prior = truncated_normal_logpdf(
+            natural.location,
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            spec.bounds,
+        )
+    scale_prior = weibull_logpdf(
+        natural.scale,
+        spec.scale_prior_shape,
+        spec.scale_prior_scale,
+    )
+    group_prior = Jet2.constant(0.0, expected_dimension)
+    if parameterization == "centered":
+        for group_effect in natural.group_effect:
+            group_prior += truncated_normal_logpdf(
+                group_effect,
+                natural.location,
+                natural.scale,
+                spec.bounds,
+            )
+    else:
+        for offset in coordinates[2:]:
+            group_prior += normal_logpdf(offset, 0.0, 1.0)
+
+    likelihood = Jet2.constant(0.0, expected_dimension)
+    for observation, group in zip(spec.observations, spec.group_index, strict=True):
+        likelihood += normal_logpdf(
+            float(observation),
+            natural.group_effect[int(group)],
+            spec.observation_scale,
+        )
+
+    return PosteriorComponents(
+        location_prior=location_prior,
+        scale_prior=scale_prior,
+        group_prior=group_prior,
+        likelihood=likelihood,
+        transform_log_jacobian=natural.free_rv_log_jacobian,
+    )

--- a/scripts/truncated_hierarchy_causal_oracle.py
+++ b/scripts/truncated_hierarchy_causal_oracle.py
@@ -9,10 +9,11 @@ mathematical hierarchical TruncatedNormal posterior.
 
 The canonical coordinate order is always location, log scale, then group
 effects.  The centered variant uses bounded coordinates for location and group
-effects.  Group inverse-CDF non-centering replaces the group coordinates with
-standard-Normal offsets; full inverse-CDF non-centering replaces the location
-coordinate as well.  Every actual constrained free-variable transform includes
-its log absolute Jacobian in the returned posterior.
+effects.  Location inverse-CDF non-centering replaces only the location
+coordinate with a standard-Normal offset; group inverse-CDF non-centering
+replaces only the group coordinates; full inverse-CDF non-centering replaces
+both.  Every actual constrained free-variable transform includes its log
+absolute Jacobian in the returned posterior.
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ LOG_SQRT_2PI = 0.5 * LOG_2PI
 
 type CausalParameterization = Literal[
     "centered",
+    "location_icdf_noncentered",
     "group_icdf_noncentered",
     "full_icdf_noncentered",
 ]
@@ -653,6 +655,7 @@ def hierarchical_natural_values(
         )
     if parameterization not in {
         "centered",
+        "location_icdf_noncentered",
         "group_icdf_noncentered",
         "full_icdf_noncentered",
     }:
@@ -662,7 +665,16 @@ def hierarchical_natural_values(
     scale_transform = positive_transform(coordinates[1])
     free_rv_log_jacobian = scale_transform.log_abs_det_jacobian
 
-    if parameterization == "full_icdf_noncentered":
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+
+    if location_noncentered:
         location = truncated_normal_from_standard_normal(
             coordinates[0],
             spec.location_base_mean,
@@ -674,7 +686,7 @@ def hierarchical_natural_values(
         location = location_transform.natural
         free_rv_log_jacobian += location_transform.log_abs_det_jacobian
 
-    if parameterization == "centered":
+    if not group_noncentered:
         group_transforms = tuple(
             support_transform(coordinate, spec.bounds) for coordinate in coordinates[2:]
         )
@@ -709,17 +721,27 @@ def hierarchical_posterior_components(
     """Evaluate one same-model hierarchy in sampler-visible coordinates.
 
     Coordinate order is always location, log scale, then one coordinate per
-    group.  Centered coordinates use the bounded support transform.  Group-NC
-    replaces group coordinates with standard-Normal offsets; full-NC also
-    replaces the location coordinate.  The return value keeps probability terms
-    separate so a mismatch can be localized before inspecting the total.
+    group.  Centered coordinates use the bounded support transform.  Location-NC
+    replaces the location coordinate with a standard-Normal offset; group-NC
+    replaces the group coordinates; full-NC replaces both.  The return value
+    keeps probability terms separate so a mismatch can be localized before
+    inspecting the total.
     """
     point = np.asarray(transformed_point, dtype=np.float64)
     natural = hierarchical_natural_values(point, spec, parameterization)
     expected_dimension = point.size
     coordinates = seed_jets(point)
 
-    if parameterization == "full_icdf_noncentered":
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+
+    if location_noncentered:
         location_prior = normal_logpdf(coordinates[0], 0.0, 1.0)
     else:
         location_prior = truncated_normal_logpdf(
@@ -734,7 +756,7 @@ def hierarchical_posterior_components(
         spec.scale_prior_scale,
     )
     group_prior = Jet2.constant(0.0, expected_dimension)
-    if parameterization == "centered":
+    if not group_noncentered:
         for group_effect in natural.group_effect:
             group_prior += truncated_normal_logpdf(
                 group_effect,

--- a/tests/test_truncated_hierarchy_causal_models.py
+++ b/tests/test_truncated_hierarchy_causal_models.py
@@ -1,0 +1,600 @@
+"""Tests for exact same-model TruncatedNormal causal parameterizations."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+from pymc.sampling.jax import get_jaxified_graph, get_jaxified_logp
+from pytensor.compile.mode import Mode
+from scipy.stats import truncnorm
+
+from scripts.truncated_hierarchy_causal_models import (
+    CausalModelContractError,
+    _truncated_normal_from_standard_normal,
+    bounded_from_unconstrained,
+    bounded_log_jacobian,
+    build_full_icdf_noncentered,
+    build_group_icdf_noncentered,
+    build_manual_centered,
+    build_native_centered,
+    manual_truncated_normal_logp,
+    truncated_normal_icdf,
+)
+from scripts.truncated_hierarchy_causal_oracle import (
+    HierarchicalPosteriorSpec,
+    Jet2,
+    TruncationBounds,
+    hierarchical_posterior_components,
+    truncated_normal_from_standard_normal,
+)
+from scripts.truncated_hierarchy_models import (
+    Bounds,
+    NativeTruncatedPrior,
+    ToyDataSpec,
+    generate_synthetic_data,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+BUILDERS: tuple[tuple[str, Callable], ...] = (
+    ("native", build_native_centered),
+    ("manual", build_manual_centered),
+    ("group-icdf", build_group_icdf_noncentered),
+    ("full-icdf", build_full_icdf_noncentered),
+)
+
+ORACLE_VARIANTS = (
+    pytest.param(
+        "native",
+        build_native_centered,
+        "centered",
+        (
+            "group_location_rv_interval__",
+            "group_scale_rv_log__",
+            "group_effect_rv_interval__",
+        ),
+        id="native",
+    ),
+    pytest.param(
+        "manual",
+        build_manual_centered,
+        "centered",
+        (
+            "group_location_coordinate",
+            "group_scale_rv_log__",
+            "group_effect_coordinate",
+        ),
+        id="manual",
+    ),
+    pytest.param(
+        "group-icdf",
+        build_group_icdf_noncentered,
+        "group_icdf_noncentered",
+        (
+            "group_location_rv_interval__",
+            "group_scale_rv_log__",
+            "group_effect_offset",
+        ),
+        id="group-icdf",
+    ),
+    pytest.param(
+        "full-icdf",
+        build_full_icdf_noncentered,
+        "full_icdf_noncentered",
+        (
+            "group_location_offset",
+            "group_scale_rv_log__",
+            "group_effect_offset",
+        ),
+        id="full-icdf",
+    ),
+)
+
+BOUND_CASES = (
+    pytest.param(Bounds(0.2, None), 0.0, 0.23, id="lower-only"),
+    pytest.param(Bounds(0.1, 0.9), 0.5, 0.13, id="finite"),
+)
+
+EXTREME_TAIL_CASES = (
+    pytest.param(Bounds(0.2, None), -4.0, 0.1, id="lower-alpha-42"),
+    pytest.param(Bounds(0.2, 0.21), -4.0, 0.1, id="finite-right-tail"),
+    pytest.param(Bounds(-0.21, -0.2), 4.0, 0.1, id="finite-left-tail"),
+)
+
+
+def _inputs(bounds: Bounds, base_mean: float, location: float):
+    spec = ToyDataSpec(
+        bounds=bounds,
+        group_location=location,
+        group_scale=0.3,
+        n_groups=3,
+        n_per_group=2,
+    )
+    data = generate_synthetic_data(spec, group_seed=1282, observation_seed=1283)
+    return NativeTruncatedPrior(bounds, base_mean), data
+
+
+def _eval(function, *values):
+    return np.asarray(function(*values), dtype=np.float64)
+
+
+def _oracle_spec(prior, data) -> HierarchicalPosteriorSpec:
+    return HierarchicalPosteriorSpec(
+        bounds=TruncationBounds(prior.bounds.lower, prior.bounds.upper),
+        location_base_mean=prior.location_base_mean,
+        location_prior_scale=prior.location_prior_sigma,
+        scale_prior_shape=prior.scale_prior_alpha,
+        scale_prior_scale=prior.scale_prior_beta,
+        n_groups=data.spec.n_groups,
+        group_index=data.group_index,
+        observations=data.y,
+        observation_scale=data.spec.observation_sigma,
+    )
+
+
+def _model_arguments(model, vector: np.ndarray) -> list[np.ndarray]:
+    """Split a canonical location/scale/groups vector in value-variable order."""
+    initial_point = model.initial_point()
+    arguments: list[np.ndarray] = []
+    cursor = 0
+    for variable in model.value_vars:
+        initial = np.asarray(initial_point[variable.name])
+        size = initial.size
+        arguments.append(vector[cursor : cursor + size].reshape(initial.shape))
+        cursor += size
+    assert cursor == vector.size
+    return arguments
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "location"), BOUND_CASES)
+@pytest.mark.parametrize(("name", "builder"), BUILDERS)
+def test_all_parameterizations_build_the_same_natural_surface(
+    bounds, base_mean, location, name, builder
+) -> None:
+    """Expose identical natural names and the frozen Weibull scale prior."""
+    prior, data = _inputs(bounds, base_mean, location)
+    model = builder(prior, data)
+
+    deterministic_names = {variable.name for variable in model.deterministics}
+    assert {"group_location", "group_scale", "group_effect"} <= deterministic_names
+    assert model.named_vars_to_dims["group_effect"] == ("group",)
+    assert len(model.coords["group"]) == 3
+    assert type(model.named_vars["group_scale_rv"].owner.op).__name__ == (
+        "WeibullBetaRV"
+    )
+    assert {variable.name for variable in model.observed_RVs} == {"y"}
+
+    free_names = {variable.name for variable in model.free_RVs}
+    if name == "native":
+        assert free_names == {
+            "group_location_rv",
+            "group_scale_rv",
+            "group_effect_rv",
+        }
+    elif name == "manual":
+        assert free_names == {
+            "group_location_coordinate",
+            "group_scale_rv",
+            "group_effect_coordinate",
+        }
+    elif name == "group-icdf":
+        assert free_names == {
+            "group_location_rv",
+            "group_scale_rv",
+            "group_effect_offset",
+        }
+        assert type(model.named_vars["group_effect_offset"].owner.op).__name__ == (
+            "NormalRV"
+        )
+    else:
+        assert free_names == {
+            "group_location_offset",
+            "group_scale_rv",
+            "group_effect_offset",
+        }
+        assert type(model.named_vars["group_location_offset"].owner.op).__name__ == (
+            "NormalRV"
+        )
+        assert type(model.named_vars["group_effect_offset"].owner.op).__name__ == (
+            "NormalRV"
+        )
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "location"), BOUND_CASES)
+def test_manual_centered_matches_native_transformed_logp(
+    bounds, base_mean, location
+) -> None:
+    """Compare complete log densities at identical transformed coordinates."""
+    prior, data = _inputs(bounds, base_mean, location)
+    native = build_native_centered(prior, data)
+    manual = build_manual_centered(prior, data)
+    native_point = native.initial_point()
+    manual_point = manual.initial_point()
+
+    location_coordinate = np.asarray(-0.35)
+    effect_coordinate = np.asarray([-0.8, 0.1, 0.9])
+    scale_coordinate = np.asarray(-1.1)
+    native_point["group_location_rv_interval__"] = location_coordinate
+    native_point["group_effect_rv_interval__"] = effect_coordinate
+    native_point["group_scale_rv_log__"] = scale_coordinate
+    manual_point["group_location_coordinate"] = location_coordinate
+    manual_point["group_effect_coordinate"] = effect_coordinate
+    manual_point["group_scale_rv_log__"] = scale_coordinate
+
+    native_logp = native.compile_logp()(native_point)
+    manual_logp = manual.compile_logp()(manual_point)
+    np.testing.assert_allclose(manual_logp, native_logp, rtol=5e-9, atol=5e-8)
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "location"), BOUND_CASES)
+@pytest.mark.parametrize(
+    ("_name", "builder", "oracle_parameterization", "value_names"),
+    ORACLE_VARIANTS,
+)
+def test_transformed_posterior_matches_independent_second_order_oracle(
+    bounds,
+    base_mean,
+    location,
+    _name,
+    builder,
+    oracle_parameterization,
+    value_names,
+) -> None:
+    """Match value, gradient, and Hessian in the oracle's exact coordinate order."""
+    prior, data = _inputs(bounds, base_mean, location)
+    model = builder(prior, data)
+    assert tuple(variable.name for variable in model.value_vars) == value_names
+
+    # The oracle freezes this order for every variant: location coordinate,
+    # log scale, then one centered coordinate or standard-Normal offset per group.
+    point = np.array([-0.45, math.log(0.22), -1.1, 0.15, 0.85])
+    arguments = _model_arguments(model, point)
+    model_logp = model.logp(jacobian=True)
+    model_gradient = model.dlogp(jacobian=True)
+    model_hessian = model.d2logp(
+        jacobian=True,
+        negate_output=False,
+    )
+    pytensor_function = model.compile_fn(
+        [model_logp, model_gradient, model_hessian],
+        inputs=model.value_vars,
+        mode=Mode(linker="py", optimizer=None),
+        on_unused_input="ignore",
+        point_fn=False,
+    )
+    observed_value, observed_gradient, observed_hessian = pytensor_function(*arguments)
+
+    expected = hierarchical_posterior_components(
+        point,
+        _oracle_spec(prior, data),
+        parameterization=oracle_parameterization,
+    ).total
+    np.testing.assert_allclose(observed_value, expected.value, rtol=2e-8, atol=5e-8)
+    np.testing.assert_allclose(
+        observed_gradient, expected.gradient, rtol=3e-7, atol=3e-7
+    )
+    np.testing.assert_allclose(observed_hessian, expected.hessian, rtol=3e-6, atol=3e-6)
+
+    # NumPyro differentiates one JAXified scalar logp.  Differentiate that same
+    # scalar here rather than merely lowering PyTensor's precomputed gradient.
+    jaxified_logp = get_jaxified_graph(
+        inputs=model.value_vars,
+        outputs=[model_logp],
+    )
+    initial_point = model.initial_point()
+    layouts = []
+    cursor = 0
+    for variable in model.value_vars:
+        shape = np.asarray(initial_point[variable.name]).shape
+        size = int(np.prod(shape, dtype=int)) if shape else 1
+        layouts.append((cursor, cursor + size, shape))
+        cursor += size
+    assert cursor == point.size
+
+    def scalar_jax_logp(vector):
+        ordered = [vector[start:stop].reshape(shape) for start, stop, shape in layouts]
+        return jaxified_logp(*ordered)[0]
+
+    jax_point = jnp.asarray(point)
+    jax_value, jax_gradient = jax.value_and_grad(scalar_jax_logp)(jax_point)
+    jax_hessian = jax.hessian(scalar_jax_logp)(jax_point)
+    np.testing.assert_allclose(jax_value, expected.value, rtol=2e-8, atol=5e-8)
+    np.testing.assert_allclose(jax_gradient, expected.gradient, rtol=3e-7, atol=3e-7)
+    np.testing.assert_allclose(jax_hessian, expected.hessian, rtol=3e-6, atol=3e-6)
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "_location"), BOUND_CASES)
+def test_manual_density_matches_scipy(bounds, base_mean, _location) -> None:
+    """Check the independently normalized density at interior natural values."""
+    value = pt.dvector("value")
+    sigma = pt.dscalar("sigma")
+    logp = manual_truncated_normal_logp(value, mu=base_mean, sigma=sigma, bounds=bounds)
+    function = pytensor.function([value, sigma], logp)
+    if bounds.upper is None:
+        values = np.array([0.201, 0.3, 1.2])
+    else:
+        values = np.array([0.101, 0.4, 0.899])
+    scale = 0.25
+    lower = (bounds.lower - base_mean) / scale
+    upper = np.inf if bounds.upper is None else (bounds.upper - base_mean) / scale
+    expected = truncnorm.logpdf(values, lower, upper, loc=base_mean, scale=scale)
+
+    np.testing.assert_allclose(
+        function(values, scale), expected, rtol=1e-11, atol=1e-11
+    )
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "_location"), BOUND_CASES)
+def test_inverse_cdf_is_monotone_accurate_and_has_the_target_density(
+    bounds, base_mean, _location
+) -> None:
+    """Exercise central and tail quantiles plus the inverse-Jacobian density."""
+    quantile = pt.dvector("quantile")
+    scale = 0.25
+    natural = truncated_normal_icdf(quantile, mu=base_mean, sigma=scale, bounds=bounds)
+    derivative = pt.grad(pt.sum(natural), quantile)
+    function = pytensor.function([quantile], [natural, derivative])
+    probabilities = np.array([1e-10, 1e-6, 0.01, 0.5, 0.99, 1 - 1e-6, 1 - 1e-10])
+    observed, derivatives = function(probabilities)
+
+    lower = (bounds.lower - base_mean) / scale
+    upper = np.inf if bounds.upper is None else (bounds.upper - base_mean) / scale
+    expected = truncnorm.ppf(probabilities, lower, upper, loc=base_mean, scale=scale)
+    expected_logp = truncnorm.logpdf(observed, lower, upper, loc=base_mean, scale=scale)
+
+    assert np.all(np.isfinite(observed))
+    assert np.all(np.diff(observed) > 0)
+    assert np.all(observed > bounds.lower)
+    if bounds.upper is not None:
+        assert np.all(observed < bounds.upper)
+    np.testing.assert_allclose(observed, expected, rtol=2e-8, atol=2e-9)
+    np.testing.assert_allclose(
+        -np.log(derivatives), expected_logp, rtol=2e-7, atol=2e-7
+    )
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "scale"), EXTREME_TAIL_CASES)
+def test_extreme_tail_icdf_and_density_match_scipy_in_pytensor_and_jax(
+    bounds, base_mean, scale
+) -> None:
+    """Keep the causal alternatives valid after ordinary CDF values underflow."""
+    quantile = pt.dscalar("quantile")
+    value = pt.dscalar("value")
+    offset = pt.dscalar("offset")
+    natural = truncated_normal_icdf(
+        quantile,
+        mu=base_mean,
+        sigma=scale,
+        bounds=bounds,
+    )
+    logp = manual_truncated_normal_logp(
+        value,
+        mu=base_mean,
+        sigma=scale,
+        bounds=bounds,
+    )
+    offset_natural = _truncated_normal_from_standard_normal(
+        offset,
+        mu=base_mean,
+        sigma=scale,
+        bounds=bounds,
+    )
+    offset_derivative = pt.grad(offset_natural, offset)
+    offset_second_derivative = pt.grad(offset_derivative, offset)
+    outputs = [
+        natural,
+        logp,
+        offset_natural,
+        offset_derivative,
+        offset_second_derivative,
+    ]
+    pytensor_function = pytensor.function([quantile, value, offset], outputs)
+    jax_function = pytensor.function(
+        [quantile, value, offset],
+        outputs,
+        mode="JAX",
+    )
+
+    probability = 0.5
+    lower = (bounds.lower - base_mean) / scale
+    upper = np.inf if bounds.upper is None else (bounds.upper - base_mean) / scale
+    expected_value = truncnorm.ppf(
+        probability,
+        lower,
+        upper,
+        loc=base_mean,
+        scale=scale,
+    )
+    expected_logp = truncnorm.logpdf(
+        expected_value,
+        lower,
+        upper,
+        loc=base_mean,
+        scale=scale,
+    )
+    expected_offset_derivative = math.exp(
+        -0.5 * math.log(2.0 * math.pi) - expected_logp
+    )
+    oracle_offset = truncated_normal_from_standard_normal(
+        Jet2.variable(0.0, index=0, dimension=1),
+        base_mean,
+        scale,
+        TruncationBounds(bounds.lower, bounds.upper),
+    )
+    expected_offset_second_derivative = oracle_offset.hessian[0, 0]
+
+    for function in (pytensor_function, jax_function):
+        (
+            observed_value,
+            observed_logp,
+            observed_offset_value,
+            observed_offset_derivative,
+            observed_offset_second_derivative,
+        ) = function(probability, expected_value, 0.0)
+        np.testing.assert_allclose(
+            observed_value, expected_value, rtol=1e-11, atol=1e-12
+        )
+        np.testing.assert_allclose(observed_logp, expected_logp, rtol=1e-11, atol=1e-11)
+        np.testing.assert_allclose(
+            observed_offset_value, expected_value, rtol=1e-11, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            observed_offset_derivative,
+            expected_offset_derivative,
+            rtol=2e-10,
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            observed_offset_second_derivative,
+            expected_offset_second_derivative,
+            rtol=2e-9,
+            atol=1e-12,
+        )
+        assert observed_offset_derivative > 0.0
+
+    # NumPyro differentiates the scalar JAXified transform itself.  Exercise
+    # that route, not only a PyTensor-derived gradient lowered into JAX.
+    jaxified_offset = get_jaxified_graph(inputs=[offset], outputs=[offset_natural])
+
+    def scalar_jax_offset(offset_value):
+        return jaxified_offset(offset_value)[0]
+
+    jax_offset = jnp.asarray(0.0)
+    jax_value, jax_derivative = jax.value_and_grad(scalar_jax_offset)(jax_offset)
+    jax_second_derivative = jax.hessian(scalar_jax_offset)(jax_offset)
+    np.testing.assert_allclose(jax_value, expected_value, rtol=1e-11, atol=1e-12)
+    np.testing.assert_allclose(
+        jax_derivative,
+        expected_offset_derivative,
+        rtol=2e-10,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        jax_second_derivative,
+        expected_offset_second_derivative,
+        rtol=2e-9,
+        atol=1e-12,
+    )
+    assert jax_derivative > 0.0
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "_location"), BOUND_CASES)
+def test_standard_normal_offset_induces_the_target_natural_density(
+    bounds, base_mean, _location
+) -> None:
+    """Verify the exact non-centering change of variables, including tails."""
+    offset = pt.dvector("offset")
+    scale = 0.25
+    quantile = 0.5 * pt.erfc(-offset / np.sqrt(2.0))
+    quantile_survival = 0.5 * pt.erfc(offset / np.sqrt(2.0))
+    natural = truncated_normal_icdf(
+        quantile,
+        mu=base_mean,
+        sigma=scale,
+        bounds=bounds,
+        quantile_survival=quantile_survival,
+    )
+    derivative = pt.grad(pt.sum(natural), offset)
+    function = pytensor.function([offset], [natural, derivative])
+    offsets = np.array([-6.0, -2.0, 0.0, 2.0, 6.0])
+    observed, derivatives = function(offsets)
+
+    lower = (bounds.lower - base_mean) / scale
+    upper = np.inf if bounds.upper is None else (bounds.upper - base_mean) / scale
+    induced_logp = -0.5 * offsets**2 - 0.5 * np.log(2.0 * np.pi) - np.log(derivatives)
+    expected_logp = truncnorm.logpdf(observed, lower, upper, loc=base_mean, scale=scale)
+
+    assert np.all(np.diff(observed) > 0)
+    np.testing.assert_allclose(induced_logp, expected_logp, rtol=3e-7, atol=3e-7)
+
+
+@pytest.mark.parametrize(("bounds", "_base_mean", "_location"), BOUND_CASES)
+def test_manual_coordinate_transform_and_jacobian(
+    bounds, _base_mean, _location
+) -> None:
+    """Verify support, monotonicity, and the explicit coordinate Jacobian."""
+    coordinate = pt.dvector("coordinate")
+    natural = bounded_from_unconstrained(coordinate, bounds)
+    derivative = pt.grad(pt.sum(natural), coordinate)
+    log_jacobian = bounded_log_jacobian(coordinate, bounds)
+    function = pytensor.function([coordinate], [natural, derivative, log_jacobian])
+    values, derivatives, observed_log_jacobian = function(
+        np.array([-8.0, -1.0, 0.0, 1.0, 8.0])
+    )
+
+    assert np.all(np.diff(values) > 0)
+    assert np.all(values > bounds.lower)
+    if bounds.upper is not None:
+        assert np.all(values < bounds.upper)
+    np.testing.assert_allclose(
+        observed_log_jacobian, np.log(derivatives), rtol=1e-12, atol=1e-12
+    )
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "location"), BOUND_CASES)
+@pytest.mark.parametrize(("_name", "builder"), BUILDERS)
+def test_model_logp_compiles_for_pytensor(
+    bounds, base_mean, location, _name, builder
+) -> None:
+    """Compile and evaluate every parameterization through PyTensor."""
+    prior, data = _inputs(bounds, base_mean, location)
+    model = builder(prior, data)
+    point = model.initial_point()
+
+    pytensor_logp = np.asarray(model.compile_logp()(point))
+    assert np.isfinite(pytensor_logp)
+
+
+@pytest.mark.parametrize(("bounds", "base_mean", "location"), BOUND_CASES)
+@pytest.mark.parametrize(("_name", "builder"), BUILDERS[1:])
+def test_manual_and_icdf_logp_compile_for_numpyro_jax_path(
+    bounds, base_mean, location, _name, builder
+) -> None:
+    """Compile the independent candidate graphs through NumPyro's JAX path."""
+    prior, data = _inputs(bounds, base_mean, location)
+    model = builder(prior, data)
+    point = model.initial_point()
+
+    pytensor_logp = np.asarray(model.compile_logp()(point))
+    jax_logp = get_jaxified_logp(model)(
+        [point[variable.name] for variable in model.value_vars]
+    )
+    assert np.isfinite(pytensor_logp)
+    assert np.isfinite(np.asarray(jax_logp))
+    np.testing.assert_allclose(jax_logp, pytensor_logp, rtol=2e-8, atol=2e-8)
+
+
+def test_inverse_cdf_primitive_lowers_to_jax_without_tfp_fallback() -> None:
+    """Prove that the independent quantile uses the NumPyro-compatible path."""
+    quantile = pt.dvector("quantile")
+    natural = truncated_normal_icdf(
+        quantile, mu=0.0, sigma=0.25, bounds=Bounds(0.2, None)
+    )
+    jax_function = get_jaxified_graph(inputs=[quantile], outputs=[natural])
+    values = np.array([1e-6, 0.5, 1 - 1e-6])
+
+    observed = _eval(jax_function, values)[0]
+    assert np.all(np.isfinite(observed))
+    assert np.all(np.diff(observed) > 0)
+
+
+def test_causal_builders_reject_upper_only_and_scale_prior_drift() -> None:
+    """Fail fast when a caller leaves the frozen same-model comparison."""
+    upper_bounds = Bounds(None, 0.8)
+    upper_prior, upper_data = _inputs(upper_bounds, 0.5, 0.7)
+    with pytest.raises(CausalModelContractError, match="finite lower"):
+        build_native_centered(upper_prior, upper_data)
+
+    bounds = Bounds(0.2, None)
+    _prior, data = _inputs(bounds, 0.0, 0.23)
+    changed_prior = NativeTruncatedPrior(bounds, 0.0, scale_prior_beta=0.4)
+    with pytest.raises(CausalModelContractError, match="beta must remain frozen"):
+        build_manual_centered(changed_prior, data)

--- a/tests/test_truncated_hierarchy_causal_models.py
+++ b/tests/test_truncated_hierarchy_causal_models.py
@@ -123,6 +123,20 @@ EXTREME_TAIL_CASES = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _pin_float64_precision():
+    """Isolate this module's declared float64 numerical contract per test."""
+    previous_floatx = pytensor.config.floatX
+    previous_jax_x64 = bool(jax.config.jax_enable_x64)
+    pytensor.config.floatX = "float64"
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        pytensor.config.floatX = previous_floatx
+        jax.config.update("jax_enable_x64", previous_jax_x64)
+
+
 def _inputs(bounds: Bounds, base_mean: float, location: float):
     spec = ToyDataSpec(
         bounds=bounds,
@@ -325,7 +339,7 @@ def test_transformed_posterior_matches_independent_second_order_oracle(
         ordered = [vector[start:stop].reshape(shape) for start, stop, shape in layouts]
         return jaxified_logp(*ordered)[0]
 
-    jax_point = jnp.asarray(point)
+    jax_point = jnp.asarray(point, dtype=jnp.float64)
     jax_value, jax_gradient = jax.value_and_grad(scalar_jax_logp)(jax_point)
     jax_hessian = jax.hessian(scalar_jax_logp)(jax_point)
     np.testing.assert_allclose(jax_value, expected.value, rtol=2e-8, atol=5e-8)

--- a/tests/test_truncated_hierarchy_causal_models.py
+++ b/tests/test_truncated_hierarchy_causal_models.py
@@ -22,6 +22,7 @@ from scripts.truncated_hierarchy_causal_models import (
     bounded_log_jacobian,
     build_full_icdf_noncentered,
     build_group_icdf_noncentered,
+    build_location_icdf_noncentered,
     build_manual_centered,
     build_native_centered,
     manual_truncated_normal_logp,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 BUILDERS: tuple[tuple[str, Callable], ...] = (
     ("native", build_native_centered),
     ("manual", build_manual_centered),
+    ("location-icdf", build_location_icdf_noncentered),
     ("group-icdf", build_group_icdf_noncentered),
     ("full-icdf", build_full_icdf_noncentered),
 )
@@ -73,6 +75,17 @@ ORACLE_VARIANTS = (
             "group_effect_coordinate",
         ),
         id="manual",
+    ),
+    pytest.param(
+        "location-icdf",
+        build_location_icdf_noncentered,
+        "location_icdf_noncentered",
+        (
+            "group_location_offset",
+            "group_scale_rv_log__",
+            "group_effect_rv_interval__",
+        ),
+        id="location-icdf",
     ),
     pytest.param(
         "group-icdf",
@@ -185,6 +198,15 @@ def test_all_parameterizations_build_the_same_natural_surface(
             "group_scale_rv",
             "group_effect_coordinate",
         }
+    elif name == "location-icdf":
+        assert free_names == {
+            "group_location_offset",
+            "group_scale_rv",
+            "group_effect_rv",
+        }
+        assert type(model.named_vars["group_location_offset"].owner.op).__name__ == (
+            "NormalRV"
+        )
     elif name == "group-icdf":
         assert free_names == {
             "group_location_rv",

--- a/tests/test_truncated_hierarchy_causal_oracle.py
+++ b/tests/test_truncated_hierarchy_causal_oracle.py
@@ -180,7 +180,15 @@ def _natural_reference(
     """Map causal coordinates to natural values using only SciPy and math."""
     scale = math.exp(point[1])
     transform_log_jacobian = point[1]
-    if parameterization == "full_icdf_noncentered":
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    if location_noncentered:
         location = _scipy_truncated_from_offset(
             point[0],
             spec.location_base_mean,
@@ -191,7 +199,7 @@ def _natural_reference(
         location, location_jacobian = _natural_and_log_jacobian(point[0], spec.bounds)
         transform_log_jacobian += location_jacobian
 
-    if parameterization == "centered":
+    if not group_noncentered:
         groups_and_jacobians = tuple(
             _natural_and_log_jacobian(value, spec.bounds) for value in point[2:]
         )
@@ -215,7 +223,15 @@ def _point_for_parameterization(
     parameterization: CausalParameterization,
 ) -> np.ndarray:
     """Construct causal coordinates for one fixed natural hierarchy."""
-    if parameterization == "full_icdf_noncentered":
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    if location_noncentered:
         location_coordinate = _scipy_offset_from_truncated(
             location,
             spec.location_base_mean,
@@ -224,7 +240,7 @@ def _point_for_parameterization(
         )
     else:
         location_coordinate = support_inverse(location, spec.bounds)
-    if parameterization == "centered":
+    if not group_noncentered:
         group_coordinates = [support_inverse(group, spec.bounds) for group in groups]
     else:
         group_coordinates = [
@@ -243,7 +259,15 @@ def _posterior_reference(
     location, scale, groups, transform_log_jacobian = _natural_reference(
         point, spec, parameterization
     )
-    if parameterization == "full_icdf_noncentered":
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    if location_noncentered:
         location_prior = float(norm.logpdf(point[0]))
     else:
         location_prior = _scipy_truncated_logpdf(
@@ -259,7 +283,7 @@ def _posterior_reference(
             scale=spec.scale_prior_scale,
         )
     )
-    if parameterization == "centered":
+    if not group_noncentered:
         group_prior = sum(
             _scipy_truncated_logpdf(group, location, scale, spec.bounds)
             for group in groups
@@ -733,7 +757,11 @@ def test_hierarchical_posterior_matches_scipy_and_finite_differences(
 
 @pytest.mark.parametrize(
     "parameterization",
-    ["group_icdf_noncentered", "full_icdf_noncentered"],
+    [
+        "location_icdf_noncentered",
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    ],
 )
 @pytest.mark.parametrize(
     ("bounds", "location", "scale", "groups", "base_mean"), POSTERIOR_CASES
@@ -746,7 +774,7 @@ def test_noncentered_posterior_matches_scipy_and_finite_differences(
     groups: list[float],
     base_mean: float,
 ) -> None:
-    """Validate both exact ICDF parameterizations through second order."""
+    """Validate every exact ICDF parameterization through second order."""
     spec = _posterior_spec(bounds, groups, base_mean)
     point = _point_for_parameterization(location, scale, groups, spec, parameterization)
     components = hierarchical_posterior_components(point, spec, parameterization)
@@ -779,7 +807,11 @@ def test_noncentered_posterior_matches_scipy_and_finite_differences(
 
 @pytest.mark.parametrize(
     "parameterization",
-    ["group_icdf_noncentered", "full_icdf_noncentered"],
+    [
+        "location_icdf_noncentered",
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    ],
 )
 @pytest.mark.parametrize(
     ("bounds", "location", "scale", "groups", "base_mean"),
@@ -820,7 +852,10 @@ def test_parameterizations_encode_the_same_natural_model_and_measure(
     )
 
     log_coordinate_jacobian = 0.0
-    if parameterization == "full_icdf_noncentered":
+    if parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }:
         _, centered_location_jacobian = _natural_and_log_jacobian(
             centered_point[0], bounds
         )
@@ -835,16 +870,20 @@ def test_parameterizations_encode_the_same_natural_model_and_measure(
             - location_tn_logpdf
             - centered_location_jacobian
         )
-    for index, group in enumerate(groups):
-        _, centered_group_jacobian = _natural_and_log_jacobian(
-            centered_point[index + 2], bounds
-        )
-        group_tn_logpdf = _scipy_truncated_logpdf(group, location, scale, bounds)
-        log_coordinate_jacobian += (
-            norm.logpdf(noncentered_point[index + 2])
-            - group_tn_logpdf
-            - centered_group_jacobian
-        )
+    if parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }:
+        for index, group in enumerate(groups):
+            _, centered_group_jacobian = _natural_and_log_jacobian(
+                centered_point[index + 2], bounds
+            )
+            group_tn_logpdf = _scipy_truncated_logpdf(group, location, scale, bounds)
+            log_coordinate_jacobian += (
+                norm.logpdf(noncentered_point[index + 2])
+                - group_tn_logpdf
+                - centered_group_jacobian
+            )
 
     centered_logp = hierarchical_posterior_components(
         centered_point, spec, "centered"

--- a/tests/test_truncated_hierarchy_causal_oracle.py
+++ b/tests/test_truncated_hierarchy_causal_oracle.py
@@ -1,0 +1,859 @@
+"""Tests for the independent second-order truncated-hierarchy oracle."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.special import expit
+from scipy.stats import norm, truncnorm, weibull_min
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from scripts.truncated_hierarchy_causal_oracle import (
+    CausalParameterization,
+    HierarchicalPosteriorSpec,
+    Jet2,
+    TruncationBounds,
+    hierarchical_natural_values,
+    hierarchical_posterior_components,
+    jet_log_ndtr,
+    jet_ndtr,
+    jet_ndtri,
+    jet_ndtri_exp,
+    normal_logpdf,
+    positive_inverse,
+    positive_transform,
+    seed_jets,
+    support_inverse,
+    support_transform,
+    truncated_normal_from_standard_normal,
+    truncated_normal_logpdf,
+    weibull_logpdf,
+)
+
+
+def _finite_difference_gradient(
+    function: Callable[[np.ndarray], float], point: np.ndarray
+) -> np.ndarray:
+    """Return an independent central-difference gradient."""
+    gradient = np.empty_like(point)
+    for index in range(point.size):
+        step = 2e-6 * max(1.0, abs(float(point[index])))
+        displacement = np.zeros_like(point)
+        displacement[index] = step
+        gradient[index] = (
+            function(point + displacement) - function(point - displacement)
+        ) / (2.0 * step)
+    return gradient
+
+
+def _finite_difference_hessian(
+    function: Callable[[np.ndarray], float], point: np.ndarray
+) -> np.ndarray:
+    """Return an independent central-difference Hessian."""
+    steps = 2e-4 * np.maximum(1.0, np.abs(point))
+    hessian = np.empty((point.size, point.size), dtype=np.float64)
+    center = function(point)
+    for row in range(point.size):
+        row_step = np.zeros_like(point)
+        row_step[row] = steps[row]
+        hessian[row, row] = (
+            function(point + row_step) - 2.0 * center + function(point - row_step)
+        ) / steps[row] ** 2
+        for column in range(row):
+            column_step = np.zeros_like(point)
+            column_step[column] = steps[column]
+            value = (
+                function(point + row_step + column_step)
+                - function(point + row_step - column_step)
+                - function(point - row_step + column_step)
+                + function(point - row_step - column_step)
+            ) / (4.0 * steps[row] * steps[column])
+            hessian[row, column] = value
+            hessian[column, row] = value
+    return hessian
+
+
+def _natural_and_log_jacobian(
+    unconstrained: float, bounds: TruncationBounds
+) -> tuple[float, float]:
+    """Evaluate support transforms without using the oracle implementation."""
+    if bounds.lower is not None and bounds.upper is None:
+        distance = math.exp(unconstrained)
+        return bounds.lower + distance, unconstrained
+    if bounds.lower is None and bounds.upper is not None:
+        distance = math.exp(unconstrained)
+        return bounds.upper - distance, unconstrained
+    assert bounds.lower is not None
+    assert bounds.upper is not None
+    width = bounds.upper - bounds.lower
+    fraction = float(expit(unconstrained))
+    log_jacobian = (
+        math.log(width)
+        - float(np.logaddexp(0.0, -unconstrained))
+        - float(np.logaddexp(0.0, unconstrained))
+    )
+    return bounds.lower + width * fraction, log_jacobian
+
+
+def _scipy_truncated_logpdf(
+    value: float,
+    location: float,
+    scale: float,
+    bounds: TruncationBounds,
+) -> float:
+    """Evaluate the corresponding SciPy TruncatedNormal density."""
+    standardized_lower = (
+        -np.inf if bounds.lower is None else (bounds.lower - location) / scale
+    )
+    standardized_upper = (
+        np.inf if bounds.upper is None else (bounds.upper - location) / scale
+    )
+    return float(
+        truncnorm.logpdf(
+            value,
+            standardized_lower,
+            standardized_upper,
+            loc=location,
+            scale=scale,
+        )
+    )
+
+
+def _scipy_truncated_from_offset(
+    offset: float,
+    location: float,
+    scale: float,
+    bounds: TruncationBounds,
+) -> float:
+    """Push a standard-Normal offset through SciPy's TN quantile."""
+    standardized_lower = (
+        -np.inf if bounds.lower is None else (bounds.lower - location) / scale
+    )
+    standardized_upper = (
+        np.inf if bounds.upper is None else (bounds.upper - location) / scale
+    )
+    return float(
+        truncnorm.ppf(
+            norm.cdf(offset),
+            standardized_lower,
+            standardized_upper,
+            loc=location,
+            scale=scale,
+        )
+    )
+
+
+def _scipy_offset_from_truncated(
+    value: float,
+    location: float,
+    scale: float,
+    bounds: TruncationBounds,
+) -> float:
+    """Map an interior TN value back to its standard-Normal offset."""
+    standardized_lower = (
+        -np.inf if bounds.lower is None else (bounds.lower - location) / scale
+    )
+    standardized_upper = (
+        np.inf if bounds.upper is None else (bounds.upper - location) / scale
+    )
+    quantile = truncnorm.cdf(
+        value,
+        standardized_lower,
+        standardized_upper,
+        loc=location,
+        scale=scale,
+    )
+    return float(norm.ppf(quantile))
+
+
+def _natural_reference(
+    point: np.ndarray,
+    spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization,
+) -> tuple[float, float, np.ndarray, float]:
+    """Map causal coordinates to natural values using only SciPy and math."""
+    scale = math.exp(point[1])
+    transform_log_jacobian = point[1]
+    if parameterization == "full_icdf_noncentered":
+        location = _scipy_truncated_from_offset(
+            point[0],
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            spec.bounds,
+        )
+    else:
+        location, location_jacobian = _natural_and_log_jacobian(point[0], spec.bounds)
+        transform_log_jacobian += location_jacobian
+
+    if parameterization == "centered":
+        groups_and_jacobians = tuple(
+            _natural_and_log_jacobian(value, spec.bounds) for value in point[2:]
+        )
+        groups = np.array([item[0] for item in groups_and_jacobians])
+        transform_log_jacobian += sum(item[1] for item in groups_and_jacobians)
+    else:
+        groups = np.array(
+            [
+                _scipy_truncated_from_offset(offset, location, scale, spec.bounds)
+                for offset in point[2:]
+            ]
+        )
+    return location, scale, groups, transform_log_jacobian
+
+
+def _point_for_parameterization(
+    location: float,
+    scale: float,
+    groups: list[float],
+    spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization,
+) -> np.ndarray:
+    """Construct causal coordinates for one fixed natural hierarchy."""
+    if parameterization == "full_icdf_noncentered":
+        location_coordinate = _scipy_offset_from_truncated(
+            location,
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            spec.bounds,
+        )
+    else:
+        location_coordinate = support_inverse(location, spec.bounds)
+    if parameterization == "centered":
+        group_coordinates = [support_inverse(group, spec.bounds) for group in groups]
+    else:
+        group_coordinates = [
+            _scipy_offset_from_truncated(group, location, scale, spec.bounds)
+            for group in groups
+        ]
+    return np.array([location_coordinate, positive_inverse(scale), *group_coordinates])
+
+
+def _posterior_reference(
+    point: np.ndarray,
+    spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization = "centered",
+) -> dict[str, float]:
+    """Evaluate posterior terms independently with SciPy distributions."""
+    location, scale, groups, transform_log_jacobian = _natural_reference(
+        point, spec, parameterization
+    )
+    if parameterization == "full_icdf_noncentered":
+        location_prior = float(norm.logpdf(point[0]))
+    else:
+        location_prior = _scipy_truncated_logpdf(
+            location,
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            spec.bounds,
+        )
+    scale_prior = float(
+        weibull_min.logpdf(
+            scale,
+            c=spec.scale_prior_shape,
+            scale=spec.scale_prior_scale,
+        )
+    )
+    if parameterization == "centered":
+        group_prior = sum(
+            _scipy_truncated_logpdf(group, location, scale, spec.bounds)
+            for group in groups
+        )
+    else:
+        group_prior = float(np.sum(norm.logpdf(point[2:])))
+    likelihood = float(
+        np.sum(
+            norm.logpdf(
+                spec.observations,
+                loc=groups[spec.group_index],
+                scale=spec.observation_scale,
+            )
+        )
+    )
+    return {
+        "location_prior": location_prior,
+        "scale_prior": scale_prior,
+        "group_prior": group_prior,
+        "likelihood": likelihood,
+        "transform_log_jacobian": transform_log_jacobian,
+    }
+
+
+def test_second_order_jet_matches_known_mixed_curvature() -> None:
+    """Check the jet's product and nonlinear composition rules analytically."""
+    x, y = seed_jets([0.7, -0.4])
+    result = (x * y + 2.0 * x) ** 3
+    inner = 0.7 * -0.4 + 2.0 * 0.7
+    inner_gradient = np.array([-0.4 + 2.0, 0.7])
+    inner_hessian = np.array([[0.0, 1.0], [1.0, 0.0]])
+    expected_hessian = (
+        6.0 * inner * np.outer(inner_gradient, inner_gradient)
+        + 3.0 * inner**2 * inner_hessian
+    )
+
+    assert result.value == pytest.approx(inner**3)
+    assert_allclose(result.gradient, 3.0 * inner**2 * inner_gradient)
+    assert_allclose(result.hessian, expected_hessian)
+    assert_allclose(result.hessian, result.hessian.T)
+
+
+@pytest.mark.parametrize("value", [-5.0, -2.0, 0.0, 2.0, 5.0])
+def test_standard_normal_cdf_quantile_jets_are_inverse(value: float) -> None:
+    """Check independent normal CDF and quantile values through second order."""
+    coordinate = Jet2.variable(value, 0, 1)
+    restored = jet_ndtri(jet_ndtr(coordinate))
+
+    assert restored.value == pytest.approx(value, abs=5e-10)
+    assert_allclose(restored.gradient, [1.0], rtol=2e-9, atol=2e-9)
+    assert_allclose(restored.hessian, [[0.0]], rtol=0.0, atol=2e-9)
+
+
+def test_log_normal_quantile_jet_preserves_underflowing_tail() -> None:
+    """Round-trip a log CDF whose ordinary probability is exactly zero."""
+    coordinate = Jet2.variable(-42.0, 0, 1)
+    log_probability = jet_log_ndtr(coordinate)
+    restored = jet_ndtri_exp(log_probability)
+
+    assert math.exp(log_probability.value) == 0.0
+    assert restored.value == pytest.approx(-42.0, abs=2e-13)
+    assert_allclose(restored.gradient, [1.0], rtol=2e-12, atol=2e-12)
+    assert_allclose(restored.hessian, [[0.0]], rtol=0.0, atol=5e-12)
+
+
+@pytest.mark.parametrize(
+    ("bounds", "location", "expected"),
+    [
+        pytest.param(
+            TruncationBounds(0.2, None),
+            -4.0,
+            0.2016490930587551,
+            id="lower-alpha-42",
+        ),
+        pytest.param(
+            TruncationBounds(0.2, 0.8),
+            -4.0,
+            0.2016490930587551,
+            id="finite-right-tail",
+        ),
+        pytest.param(
+            TruncationBounds(0.2, 0.8),
+            5.0,
+            0.7983509069412449,
+            id="finite-left-tail",
+        ),
+    ],
+)
+def test_truncated_inverse_cdf_is_log_stable_beyond_probability_underflow(
+    bounds: TruncationBounds,
+    location: float,
+    expected: float,
+) -> None:
+    """Regress alpha=42 and symmetric finite-tail value/derivative failures."""
+    point = np.array([0.0, location, math.log(0.1)])
+
+    def evaluate(candidate: np.ndarray):
+        offset, location_jet, log_scale = seed_jets(candidate)
+        return truncated_normal_from_standard_normal(
+            offset,
+            location_jet,
+            positive_transform(log_scale).natural,
+            bounds,
+        )
+
+    def scipy_reference(candidate: np.ndarray) -> float:
+        offset, candidate_location, log_scale = candidate
+        scale = math.exp(log_scale)
+        standardized_lower = (
+            -np.inf
+            if bounds.lower is None
+            else (bounds.lower - candidate_location) / scale
+        )
+        standardized_upper = (
+            np.inf
+            if bounds.upper is None
+            else (bounds.upper - candidate_location) / scale
+        )
+        return float(
+            truncnorm.ppf(
+                norm.cdf(offset),
+                standardized_lower,
+                standardized_upper,
+                loc=candidate_location,
+                scale=scale,
+            )
+        )
+
+    result = evaluate(point)
+
+    assert result.value == pytest.approx(expected, rel=0.0, abs=2e-15)
+    assert result.value == pytest.approx(scipy_reference(point), abs=2e-15)
+    assert np.all(np.isfinite(result.gradient))
+    assert np.all(np.isfinite(result.hessian))
+    assert_allclose(
+        result.gradient,
+        _finite_difference_gradient(scipy_reference, point),
+        rtol=8e-6,
+        atol=3e-9,
+    )
+    assert_allclose(
+        result.hessian,
+        _finite_difference_hessian(scipy_reference, point),
+        rtol=2e-4,
+        atol=5e-8,
+    )
+
+
+@pytest.mark.parametrize(
+    ("bounds", "location", "scale"),
+    [
+        pytest.param(TruncationBounds(0.2, None), 0.0, 0.25, id="lower"),
+        pytest.param(TruncationBounds(0.1, 0.9), 0.5, 0.25, id="finite"),
+        pytest.param(TruncationBounds(0.1, 0.9), -0.5, 0.1, id="finite-tail"),
+    ],
+)
+@pytest.mark.parametrize("offset", [-4.0, 0.0, 4.0])
+def test_truncated_inverse_cdf_matches_scipy_and_change_of_variables(
+    bounds: TruncationBounds,
+    location: float,
+    scale: float,
+    offset: float,
+) -> None:
+    """Verify exact TN quantiles, curvature, and their pushforward Jacobian."""
+
+    def evaluate(candidate: np.ndarray):
+        coordinate = Jet2.variable(float(candidate[0]), 0, 1)
+        return truncated_normal_from_standard_normal(
+            coordinate, location, scale, bounds
+        )
+
+    point = np.array([offset])
+    result = evaluate(point)
+    expected = _scipy_truncated_from_offset(offset, location, scale, bounds)
+    log_tn_density = _scipy_truncated_logpdf(expected, location, scale, bounds)
+    expected_derivative = math.exp(norm.logpdf(offset) - log_tn_density)
+    scalar_function = lambda candidate: evaluate(candidate).value
+
+    assert result.value == pytest.approx(expected, rel=2e-10, abs=2e-12)
+    assert result.gradient[0] == pytest.approx(expected_derivative, rel=3e-8, abs=2e-11)
+    assert_allclose(
+        result.gradient,
+        _finite_difference_gradient(scalar_function, point),
+        rtol=3e-6,
+        atol=2e-8,
+    )
+    assert_allclose(
+        result.hessian,
+        _finite_difference_hessian(scalar_function, point),
+        rtol=4e-4,
+        atol=2e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        pytest.param(TruncationBounds(0.2, None), id="lower"),
+        pytest.param(TruncationBounds(None, 0.8), id="upper"),
+        pytest.param(TruncationBounds(0.1, 0.9), id="finite"),
+    ],
+)
+@pytest.mark.parametrize("unconstrained", [-15.0, -2.0, 0.0, 3.0, 15.0])
+def test_support_transform_round_trip_and_derivatives(
+    bounds: TruncationBounds, unconstrained: float
+) -> None:
+    """Cover both tails of every interval transform and its log Jacobian."""
+    coordinate = Jet2.variable(unconstrained, 0, 1)
+    transformed = support_transform(coordinate, bounds)
+    restored = support_inverse(transformed.natural.value, bounds)
+
+    assert restored == pytest.approx(unconstrained, abs=2e-9)
+    assert bounds.contains(transformed.natural.value)
+
+    def natural_function(point: np.ndarray) -> float:
+        jet = Jet2.variable(float(point[0]), 0, 1)
+        return support_transform(jet, bounds).natural.value
+
+    def jacobian_function(point: np.ndarray) -> float:
+        jet = Jet2.variable(float(point[0]), 0, 1)
+        return support_transform(jet, bounds).log_abs_det_jacobian.value
+
+    point = np.array([unconstrained])
+    assert_allclose(
+        transformed.natural.gradient,
+        _finite_difference_gradient(natural_function, point),
+        rtol=2e-7,
+        atol=2e-10,
+    )
+    assert_allclose(
+        transformed.log_abs_det_jacobian.hessian,
+        _finite_difference_hessian(jacobian_function, point),
+        rtol=2e-5,
+        atol=2e-8,
+    )
+
+
+@pytest.mark.parametrize("natural", [1e-8, 0.03, 1.0, 200.0])
+def test_positive_transform_round_trip(natural: float) -> None:
+    """Check the log transform across several scale regimes."""
+    unconstrained = positive_inverse(natural)
+    transformed = positive_transform(Jet2.variable(unconstrained, 0, 1))
+
+    assert transformed.natural.value == pytest.approx(natural)
+    assert transformed.log_abs_det_jacobian.value == pytest.approx(unconstrained)
+    assert_allclose(transformed.natural.gradient, [natural])
+    assert_allclose(transformed.natural.hessian, [[natural]])
+    assert_allclose(transformed.log_abs_det_jacobian.gradient, [1.0])
+    assert_allclose(transformed.log_abs_det_jacobian.hessian, [[0.0]])
+
+
+@pytest.mark.parametrize(
+    ("bounds", "value", "location", "scale"),
+    [
+        pytest.param(TruncationBounds(0.2, None), 0.200001, 0.0, 0.03, id="lower-tail"),
+        pytest.param(TruncationBounds(None, 0.8), 0.799999, 1.0, 0.03, id="upper-tail"),
+        pytest.param(
+            TruncationBounds(0.0, 1.0), 0.01, -2.0, 0.1, id="finite-right-tail"
+        ),
+        pytest.param(
+            TruncationBounds(-1.0, 0.0), -0.01, 2.0, 0.1, id="finite-left-tail"
+        ),
+        pytest.param(
+            TruncationBounds(0.1, 0.9), 0.100001, 0.5, 100.0, id="broad-scale"
+        ),
+    ],
+)
+def test_truncated_normal_matches_scipy_in_boundary_and_scale_regimes(
+    bounds: TruncationBounds, value: float, location: float, scale: float
+) -> None:
+    """Exercise stable one- and two-sided normalizers against SciPy."""
+    actual = truncated_normal_logpdf(value, location, scale, bounds).value
+    expected = _scipy_truncated_logpdf(value, location, scale, bounds)
+
+    assert math.isfinite(actual)
+    assert actual == pytest.approx(expected, rel=2e-12, abs=2e-12)
+
+
+@pytest.mark.parametrize(
+    ("bounds", "natural_value", "location", "natural_scale"),
+    [
+        pytest.param(TruncationBounds(0.2, None), 0.2002, 0.23, 0.015, id="lower-near"),
+        pytest.param(TruncationBounds(0.1, 0.9), 0.1002, 0.13, 0.06, id="finite-near"),
+        pytest.param(TruncationBounds(0.1, 0.9), 0.55, 0.45, 0.8, id="finite-broad"),
+    ],
+)
+def test_transformed_truncated_normal_gradient_and_hessian_match_differences(
+    bounds: TruncationBounds,
+    natural_value: float,
+    location: float,
+    natural_scale: float,
+) -> None:
+    """Verify TN value, gradient, and curvature in transformed coordinates."""
+    point = np.array(
+        [support_inverse(natural_value, bounds), location, math.log(natural_scale)]
+    )
+
+    def evaluate(candidate: np.ndarray):
+        value_coordinate, location_jet, scale_coordinate = seed_jets(candidate)
+        value_transform = support_transform(value_coordinate, bounds)
+        scale_transform = positive_transform(scale_coordinate)
+        return (
+            truncated_normal_logpdf(
+                value_transform.natural,
+                location_jet,
+                scale_transform.natural,
+                bounds,
+            )
+            + value_transform.log_abs_det_jacobian
+            + scale_transform.log_abs_det_jacobian
+        )
+
+    result = evaluate(point)
+    scalar_function = lambda candidate: evaluate(candidate).value
+
+    assert_allclose(
+        result.gradient,
+        _finite_difference_gradient(scalar_function, point),
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    assert_allclose(
+        result.hessian,
+        _finite_difference_hessian(scalar_function, point),
+        rtol=7e-4,
+        atol=5e-4,
+    )
+
+
+def test_normal_and_weibull_components_match_scipy_and_finite_differences() -> None:
+    """Check the remaining posterior distributions independently."""
+    point = np.array([0.4, -1.7])
+
+    def evaluate(candidate: np.ndarray):
+        location, log_scale = seed_jets(candidate)
+        scale_transform = positive_transform(log_scale)
+        return (
+            normal_logpdf(0.7, location, 0.3)
+            + weibull_logpdf(scale_transform.natural, 1.5, 0.3)
+            + scale_transform.log_abs_det_jacobian
+        )
+
+    result = evaluate(point)
+    natural_scale = math.exp(point[1])
+    expected = (
+        norm.logpdf(0.7, loc=point[0], scale=0.3)
+        + weibull_min.logpdf(natural_scale, c=1.5, scale=0.3)
+        + point[1]
+    )
+    scalar_function = lambda candidate: evaluate(candidate).value
+
+    assert result.value == pytest.approx(expected, rel=1e-13, abs=1e-13)
+    assert_allclose(
+        result.gradient,
+        _finite_difference_gradient(scalar_function, point),
+        rtol=2e-6,
+        atol=2e-7,
+    )
+    assert_allclose(
+        result.hessian,
+        _finite_difference_hessian(scalar_function, point),
+        rtol=2e-6,
+        atol=2e-7,
+    )
+
+
+POSTERIOR_CASES = (
+    pytest.param(
+        TruncationBounds(0.2, None),
+        0.205,
+        0.015,
+        [0.2008, 0.207, 0.23],
+        0.0,
+        id="lower-boundary-small-scale",
+    ),
+    pytest.param(
+        TruncationBounds(0.2, None),
+        0.9,
+        0.6,
+        [0.35, 0.8, 1.6],
+        0.5,
+        id="lower-interior-broad-scale",
+    ),
+    pytest.param(
+        TruncationBounds(0.1, 0.9),
+        0.13,
+        0.06,
+        [0.1008, 0.14, 0.27],
+        0.5,
+        id="finite-boundary-small-scale",
+    ),
+    pytest.param(
+        TruncationBounds(0.1, 0.9),
+        0.5,
+        0.5,
+        [0.2, 0.55, 0.82],
+        0.5,
+        id="finite-interior-broad-scale",
+    ),
+)
+
+
+def _posterior_spec(
+    bounds: TruncationBounds,
+    groups: list[float],
+    base_mean: float,
+) -> HierarchicalPosteriorSpec:
+    """Build the common deterministic full-posterior test fixture."""
+    return HierarchicalPosteriorSpec(
+        bounds=bounds,
+        location_base_mean=base_mean,
+        location_prior_scale=0.25,
+        scale_prior_shape=1.5,
+        scale_prior_scale=0.3,
+        n_groups=3,
+        group_index=np.array([0, 0, 1, 1, 2, 2], dtype=np.int64),
+        observations=np.array(
+            [
+                groups[0] - 0.02,
+                groups[0] + 0.01,
+                groups[1],
+                groups[1] + 0.03,
+                groups[2] - 0.01,
+                groups[2] + 0.02,
+            ]
+        ),
+        observation_scale=0.5,
+    )
+
+
+@pytest.mark.parametrize(
+    ("bounds", "location", "scale", "groups", "base_mean"), POSTERIOR_CASES
+)
+def test_hierarchical_posterior_matches_scipy_and_finite_differences(
+    bounds: TruncationBounds,
+    location: float,
+    scale: float,
+    groups: list[float],
+    base_mean: float,
+) -> None:
+    """Validate every term and total Hessian for causal study regimes."""
+    spec = _posterior_spec(bounds, groups, base_mean)
+    point = _point_for_parameterization(location, scale, groups, spec, "centered")
+    components = hierarchical_posterior_components(point, spec)
+    reference = _posterior_reference(point, spec)
+
+    for name, expected in reference.items():
+        actual = getattr(components, name).value
+        assert actual == pytest.approx(expected, rel=3e-11, abs=3e-11), name
+    assert components.total.value == pytest.approx(
+        sum(reference.values()), rel=3e-11, abs=3e-11
+    )
+
+    scalar_function = lambda candidate: (
+        hierarchical_posterior_components(candidate, spec).total.value
+    )
+    assert_allclose(
+        components.total.gradient,
+        _finite_difference_gradient(scalar_function, point),
+        rtol=8e-5,
+        atol=5e-5,
+    )
+    assert_allclose(
+        components.total.hessian,
+        _finite_difference_hessian(scalar_function, point),
+        rtol=1.5e-3,
+        atol=2e-3,
+    )
+    assert_allclose(components.total.hessian, components.total.hessian.T, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "parameterization",
+    ["group_icdf_noncentered", "full_icdf_noncentered"],
+)
+@pytest.mark.parametrize(
+    ("bounds", "location", "scale", "groups", "base_mean"), POSTERIOR_CASES
+)
+def test_noncentered_posterior_matches_scipy_and_finite_differences(
+    parameterization: CausalParameterization,
+    bounds: TruncationBounds,
+    location: float,
+    scale: float,
+    groups: list[float],
+    base_mean: float,
+) -> None:
+    """Validate both exact ICDF parameterizations through second order."""
+    spec = _posterior_spec(bounds, groups, base_mean)
+    point = _point_for_parameterization(location, scale, groups, spec, parameterization)
+    components = hierarchical_posterior_components(point, spec, parameterization)
+    reference = _posterior_reference(point, spec, parameterization)
+
+    for name, expected in reference.items():
+        actual = getattr(components, name).value
+        assert actual == pytest.approx(expected, rel=2e-9, abs=2e-9), name
+    assert components.total.value == pytest.approx(
+        sum(reference.values()), rel=2e-9, abs=2e-9
+    )
+
+    scalar_function = lambda candidate: (
+        hierarchical_posterior_components(candidate, spec, parameterization).total.value
+    )
+    assert_allclose(
+        components.total.gradient,
+        _finite_difference_gradient(scalar_function, point),
+        rtol=2e-4,
+        atol=8e-5,
+    )
+    assert_allclose(
+        components.total.hessian,
+        _finite_difference_hessian(scalar_function, point),
+        rtol=3e-3,
+        atol=3e-3,
+    )
+    assert_allclose(components.total.hessian, components.total.hessian.T, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "parameterization",
+    ["group_icdf_noncentered", "full_icdf_noncentered"],
+)
+@pytest.mark.parametrize(
+    ("bounds", "location", "scale", "groups", "base_mean"),
+    [POSTERIOR_CASES[0], POSTERIOR_CASES[2], POSTERIOR_CASES[3]],
+)
+def test_parameterizations_encode_the_same_natural_model_and_measure(
+    parameterization: CausalParameterization,
+    bounds: TruncationBounds,
+    location: float,
+    scale: float,
+    groups: list[float],
+    base_mean: float,
+) -> None:
+    """Check natural equality and the exact coordinate-density Jacobian."""
+    spec = _posterior_spec(bounds, groups, base_mean)
+    centered_point = _point_for_parameterization(
+        location, scale, groups, spec, "centered"
+    )
+    noncentered_point = _point_for_parameterization(
+        location, scale, groups, spec, parameterization
+    )
+    centered_natural = hierarchical_natural_values(centered_point, spec, "centered")
+    noncentered_natural = hierarchical_natural_values(
+        noncentered_point, spec, parameterization
+    )
+
+    assert noncentered_natural.location.value == pytest.approx(
+        centered_natural.location.value, rel=2e-10, abs=2e-12
+    )
+    assert noncentered_natural.scale.value == pytest.approx(
+        centered_natural.scale.value, rel=2e-13, abs=2e-13
+    )
+    assert_allclose(
+        [item.value for item in noncentered_natural.group_effect],
+        [item.value for item in centered_natural.group_effect],
+        rtol=2e-9,
+        atol=2e-11,
+    )
+
+    log_coordinate_jacobian = 0.0
+    if parameterization == "full_icdf_noncentered":
+        _, centered_location_jacobian = _natural_and_log_jacobian(
+            centered_point[0], bounds
+        )
+        location_tn_logpdf = _scipy_truncated_logpdf(
+            location,
+            spec.location_base_mean,
+            spec.location_prior_scale,
+            bounds,
+        )
+        log_coordinate_jacobian += (
+            norm.logpdf(noncentered_point[0])
+            - location_tn_logpdf
+            - centered_location_jacobian
+        )
+    for index, group in enumerate(groups):
+        _, centered_group_jacobian = _natural_and_log_jacobian(
+            centered_point[index + 2], bounds
+        )
+        group_tn_logpdf = _scipy_truncated_logpdf(group, location, scale, bounds)
+        log_coordinate_jacobian += (
+            norm.logpdf(noncentered_point[index + 2])
+            - group_tn_logpdf
+            - centered_group_jacobian
+        )
+
+    centered_logp = hierarchical_posterior_components(
+        centered_point, spec, "centered"
+    ).total.value
+    noncentered_logp = hierarchical_posterior_components(
+        noncentered_point, spec, parameterization
+    ).total.value
+    assert noncentered_logp == pytest.approx(
+        centered_logp + log_coordinate_jacobian,
+        rel=3e-9,
+        abs=3e-9,
+    )


### PR DESCRIPTION
## Summary

This is the first causal child of #1288 for #1282. It adds an independent second-order oracle and five exactly equivalent representations of one hierarchical TruncatedNormal model:

- native centered PyMC;
- manual centered density plus explicit Jacobians;
- location-only inverse-CDF non-centering with centered group effects;
- group-only inverse-CDF non-centering with a centered location;
- full inverse-CDF non-centering.

The four coordinate forms complete the 2×2 intervention on location centering and group-effect centering. The manual centered form is an implementation control. The oracle uses only the standard library, NumPy, and SciPy. The model tests compare full transformed log density, gradient, and Hessian against that oracle under PyTensor and genuine JAX autodiff.

## What this establishes

For the declared lower-only and finite-bound cases, all five representations encode the same natural model and agree numerically through second order. During review, the new regressions also found and fixed two defects in the research alternatives themselves: ordinary-probability tail underflow and an incorrect JAX subgradient at the log-CDF branch point.

This PR does **not** sample, qualify hierarchical TruncatedNormal defaults, alter HSSM production code, or authorize merging the rejected default experiment from #1277. Its output is the controlled substrate for the next causal sampling experiment.

## Validation

- 125 focused tests passed in the frozen Python 3.12 / PyMC 6.3.1 / PyTensor 3.3.0 / JAX 0.11.1 environment;
- all ten builder-by-bound oracle comparisons passed for PyTensor and actual JAX value, gradient, and Hessian;
- extreme lower, finite-right, and finite-left tail regressions passed after ordinary CDF underflow;
- Ruff check and format passed;
- mypy and Pyrefly passed;
- independent read-only review found no remaining correctness blocker;
- frozen v2 harness and evidence files are unchanged.

## Next experiment

A follow-up child will run the same data, natural-scale starts, and sampler randomization across all five representations. The predeclared 2×2 classifier can then distinguish location-centering, group-conditional-centering, their interaction, native graph/adaptation behavior, backend specificity, and residual TruncatedNormal geometry.

Closes no issue. Research tracker: #1282.
