### PR TITLE
test: execute causal truncated-hierarchy qualification (#1282)

### DIFF
--- a/.github/workflows/qualify_truncated_hierarchy_causal.yml
+++ b/.github/workflows/qualify_truncated_hierarchy_causal.yml
@@ -69,7 +69,7 @@ jobs:
           uv sync --project "$PROFILE_PROJECT" --frozen
           contract=(
             uv run --project "$PROFILE_PROJECT" --frozen python
-            scripts/truncated_hierarchy_causal_contract.py
+            -m scripts.truncated_hierarchy_causal_contract
             --manifest "$CAUSAL_MANIFEST"
           )
           "${contract[@]}" validate
@@ -121,7 +121,7 @@ jobs:
           uv sync --project "$PROFILE_PROJECT" --frozen
           contract=(
             uv run --project "$PROFILE_PROJECT" --frozen python
-            scripts/truncated_hierarchy_causal_contract.py
+            -m scripts.truncated_hierarchy_causal_contract
             --manifest "$CAUSAL_MANIFEST"
           )
           runner=(
@@ -290,7 +290,7 @@ jobs:
           )
           contract=(
             uv run --project "$PROFILE_PROJECT" --frozen python
-            scripts/truncated_hierarchy_causal_contract.py
+            -m scripts.truncated_hierarchy_causal_contract
             --manifest "$CAUSAL_MANIFEST"
           )
           "${runner[@]}" merge-runs --source-dir "$pair_root" \
@@ -463,7 +463,7 @@ jobs:
           )
           contract=(
             uv run --project "$PROFILE_PROJECT" --frozen python
-            scripts/truncated_hierarchy_causal_contract.py
+            -m scripts.truncated_hierarchy_causal_contract
             --manifest "$CAUSAL_MANIFEST"
           )
           "${runner[@]}" merge-runs --source-dir "$pair_root" \

--- a/.github/workflows/qualify_truncated_hierarchy_causal.yml
+++ b/.github/workflows/qualify_truncated_hierarchy_causal.yml
@@ -1,0 +1,491 @@
+name: Classify hierarchical TruncatedNormal causal failures
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Causal tier(s) to execute after mandatory smoke"
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - confirmation
+
+permissions:
+  contents: read
+
+concurrency:
+  group: truncated-hierarchy-causal-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CAUSAL_MANIFEST: benchmarks/specs/truncated_hierarchy_causal_v3.json
+  CAUSAL_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  PROFILE_PROJECT: benchmarks/environments/truncated_hierarchy/current-resolved
+  UV_VERSION: "0.11.21"
+
+jobs:
+  prepare:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' &&
+       (github.event.label.name == 'run-truncated-hierarchy-causal-smoke' ||
+        github.event.label.name == 'run-truncated-hierarchy-causal-confirmation') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      smoke_matrix: ${{ steps.plan.outputs.smoke_matrix }}
+      confirmation_matrix: ${{ steps.plan.outputs.confirmation_matrix }}
+      run_confirmation: ${{ steps.plan.outputs.run_confirmation }}
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Validate contract and build exact backend-pair matrices
+        id: plan
+        shell: bash
+        env:
+          REQUESTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || (github.event.label.name == 'run-truncated-hierarchy-causal-confirmation' && 'confirmation' || 'smoke') }}
+        run: |
+          set -euo pipefail
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          contract=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            scripts/truncated_hierarchy_causal_contract.py
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          "${contract[@]}" validate
+          smoke_matrix=$("${contract[@]}" matrix --tier smoke)
+          confirmation_matrix=$("${contract[@]}" matrix --tier confirmation)
+          python -c 'import json, sys; values = tuple(len(json.loads(value)["include"]) for value in sys.argv[1:]); sys.exit(0 if values == (2, 16) else f"unexpected causal matrices: {values}")' "$smoke_matrix" "$confirmation_matrix"
+          printf 'smoke_matrix=%s\n' "$smoke_matrix" >> "$GITHUB_OUTPUT"
+          printf 'confirmation_matrix=%s\n' "$confirmation_matrix" >> "$GITHUB_OUTPUT"
+          case "$REQUESTED_MODE" in
+            smoke) run_confirmation=false ;;
+            confirmation) run_confirmation=true ;;
+            *)
+              printf 'Unsupported causal mode: %s\n' "$REQUESTED_MODE" >&2
+              exit 2
+              ;;
+          esac
+          printf 'run_confirmation=%s\n' "$run_confirmation" >> "$GITHUB_OUTPUT"
+
+  materialize:
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Freeze environment and materialize shared inputs once
+        shell: bash
+        env:
+          RUN_CONFIRMATION: ${{ needs.prepare.outputs.run_confirmation }}
+        run: |
+          set -euo pipefail
+          run_root="$RUNNER_TEMP/causal-shared"
+          mkdir -p -- "$run_root/environment" "$run_root/logs"
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          contract=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            scripts/truncated_hierarchy_causal_contract.py
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          runner=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            -m scripts.truncated_hierarchy_causal_runner
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          "${contract[@]}" environment \
+            --output "$run_root/environment/environment.json"
+          "${runner[@]}" materialize-inputs --tier smoke --run-dir "$run_root" \
+            2>&1 | tee "$run_root/logs/materialize-smoke.log"
+          if [[ "$RUN_CONFIRMATION" == "true" ]]; then
+            "${runner[@]}" materialize-inputs \
+              --tier confirmation --run-dir "$run_root" \
+              2>&1 | tee "$run_root/logs/materialize-confirmation.log"
+          fi
+
+      - name: Upload immutable shared inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-shared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/causal-shared/environment/
+            ${{ runner.temp }}/causal-shared/data/
+            ${{ runner.temp }}/causal-shared/starts/natural/
+            ${{ runner.temp }}/causal-shared/logs/
+          if-no-files-found: error
+          retention-days: 90
+
+  smoke:
+    needs: [prepare, materialize]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.prepare.outputs.smoke_matrix) }}
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Download immutable shared inputs
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: tn-causal-shared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-evidence
+
+      - name: Run one co-located ten-cell smoke backend pair
+        shell: bash
+        env:
+          PAIR_ID: ${{ matrix.pair_id }}
+          WORKER_IDENTITY: ${{ github.run_id }}:${{ github.run_attempt }}:${{ github.job }}:${{ matrix.pair_id }}
+        run: |
+          set -euo pipefail
+          run_root="$RUNNER_TEMP/causal-evidence"
+          mkdir -p -- "$run_root/logs"
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          set +e
+          uv run --project "$PROFILE_PROJECT" --frozen python \
+            -m scripts.truncated_hierarchy_causal_runner \
+            --manifest "$CAUSAL_MANIFEST" run-unit \
+            --tier smoke --pair-id "$PAIR_ID" --run-dir "$run_root" \
+            --worker-identity "$WORKER_IDENTITY" \
+            --expected-git-commit "$CAUSAL_SHA" \
+            2>&1 | tee "$run_root/logs/$PAIR_ID.log"
+          runner_status=${PIPESTATUS[0]}
+          set -e
+          case "$runner_status" in
+            0|1)
+              printf 'Backend pair finished with evidence status %s.\n' "$runner_status"
+              ;;
+            *) exit "$runner_status" ;;
+          esac
+
+      - name: Upload smoke backend-pair evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-smoke-${{ matrix.pair_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/causal-evidence/contexts/${{ matrix.pair_id }}.json
+            ${{ runner.temp }}/causal-evidence/starts/coordinates/
+            ${{ runner.temp }}/causal-evidence/chains/
+            ${{ runner.temp }}/causal-evidence/diagnostics/
+            ${{ runner.temp }}/causal-evidence/cells/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload smoke backend-pair log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-log-smoke-${{ matrix.pair_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-evidence/logs/${{ matrix.pair_id }}.log
+          if-no-files-found: warn
+          retention-days: 90
+
+  smoke_aggregate:
+    if: ${{ always() && needs.prepare.result == 'success' && needs.materialize.result == 'success' }}
+    needs: [prepare, materialize, smoke]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Download immutable shared inputs
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: tn-causal-shared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-run
+
+      - name: Download isolated smoke backend-pair artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: tn-causal-smoke-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-pairs
+          merge-multiple: false
+
+      - name: Merge exact evidence and assess smoke completeness
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_root="$RUNNER_TEMP/causal-run"
+          pair_root="$RUNNER_TEMP/causal-pairs"
+          if [[ ! -d "$pair_root" ]]; then
+            printf 'No smoke backend-pair artifacts were downloaded.\n' >&2
+            exit 2
+          fi
+          aggregate="$run_root/aggregate/smoke"
+          mkdir -p -- "$aggregate" "$run_root/logs"
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          runner=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            -m scripts.truncated_hierarchy_causal_runner
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          contract=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            scripts/truncated_hierarchy_causal_contract.py
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          "${runner[@]}" merge-runs --source-dir "$pair_root" \
+            --run-dir "$run_root" \
+            2>&1 | tee "$run_root/logs/smoke-merge.log"
+          "${contract[@]}" aggregate --tier smoke --run-dir "$run_root" \
+            --output "$aggregate/results.jsonl" \
+            2>&1 | tee "$run_root/logs/smoke-aggregate.log"
+          "${contract[@]}" assess --tier smoke \
+            --results "$aggregate/results.jsonl" \
+            --output "$aggregate/assessment.json" \
+            2>&1 | tee "$run_root/logs/smoke-assess.log"
+          python -c 'import json, sys; value = json.load(open(sys.argv[1], encoding="utf-8")); sys.exit(0 if value.get("contract_valid") is True and value.get("evidence_complete") is True and value.get("proceed_to_confirmation") is True else "smoke evidence is not complete enough for confirmation")' "$aggregate/assessment.json"
+
+      - name: Upload smoke aggregate and assessment
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-summary-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/causal-run/aggregate/smoke/
+            ${{ runner.temp }}/causal-run/logs/smoke-merge.log
+            ${{ runner.temp }}/causal-run/logs/smoke-aggregate.log
+            ${{ runner.temp }}/causal-run/logs/smoke-assess.log
+          if-no-files-found: warn
+          retention-days: 90
+
+  confirmation:
+    if: >-
+      needs.prepare.outputs.run_confirmation == 'true' &&
+      needs.smoke_aggregate.result == 'success'
+    needs: [prepare, materialize, smoke_aggregate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.prepare.outputs.confirmation_matrix) }}
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Download immutable shared inputs
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: tn-causal-shared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-evidence
+
+      - name: Run one co-located ten-cell confirmation backend pair
+        shell: bash
+        env:
+          PAIR_ID: ${{ matrix.pair_id }}
+          WORKER_IDENTITY: ${{ github.run_id }}:${{ github.run_attempt }}:${{ github.job }}:${{ matrix.pair_id }}
+        run: |
+          set -euo pipefail
+          run_root="$RUNNER_TEMP/causal-evidence"
+          mkdir -p -- "$run_root/logs"
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          set +e
+          uv run --project "$PROFILE_PROJECT" --frozen python \
+            -m scripts.truncated_hierarchy_causal_runner \
+            --manifest "$CAUSAL_MANIFEST" run-unit \
+            --tier confirmation --pair-id "$PAIR_ID" --run-dir "$run_root" \
+            --worker-identity "$WORKER_IDENTITY" \
+            --expected-git-commit "$CAUSAL_SHA" \
+            2>&1 | tee "$run_root/logs/$PAIR_ID.log"
+          runner_status=${PIPESTATUS[0]}
+          set -e
+          case "$runner_status" in
+            0|1)
+              printf 'Backend pair finished with evidence status %s.\n' "$runner_status"
+              ;;
+            *) exit "$runner_status" ;;
+          esac
+
+      - name: Upload confirmation backend-pair evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-confirmation-${{ matrix.pair_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/causal-evidence/contexts/${{ matrix.pair_id }}.json
+            ${{ runner.temp }}/causal-evidence/starts/coordinates/
+            ${{ runner.temp }}/causal-evidence/chains/
+            ${{ runner.temp }}/causal-evidence/diagnostics/
+            ${{ runner.temp }}/causal-evidence/cells/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Upload confirmation backend-pair log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-log-confirmation-${{ matrix.pair_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-evidence/logs/${{ matrix.pair_id }}.log
+          if-no-files-found: warn
+          retention-days: 90
+
+  confirmation_aggregate:
+    if: >-
+      always() &&
+      needs.prepare.outputs.run_confirmation == 'true' &&
+      needs.smoke_aggregate.result == 'success'
+    needs: [prepare, materialize, smoke_aggregate, confirmation]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Check out the exact causal-study commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.CAUSAL_SHA }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Download immutable shared inputs
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: tn-causal-shared-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-run
+
+      - name: Download isolated confirmation backend-pair artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: tn-causal-confirmation-*-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/causal-pairs
+          merge-multiple: false
+
+      - name: Merge exact evidence and assess confirmation
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_root="$RUNNER_TEMP/causal-run"
+          pair_root="$RUNNER_TEMP/causal-pairs"
+          if [[ ! -d "$pair_root" ]]; then
+            printf 'No confirmation backend-pair artifacts were downloaded.\n' >&2
+            exit 2
+          fi
+          aggregate="$run_root/aggregate/confirmation"
+          mkdir -p -- "$aggregate" "$run_root/logs"
+          uv sync --project "$PROFILE_PROJECT" --frozen
+          runner=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            -m scripts.truncated_hierarchy_causal_runner
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          contract=(
+            uv run --project "$PROFILE_PROJECT" --frozen python
+            scripts/truncated_hierarchy_causal_contract.py
+            --manifest "$CAUSAL_MANIFEST"
+          )
+          "${runner[@]}" merge-runs --source-dir "$pair_root" \
+            --run-dir "$run_root" \
+            2>&1 | tee "$run_root/logs/confirmation-merge.log"
+          "${contract[@]}" aggregate --tier confirmation --run-dir "$run_root" \
+            --output "$aggregate/results.jsonl" \
+            2>&1 | tee "$run_root/logs/confirmation-aggregate.log"
+          "${contract[@]}" assess --tier confirmation \
+            --results "$aggregate/results.jsonl" \
+            --output "$aggregate/assessment.json" \
+            2>&1 | tee "$run_root/logs/confirmation-assess.log"
+
+      - name: Upload confirmation aggregate and assessment
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tn-causal-summary-confirmation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/causal-run/aggregate/confirmation/
+            ${{ runner.temp }}/causal-run/logs/confirmation-merge.log
+            ${{ runner.temp }}/causal-run/logs/confirmation-aggregate.log
+            ${{ runner.temp }}/causal-run/logs/confirmation-assess.log
+          if-no-files-found: warn
+          retention-days: 90

--- a/benchmarks/specs/truncated_hierarchy_causal_v3.json
+++ b/benchmarks/specs/truncated_hierarchy_causal_v3.json
@@ -1,0 +1,394 @@
+{
+  "schema_version": 3,
+  "study_id": "truncated_hierarchy_causal_v3",
+  "status": "frozen-before-sampling",
+  "description": "Prospective same-model causal experiment for the two hierarchical TruncatedNormal regimes that failed the frozen v2 smoke screen.",
+  "master_seed": 1282,
+  "seed_derivation": {
+    "algorithm": "blake2b-64-causal-v3",
+    "person": "hssm1282cv3",
+    "domain": "hssm-truncated-hierarchy-causal-v3",
+    "positive_integer_range": [
+      1,
+      2147483647
+    ],
+    "replicate_zero_data": "exact-frozen-v2-streams",
+    "later_data": "causal-v3-domain-separated-streams"
+  },
+  "frozen_v2": {
+    "path": "benchmarks/specs/truncated_hierarchy_v2.json",
+    "file_sha256": "a0e5ef9415ce580b226a15621fbb50635547abbbdebcc11c16ab4e52e75a4ab7",
+    "study_id": "truncated_hierarchy_v2",
+    "schema_version": 2,
+    "status": "frozen-before-primary-runs"
+  },
+  "dependency_profile": {
+    "name": "current-resolved",
+    "python": "3.12",
+    "project_path": "benchmarks/environments/truncated_hierarchy/current-resolved/pyproject.toml",
+    "project_sha256": "1c50a87e93048e6187b29fe8d104565438dacd91e4c07a02973bbf4cca37b373",
+    "lock_path": "benchmarks/environments/truncated_hierarchy/current-resolved/uv.lock",
+    "lock_sha256": "6567c87ae8f9d0d24d6c482204b3bafccc73a0a13be4eab2d38aee0aae12f1f3",
+    "required_versions": {
+      "arviz": "1.3.0",
+      "bambi": "0.20.0",
+      "jax": "0.11.1",
+      "jaxlib": "0.11.1",
+      "numpy": "2.4.6",
+      "numpyro": "0.21.0",
+      "pymc": "6.3.1",
+      "pytensor": "3.3.0",
+      "scipy": "1.18.1"
+    }
+  },
+  "natural_model": {
+    "likelihood": "y[i] ~ Normal(group_effect[group_index[i]], 0.5)",
+    "location_prior": "TruncatedNormal(prior_hyper_location, 0.25, bounds)",
+    "scale_prior": "Weibull(alpha=1.5, beta=0.3)",
+    "group_prior": "TruncatedNormal(group_location, group_scale, bounds)",
+    "location_prior_sigma": 0.25,
+    "scale_prior_alpha": 1.5,
+    "scale_prior_beta": 0.3,
+    "observation_sigma": 0.5
+  },
+  "representations": [
+    {
+      "representation_id": "native-centered",
+      "builder": "native_centered",
+      "location_coordinates": "centered",
+      "group_coordinates": "centered",
+      "density_implementation": "pymc-native",
+      "factorial_cell": "C-C",
+      "role": "native-reference"
+    },
+    {
+      "representation_id": "manual-centered",
+      "builder": "manual_centered",
+      "location_coordinates": "centered",
+      "group_coordinates": "centered",
+      "density_implementation": "independent-manual",
+      "factorial_cell": "C-C",
+      "role": "implementation-control"
+    },
+    {
+      "representation_id": "group-icdf-noncentered",
+      "builder": "group_icdf_noncentered",
+      "location_coordinates": "centered",
+      "group_coordinates": "icdf-noncentered",
+      "density_implementation": "pymc-native-location-independent-icdf-groups",
+      "factorial_cell": "C-NC",
+      "role": "factorial"
+    },
+    {
+      "representation_id": "location-icdf-noncentered",
+      "builder": "location_icdf_noncentered",
+      "location_coordinates": "icdf-noncentered",
+      "group_coordinates": "centered",
+      "density_implementation": "independent-icdf-location-pymc-native-groups",
+      "factorial_cell": "NC-C",
+      "role": "factorial"
+    },
+    {
+      "representation_id": "full-icdf-noncentered",
+      "builder": "full_icdf_noncentered",
+      "location_coordinates": "icdf-noncentered",
+      "group_coordinates": "icdf-noncentered",
+      "density_implementation": "independent-icdf",
+      "factorial_cell": "NC-NC",
+      "role": "factorial"
+    }
+  ],
+  "backends": [
+    {
+      "backend_id": "pymc",
+      "sampler": "pymc-nuts",
+      "compiler_path": "pytensor",
+      "device": "cpu"
+    },
+    {
+      "backend_id": "numpyro",
+      "sampler": "numpyro-nuts-via-pymc",
+      "compiler_path": "pytensor-to-jax",
+      "device": "cpu"
+    }
+  ],
+  "tiers": {
+    "smoke": {
+      "role": "execution-and-frozen-failing-dataset-regime-replay-only",
+      "qualifies_causal_conclusion": false,
+      "replicates": 1,
+      "chains": 2,
+      "tune": 250,
+      "draws": 250,
+      "target_accept": 0.9,
+      "max_treedepth": 10,
+      "expected_fit_count": 20
+    },
+    "confirmation": {
+      "role": "primary-causal-classification",
+      "qualifies_causal_conclusion": true,
+      "replicates": 8,
+      "chains": 4,
+      "tune": 1000,
+      "draws": 1000,
+      "target_accept": 0.9,
+      "max_treedepth": 10,
+      "expected_fit_count": 160
+    }
+  },
+  "regimes": [
+    {
+      "regime_id": "lower-outside-weak",
+      "source_v2_scenario_id": "smoke-pymc-lower-outside",
+      "source_v2_data_id": "smoke-toy-lower-outside",
+      "bound_kind": "lower",
+      "lower": 0.2,
+      "upper": null,
+      "prior_hyper_location": 0.0,
+      "truth_group_location": 0.23,
+      "truth_group_scale": 0.3,
+      "n_groups": 4,
+      "n_per_group": 2,
+      "group_indices": [
+        0,
+        2,
+        3
+      ],
+      "floatx": "float64",
+      "replicate_zero_v2_seeds": {
+        "data_seed": 1818466647,
+        "truth_seed": 746768835,
+        "group_seed": 2035821882,
+        "observation_seed": 259518566
+      }
+    },
+    {
+      "regime_id": "two-sided-near",
+      "source_v2_scenario_id": "smoke-pymc-two-sided-near",
+      "source_v2_data_id": "smoke-pymc-two-sided-near",
+      "bound_kind": "two_sided",
+      "lower": 0.1,
+      "upper": 0.9,
+      "prior_hyper_location": 0.5,
+      "truth_group_location": 0.13,
+      "truth_group_scale": 0.3,
+      "n_groups": 4,
+      "n_per_group": 25,
+      "group_indices": [
+        0,
+        2,
+        3
+      ],
+      "floatx": "float32",
+      "replicate_zero_v2_seeds": {
+        "data_seed": 401637509,
+        "truth_seed": 564408077,
+        "group_seed": 1871618804,
+        "observation_seed": 902570113
+      }
+    }
+  ],
+  "execution_policy": {
+    "scheduling_unit": "backend-paired-ten-cell-worker",
+    "pair_identity": "tier-regime-replicate",
+    "block_identity": "tier-regime-backend-replicate",
+    "pair_members": "both-five-representation-backend-blocks-exactly-once",
+    "block_members": "all-five-representations-exactly-once",
+    "placement": "one-physical-worker-per-backend-pair",
+    "failure": "attempt-all-ten-members-and-publish-an-independent-final-record-for-each",
+    "backend_order": "left-rotation-of-manifest-backend-order-by-(replicate+regime_index)-modulo-2",
+    "order": "within-each-backend-left-rotation-of-manifest-representation-order-by-(4*replicate+2*regime_index+backend_index)-modulo-5",
+    "process_isolation": "one-cell-per-fresh-process",
+    "cache_policy": "unique-pytensor-and-jax-cache-per-cell-and-phase",
+    "data_sharing": "one-byte-identical-immutable-data-artifact-per-tier-regime-replicate-shared-across-backends-and-representations",
+    "natural_start_sharing": "one-byte-identical-immutable-natural-start-artifact-per-tier-regime-replicate-shared-across-backends-and-representations",
+    "natural_start_generation": {
+      "source_model": "native-centered",
+      "support_points": "pymc-initial-point",
+      "function": "pymc.initial_point.make_initial_point_fns_per_chain",
+      "jitter_rvs": "all-free-rvs",
+      "jitter_distribution": "uniform-minus-one-to-one-in-transformed-coordinates",
+      "seed": "natural_start_chain_seeds-derived-from-natural_start_seed",
+      "materialization": "map-each-jittered-native-coordinate-point-to-natural-scale-once",
+      "sampling_init": "adapt_diag-with-exact-mapped-start-and-no-second-jitter"
+    },
+    "coordinate_start_mapping": "bijection-from-shared-natural-start-to-each-representation-with-recorded-round-trip",
+    "backend_start_policy": "reuse-the-same-natural-chain-starts-across-pymc-and-numpyro",
+    "sampler_seed_policy": {
+      "pymc_plan": "chain_seeds-are-seedsequence-entropy-words",
+      "pymc_execution": "pymc-6.3.1-spawns-one-pcg64-generator-per-chain-draws-one-init-step-integer-below-2^30-then-samples-with-the-advanced-generators",
+      "pymc_provenance": "record-entropy-spawn-key-init-step-integer-and-post-draw-generator-state-hash",
+      "numpyro_plan": "one-scalar-sampler-seed",
+      "numpyro_provenance": "record-exact-uint32-jax-prngkey-or-split-keys"
+    },
+    "timing_scope": "sampler-call-including-compilation-warmup-and-retained-draws-only",
+    "threads": 1,
+    "jax_enable_x64": "true-iff-regime-floatx-is-float64"
+  },
+  "artifact_policy": {
+    "hash": "sha256-exact-bytes",
+    "serialization": "strict-canonical-json-or-netcdf",
+    "publish": "atomic-no-overwrite",
+    "final_marker": "cell-result-json-written-last",
+    "context_path": "contexts/<pair_id>.json",
+    "data_path": "data/<data_id>.json",
+    "natural_start_path": "starts/natural/<start_id>.json",
+    "coordinate_start_path": "starts/coordinates/<cell_id>.json",
+    "chain_path": "chains/<cell_id>.nc",
+    "diagnostic_path": "diagnostics/<cell_id>.json",
+    "cell_path": "cells/<cell_id>.json",
+    "aggregate_path": "aggregate/<tier>/results.jsonl",
+    "assessment_path": "aggregate/<tier>/assessment.json"
+  },
+  "failure_policy": {
+    "scientific_stages": [
+      "data",
+      "build",
+      "initialize",
+      "compile",
+      "sample",
+      "summarize",
+      "diagnose"
+    ],
+    "contract_environment_artifact_and_programming_errors": "infrastructure-errors-never-published-as-scientific-cell-failures",
+    "interrupts": "propagate-without-a-scientific-cell-record",
+    "block_failure": "one-member-failure-does-not-suppress-the-other-nine-attempts",
+    "missing_result": "incomplete-never-pass"
+  },
+  "analysis_policy": {
+    "scope": "classify-each-regime-separately-never-pool-regimes",
+    "monitored_parameters": [
+      "group_location",
+      "group_scale",
+      "group_first",
+      "group_middle",
+      "group_last"
+    ],
+    "oracle_gate": {
+      "evaluation_points": [
+        "fixed-grid",
+        "every-shared-natural-start",
+        "hash-selected-posterior-trajectory-points"
+      ],
+      "point_counts": {
+        "fixed_grid_on_replicate_zero": 1,
+        "shared_start_points_per_chain": 1,
+        "icdf_points_per_noncentered_layer": 5,
+        "posterior_trajectory_points_per_chain": 1,
+        "failed_sample_phase": "pre-sampling-only",
+        "completed_phase": "pre-sampling-plus-posterior-trajectory"
+      },
+      "required_checks": [
+        "transformed-logp",
+        "transformed-gradient",
+        "transformed-hessian",
+        "natural-coordinate-roundtrip",
+        "icdf-tail-finiteness",
+        "icdf-branch-continuity"
+      ],
+      "combined_scaled_error": "abs(observed-reference)/(absolute_tolerance+relative_tolerance*max(abs(reference),abs(observed)))",
+      "component_tolerances": {
+        "float64": {
+          "logp": {
+            "absolute_tolerance": 5e-8,
+            "relative_tolerance": 2e-8
+          },
+          "gradient": {
+            "absolute_tolerance": 3e-7,
+            "relative_tolerance": 3e-7
+          },
+          "hessian": {
+            "absolute_tolerance": 3e-6,
+            "relative_tolerance": 3e-6
+          }
+        },
+        "float32": {
+          "logp": {
+            "absolute_tolerance": 0.0002,
+            "relative_tolerance": 0.0002
+          },
+          "gradient": {
+            "absolute_tolerance": 0.0005,
+            "relative_tolerance": 0.0007
+          },
+          "hessian": {
+            "absolute_tolerance": 0.003,
+            "relative_tolerance": 0.003
+          }
+        }
+      },
+      "scaled_error_max": 1.0,
+      "roundtrip_absolute_error_max": {
+        "float64": 1e-10,
+        "float32": 2e-5
+      }
+    },
+    "per_fit_health": {
+      "compile_success": true,
+      "initialization_success": true,
+      "logp_finite": true,
+      "gradient_finite": true,
+      "sampling_success": true,
+      "divergence_rate_lt": 0.01,
+      "hyper_rhat_max_lt": 1.01,
+      "hyper_ess_bulk_min_ge": 400,
+      "hyper_ess_tail_min_ge": 400,
+      "bfmi_min_ge": 0.3,
+      "treedepth_saturation_rate_lt": 0.001,
+      "hyper_mcse_over_sd_max_le": 0.05,
+      "group_rhat_max_lt": 1.01,
+      "group_ess_bulk_fraction_ge_400_ge": 0.95,
+      "group_ess_tail_fraction_ge_400_ge": 0.95
+    },
+    "family_health": {
+      "aggregate_divergence_rate_lt": 0.001,
+      "per_fit_pass_fraction_ge": 0.95,
+      "maximum_failed_replicates": 0,
+      "compile_initialize_nonfinite_or_sampling_failure": "unhealthy"
+    },
+    "paired_inference": {
+      "replicates": 8,
+      "familywise_alpha": 0.05,
+      "bonferroni_comparisons": 6,
+      "per_comparison_alpha": 0.008333333333333333,
+      "test": "two-sided-exact-sign-test-on-discordant-paired-health-outcomes",
+      "minimum_all-directional_p_value": 0.0078125,
+      "comparison_family": [
+        "native-vs-manual-IUT-across-both-backends",
+        "group-effect-at-location-centered-IUT-across-both-backends",
+        "group-effect-at-location-noncentered-IUT-across-both-backends",
+        "location-effect-at-groups-centered-IUT-across-both-backends",
+        "location-effect-at-groups-noncentered-IUT-across-both-backends",
+        "backend-five-form-health-count-omnibus"
+      ],
+      "backend_omnibus_statistic": "per-replicate-pymc-healthy-form-count-minus-numpyro-healthy-form-count",
+      "backend_omnibus_direction": "same-nonzero-sign-in-all-eight-paired-replicates",
+      "representation_backend_contrasts": "descriptive-only-never-classifying",
+      "interpretation": "minimum-inferentially-defensible-grid-not-a-high-power-small-effect-design"
+    },
+    "classifier_precedence": [
+      "native-pymc-correctness-defect",
+      "native-graph-or-adaptation",
+      "group-conditional-centering",
+      "location-centering",
+      "joint-centering-interaction",
+      "backend-path-specific",
+      "residual-tn-or-scale-geometry",
+      "initialization-or-budget-sensitive",
+      "all-representations-healthy",
+      "mixed-inconclusive"
+    ],
+    "classifier_rules": {
+      "native-pymc-correctness-defect": "native transformed value-gradient-or-hessian disagrees with the independent oracle on at least two distinct dataset replicates while corresponding manual C-C replicate-backend evidence agrees; sampling is not required for this classification",
+      "native-graph-or-adaptation": "native C-C is unhealthy and manual C-C is healthy on paired datasets while both pass the oracle gate",
+      "group-conditional-centering": "both group-centered factorial cells are unhealthy and both group-noncentered cells are healthy",
+      "location-centering": "both location-centered factorial cells are unhealthy and both location-noncentered cells are healthy",
+      "joint-centering-interaction": "only NC-NC is healthy; this does not establish two independent main effects",
+      "backend-path-specific": "the five-form healthy-count difference between PyMC and NumPyro has the same nonzero direction on all eight paired blocks; per-representation backend contrasts are descriptive only",
+      "residual-tn-or-scale-geometry": "all exact same-model representations are unhealthy after every oracle and ICDF gate passes",
+      "initialization-or-budget-sensitive": "reserved for a separately predeclared diagnostic replay; primary evidence alone cannot assign it",
+      "all-representations-healthy": "all five representations are healthy on both backends",
+      "mixed-inconclusive": "complete evidence matches no stronger predeclared rule"
+    }
+  }
+}

--- a/design/truncated_hierarchy_causal/README.md
+++ b/design/truncated_hierarchy_causal/README.md
@@ -1,0 +1,375 @@
+# Hierarchical TruncatedNormal causal experiment
+
+This directory defines the follow-up experiment for the hierarchical
+`TruncatedNormal` sampling failures observed by the frozen v2 qualification. It is a
+research contract, not an HSSM default-policy change. The general prior-construction
+work and this causal investigation deliberately remain separate; a later policy
+change may use the evidence produced here, but this experiment does not modify a
+default by itself.
+
+The frozen v2 result establishes three useful facts:
+
+1. the failure is not confined to HSSM or Bambi, because a direct PyMC Gaussian
+   hierarchy failed the smoke divergence screen;
+2. the tested PyTensor and JAX gradients agreed locally, so the historical failure
+   is not already explained by a demonstrated wrong gradient at those points; and
+3. a linked-Normal hierarchy can be a practical alternative, but it changes the
+   prior and therefore cannot identify the cause of a same-model failure.
+
+V3 answers the narrower causal question: when the natural probability model is held
+fixed, which density implementation or centering choice changes sampling health?
+
+## Frozen inputs and independence from v2
+
+[`truncated_hierarchy_causal_v3.json`](../../benchmarks/specs/truncated_hierarchy_causal_v3.json)
+is the only executable design. It has a new schema, study identifier, seed domain,
+artifact namespace, runner, and assessor. It does not import or extend the v2
+validator. The v2 manifest remains immutable and is protected by an exact-byte
+SHA-256 assertion. V3 additionally verifies that both copied regimes still match
+their named v2 source scenarios field by field.
+
+Replicate zero reuses the exact v2 data, truth, group, and observation seeds. Later
+replicates use a new BLAKE2b domain with explicit purpose separation. Python's
+process-randomized `hash()` is never used.
+
+The two regimes are the exact direct-PyMC smoke failures:
+
+| Regime | Bounds | Prior anchor | Truth | Data | Precision |
+| --- | --- | --- | --- | --- | --- |
+| `lower-outside-weak` | `[0.2, +inf)` | `0.0` | location `0.23`, scale `0.3` | 4 groups × 2 observations, observation SD `0.5` | float64 |
+| `two-sided-near` | `[0.1, 0.9]` | `0.5` | location `0.13`, scale `0.3` | 4 groups × 25 observations, observation SD `0.5` | float32 |
+
+They are never pooled. Support shape, anchor conflict, information, and precision all
+differ, so a pooled label would make the causal conclusion ambiguous.
+
+## Same natural model, five representations
+
+Every fit defines exactly this natural-scale hierarchy:
+
+```text
+group_location ~ TruncatedNormal(prior_anchor, 0.25, bounds)
+group_scale ~ Weibull(alpha=1.5, beta=0.3)
+group_effect[g] ~ TruncatedNormal(group_location, group_scale, bounds)
+y[i] ~ Normal(group_effect[group_index[i]], 0.5)
+```
+
+Only computational coordinates and density implementation change:
+
+| Representation | Location | Groups | Role |
+| --- | --- | --- | --- |
+| `native-centered` | centered | centered | native PyMC reference |
+| `manual-centered` | centered | centered | independently normalized density and Jacobians |
+| `group-icdf-noncentered` | centered | inverse-CDF non-centered | C/NC factorial cell |
+| `location-icdf-noncentered` | inverse-CDF non-centered | centered | NC/C factorial cell |
+| `full-icdf-noncentered` | inverse-CDF non-centered | inverse-CDF non-centered | NC/NC factorial cell |
+
+The fifth, NC/C representation is essential. Four forms would omit one cell of the
+2×2 centering intervention, making a location main effect indistinguishable from an
+interaction. Native and manual C/C occupy the same factorial cell; their difference
+isolates native density/graph behavior from centering geometry.
+
+The inverse-CDF forms are exact reparameterizations, not linked-Normal controls. A
+standard-Normal offset is mapped through its CDF to a uniform quantile and then
+through the independently implemented truncated-Normal inverse CDF. The induced
+natural prior remains the same.
+
+## Matrix and execution blocks
+
+Both sampler paths are mandatory:
+
+- PyMC NUTS through PyTensor;
+- NumPyro NUTS through PyTensor-to-JAX.
+
+The smoke tier has one replicate, two chains, 250 warmup draws, and 250 retained
+draws. Its 20 fits validate construction, replay of the same frozen failing dataset
+and regime, initialization, artifact flow, and short-chain execution. Natural-start
+and sampler seeds are newly derived in the v3 domain, so this is not a literal replay
+of the original v2 chains or their exact failure. Smoke cannot support a causal
+conclusion: the assessor reports `screening-only` for each regime and no causal label,
+even if a one-replicate health pattern happens to match a confirmation rule.
+
+The confirmation tier has eight replicates, four chains, 1,000 warmup draws, and
+1,000 retained draws. It contains 160 fits. Eight paired datasets are the smallest
+grid on which an all-directional two-sided exact sign test reaches `0.0078125`, below
+the predeclared Bonferroni threshold `0.05 / 6 = 0.008333...`. The six stochastic
+comparisons are five conceptual within-backend contrasts—native versus manual and
+the four factorial simple effects—each treated as an intersection-union test that
+must pass in the frozen direction on both backend strata, plus one block-level
+backend omnibus. Representation-specific backend contrasts are descriptive only.
+The deterministic density/derivative oracle is a correctness gate, not a seventh
+stochastic hypothesis. This is an inferentially
+defensible minimum for near-deterministic effects, not a high-power design for small
+effects.
+
+Both tiers fix `target_accept=0.90` and maximum tree depth 10. Raising
+`target_accept`, extending warmup after seeing a result, or selecting favorable seeds
+cannot rescue a primary classification.
+
+Each logical regime × backend × replicate block still contains all five
+representations, but the scheduler's indivisible worker unit is the pair of PyMC and
+NumPyro blocks for one regime × replicate: ten cells total. The paired placement is
+necessary for the backend omnibus; otherwise a backend label would be confounded with
+different hosted workers. The two backend blocks share a worker identity and one
+auditable pair-execution identity. Backend order rotates by
+`(replicate + regime index) modulo 2`, so the two smoke workers use opposite orders
+and each confirmation regime runs four pairs in each order.
+
+Within a backend block, representation order rotates by
+`(4 × replicate + 2 × regime index + backend index) modulo 5`. The four logical smoke
+blocks therefore start at four distinct positions, and confirmation traverses all
+five positions. A cell failure does not suppress the other nine attempts. Every cell
+still runs in a fresh child process with fresh PyTensor and JAX caches.
+
+## Shared data and starts
+
+All forms and both backends consume byte-identical immutable data for a given tier,
+regime, and replicate. Data generation is completed and hash-bound before model
+construction.
+
+Starts are also an intervention control. For every chain, the runner builds the
+native centered model, calls PyMC's per-chain initial-point generator with all free
+variables jittered uniformly from −1 to 1 in transformed coordinates, and uses the
+predeclared chain seed. It maps that point to natural `group_location`,
+`group_scale`, and every `group_effect` exactly once. Each representation then maps
+the shared natural point into its own coordinates and must round-trip it back to
+natural scale within the frozen float32 or float64 tolerance.
+
+PyMC and NumPyro receive the same natural starts. Sampling uses `adapt_diag` with
+those exact mapped coordinates and no second jitter. This removes backend-default
+initialization as a hidden intervention while retaining ordinary diagonal mass-matrix
+adaptation. Chains have distinct start points.
+
+Sampler randomness remains backend-specific and explicit. For PyMC 6.3.1, the
+planned integer sequence is `SeedSequence` entropy, not one directly consumed seed
+per chain. PyMC spawns one `numpy.random.Generator(PCG64)` per chain, draws one
+integer below `2**30` for initial-point/NUTS-step construction, and then samples with
+the advanced generators. Provenance records the entropy input and, for every chain,
+the spawn key, pool size, initialization/step integer, and exact post-draw generator
+state hash. NumPyro receives one scalar seed, and provenance records the exact uint32
+JAX `PRNGKey` or `jax.random.split` key for every chain.
+
+## Deterministic correctness gate
+
+Sampling geometry is interpreted only after each graph passes the independent B1
+oracle. At fixed grid points, every shared start, and hash-selected posterior
+trajectory points, the runner compares transformed log density, gradient, and
+Hessian. The gate uses the componentwise combined error
+
+```text
+abs(observed - reference)
+-----------------------------------------------
+atol + rtol * max(abs(reference), abs(observed))
+```
+
+and requires the maximum to be at most one. Value, gradient, and Hessian tolerances
+are frozen separately for float32 and float64 in the manifest. The gate also checks
+the natural-coordinate round trip, tail finiteness, and inverse-CDF branch
+continuity.
+
+The evidence count is executable rather than a claimed nonzero scalar. Before
+sampling it is `chains + int(replicate == 0) + 5 × non-centered ICDF layers`: the
+shared starts, the replicate-zero fixed point, and five branch/tail points for each
+non-centered layer. A completed cell adds one hash-selected posterior-trajectory
+point per chain. Failures after the pre-sampling oracle preserve that evidence:
+`compile` and `sample` failures have no chain, while a `diagnose` failure may retain
+the sampled chain and the complete pre-sampling oracle. A `summarize` failure occurs
+after the full trajectory oracle and preserves that full phase. Whenever raw oracle
+diagnostics are retained, the complete registered oracle metrics are retained too;
+raw-oracle/summary mismatches are contract errors. This permits correctness evidence
+to survive any later scientific failure. Sampling-based labels still require a
+completed fit and full posterior-trajectory evidence.
+
+Aggregation does not trust the runner's oracle summaries. It recomputes the scaled
+value, gradient, and Hessian errors from the retained observed/reference arrays and
+re-derives the natural-coordinate round-trip error, tail finiteness, and branch
+continuity. Every oracle record retains its coordinate vector and natural values.
+Aggregation maps that vector back to natural scale and binds fixed truth to the data
+artifact, every start to both shared-natural and representation-coordinate start
+artifacts, each ICDF probe to the exact chain-zero construction, and each trajectory
+probe to the independently selected lowest-SHA draw in the natural chain artifact.
+It also requires the exact frozen fixed/start/trajectory point IDs and, for each
+non-centered layer, exactly one left/zero/right branch triplet and low/high tail pair
+at the expected coordinate. Missing, relabelled, duplicated, self-consistent but
+non-minimal trajectory selections, forged round-trip summaries, or summary-only
+oracle evidence fail the contract.
+
+A native-only value, gradient, or Hessian mismatch on at least two distinct dataset
+replicates, with corresponding replicate/backend manual C/C evidence agreeing, is
+sufficient evidence of a native PyMC correctness defect. Counting the two backend
+paths on one dataset twice is not reproducibility. Sampling success is unnecessary;
+sampling failure, round-trip failure, or divergences alone are never treated as a
+density/derivative mismatch. Conversely, oracle agreement does not guarantee usable
+NUTS geometry; it only rules out the measured deterministic mismatch.
+
+## Health gates
+
+Confirmation health applies the existing v2 thresholds to each regime × backend ×
+representation family, never across easy and difficult cells:
+
+- compilation, initialization, finite log density, finite gradient, and sampling
+  must succeed;
+- per-fit divergence rate must be below 1%, and the eight-fit aggregate rate below
+  0.1%;
+- rank-normalized split R-hat must be below 1.01;
+- bulk and tail ESS must be at least 400 for both hyperparameters and for at least
+  95% of group effects;
+- BFMI must be at least 0.30 for every chain;
+- tree-depth saturation must be below 0.1%; and
+- hyperparameter MCSE divided by posterior SD must be at most 0.05.
+
+The family fit-pass fraction is at least 95%. With eight replicates that means 8/8;
+the manifest therefore explicitly permits zero failed replicates. This exact integer
+boundary is tested. A sampling-based classifier branch must satisfy both its paired
+per-fit sign pattern and the corresponding family-level health pattern; a form that
+passes the 1% per-fit divergence bound but fails the 0.1% aggregate bound cannot be
+called healthy by a causal label. Every sampling-based label also requires the full
+oracle gate for all five forms on both backends.
+
+V3 does not add a second posterior-agreement decision gate. Exact same-model identity
+is checked deterministically by the independent value/gradient/Hessian oracle, while
+the classifier compares sampling health. The raw natural-scale chains are retained,
+so a later review may describe posterior agreement among healthy fits, but such an
+unimplemented statistic is not allowed to affect the frozen v3 conclusion.
+
+## Predeclared classification
+
+The assessor classifies each regime separately in this precedence order:
+
+1. `native-pymc-correctness-defect`: native transformed derivatives or density
+   disagree on at least two distinct dataset replicates while the corresponding
+   manual C/C replicate/backend evidence agrees.
+2. `native-graph-or-adaptation`: native C/C is unhealthy, manual C/C is healthy, and
+   both agree with the oracle.
+3. `group-conditional-centering`: the two group-centered factorial cells are
+   unhealthy while both group-non-centered cells are healthy.
+4. `location-centering`: the two location-centered factorial cells are unhealthy
+   while both location-non-centered cells are healthy.
+5. `joint-centering-interaction`: only full NC/NC is healthy. This does not establish
+   two independent main effects.
+6. `backend-path-specific`: within every paired replicate, subtract NumPyro's number
+   of healthy forms from PyMC's number of healthy forms. All eight differences must
+   have the same nonzero sign, pass the exact sign test, and agree with the aggregate
+   family-count direction. This localizes a compiler/lowering or adaptation-path
+   interaction; it does not by itself prove which component is wrong.
+7. `residual-tn-or-scale-geometry`: every exact representation is unhealthy after
+   all oracle and inverse-CDF checks pass.
+8. `initialization-or-budget-sensitive`: reserved for a separately frozen replay;
+   the primary matrix cannot assign this label post hoc.
+9. `all-representations-healthy`: all five forms pass on both backends.
+10. `mixed-inconclusive`: complete evidence matches no stronger rule.
+
+Missing cells always produce `incomplete`. Infrastructure, environment, artifact,
+contract, assertion, and programming failures are not published as scientific cell
+failures. A scientific failure has one closed stage—`data`, `build`, `initialize`,
+`compile`, `sample`, `summarize`, or `diagnose`—and may reference only artifacts
+completed before that stage.
+
+## Artifacts and provenance
+
+Every backend pair receives a parent-minted context binding its two ordered logical
+blocks and exact ordered ten cells to the manifest digest, source commit, worker
+identity, pair execution identity, and ten distinct attempt identities. The context
+embeds the complete worker-local
+environment attestation as well as its digest; aggregation recomputes that digest and
+validates the embedded packages, lock, source, runtime, and clean-tree state against
+the manifest. A sidecar collected by a different job cannot stand in for the sampling
+worker. Cell processes cannot mint or replace that identity.
+
+The run tree is:
+
+```text
+contexts/<pair_id>.json
+data/<data_id>.json
+starts/natural/<start_id>.json
+starts/coordinates/<cell_id>.json
+chains/<cell_id>.nc
+diagnostics/<cell_id>.json
+cells/<cell_id>.json
+aggregate/<tier>/results.jsonl
+aggregate/<tier>/assessment.json
+```
+
+JSON is strict, canonical, and finite. Every reference records path, exact-byte
+SHA-256, and byte count. Writes are atomic and cannot replace an existing path. The
+cell result is written last as the completion marker. Aggregation checks safe paths,
+sizes, hashes, context bindings, cell identity, effective precision, and sampler
+RNG provenance. A missing marker remains missing evidence even if partial files
+exist.
+
+Raw chains retain the natural parameters and sampler statistics needed to recompute
+health, adaptation behavior, divergence locations, costs, and optional descriptive
+cross-fit comparisons. Those comparisons are explicitly non-gating in v3. The
+compact result record contains only registered scalar metrics; a runner cannot
+self-report that a gate passed.
+
+## No-sampling commands
+
+Validate the manifest and its frozen v2 byte anchor:
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py validate
+```
+
+Write deterministic JSONL and CSV plans:
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py plan \
+  --tier smoke \
+  --output-dir /tmp/hssm-1282-causal-smoke
+```
+
+Emit the backend-pair hosted-job matrix (2 smoke workers or 16 confirmation workers):
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py matrix \
+  --tier confirmation
+```
+
+Collect the exact dependency and source attestation:
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py environment \
+  --output /path/to/run/environment/environment.json
+```
+
+Aggregate hash-verified final markers in canonical plan order:
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py aggregate \
+  --tier confirmation \
+  --run-dir /path/to/run \
+  --output /path/to/run/aggregate/confirmation/results.jsonl
+```
+
+Apply the frozen gates and classifier:
+
+```bash
+uv run python scripts/truncated_hierarchy_causal_contract.py assess \
+  --tier confirmation \
+  --results /path/to/run/aggregate/confirmation/results.jsonl \
+  --output /path/to/run/aggregate/confirmation/assessment.json
+```
+
+The contract commands do not construct models or sample. Sampling belongs to the
+separate causal runner and opt-in workflow. Raw run directories are not committed;
+only the frozen design and a later reviewed aggregate evidence bundle belong in Git.
+Before this workflow lands on the default branch, label-triggered pull-request runs
+can exercise the workflow from the PR merge ref, but manual `workflow_dispatch` is
+unavailable because GitHub requires the workflow file on the default branch for
+manual dispatch. No separate scaffold is required for the label-triggered path.
+
+## Limits and follow-up policy
+
+The two regimes are targeted reproductions, not a survey of every HSSM model. Eight
+replicates can support a strong, consistent paired contrast but do not imply high
+power for subtle effects. A calibrated prior anchor changes the prior, truth-based
+starts change initialization, a linked Normal changes the family, and a higher
+`target_accept` changes the sampler policy. Those can be useful diagnostics or
+practical alternatives, but none can be introduced after seeing v3 outcomes and
+called part of this primary causal experiment.
+
+If evidence selects a safe representation or establishes that no tested exact form
+is reliable, the resulting default-policy proposal belongs in a separate production
+PR. That bridge must state exactly which finding it uses, retain the broader prior
+robustification work independently, and rerun any production-level qualification
+required by the chosen policy.

--- a/scripts/truncated_hierarchy_causal_artifacts.py
+++ b/scripts/truncated_hierarchy_causal_artifacts.py
@@ -1,0 +1,371 @@
+"""Immutable, hash-bound artifacts for the #1282 causal experiment.
+
+The causal runner treats a cell JSON as a commit marker.  Every artifact it
+references is therefore written first, without replacement, and the exact bytes
+are bound by SHA-256.  JSON is restricted to the deterministic finite subset so
+that a digest identifies one unambiguous payload on every supported Python.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+SHA256_HEX_LENGTH = 64
+
+
+class CausalArtifactError(RuntimeError):
+    """Raised when immutable artifact publication or verification fails."""
+
+
+def _validate_json_value(value: Any, path: str = "$") -> None:
+    """Reject values outside canonical finite JSON before serialization."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CausalArtifactError(f"{path} contains a non-finite float")
+        return
+    if isinstance(value, list | tuple):
+        for index, item in enumerate(value):
+            _validate_json_value(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CausalArtifactError(f"{path} contains a non-string key")
+            _validate_json_value(item, f"{path}.{key}")
+        return
+    raise CausalArtifactError(
+        f"{path} contains unsupported JSON value {type(value).__name__}"
+    )
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    """Encode one finite JSON value in the experiment's canonical form."""
+    _validate_json_value(payload)
+    return (
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _reject_constant(token: str) -> None:
+    raise CausalArtifactError(f"JSON contains forbidden constant {token!r}")
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CausalArtifactError(f"JSON contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def decode_canonical_json(data: bytes) -> Any:
+    """Decode strict JSON and require its bytes to already be canonical."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise CausalArtifactError("JSON artifact is not valid UTF-8") from error
+    try:
+        payload = json.loads(
+            text,
+            parse_constant=_reject_constant,
+            object_pairs_hook=_reject_duplicate_pairs,
+        )
+    except (json.JSONDecodeError, TypeError) as error:
+        raise CausalArtifactError("artifact is not strict JSON") from error
+    if canonical_json_bytes(payload) != data:
+        raise CausalArtifactError("JSON artifact is not in canonical byte form")
+    return payload
+
+
+def sha256_bytes(data: bytes) -> str:
+    """Return the lowercase SHA-256 digest of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Hash a regular file without loading it into memory."""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise CausalArtifactError(f"cannot hash artifact {path}") from error
+    return digest.hexdigest()
+
+
+def validate_sha256(value: str) -> str:
+    """Validate and normalize a lowercase SHA-256 digest."""
+    if (
+        not isinstance(value, str)
+        or len(value) != SHA256_HEX_LENGTH
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise CausalArtifactError("SHA-256 must be 64 lowercase hexadecimal digits")
+    return value
+
+
+def validate_relative_path(value: str) -> str:
+    """Return one normalized artifact-relative POSIX path.
+
+    Absolute paths, empty components, dot components, platform separators, and
+    traversal are rejected.  The resulting path is safe to resolve below a run
+    root and stable when recorded in JSON on any platform.
+    """
+    if not isinstance(value, str) or not value:
+        raise CausalArtifactError("artifact path must be a non-empty string")
+    if "\\" in value or "\x00" in value:
+        raise CausalArtifactError("artifact path must use safe POSIX components")
+    pure = PurePosixPath(value)
+    if pure.is_absolute() or str(pure) != value:
+        raise CausalArtifactError("artifact path must be normalized and relative")
+    if any(part in {"", ".", ".."} for part in pure.parts):
+        raise CausalArtifactError("artifact path contains an unsafe component")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRef:
+    """A run-relative immutable artifact bound to its exact bytes."""
+
+    path: str
+    sha256: str
+    size_bytes: int
+
+    def __post_init__(self) -> None:
+        """Validate the relative path, exact digest, and byte count."""
+        object.__setattr__(self, "path", validate_relative_path(self.path))
+        object.__setattr__(self, "sha256", validate_sha256(self.sha256))
+        if (
+            isinstance(self.size_bytes, bool)
+            or not isinstance(self.size_bytes, int)
+            or self.size_bytes < 0
+        ):
+            raise CausalArtifactError("artifact size_bytes must be non-negative")
+
+    def as_dict(self) -> dict[str, str | int]:
+        """Return the canonical result-record representation."""
+        return {
+            "path": self.path,
+            "sha256": self.sha256,
+            "size_bytes": self.size_bytes,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> ArtifactRef:
+        """Parse an exact artifact reference without accepting extra fields."""
+        if set(value) != {"path", "sha256", "size_bytes"}:
+            raise CausalArtifactError("artifact reference has unexpected fields")
+        return cls(
+            path=value["path"],
+            sha256=value["sha256"],
+            size_bytes=value["size_bytes"],
+        )
+
+
+class ArtifactStore:
+    """Publish and verify immutable files below one explicit run root."""
+
+    def __init__(self, root: str | Path) -> None:
+        root_path = Path(root)
+        if not root_path.is_absolute():
+            raise CausalArtifactError("artifact root must be absolute")
+        self.root = root_path.resolve(strict=False)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def resolve(self, relative_path: str) -> Path:
+        """Resolve an artifact path while preventing symlink escape."""
+        relative = validate_relative_path(relative_path)
+        candidate = self.root.joinpath(*PurePosixPath(relative).parts)
+        parent = candidate.parent
+        parent.mkdir(parents=True, exist_ok=True)
+        try:
+            resolved_parent = parent.resolve(strict=True)
+            resolved_parent.relative_to(self.root)
+        except (OSError, ValueError) as error:
+            raise CausalArtifactError("artifact path escapes the run root") from error
+        if candidate.is_symlink():
+            raise CausalArtifactError("artifact destination may not be a symlink")
+        return candidate
+
+    def write_bytes(
+        self,
+        relative_path: str,
+        data: bytes,
+        *,
+        expected_sha256: str | None = None,
+    ) -> ArtifactRef:
+        """Publish bytes atomically and refuse to replace any existing path."""
+        if not isinstance(data, bytes):
+            raise TypeError("artifact payload must be bytes")
+        digest = sha256_bytes(data)
+        if expected_sha256 is not None and digest != validate_sha256(expected_sha256):
+            raise CausalArtifactError("artifact bytes do not match expected SHA-256")
+        destination = self.resolve(relative_path)
+        temporary: Path | None = None
+        descriptor: int | None = None
+        try:
+            descriptor, temporary_name = tempfile.mkstemp(
+                prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent
+            )
+            temporary = Path(temporary_name)
+            with os.fdopen(descriptor, "wb", closefd=True) as stream:
+                descriptor = None
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            # link(2) is the portable no-clobber atomic publication primitive.
+            os.link(temporary, destination)
+            directory_descriptor = os.open(destination.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+        except FileExistsError as error:
+            raise CausalArtifactError(
+                f"refusing to overwrite immutable artifact {relative_path!r}"
+            ) from error
+        except OSError as error:
+            raise CausalArtifactError(
+                f"could not publish artifact {relative_path!r}"
+            ) from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+        return ArtifactRef(relative_path, digest, len(data))
+
+    def write_json(self, relative_path: str, payload: Any) -> ArtifactRef:
+        """Canonicalize and atomically publish one JSON artifact."""
+        return self.write_bytes(relative_path, canonical_json_bytes(payload))
+
+    def ensure_bytes(self, relative_path: str, data: bytes) -> ArtifactRef:
+        """Publish deterministic bytes once, or verify an identical prior writer.
+
+        Shared inputs may be materialized concurrently by backend-pair workers.
+        A losing writer is allowed to reuse the winner's file only
+        when its expected size and digest match exactly.
+        """
+        expected = ArtifactRef(relative_path, sha256_bytes(data), len(data))
+        try:
+            return self.write_bytes(relative_path, data)
+        except CausalArtifactError as error:
+            path = self.root.joinpath(*PurePosixPath(expected.path).parts)
+            if not path.exists():
+                raise
+            try:
+                self.verify(expected)
+            except CausalArtifactError:
+                raise error
+            return expected
+
+    def ensure_json(self, relative_path: str, payload: Any) -> ArtifactRef:
+        """Publish or verify one deterministic shared JSON artifact."""
+        return self.ensure_bytes(relative_path, canonical_json_bytes(payload))
+
+    def verify(self, reference: ArtifactRef) -> Path:
+        """Verify path type, size, and digest before returning a file path."""
+        path = self.resolve(reference.path)
+        if not path.is_file() or path.is_symlink():
+            raise CausalArtifactError(f"artifact {reference.path!r} is not a file")
+        if path.stat().st_size != reference.size_bytes:
+            raise CausalArtifactError(f"artifact {reference.path!r} has wrong size")
+        if sha256_file(path) != reference.sha256:
+            raise CausalArtifactError(f"artifact {reference.path!r} has wrong SHA-256")
+        return path
+
+    def read_bytes(self, reference: ArtifactRef) -> bytes:
+        """Read an artifact only after verifying its exact bytes."""
+        try:
+            return self.verify(reference).read_bytes()
+        except OSError as error:
+            raise CausalArtifactError(
+                f"cannot read artifact {reference.path!r}"
+            ) from error
+
+    def read_json(self, reference: ArtifactRef) -> Any:
+        """Read and decode a hash-verified canonical JSON artifact."""
+        return decode_canonical_json(self.read_bytes(reference))
+
+
+def merge_run_directories(
+    source_directory: Path, destination_root: Path
+) -> dict[str, int]:
+    """Merge downloaded per-pair run roots without overwriting evidence.
+
+    Each immediate child of ``source_directory`` is one extracted pair artifact.
+    Duplicate shared inputs are accepted only when their exact bytes agree.  The
+    function rejects links and unexpected top-level paths before publication.
+    """
+    source = source_directory.resolve(strict=True)
+    destination = destination_root.resolve(strict=False)
+    if (
+        source == destination
+        or source in destination.parents
+        or destination in source.parents
+    ):
+        raise CausalArtifactError("merge source and destination must be disjoint")
+    allowed_roots = {
+        "contexts",
+        "data",
+        "starts",
+        "chains",
+        "diagnostics",
+        "cells",
+    }
+    store = ArtifactStore(destination)
+    published = 0
+    identical = 0
+    children = sorted(source.iterdir())
+    if not children:
+        raise CausalArtifactError("merge source directory is empty")
+    for run_root in children:
+        if run_root.is_symlink() or not run_root.is_dir():
+            raise CausalArtifactError(
+                "every merge source child must be a real directory"
+            )
+        for path in sorted(run_root.rglob("*")):
+            if path.is_symlink():
+                raise CausalArtifactError("merge sources may not contain symlinks")
+            if path.is_dir():
+                continue
+            if not path.is_file():
+                raise CausalArtifactError(
+                    "merge sources may contain only regular files"
+                )
+            relative = path.relative_to(run_root).as_posix()
+            validate_relative_path(relative)
+            if PurePosixPath(relative).parts[0] not in allowed_roots:
+                raise CausalArtifactError(
+                    f"unexpected top-level merge artifact {relative!r}"
+                )
+            data = path.read_bytes()
+            target = destination.joinpath(*PurePosixPath(relative).parts)
+            existed = target.exists()
+            store.ensure_bytes(relative, data)
+            if existed:
+                identical += 1
+            else:
+                published += 1
+    return {"published": published, "identical": identical}

--- a/scripts/truncated_hierarchy_causal_contract.py
+++ b/scripts/truncated_hierarchy_causal_contract.py
@@ -2636,7 +2636,20 @@ def _audit_oracle_point_bindings(
         if not isinstance(summary, Mapping):
             raise CausalContractError(f"{source}.roundtrip is malformed")
         retained_natural = natural_vector(summary, f"{source}.roundtrip")
-        if not np.array_equal(retained_natural, restored):
+        comparison_scale = max(
+            1.0,
+            float(np.max(np.abs(retained_natural))),
+            float(np.max(np.abs(restored))),
+        )
+        recomputation_tolerance = (
+            64.0 * float(np.finfo(np.float64).eps) * comparison_scale
+        )
+        if not np.allclose(
+            retained_natural,
+            restored,
+            rtol=0.0,
+            atol=recomputation_tolerance,
+        ):
             raise CausalContractError(
                 f"{source} retained roundtrip differs from recomputed natural values"
             )

--- a/scripts/truncated_hierarchy_causal_contract.py
+++ b/scripts/truncated_hierarchy_causal_contract.py
@@ -1,0 +1,4090 @@
+"""Frozen no-sampling contract for the TruncatedNormal causal experiment.
+
+The v2 study established a real sampling failure but deliberately could not assign
+its cause.  This module owns a separate v3 experiment: two exact failing regimes,
+five same-natural-model representations, and both PyMC and NumPyro.  It validates
+the immutable design, expands deterministic five-member execution blocks, records
+environment and parent-minted execution identity, aggregates cell markers, and
+applies the predeclared classifier.  Model construction and sampling live elsewhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import io
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, Self
+
+SCHEMA_VERSION = 3
+RUNNER_VERSION = 3
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "benchmarks/specs/truncated_hierarchy_causal_v3.json"
+DEFAULT_FROZEN_V2 = REPO_ROOT / "benchmarks/specs/truncated_hierarchy_v2.json"
+ALLOWED_TIERS = ("smoke", "confirmation")
+REPRESENTATION_IDS = (
+    "native-centered",
+    "manual-centered",
+    "group-icdf-noncentered",
+    "location-icdf-noncentered",
+    "full-icdf-noncentered",
+)
+BACKEND_IDS = ("pymc", "numpyro")
+REGIME_IDS = ("lower-outside-weak", "two-sided-near")
+SCIENTIFIC_FAILURE_STAGES = (
+    "data",
+    "build",
+    "initialize",
+    "compile",
+    "sample",
+    "summarize",
+    "diagnose",
+)
+SAFE_ID = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SAFE_PARAMETER = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+SAFE_COMPOSITE_ID = re.compile(
+    r"^[a-z0-9]+(?:-[a-z0-9]+)*(?:--[a-z0-9]+(?:-[a-z0-9]+)*)+$"
+)
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+GIT_SHA = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+SEED_MAX = 2**31 - 1
+_BLAKE_PERSON = b"hssm1282cv3"
+_BLAKE_DOMAIN = "hssm-truncated-hierarchy-causal-v3"
+TRAJECTORY_POINTS_PER_CHAIN = 1
+ICDF_DIAGNOSTIC_POINTS_PER_LAYER = 5
+PAIRED_COMPARISON_ALPHA = 0.05 / 6
+FROZEN_MANIFEST_SHA256 = (
+    "dde2ce8a7bdce1db72c5cb343887be6817cf56177fd9981e7d19d48963d97744"
+)
+
+TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "study_id",
+        "status",
+        "description",
+        "master_seed",
+        "seed_derivation",
+        "frozen_v2",
+        "dependency_profile",
+        "natural_model",
+        "representations",
+        "backends",
+        "tiers",
+        "regimes",
+        "execution_policy",
+        "artifact_policy",
+        "failure_policy",
+        "analysis_policy",
+    }
+)
+REGIME_KEYS = frozenset(
+    {
+        "regime_id",
+        "source_v2_scenario_id",
+        "source_v2_data_id",
+        "bound_kind",
+        "lower",
+        "upper",
+        "prior_hyper_location",
+        "truth_group_location",
+        "truth_group_scale",
+        "n_groups",
+        "n_per_group",
+        "group_indices",
+        "floatx",
+        "replicate_zero_v2_seeds",
+    }
+)
+REPRESENTATION_KEYS = frozenset(
+    {
+        "representation_id",
+        "builder",
+        "location_coordinates",
+        "group_coordinates",
+        "density_implementation",
+        "factorial_cell",
+        "role",
+    }
+)
+BACKEND_KEYS = frozenset({"backend_id", "sampler", "compiler_path", "device"})
+TIER_KEYS = frozenset(
+    {
+        "role",
+        "qualifies_causal_conclusion",
+        "replicates",
+        "chains",
+        "tune",
+        "draws",
+        "target_accept",
+        "max_treedepth",
+        "expected_fit_count",
+    }
+)
+PLAN_KEYS = frozenset(
+    {
+        "schema_version",
+        "study_id",
+        "manifest_sha256",
+        "tier",
+        "regime_id",
+        "backend_id",
+        "representation_id",
+        "builder",
+        "replicate",
+        "pair_id",
+        "pair_position",
+        "block_id",
+        "block_position",
+        "canonical_position",
+        "cell_id",
+        "data_id",
+        "start_id",
+        "data_seed",
+        "truth_seed",
+        "group_seed",
+        "observation_seed",
+        "natural_start_seed",
+        "natural_start_chain_seeds",
+        "sampler_seed",
+        "chain_seeds",
+        "chains",
+        "tune",
+        "draws",
+        "target_accept",
+        "max_treedepth",
+        "floatx",
+        "regime",
+        "natural_model",
+    }
+)
+CONTEXT_KEYS = frozenset(
+    {
+        "schema_version",
+        "study_id",
+        "manifest_sha256",
+        "pair_id",
+        "block_ids",
+        "cell_ids",
+        "execution_order",
+        "environment",
+        "environment_sha256",
+        "git_commit",
+        "worker_identity_sha256",
+        "pair_execution_id",
+        "execution_attempt_ids",
+    }
+)
+ARTIFACT_KEYS = frozenset(
+    {
+        "context",
+        "data",
+        "natural_start",
+        "coordinate_start",
+        "chain",
+        "diagnostics",
+    }
+)
+ARTIFACT_REF_KEYS = frozenset({"path", "sha256", "size_bytes"})
+RESULT_KEYS = frozenset(
+    {
+        "schema_version",
+        "runner_version",
+        "study_id",
+        "manifest_sha256",
+        "tier",
+        "regime_id",
+        "backend_id",
+        "representation_id",
+        "replicate",
+        "pair_id",
+        "pair_position",
+        "block_id",
+        "block_position",
+        "cell_id",
+        "execution_status",
+        "metrics",
+        "parameter_summaries",
+        "artifacts",
+        "failure",
+        "provenance",
+    }
+)
+FAILURE_KEYS = frozenset({"stage", "error_type", "message"})
+PROVENANCE_KEYS = frozenset(
+    {
+        "environment_sha256",
+        "git_commit",
+        "worker_identity_sha256",
+        "pair_execution_id",
+        "execution_attempt_id",
+        "sampler",
+        "compiler_path",
+        "device",
+        "floatx",
+        "pytensor_floatx",
+        "jax_enable_x64",
+        "sampler_seed_input",
+        "chain_rng_provenance",
+    }
+)
+PARAMETER_SUMMARY_KEYS = frozenset({"parameter_id", "index", "mean", "sd", "mcse_mean"})
+BOOL_METRICS = frozenset(
+    {
+        "compile_success",
+        "initialization_success",
+        "logp_finite",
+        "gradient_finite",
+        "sampling_success",
+        "icdf_tail_finite",
+        "icdf_branch_continuous",
+    }
+)
+INTEGER_METRICS = frozenset(
+    {"divergence_count", "posterior_draw_count", "oracle_evaluation_count"}
+)
+FLOAT_METRICS = frozenset(
+    {
+        "divergence_rate",
+        "hyper_rhat_max",
+        "hyper_ess_bulk_min",
+        "hyper_ess_tail_min",
+        "bfmi_min",
+        "treedepth_saturation_rate",
+        "hyper_mcse_over_sd_max",
+        "group_rhat_max",
+        "group_ess_bulk_fraction_ge_400",
+        "group_ess_tail_fraction_ge_400",
+        "sampling_elapsed_seconds",
+        "step_size_final_min",
+        "step_size_final_max",
+        "leapfrog_step_count",
+        "oracle_logp_scaled_error_max",
+        "oracle_gradient_scaled_error_max",
+        "oracle_hessian_scaled_error_max",
+        "roundtrip_absolute_error_max",
+    }
+)
+ALLOWED_METRICS = BOOL_METRICS | INTEGER_METRICS | FLOAT_METRICS
+SCREENING_METRICS = frozenset(
+    {
+        "compile_success",
+        "initialization_success",
+        "logp_finite",
+        "gradient_finite",
+        "sampling_success",
+        "divergence_count",
+        "posterior_draw_count",
+        "divergence_rate",
+    }
+)
+ORACLE_METRICS = frozenset(
+    {
+        "oracle_evaluation_count",
+        "oracle_logp_scaled_error_max",
+        "oracle_gradient_scaled_error_max",
+        "oracle_hessian_scaled_error_max",
+        "roundtrip_absolute_error_max",
+        "icdf_tail_finite",
+        "icdf_branch_continuous",
+    }
+)
+CONFIRMATION_METRICS = SCREENING_METRICS | frozenset(
+    {
+        "hyper_rhat_max",
+        "hyper_ess_bulk_min",
+        "hyper_ess_tail_min",
+        "bfmi_min",
+        "treedepth_saturation_rate",
+        "hyper_mcse_over_sd_max",
+        "group_rhat_max",
+        "group_ess_bulk_fraction_ge_400",
+        "group_ess_tail_fraction_ge_400",
+    }
+)
+
+
+class CausalContractError(ValueError):
+    """Raised when evidence does not satisfy the frozen causal contract."""
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: frozenset[str], path: str
+) -> None:
+    observed = frozenset(value)
+    if observed != expected:
+        missing = sorted(expected - observed)
+        extra = sorted(observed - expected)
+        raise CausalContractError(
+            f"{path} keys differ; missing={missing}, extra={extra}"
+        )
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CausalContractError(f"JSON input contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def strict_json_loads(text: str, *, source: str = "JSON input") -> Any:
+    """Parse strict JSON, rejecting duplicate keys and non-finite constants."""
+
+    def reject_constant(value: str) -> None:
+        raise CausalContractError(f"{source} contains invalid constant {value}")
+
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=reject_constant,
+        )
+    except json.JSONDecodeError as error:
+        raise CausalContractError(f"invalid {source}: {error}") from error
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Serialize canonical strict JSON with a terminal newline."""
+    try:
+        rendered = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise CausalContractError(f"value is not strict JSON: {error}") from error
+    return f"{rendered}\n".encode()
+
+
+def sha256_bytes(value: bytes) -> str:
+    """Hash exact bytes with SHA-256."""
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Hash an existing regular file without following contract paths."""
+    if not path.is_file():
+        raise CausalContractError(f"required file does not exist: {path}")
+    return sha256_bytes(path.read_bytes())
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        text = path.read_text()
+    except OSError as error:
+        raise CausalContractError(f"cannot read {path}: {error}") from error
+    return strict_json_loads(text, source=str(path))
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise CausalContractError(f"refusing to overwrite existing artifact: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _relative_contract_path(value: str, *, suffix: str | None = None) -> None:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or "." in path.parts
+        or "\\" in value
+        or str(path) != value
+    ):
+        raise CausalContractError(f"unsafe relative artifact path: {value!r}")
+    if suffix is not None and path.suffix != suffix:
+        raise CausalContractError(f"artifact path {value!r} must end in {suffix}")
+
+
+def _validate_slug(value: Any, path: str, *, composite: bool = False) -> str:
+    pattern = SAFE_COMPOSITE_ID if composite else SAFE_ID
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise CausalContractError(f"{path} must be a canonical slug")
+    return value
+
+
+def _validate_seed(value: Any, path: str) -> int:
+    if not _is_int(value) or not 0 < value <= SEED_MAX:
+        raise CausalContractError(f"{path} must be a positive 31-bit integer")
+    return value
+
+
+def manifest_digest(manifest: Mapping[str, Any]) -> str:
+    """Return the semantic SHA-256 used by every v3 artifact."""
+    return sha256_bytes(canonical_json_bytes(manifest))
+
+
+def _derive_v2_seed(
+    master_seed: int,
+    owner: str,
+    replicate: int,
+    purpose: str,
+    *,
+    root_seed: int | None = None,
+) -> int:
+    first = master_seed if root_seed is None else root_seed
+    payload = "\0".join(
+        [
+            "hssm-truncated-hierarchy-seed-v2",
+            str(first),
+            owner,
+            str(replicate),
+            purpose,
+            "",
+        ]
+    ).encode()
+    digest = hashlib.blake2b(payload, digest_size=8, person=b"hssm1282v2").digest()
+    return int.from_bytes(digest, "big") % SEED_MAX + 1
+
+
+def derive_seed(master_seed: int, *components: str | int) -> int:
+    """Derive a positive 31-bit seed in the new causal-v3 BLAKE2 domain."""
+    if not _is_int(master_seed) or master_seed < 0:
+        raise CausalContractError("master_seed must be a non-negative integer")
+    if not components:
+        raise CausalContractError("at least one seed component is required")
+    rendered: list[str] = []
+    for component in components:
+        if isinstance(component, bool) or not isinstance(component, (str, int)):
+            raise CausalContractError("seed components must be strings or integers")
+        text = str(component)
+        if not text or "\0" in text:
+            raise CausalContractError("seed components must be non-empty and NUL-free")
+        rendered.append(text)
+    payload = "\0".join([_BLAKE_DOMAIN, str(master_seed), *rendered]).encode()
+    digest = hashlib.blake2b(payload, digest_size=8, person=_BLAKE_PERSON).digest()
+    return int.from_bytes(digest, "big") % SEED_MAX + 1
+
+
+def _validate_frozen_v2(
+    manifest: Mapping[str, Any], frozen_v2_path: Path
+) -> Mapping[str, Any]:
+    frozen = manifest["frozen_v2"]
+    _require_exact_keys(
+        frozen,
+        frozenset({"path", "file_sha256", "study_id", "schema_version", "status"}),
+        "frozen_v2",
+    )
+    expected_path = "benchmarks/specs/truncated_hierarchy_v2.json"
+    if frozen["path"] != expected_path:
+        raise CausalContractError(f"frozen_v2.path must remain {expected_path!r}")
+    actual_hash = sha256_file(frozen_v2_path)
+    if frozen["file_sha256"] != actual_hash:
+        raise CausalContractError(
+            "frozen v2 bytes changed; causal evidence cannot be attached to this design"
+        )
+    v2 = _load_json(frozen_v2_path)
+    if not isinstance(v2, Mapping):
+        raise CausalContractError("frozen v2 manifest must contain an object")
+    for key in ("study_id", "schema_version", "status"):
+        if v2.get(key) != frozen[key]:
+            raise CausalContractError(f"frozen_v2.{key} does not match frozen bytes")
+    return v2
+
+
+def _validate_regimes(manifest: Mapping[str, Any], v2: Mapping[str, Any]) -> None:
+    regimes = manifest["regimes"]
+    if not isinstance(regimes, list) or len(regimes) != 2:
+        raise CausalContractError("regimes must contain exactly two entries")
+    if tuple(item.get("regime_id") for item in regimes) != REGIME_IDS:
+        raise CausalContractError(f"regime order must remain {REGIME_IDS}")
+    v2_scenarios = {
+        item.get("scenario_id"): item
+        for item in v2.get("scenarios", [])
+        if isinstance(item, Mapping)
+    }
+    source_fields = (
+        "bound_kind",
+        "lower",
+        "upper",
+        "prior_hyper_location",
+        "truth_group_location",
+        "truth_group_scale",
+        "n_groups",
+        "n_per_group",
+        "group_indices",
+        "floatx",
+    )
+    for index, regime in enumerate(regimes):
+        if not isinstance(regime, Mapping):
+            raise CausalContractError(f"regimes[{index}] must be an object")
+        _require_exact_keys(regime, REGIME_KEYS, f"regimes[{index}]")
+        source_id = _validate_slug(
+            regime["source_v2_scenario_id"],
+            f"regimes[{index}].source_v2_scenario_id",
+        )
+        source = v2_scenarios.get(source_id)
+        if source is None:
+            raise CausalContractError(f"v2 source scenario {source_id!r} is absent")
+        if source.get("tier") != "smoke" or source.get("sampler") != "pymc":
+            raise CausalContractError(
+                f"{source_id} is not the frozen failing PyMC smoke"
+            )
+        if source.get("data_id") != regime["source_v2_data_id"]:
+            raise CausalContractError(f"{source_id} data_id changed")
+        for field in source_fields:
+            if source.get(field) != regime[field]:
+                raise CausalContractError(
+                    f"regimes[{index}].{field} does not match {source_id}"
+                )
+        if regime["floatx"] not in {"float32", "float64"}:
+            raise CausalContractError("regime floatx must be float32 or float64")
+        if not _is_int(regime["n_groups"]) or regime["n_groups"] <= 0:
+            raise CausalContractError("n_groups must be positive")
+        if not _is_int(regime["n_per_group"]) or regime["n_per_group"] <= 0:
+            raise CausalContractError("n_per_group must be positive")
+        seeds = regime["replicate_zero_v2_seeds"]
+        expected_seed_keys = frozenset(
+            {"data_seed", "truth_seed", "group_seed", "observation_seed"}
+        )
+        if not isinstance(seeds, Mapping):
+            raise CausalContractError("replicate_zero_v2_seeds must be an object")
+        _require_exact_keys(seeds, expected_seed_keys, "replicate_zero_v2_seeds")
+        data_seed = _derive_v2_seed(
+            manifest["master_seed"], regime["source_v2_data_id"], 0, "data"
+        )
+        expected_seeds = {
+            "data_seed": data_seed,
+            "truth_seed": _derive_v2_seed(
+                manifest["master_seed"],
+                regime["source_v2_data_id"],
+                0,
+                "truth",
+                root_seed=data_seed,
+            ),
+            "group_seed": _derive_v2_seed(
+                manifest["master_seed"],
+                regime["source_v2_data_id"],
+                0,
+                "group",
+                root_seed=data_seed,
+            ),
+            "observation_seed": _derive_v2_seed(
+                manifest["master_seed"],
+                regime["source_v2_data_id"],
+                0,
+                "observation",
+                root_seed=data_seed,
+            ),
+        }
+        if dict(seeds) != expected_seeds:
+            raise CausalContractError(
+                f"{regime['regime_id']} replicate-zero seeds do not replay v2"
+            )
+
+
+def validate_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    frozen_v2_path: Path | None = None,
+) -> Mapping[str, Any]:
+    """Validate the complete, prospectively frozen v3 design."""
+    if not isinstance(manifest, Mapping):
+        raise CausalContractError("manifest must contain a JSON object")
+    _require_exact_keys(manifest, TOP_LEVEL_KEYS, "manifest")
+    if manifest["schema_version"] != SCHEMA_VERSION:
+        raise CausalContractError(f"schema_version must be {SCHEMA_VERSION}")
+    if manifest["study_id"] != "truncated_hierarchy_causal_v3":
+        raise CausalContractError("study_id must be truncated_hierarchy_causal_v3")
+    if manifest["status"] != "frozen-before-sampling":
+        raise CausalContractError("manifest must be frozen before sampling")
+    if manifest["master_seed"] != 1282:
+        raise CausalContractError("master_seed must remain 1282")
+
+    seed_contract = manifest["seed_derivation"]
+    expected_seed_contract = {
+        "algorithm": "blake2b-64-causal-v3",
+        "person": "hssm1282cv3",
+        "domain": _BLAKE_DOMAIN,
+        "positive_integer_range": [1, SEED_MAX],
+        "replicate_zero_data": "exact-frozen-v2-streams",
+        "later_data": "causal-v3-domain-separated-streams",
+    }
+    if seed_contract != expected_seed_contract:
+        raise CausalContractError("seed_derivation changes the reviewed v3 domain")
+
+    resolved_v2 = DEFAULT_FROZEN_V2 if frozen_v2_path is None else frozen_v2_path
+    v2 = _validate_frozen_v2(manifest, resolved_v2)
+    _validate_regimes(manifest, v2)
+
+    expected_natural_model = {
+        "likelihood": "y[i] ~ Normal(group_effect[group_index[i]], 0.5)",
+        "location_prior": "TruncatedNormal(prior_hyper_location, 0.25, bounds)",
+        "scale_prior": "Weibull(alpha=1.5, beta=0.3)",
+        "group_prior": "TruncatedNormal(group_location, group_scale, bounds)",
+        "location_prior_sigma": 0.25,
+        "scale_prior_alpha": 1.5,
+        "scale_prior_beta": 0.3,
+        "observation_sigma": 0.5,
+    }
+    if manifest["natural_model"] != expected_natural_model:
+        raise CausalContractError("natural_model changed")
+
+    representations = manifest["representations"]
+    if not isinstance(representations, list) or len(representations) != 5:
+        raise CausalContractError("representations must contain exactly five entries")
+    if (
+        tuple(item.get("representation_id") for item in representations)
+        != REPRESENTATION_IDS
+    ):
+        raise CausalContractError(
+            f"representation order must remain {REPRESENTATION_IDS}"
+        )
+    expected_builders = (
+        "native_centered",
+        "manual_centered",
+        "group_icdf_noncentered",
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    )
+    for index, (representation, builder) in enumerate(
+        zip(representations, expected_builders, strict=True)
+    ):
+        if not isinstance(representation, Mapping):
+            raise CausalContractError(f"representations[{index}] must be an object")
+        _require_exact_keys(
+            representation, REPRESENTATION_KEYS, f"representations[{index}]"
+        )
+        if representation["builder"] != builder:
+            raise CausalContractError(f"representations[{index}].builder changed")
+    factorial = [item["factorial_cell"] for item in representations]
+    if factorial != ["C-C", "C-C", "C-NC", "NC-C", "NC-NC"]:
+        raise CausalContractError("representations no longer form the frozen 2x2")
+    expected_representations = [
+        {
+            "representation_id": "native-centered",
+            "builder": "native_centered",
+            "location_coordinates": "centered",
+            "group_coordinates": "centered",
+            "density_implementation": "pymc-native",
+            "factorial_cell": "C-C",
+            "role": "native-reference",
+        },
+        {
+            "representation_id": "manual-centered",
+            "builder": "manual_centered",
+            "location_coordinates": "centered",
+            "group_coordinates": "centered",
+            "density_implementation": "independent-manual",
+            "factorial_cell": "C-C",
+            "role": "implementation-control",
+        },
+        {
+            "representation_id": "group-icdf-noncentered",
+            "builder": "group_icdf_noncentered",
+            "location_coordinates": "centered",
+            "group_coordinates": "icdf-noncentered",
+            "density_implementation": ("pymc-native-location-independent-icdf-groups"),
+            "factorial_cell": "C-NC",
+            "role": "factorial",
+        },
+        {
+            "representation_id": "location-icdf-noncentered",
+            "builder": "location_icdf_noncentered",
+            "location_coordinates": "icdf-noncentered",
+            "group_coordinates": "centered",
+            "density_implementation": ("independent-icdf-location-pymc-native-groups"),
+            "factorial_cell": "NC-C",
+            "role": "factorial",
+        },
+        {
+            "representation_id": "full-icdf-noncentered",
+            "builder": "full_icdf_noncentered",
+            "location_coordinates": "icdf-noncentered",
+            "group_coordinates": "icdf-noncentered",
+            "density_implementation": "independent-icdf",
+            "factorial_cell": "NC-NC",
+            "role": "factorial",
+        },
+    ]
+    if representations != expected_representations:
+        raise CausalContractError("representation semantics changed")
+
+    backends = manifest["backends"]
+    if not isinstance(backends, list) or len(backends) != 2:
+        raise CausalContractError("backends must contain exactly two entries")
+    if tuple(item.get("backend_id") for item in backends) != BACKEND_IDS:
+        raise CausalContractError(f"backend order must remain {BACKEND_IDS}")
+    for index, backend in enumerate(backends):
+        if not isinstance(backend, Mapping):
+            raise CausalContractError(f"backends[{index}] must be an object")
+        _require_exact_keys(backend, BACKEND_KEYS, f"backends[{index}]")
+        if backend["device"] != "cpu":
+            raise CausalContractError("causal comparison is CPU-only")
+    expected_backends = [
+        {
+            "backend_id": "pymc",
+            "sampler": "pymc-nuts",
+            "compiler_path": "pytensor",
+            "device": "cpu",
+        },
+        {
+            "backend_id": "numpyro",
+            "sampler": "numpyro-nuts-via-pymc",
+            "compiler_path": "pytensor-to-jax",
+            "device": "cpu",
+        },
+    ]
+    if backends != expected_backends:
+        raise CausalContractError("backend sampler/compiler policy changed")
+
+    tiers = manifest["tiers"]
+    if not isinstance(tiers, Mapping) or tuple(tiers) != ALLOWED_TIERS:
+        raise CausalContractError(f"tiers must remain ordered as {ALLOWED_TIERS}")
+    expected_budgets = {
+        "smoke": (1, 2, 250, 250, False),
+        "confirmation": (8, 4, 1000, 1000, True),
+    }
+    for tier, (replicates, chains, tune, draws, qualifies) in expected_budgets.items():
+        spec = tiers[tier]
+        if not isinstance(spec, Mapping):
+            raise CausalContractError(f"tiers.{tier} must be an object")
+        _require_exact_keys(spec, TIER_KEYS, f"tiers.{tier}")
+        observed = (
+            spec["replicates"],
+            spec["chains"],
+            spec["tune"],
+            spec["draws"],
+            spec["qualifies_causal_conclusion"],
+        )
+        if observed != (replicates, chains, tune, draws, qualifies):
+            raise CausalContractError(f"tiers.{tier} budget changed")
+        if spec["target_accept"] != 0.9 or spec["max_treedepth"] != 10:
+            raise CausalContractError(f"tiers.{tier} sampler policy changed")
+        expected_fits = 2 * 5 * 2 * replicates
+        if spec["expected_fit_count"] != expected_fits:
+            raise CausalContractError(f"tiers.{tier}.expected_fit_count is wrong")
+
+    profile = manifest["dependency_profile"]
+    if not isinstance(profile, Mapping) or profile.get("name") != "current-resolved":
+        raise CausalContractError("dependency_profile must be current-resolved")
+    for field in ("project_path", "lock_path"):
+        _relative_contract_path(profile[field])
+    for field, hash_field in (
+        ("project_path", "project_sha256"),
+        ("lock_path", "lock_sha256"),
+    ):
+        actual = sha256_file(REPO_ROOT / profile[field])
+        if profile[hash_field] != actual:
+            raise CausalContractError(f"dependency_profile.{hash_field} is stale")
+    expected_profile_static = {
+        "name": "current-resolved",
+        "python": "3.12",
+        "project_path": (
+            "benchmarks/environments/truncated_hierarchy/current-resolved/pyproject.toml"
+        ),
+        "lock_path": (
+            "benchmarks/environments/truncated_hierarchy/current-resolved/uv.lock"
+        ),
+        "required_versions": {
+            "arviz": "1.3.0",
+            "bambi": "0.20.0",
+            "jax": "0.11.1",
+            "jaxlib": "0.11.1",
+            "numpy": "2.4.6",
+            "numpyro": "0.21.0",
+            "pymc": "6.3.1",
+            "pytensor": "3.3.0",
+            "scipy": "1.18.1",
+        },
+    }
+    if any(profile.get(key) != value for key, value in expected_profile_static.items()):
+        raise CausalContractError("dependency profile semantics changed")
+
+    execution = manifest["execution_policy"]
+    if execution.get("scheduling_unit") != "backend-paired-ten-cell-worker":
+        raise CausalContractError(
+            "execution must pair both backend blocks on one worker"
+        )
+    if execution.get("pair_identity") != "tier-regime-replicate":
+        raise CausalContractError("backend-pair identity changed")
+    if (
+        execution.get("pair_members")
+        != "both-five-representation-backend-blocks-exactly-once"
+    ):
+        raise CausalContractError("backend pair must contain both five-form blocks")
+    expected_backend_order = (
+        "left-rotation-of-manifest-backend-order-by-(replicate+regime_index)-modulo-2"
+    )
+    if execution.get("backend_order") != expected_backend_order:
+        raise CausalContractError("backend counterbalancing order changed")
+    expected_order = (
+        "within-each-backend-left-rotation-of-manifest-representation-order-by-"
+        "(4*replicate+2*regime_index+backend_index)-modulo-5"
+    )
+    if execution.get("order") != expected_order:
+        raise CausalContractError("five-form counterbalancing order changed")
+    if execution.get("target_accept") is not None:
+        raise CausalContractError("target_accept belongs only to frozen tier budgets")
+    if execution.get("threads") != 1:
+        raise CausalContractError("execution_policy.threads must remain one")
+    expected_start_generation = {
+        "source_model": "native-centered",
+        "support_points": "pymc-initial-point",
+        "function": "pymc.initial_point.make_initial_point_fns_per_chain",
+        "jitter_rvs": "all-free-rvs",
+        "jitter_distribution": "uniform-minus-one-to-one-in-transformed-coordinates",
+        "seed": "natural_start_chain_seeds-derived-from-natural_start_seed",
+        "materialization": (
+            "map-each-jittered-native-coordinate-point-to-natural-scale-once"
+        ),
+        "sampling_init": "adapt_diag-with-exact-mapped-start-and-no-second-jitter",
+    }
+    if execution.get("natural_start_generation") != expected_start_generation:
+        raise CausalContractError("natural start generation rule changed")
+    expected_sampler_seed_policy = {
+        "pymc_plan": "chain_seeds-are-seedsequence-entropy-words",
+        "pymc_execution": (
+            "pymc-6.3.1-spawns-one-pcg64-generator-per-chain-draws-one-init-step-"
+            "integer-below-2^30-then-samples-with-the-advanced-generators"
+        ),
+        "pymc_provenance": (
+            "record-entropy-spawn-key-init-step-integer-and-post-draw-generator-"
+            "state-hash"
+        ),
+        "numpyro_plan": "one-scalar-sampler-seed",
+        "numpyro_provenance": "record-exact-uint32-jax-prngkey-or-split-keys",
+    }
+    if execution.get("sampler_seed_policy") != expected_sampler_seed_policy:
+        raise CausalContractError("backend sampler-seed semantics changed")
+    failure = manifest["failure_policy"]
+    if failure.get("scientific_stages") != list(SCIENTIFIC_FAILURE_STAGES):
+        raise CausalContractError("scientific failure stage vocabulary changed")
+    artifact = manifest["artifact_policy"]
+    expected_artifact_templates = {
+        "context_path": "contexts/<pair_id>.json",
+        "data_path": "data/<data_id>.json",
+        "natural_start_path": "starts/natural/<start_id>.json",
+        "coordinate_start_path": "starts/coordinates/<cell_id>.json",
+        "chain_path": "chains/<cell_id>.nc",
+        "diagnostic_path": "diagnostics/<cell_id>.json",
+        "cell_path": "cells/<cell_id>.json",
+        "aggregate_path": "aggregate/<tier>/results.jsonl",
+        "assessment_path": "aggregate/<tier>/assessment.json",
+    }
+    for field, value in expected_artifact_templates.items():
+        if artifact.get(field) != value:
+            raise CausalContractError(f"artifact_policy.{field} changed")
+    classifier = manifest["analysis_policy"]
+    if classifier.get("scope") != "classify-each-regime-separately-never-pool-regimes":
+        raise CausalContractError("regime-specific classification is mandatory")
+    expected_paired_inference = {
+        "replicates": 8,
+        "familywise_alpha": 0.05,
+        "bonferroni_comparisons": 6,
+        "per_comparison_alpha": PAIRED_COMPARISON_ALPHA,
+        "test": "two-sided-exact-sign-test-on-discordant-paired-health-outcomes",
+        "minimum_all-directional_p_value": 0.0078125,
+        "comparison_family": [
+            "native-vs-manual-IUT-across-both-backends",
+            "group-effect-at-location-centered-IUT-across-both-backends",
+            "group-effect-at-location-noncentered-IUT-across-both-backends",
+            "location-effect-at-groups-centered-IUT-across-both-backends",
+            "location-effect-at-groups-noncentered-IUT-across-both-backends",
+            "backend-five-form-health-count-omnibus",
+        ],
+        "backend_omnibus_statistic": (
+            "per-replicate-pymc-healthy-form-count-minus-numpyro-healthy-form-count"
+        ),
+        "backend_omnibus_direction": (
+            "same-nonzero-sign-in-all-eight-paired-replicates"
+        ),
+        "representation_backend_contrasts": ("descriptive-only-never-classifying"),
+        "interpretation": (
+            "minimum-inferentially-defensible-grid-not-a-high-power-small-effect-design"
+        ),
+    }
+    if classifier.get("paired_inference") != expected_paired_inference:
+        raise CausalContractError("paired-inference family or threshold changed")
+    expected_tolerances = {
+        "float64": {
+            "logp": {"absolute_tolerance": 5e-8, "relative_tolerance": 2e-8},
+            "gradient": {
+                "absolute_tolerance": 3e-7,
+                "relative_tolerance": 3e-7,
+            },
+            "hessian": {
+                "absolute_tolerance": 3e-6,
+                "relative_tolerance": 3e-6,
+            },
+        },
+        "float32": {
+            "logp": {
+                "absolute_tolerance": 2e-4,
+                "relative_tolerance": 2e-4,
+            },
+            "gradient": {
+                "absolute_tolerance": 5e-4,
+                "relative_tolerance": 7e-4,
+            },
+            "hessian": {
+                "absolute_tolerance": 3e-3,
+                "relative_tolerance": 3e-3,
+            },
+        },
+    }
+    oracle_gate = classifier.get("oracle_gate", {})
+    expected_evaluation_points = [
+        "fixed-grid",
+        "every-shared-natural-start",
+        "hash-selected-posterior-trajectory-points",
+    ]
+    if oracle_gate.get("evaluation_points") != expected_evaluation_points:
+        raise CausalContractError("oracle evaluation-point family changed")
+    expected_point_counts = {
+        "fixed_grid_on_replicate_zero": 1,
+        "shared_start_points_per_chain": 1,
+        "icdf_points_per_noncentered_layer": ICDF_DIAGNOSTIC_POINTS_PER_LAYER,
+        "posterior_trajectory_points_per_chain": TRAJECTORY_POINTS_PER_CHAIN,
+        "failed_sample_phase": "pre-sampling-only",
+        "completed_phase": "pre-sampling-plus-posterior-trajectory",
+    }
+    if oracle_gate.get("point_counts") != expected_point_counts:
+        raise CausalContractError("oracle evaluation counts or phases changed")
+    if oracle_gate.get("component_tolerances") != expected_tolerances:
+        raise CausalContractError("oracle component tolerances changed")
+    expected_scaled_error = (
+        "abs(observed-reference)/(absolute_tolerance+relative_tolerance*"
+        "max(abs(reference),abs(observed)))"
+    )
+    if oracle_gate.get("combined_scaled_error") != expected_scaled_error:
+        raise CausalContractError("oracle combined scaled-error rule changed")
+    family_health = classifier.get("family_health", {})
+    if (
+        family_health.get("per_fit_pass_fraction_ge") != 0.95
+        or family_health.get("maximum_failed_replicates") != 0
+    ):
+        raise CausalContractError("eight-replicate family gate must require 8/8 fits")
+    expected_precedence = [
+        "native-pymc-correctness-defect",
+        "native-graph-or-adaptation",
+        "group-conditional-centering",
+        "location-centering",
+        "joint-centering-interaction",
+        "backend-path-specific",
+        "residual-tn-or-scale-geometry",
+        "initialization-or-budget-sensitive",
+        "all-representations-healthy",
+        "mixed-inconclusive",
+    ]
+    if classifier.get("classifier_precedence") != expected_precedence:
+        raise CausalContractError("classifier precedence changed")
+    if manifest_digest(manifest) != FROZEN_MANIFEST_SHA256:
+        raise CausalContractError("manifest semantic digest differs from frozen v3")
+
+    # Bind validation to the selected manifest path without requiring that a
+    # copied fixture live under the repository.  The bytes themselves are the
+    # evidence identity; source paths inside the manifest remain repository-relative.
+    if manifest_path.name != "truncated_hierarchy_causal_v3.json":
+        raise CausalContractError("manifest filename must identify causal v3")
+    return manifest
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> Mapping[str, Any]:
+    """Load and validate the causal v3 manifest."""
+    value = _load_json(path)
+    if not isinstance(value, Mapping):
+        raise CausalContractError("manifest must contain an object")
+    return validate_manifest(value, manifest_path=path)
+
+
+@dataclass(frozen=True, slots=True)
+class UnitSpec:
+    """One cell in a five-representation causal execution block."""
+
+    schema_version: int
+    study_id: str
+    manifest_sha256: str
+    tier: str
+    regime_id: str
+    backend_id: str
+    representation_id: str
+    builder: str
+    replicate: int
+    pair_id: str
+    pair_position: int
+    block_id: str
+    block_position: int
+    canonical_position: int
+    cell_id: str
+    data_id: str
+    start_id: str
+    data_seed: int
+    truth_seed: int
+    group_seed: int
+    observation_seed: int
+    natural_start_seed: int
+    natural_start_chain_seeds: tuple[int, ...]
+    sampler_seed: int | None
+    chain_seeds: tuple[int, ...]
+    chains: int
+    tune: int
+    draws: int
+    target_accept: float
+    max_treedepth: int
+    floatx: str
+    regime: Mapping[str, Any]
+    natural_model: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a detached strict-JSON representation."""
+        value = {
+            field: getattr(self, field)
+            for field in PLAN_KEYS
+            if field not in {"natural_start_chain_seeds", "chain_seeds"}
+        }
+        value["natural_start_chain_seeds"] = list(self.natural_start_chain_seeds)
+        value["chain_seeds"] = list(self.chain_seeds)
+        return strict_json_loads(canonical_json_bytes(value).decode())
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Validate and construct a unit from its canonical mapping."""
+        _require_exact_keys(value, PLAN_KEYS, "plan unit")
+        kwargs = dict(value)
+        kwargs["natural_start_chain_seeds"] = tuple(value["natural_start_chain_seeds"])
+        kwargs["chain_seeds"] = tuple(value["chain_seeds"])
+        unit = cls(**kwargs)
+        _validate_unit(unit)
+        return unit
+
+
+def _validate_unit(unit: UnitSpec) -> None:
+    if unit.schema_version != SCHEMA_VERSION:
+        raise CausalContractError("unit schema_version is wrong")
+    if unit.study_id != "truncated_hierarchy_causal_v3":
+        raise CausalContractError("unit study_id is wrong")
+    if not SHA256.fullmatch(unit.manifest_sha256):
+        raise CausalContractError("unit manifest_sha256 is invalid")
+    if unit.tier not in ALLOWED_TIERS:
+        raise CausalContractError("unit tier is invalid")
+    if unit.regime_id not in REGIME_IDS:
+        raise CausalContractError("unit regime_id is invalid")
+    if unit.backend_id not in BACKEND_IDS:
+        raise CausalContractError("unit backend_id is invalid")
+    if unit.representation_id not in REPRESENTATION_IDS:
+        raise CausalContractError("unit representation_id is invalid")
+    for name in ("pair_id", "block_id", "cell_id"):
+        _validate_slug(getattr(unit, name), f"unit.{name}", composite=True)
+    for name in ("data_id", "start_id"):
+        _validate_slug(getattr(unit, name), f"unit.{name}", composite=True)
+    if not 0 <= unit.pair_position < 10:
+        raise CausalContractError("unit pair_position must be in [0, 10)")
+    if not 0 <= unit.block_position < 5 or not 0 <= unit.canonical_position < 5:
+        raise CausalContractError("unit block/canonical positions must be in [0, 5)")
+    if unit.replicate < 0:
+        raise CausalContractError("unit replicate must be non-negative")
+    for name in (
+        "data_seed",
+        "truth_seed",
+        "group_seed",
+        "observation_seed",
+        "natural_start_seed",
+    ):
+        _validate_seed(getattr(unit, name), f"unit.{name}")
+    if len(unit.natural_start_chain_seeds) != unit.chains:
+        raise CausalContractError("natural start seed count must equal chains")
+    if unit.backend_id == "pymc":
+        if unit.sampler_seed is not None or len(unit.chain_seeds) != unit.chains:
+            raise CausalContractError(
+                "PyMC units require one entropy word per chain and no scalar "
+                "sampler seed"
+            )
+    elif unit.backend_id == "numpyro":
+        _validate_seed(unit.sampler_seed, "unit.sampler_seed")
+        if unit.chain_seeds:
+            raise CausalContractError(
+                "NumPyro units require one scalar sampler seed and no integer "
+                "chain seeds"
+            )
+    for seed in unit.natural_start_chain_seeds:
+        _validate_seed(seed, "unit natural-start chain seed")
+    for seed in unit.chain_seeds:
+        _validate_seed(seed, "unit PyMC entropy word")
+
+
+def _data_seeds(
+    manifest: Mapping[str, Any], regime: Mapping[str, Any], replicate: int
+) -> tuple[int, int, int, int]:
+    if replicate == 0:
+        seeds = regime["replicate_zero_v2_seeds"]
+        return (
+            seeds["data_seed"],
+            seeds["truth_seed"],
+            seeds["group_seed"],
+            seeds["observation_seed"],
+        )
+    master = manifest["master_seed"]
+    regime_id = regime["regime_id"]
+    data_seed = derive_seed(master, "data", regime_id, replicate)
+    return (
+        data_seed,
+        derive_seed(master, "truth", regime_id, replicate, data_seed),
+        derive_seed(master, "group", regime_id, replicate, data_seed),
+        derive_seed(master, "observation", regime_id, replicate, data_seed),
+    )
+
+
+def build_plan(manifest: Mapping[str, Any], tier: str) -> tuple[UnitSpec, ...]:
+    """Expand backend-paired workers and their five-form blocks in exact order."""
+    validate_manifest(manifest)
+    if tier not in ALLOWED_TIERS:
+        raise CausalContractError(f"tier must be one of {ALLOWED_TIERS}")
+    tier_spec = manifest["tiers"][tier]
+    digest = manifest_digest(manifest)
+    representations = manifest["representations"]
+    units: list[UnitSpec] = []
+    for regime_index, regime in enumerate(manifest["regimes"]):
+        regime_id = regime["regime_id"]
+        for replicate in range(tier_spec["replicates"]):
+            pair_id = f"{tier}--{regime_id}--replicate-{replicate:02d}"
+            data_id = pair_id
+            start_id = data_id
+            data_seed, truth_seed, group_seed, observation_seed = _data_seeds(
+                manifest, regime, replicate
+            )
+            natural_start_seed = derive_seed(
+                manifest["master_seed"], "natural-start", tier, regime_id, replicate
+            )
+            natural_start_chain_seeds = tuple(
+                derive_seed(
+                    natural_start_seed,
+                    "chain",
+                    chain,
+                )
+                for chain in range(tier_spec["chains"])
+            )
+            backend_shift = (replicate + regime_index) % len(BACKEND_IDS)
+            ordered_backends = (
+                manifest["backends"][backend_shift:]
+                + manifest["backends"][:backend_shift]
+            )
+            for pair_backend_position, backend in enumerate(ordered_backends):
+                backend_id = backend["backend_id"]
+                backend_index = BACKEND_IDS.index(backend_id)
+                block_id = (
+                    f"{tier}--{regime_id}--{backend_id}--replicate-{replicate:02d}"
+                )
+                shift = (4 * replicate + 2 * regime_index + backend_index) % len(
+                    representations
+                )
+                ordered = representations[shift:] + representations[:shift]
+                for block_position, representation in enumerate(ordered):
+                    canonical_position = REPRESENTATION_IDS.index(
+                        representation["representation_id"]
+                    )
+                    cell_id = f"{block_id}--{representation['representation_id']}"
+                    sampler_seed = (
+                        derive_seed(manifest["master_seed"], "sampler", cell_id)
+                        if backend_id == "numpyro"
+                        else None
+                    )
+                    chain_seeds = (
+                        tuple(
+                            derive_seed(
+                                manifest["master_seed"],
+                                "sampler-chain",
+                                cell_id,
+                                chain,
+                            )
+                            for chain in range(tier_spec["chains"])
+                        )
+                        if backend_id == "pymc"
+                        else ()
+                    )
+                    unit = UnitSpec(
+                        schema_version=SCHEMA_VERSION,
+                        study_id=manifest["study_id"],
+                        manifest_sha256=digest,
+                        tier=tier,
+                        regime_id=regime_id,
+                        backend_id=backend_id,
+                        representation_id=representation["representation_id"],
+                        builder=representation["builder"],
+                        replicate=replicate,
+                        pair_id=pair_id,
+                        pair_position=pair_backend_position * 5 + block_position,
+                        block_id=block_id,
+                        block_position=block_position,
+                        canonical_position=canonical_position,
+                        cell_id=cell_id,
+                        data_id=data_id,
+                        start_id=start_id,
+                        data_seed=data_seed,
+                        truth_seed=truth_seed,
+                        group_seed=group_seed,
+                        observation_seed=observation_seed,
+                        natural_start_seed=natural_start_seed,
+                        natural_start_chain_seeds=natural_start_chain_seeds,
+                        sampler_seed=sampler_seed,
+                        chain_seeds=chain_seeds,
+                        chains=tier_spec["chains"],
+                        tune=tier_spec["tune"],
+                        draws=tier_spec["draws"],
+                        target_accept=tier_spec["target_accept"],
+                        max_treedepth=tier_spec["max_treedepth"],
+                        floatx=regime["floatx"],
+                        regime=dict(regime),
+                        natural_model=dict(manifest["natural_model"]),
+                    )
+                    _validate_unit(unit)
+                    units.append(unit)
+    expected = manifest["tiers"][tier]["expected_fit_count"]
+    if len(units) != expected:
+        raise CausalContractError(
+            f"expanded {len(units)} cells but manifest requires {expected}"
+        )
+    _validate_execution_groups(units)
+    return tuple(units)
+
+
+def _validate_execution_groups(units: Sequence[UnitSpec]) -> None:
+    pairs: dict[str, list[UnitSpec]] = {}
+    blocks: dict[str, list[UnitSpec]] = {}
+    for unit in units:
+        pairs.setdefault(unit.pair_id, []).append(unit)
+        blocks.setdefault(unit.block_id, []).append(unit)
+    for pair_id, members in pairs.items():
+        if len(members) != 10:
+            raise CausalContractError(
+                f"{pair_id} is not a complete backend-paired ten-cell worker"
+            )
+        if [member.pair_position for member in members] != list(range(10)):
+            raise CausalContractError(f"{pair_id} has invalid pair positions")
+        if {(member.backend_id, member.representation_id) for member in members} != set(
+            (backend, representation)
+            for backend in BACKEND_IDS
+            for representation in REPRESENTATION_IDS
+        ):
+            raise CausalContractError(
+                f"{pair_id} does not contain both complete five-form blocks"
+            )
+        shared = {
+            (
+                member.data_id,
+                member.start_id,
+                member.data_seed,
+                member.truth_seed,
+                member.group_seed,
+                member.observation_seed,
+                member.natural_start_seed,
+                member.natural_start_chain_seeds,
+            )
+            for member in members
+        }
+        if len(shared) != 1:
+            raise CausalContractError(
+                f"{pair_id} does not share byte-identical data and natural starts"
+            )
+    for block_id, members in blocks.items():
+        if len(members) != 5:
+            raise CausalContractError(
+                f"{block_id} is not an indivisible five-form block"
+            )
+        if [member.block_position for member in members] != list(range(5)):
+            raise CausalContractError(f"{block_id} has invalid block positions")
+        if {member.representation_id for member in members} != set(REPRESENTATION_IDS):
+            raise CausalContractError(f"{block_id} does not contain all five forms")
+
+
+def plan_unit_by_id(manifest: Mapping[str, Any], tier: str, cell_id: str) -> UnitSpec:
+    """Return one exact planned unit or reject an unplanned cell."""
+    matches = [unit for unit in build_plan(manifest, tier) if unit.cell_id == cell_id]
+    if len(matches) != 1:
+        raise CausalContractError(f"cell_id is not planned exactly once: {cell_id!r}")
+    return matches[0]
+
+
+def block_units(
+    manifest: Mapping[str, Any], tier: str, block_id: str
+) -> tuple[UnitSpec, ...]:
+    """Return all five members in their frozen execution order."""
+    members = tuple(
+        unit for unit in build_plan(manifest, tier) if unit.block_id == block_id
+    )
+    if len(members) != 5:
+        raise CausalContractError(f"block_id is not planned exactly once: {block_id!r}")
+    return members
+
+
+def pair_units(
+    manifest: Mapping[str, Any], tier: str, pair_id: str
+) -> tuple[UnitSpec, ...]:
+    """Return both five-form backend blocks in one worker's frozen order."""
+    members = tuple(
+        unit for unit in build_plan(manifest, tier) if unit.pair_id == pair_id
+    )
+    if len(members) != 10:
+        raise CausalContractError(f"pair_id is not planned exactly once: {pair_id!r}")
+    return members
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    """Parent-minted identity binding both backend blocks on one worker."""
+
+    schema_version: int
+    study_id: str
+    manifest_sha256: str
+    pair_id: str
+    block_ids: tuple[str, ...]
+    cell_ids: tuple[str, ...]
+    execution_order: tuple[str, ...]
+    environment: Mapping[str, Any]
+    environment_sha256: str
+    git_commit: str
+    worker_identity_sha256: str
+    pair_execution_id: str
+    execution_attempt_ids: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the strict canonical mapping stored by the parent."""
+        return {
+            "schema_version": self.schema_version,
+            "study_id": self.study_id,
+            "manifest_sha256": self.manifest_sha256,
+            "pair_id": self.pair_id,
+            "block_ids": list(self.block_ids),
+            "cell_ids": list(self.cell_ids),
+            "execution_order": list(self.execution_order),
+            "environment": strict_json_loads(
+                canonical_json_bytes(self.environment).decode()
+            ),
+            "environment_sha256": self.environment_sha256,
+            "git_commit": self.git_commit,
+            "worker_identity_sha256": self.worker_identity_sha256,
+            "pair_execution_id": self.pair_execution_id,
+            "execution_attempt_ids": list(self.execution_attempt_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> Self:
+        """Construct a strict context without accepting unbound extra fields."""
+        _require_exact_keys(value, CONTEXT_KEYS, "run context")
+        context = cls(
+            schema_version=value["schema_version"],
+            study_id=value["study_id"],
+            manifest_sha256=value["manifest_sha256"],
+            pair_id=value["pair_id"],
+            block_ids=tuple(value["block_ids"]),
+            cell_ids=tuple(value["cell_ids"]),
+            execution_order=tuple(value["execution_order"]),
+            environment=dict(value["environment"]),
+            environment_sha256=value["environment_sha256"],
+            git_commit=value["git_commit"],
+            worker_identity_sha256=value["worker_identity_sha256"],
+            pair_execution_id=value["pair_execution_id"],
+            execution_attempt_ids=tuple(value["execution_attempt_ids"]),
+        )
+        validate_run_context(context)
+        return context
+
+
+def validate_run_context(
+    context: RunContext,
+    units: Sequence[UnitSpec] | None = None,
+    manifest: Mapping[str, Any] | None = None,
+) -> RunContext:
+    """Validate context identity and optionally bind it to ten paired units."""
+    if context.schema_version != SCHEMA_VERSION:
+        raise CausalContractError("run context schema_version is wrong")
+    if context.study_id != "truncated_hierarchy_causal_v3":
+        raise CausalContractError("run context study_id is wrong")
+    for field in (
+        "manifest_sha256",
+        "environment_sha256",
+        "worker_identity_sha256",
+        "pair_execution_id",
+    ):
+        if not SHA256.fullmatch(getattr(context, field)):
+            raise CausalContractError(f"run context {field} must be SHA-256")
+    if not GIT_SHA.fullmatch(context.git_commit):
+        raise CausalContractError("run context git_commit must be a full commit hash")
+    _validate_slug(context.pair_id, "run context pair_id", composite=True)
+    if len(context.block_ids) != 2 or len(set(context.block_ids)) != 2:
+        raise CausalContractError("run context must bind two distinct backend blocks")
+    if any(
+        _validate_slug(block_id, "run context block_id", composite=True) != block_id
+        for block_id in context.block_ids
+    ):
+        raise AssertionError("validated block ID changed")
+    if len(context.cell_ids) != 10 or len(set(context.cell_ids)) != 10:
+        raise CausalContractError("run context must bind ten distinct cell IDs")
+    if context.execution_order != context.cell_ids:
+        raise CausalContractError(
+            "execution_order must equal the frozen ordered cell_ids"
+        )
+    if len(context.execution_attempt_ids) != 10:
+        raise CausalContractError("run context must bind ten execution attempts")
+    if any(not SHA256.fullmatch(value) for value in context.execution_attempt_ids):
+        raise CausalContractError("execution attempt IDs must be SHA-256 values")
+    if len(set(context.execution_attempt_ids)) != 10:
+        raise CausalContractError("execution attempt IDs must be distinct")
+    if not isinstance(context.environment, Mapping):
+        raise CausalContractError("run context environment must be an object")
+    if context.environment.get("environment_sha256") != context.environment_sha256:
+        raise CausalContractError(
+            "embedded environment self-digest is not context-bound"
+        )
+    if environment_digest(context.environment) != context.environment_sha256:
+        raise CausalContractError("embedded environment bytes have the wrong digest")
+    environment_git = context.environment.get("git")
+    if not isinstance(environment_git, Mapping) or (
+        environment_git.get("commit") != context.git_commit
+    ):
+        raise CausalContractError("embedded environment commit is not context-bound")
+    if manifest is not None:
+        validate_environment(context.environment, manifest)
+    if units is not None:
+        if len(units) != 10 or {unit.pair_id for unit in units} != {context.pair_id}:
+            raise CausalContractError("context units must be one complete backend pair")
+        ordered_blocks = tuple(dict.fromkeys(unit.block_id for unit in units))
+        if context.block_ids != ordered_blocks:
+            raise CausalContractError("context backend block order does not match plan")
+        ordered = tuple(unit.cell_id for unit in units)
+        if context.cell_ids != ordered:
+            raise CausalContractError("context cell order does not match the plan")
+        if {unit.manifest_sha256 for unit in units} != {context.manifest_sha256}:
+            raise CausalContractError("context manifest does not match the plan")
+    return context
+
+
+def write_run_context(path: Path, context: RunContext) -> Path:
+    """Atomically publish a validated parent context without overwrite."""
+    validate_run_context(context)
+    _atomic_write(path, canonical_json_bytes(context.as_dict()))
+    return path
+
+
+def load_run_context(path: Path) -> RunContext:
+    """Load a strict parent context."""
+    value = _load_json(path)
+    if not isinstance(value, Mapping):
+        raise CausalContractError("run context must contain an object")
+    return RunContext.from_dict(value)
+
+
+def context_path(root: Path, pair_id: str) -> Path:
+    """Return the parent-minted backend-pair context path."""
+    _validate_slug(pair_id, "pair_id", composite=True)
+    return root / "contexts" / f"{pair_id}.json"
+
+
+def data_artifact_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the shared immutable data path for a unit."""
+    return root / "data" / f"{unit.data_id}.json"
+
+
+def natural_start_artifact_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the shared natural-start path for a unit."""
+    return root / "starts" / "natural" / f"{unit.start_id}.json"
+
+
+def coordinate_start_artifact_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the representation-specific coordinate-start path."""
+    return root / "starts" / "coordinates" / f"{unit.cell_id}.json"
+
+
+def chain_artifact_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the standardized natural-scale posterior path."""
+    return root / "chains" / f"{unit.cell_id}.nc"
+
+
+def diagnostic_artifact_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the raw diagnostic and oracle evidence path."""
+    return root / "diagnostics" / f"{unit.cell_id}.json"
+
+
+def cell_result_path(root: Path, unit: UnitSpec) -> Path:
+    """Return the final atomic cell-marker path."""
+    return root / "cells" / f"{unit.cell_id}.json"
+
+
+def _git(*arguments: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise CausalContractError(f"cannot collect git provenance: {error}") from error
+
+
+def collect_environment(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Collect a strict environment attestation without importing samplers."""
+    validate_manifest(manifest)
+    profile = manifest["dependency_profile"]
+    packages: dict[str, str | None] = {}
+    for package, expected in profile["required_versions"].items():
+        try:
+            packages[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            packages[package] = None
+        if packages[package] != expected:
+            # Collection remains useful for diagnosis.  Validation below is the
+            # hard execution gate and will reject the drifted record.
+            continue
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "study_id": manifest["study_id"],
+        "manifest_sha256": manifest_digest(manifest),
+        "runner_version": RUNNER_VERSION,
+        "dependency_profile": profile["name"],
+        "git": {
+            "commit": _git("rev-parse", "HEAD"),
+            "branch": _git("branch", "--show-current"),
+            "dirty": bool(_git("status", "--porcelain")),
+        },
+        "project": {
+            "path": profile["project_path"],
+            "sha256": sha256_file(REPO_ROOT / profile["project_path"]),
+            "lock_path": profile["lock_path"],
+            "lock_sha256": sha256_file(REPO_ROOT / profile["lock_path"]),
+        },
+        "runtime": {
+            "python": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "executable": str(Path(sys.executable).resolve()),
+            "platform": platform.platform(),
+        },
+        "packages": packages,
+    }
+    record["environment_sha256"] = environment_digest(record)
+    return record
+
+
+def environment_digest(record: Mapping[str, Any]) -> str:
+    """Hash an environment record independent of its self-digest field."""
+    value = dict(record)
+    value.pop("environment_sha256", None)
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def validate_environment(
+    record: Mapping[str, Any], manifest: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    """Require the exact frozen dependency and clean source environment."""
+    expected_keys = frozenset(
+        {
+            "schema_version",
+            "study_id",
+            "manifest_sha256",
+            "runner_version",
+            "dependency_profile",
+            "git",
+            "project",
+            "runtime",
+            "packages",
+            "environment_sha256",
+        }
+    )
+    _require_exact_keys(record, expected_keys, "environment")
+    if (
+        record["schema_version"] != SCHEMA_VERSION
+        or record["runner_version"] != RUNNER_VERSION
+    ):
+        raise CausalContractError("environment schema/runner version is wrong")
+    if record["study_id"] != manifest["study_id"]:
+        raise CausalContractError("environment study_id is wrong")
+    if record["manifest_sha256"] != manifest_digest(manifest):
+        raise CausalContractError("environment manifest digest is wrong")
+    profile = manifest["dependency_profile"]
+    if record["dependency_profile"] != profile["name"]:
+        raise CausalContractError("environment dependency profile is wrong")
+    if record["packages"] != profile["required_versions"]:
+        raise CausalContractError("environment package versions do not match the lock")
+    if not record["runtime"]["python"].startswith(f"{profile['python']}."):
+        raise CausalContractError("environment Python minor version is wrong")
+    if record["git"]["dirty"] is not False:
+        raise CausalContractError("scientific execution requires a clean worktree")
+    if record["project"]["sha256"] != profile["project_sha256"]:
+        raise CausalContractError("environment project hash is wrong")
+    if record["project"]["lock_sha256"] != profile["lock_sha256"]:
+        raise CausalContractError("environment lock hash is wrong")
+    if record["environment_sha256"] != environment_digest(record):
+        raise CausalContractError("environment self-digest is wrong")
+    return record
+
+
+def _validate_artifact_ref(value: Any, path: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise CausalContractError(f"{path} must be null or an artifact reference")
+    _require_exact_keys(value, ARTIFACT_REF_KEYS, path)
+    _relative_contract_path(value["path"])
+    if not isinstance(value["sha256"], str) or not SHA256.fullmatch(value["sha256"]):
+        raise CausalContractError(f"{path}.sha256 must be lowercase SHA-256")
+    if not _is_int(value["size_bytes"]) or value["size_bytes"] < 0:
+        raise CausalContractError(f"{path}.size_bytes must be non-negative")
+
+
+def _validate_metrics(metrics: Any, *, completed: bool, tier: str) -> None:
+    if not isinstance(metrics, Mapping):
+        raise CausalContractError("metrics must be an object")
+    unknown = set(metrics) - ALLOWED_METRICS
+    if unknown:
+        raise CausalContractError(
+            f"metrics contain unregistered fields: {sorted(unknown)}"
+        )
+    required = (
+        (SCREENING_METRICS | ORACLE_METRICS)
+        if tier == "smoke"
+        else (CONFIRMATION_METRICS | ORACLE_METRICS)
+    )
+    if completed and not required <= set(metrics):
+        raise CausalContractError(
+            f"completed {tier} result misses metrics: {sorted(required - set(metrics))}"
+        )
+    observed_oracle = set(metrics) & ORACLE_METRICS
+    if observed_oracle and observed_oracle != ORACLE_METRICS:
+        raise CausalContractError(
+            "oracle evidence must publish the complete registered metric set"
+        )
+    for key, value in metrics.items():
+        if key in BOOL_METRICS and not isinstance(value, bool):
+            raise CausalContractError(f"metrics.{key} must be Boolean")
+        if key in INTEGER_METRICS and (not _is_int(value) or value < 0):
+            raise CausalContractError(f"metrics.{key} must be a non-negative integer")
+        if key in FLOAT_METRICS and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or float(value) < 0
+        ):
+            raise CausalContractError(f"metrics.{key} must be finite and non-negative")
+    trio = {"divergence_count", "posterior_draw_count", "divergence_rate"}
+    if trio <= set(metrics):
+        if metrics["posterior_draw_count"] <= 0:
+            raise CausalContractError("posterior_draw_count must be positive")
+        expected = metrics["divergence_count"] / metrics["posterior_draw_count"]
+        if not math.isclose(metrics["divergence_rate"], expected, abs_tol=1e-15):
+            raise CausalContractError("divergence count/rate/draw count disagree")
+
+
+def _validate_parameter_summaries(value: Any, *, completed: bool) -> None:
+    if not isinstance(value, list):
+        raise CausalContractError("parameter_summaries must be a list")
+    if not completed and value:
+        raise CausalContractError("failed cells cannot publish posterior summaries")
+    identities: set[tuple[str, int | None]] = set()
+    for index, summary in enumerate(value):
+        if not isinstance(summary, Mapping):
+            raise CausalContractError(f"parameter_summaries[{index}] must be an object")
+        _require_exact_keys(
+            summary, PARAMETER_SUMMARY_KEYS, f"parameter_summaries[{index}]"
+        )
+        if not isinstance(summary["parameter_id"], str) or not SAFE_PARAMETER.fullmatch(
+            summary["parameter_id"]
+        ):
+            raise CausalContractError("parameter_id must be a canonical parameter name")
+        if summary["index"] is not None and (
+            not _is_int(summary["index"]) or summary["index"] < 0
+        ):
+            raise CausalContractError(
+                "parameter summary index must be null/non-negative"
+            )
+        identity = (summary["parameter_id"], summary["index"])
+        if identity in identities:
+            raise CausalContractError("parameter summary identities must be unique")
+        identities.add(identity)
+        for field in ("mean", "sd", "mcse_mean"):
+            number = summary[field]
+            if (
+                isinstance(number, bool)
+                or not isinstance(number, (int, float))
+                or not math.isfinite(float(number))
+            ):
+                raise CausalContractError(f"parameter summary {field} must be finite")
+        if summary["sd"] < 0 or summary["mcse_mean"] < 0:
+            raise CausalContractError("posterior SD/MCSE must be non-negative")
+
+
+def derive_pymc_chain_rng_provenance(
+    entropy_words: Sequence[int], chains: int
+) -> list[dict[str, Any]]:
+    """Derive the exact PyMC 6.3.1 spawned-generator provenance.
+
+    PyMC does not consume a supplied integer sequence as one seed per chain.  It
+    treats the sequence as ``SeedSequence`` entropy, spawns one generator per
+    chain, draws one integer for initial-point/NUTS-step construction, and then
+    hands each advanced generator to the chain sampler.
+    """
+    if not _is_int(chains) or chains <= 0:
+        raise CausalContractError("PyMC chains must be a positive integer")
+    if len(entropy_words) != chains:
+        raise CausalContractError("PyMC entropy-word count must equal chains")
+    for word in entropy_words:
+        _validate_seed(word, "PyMC entropy word")
+    try:
+        import numpy as np
+    except ImportError as error:  # pragma: no cover - NumPy is a frozen dependency.
+        raise CausalContractError(
+            "NumPy is required to validate effective PyMC chain seeds"
+        ) from error
+    result: list[dict[str, Any]] = []
+    generators = np.random.default_rng(list(entropy_words)).spawn(chains)
+    for chain, generator in enumerate(generators):
+        seed_sequence = generator.bit_generator.seed_seq
+        spawn_key = list(getattr(seed_sequence, "spawn_key"))
+        pool_size = int(getattr(seed_sequence, "pool_size"))
+        if spawn_key != [chain] or pool_size != 4:
+            raise CausalContractError("pinned NumPy SeedSequence semantics changed")
+        init_step_seed = int(generator.integers(2**30))
+        result.append(
+            {
+                "chain": chain,
+                "rng": "numpy.random.Generator(PCG64)",
+                "spawn_key": spawn_key,
+                "seed_sequence_pool_size": pool_size,
+                "init_step_seed": init_step_seed,
+                "post_init_draw_state_sha256": sha256_bytes(
+                    canonical_json_bytes(generator.bit_generator.state)
+                ),
+            }
+        )
+    return result
+
+
+def derive_numpyro_chain_keys(seed: int, chains: int) -> list[list[int]]:
+    """Derive the exact pinned JAX PRNG keys consumed by NumPyro."""
+    _validate_seed(seed, "NumPyro sampler seed")
+    if not _is_int(chains) or chains <= 0:
+        raise CausalContractError("NumPyro chains must be a positive integer")
+    try:
+        import jax  # Imported only when validating NumPyro execution evidence.
+        import numpy as np
+    except ImportError as error:
+        raise CausalContractError(
+            "JAX is required to validate effective NumPyro PRNG keys"
+        ) from error
+    master = jax.random.PRNGKey(seed)
+    keys = master[None, :] if chains == 1 else jax.random.split(master, chains)
+    array = np.asarray(keys, dtype=np.uint32)
+    return [[int(item) for item in row] for row in array]
+
+
+def validate_result_record(
+    record: Mapping[str, Any], unit: UnitSpec, context: RunContext | None = None
+) -> Mapping[str, Any]:
+    """Validate one final cell marker against its exact plan and parent context."""
+    if not isinstance(record, Mapping):
+        raise CausalContractError("result record must be an object")
+    _require_exact_keys(record, RESULT_KEYS, "result record")
+    expected_identity = {
+        "schema_version": unit.schema_version,
+        "runner_version": RUNNER_VERSION,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "replicate": unit.replicate,
+        "pair_id": unit.pair_id,
+        "pair_position": unit.pair_position,
+        "block_id": unit.block_id,
+        "block_position": unit.block_position,
+        "cell_id": unit.cell_id,
+    }
+    for field, expected in expected_identity.items():
+        if record[field] != expected:
+            raise CausalContractError(f"result {field} does not match the plan")
+    status = record["execution_status"]
+    if status not in {"completed", "failed"}:
+        raise CausalContractError("execution_status must be completed or failed")
+    completed = status == "completed"
+    _validate_metrics(record["metrics"], completed=completed, tier=unit.tier)
+    _validate_parameter_summaries(record["parameter_summaries"], completed=completed)
+
+    artifacts = record["artifacts"]
+    if not isinstance(artifacts, Mapping):
+        raise CausalContractError("artifacts must be an object")
+    _require_exact_keys(artifacts, ARTIFACT_KEYS, "artifacts")
+    for key, value in artifacts.items():
+        _validate_artifact_ref(value, f"artifacts.{key}")
+    expected_paths = {
+        "context": f"contexts/{unit.pair_id}.json",
+        "data": f"data/{unit.data_id}.json",
+        "natural_start": f"starts/natural/{unit.start_id}.json",
+        "coordinate_start": f"starts/coordinates/{unit.cell_id}.json",
+        "chain": f"chains/{unit.cell_id}.nc",
+        "diagnostics": f"diagnostics/{unit.cell_id}.json",
+    }
+    for key, reference in artifacts.items():
+        if reference is not None and reference["path"] != expected_paths[key]:
+            raise CausalContractError(f"artifacts.{key}.path does not match the plan")
+    if completed and any(artifacts[key] is None for key in ARTIFACT_KEYS):
+        raise CausalContractError("completed cells require all six artifact references")
+
+    failure = record["failure"]
+    if completed:
+        if failure is not None:
+            raise CausalContractError("completed cells cannot contain failure details")
+    else:
+        if not isinstance(failure, Mapping):
+            raise CausalContractError("failed cells require failure details")
+        _require_exact_keys(failure, FAILURE_KEYS, "failure")
+        if failure["stage"] not in SCIENTIFIC_FAILURE_STAGES:
+            raise CausalContractError("failure stage is not a scientific stage")
+        if not all(
+            isinstance(failure[field], str) and failure[field]
+            for field in ("error_type", "message")
+        ):
+            raise CausalContractError("failure type/message must be non-empty strings")
+        required_before_failure = {
+            "data": (),
+            "build": ("data",),
+            "initialize": ("data",),
+            "compile": ("data", "natural_start", "coordinate_start"),
+            "sample": ("data", "natural_start", "coordinate_start"),
+            "summarize": ("data", "natural_start", "coordinate_start", "chain"),
+            "diagnose": ("data", "natural_start", "coordinate_start", "chain"),
+        }[failure["stage"]]
+        if any(artifacts[key] is None for key in required_before_failure):
+            raise CausalContractError(
+                f"failure at {failure['stage']} omits a completed prerequisite artifact"
+            )
+
+    has_oracle_evidence = ORACLE_METRICS <= set(record["metrics"])
+    if completed:
+        expected_oracle_count = _expected_oracle_evaluation_count(
+            record,
+            unit.tier,
+            posterior_trajectory=True,
+        )
+        if record["metrics"]["oracle_evaluation_count"] != expected_oracle_count:
+            raise CausalContractError(
+                "completed cell oracle count omits frozen trajectory/static evidence"
+            )
+    elif has_oracle_evidence:
+        failure_stage = failure["stage"]
+        if failure_stage not in {"compile", "sample", "diagnose", "summarize"}:
+            raise CausalContractError(
+                "oracle evidence is invalid before graph evaluation"
+            )
+        if artifacts["diagnostics"] is None:
+            raise CausalContractError("failed oracle evidence requires diagnostics")
+        if failure_stage in {"compile", "sample"} and artifacts["chain"] is not None:
+            raise CausalContractError(
+                "compile/sample-stage pre-oracle failure cannot publish a chain"
+            )
+        expected_basic = {
+            "initialization_success": True,
+            "logp_finite": True,
+            "gradient_finite": True,
+        }
+        expected_basic["compile_success"] = failure_stage != "compile"
+        if failure_stage in {"sample", "diagnose", "summarize"}:
+            expected_basic["sampling_success"] = failure_stage != "sample"
+        if any(
+            record["metrics"].get(key) is not value
+            for key, value in expected_basic.items()
+        ):
+            raise CausalContractError(
+                "failed oracle result has inconsistent execution metrics"
+            )
+        posterior_trajectory = failure_stage == "summarize"
+        expected_oracle_count = _expected_oracle_evaluation_count(
+            record,
+            unit.tier,
+            posterior_trajectory=posterior_trajectory,
+        )
+        if record["metrics"]["oracle_evaluation_count"] != expected_oracle_count:
+            raise CausalContractError(
+                "failed cell oracle count differs from its frozen evidence phase"
+            )
+
+    provenance = record["provenance"]
+    if not isinstance(provenance, Mapping):
+        raise CausalContractError("provenance must be an object")
+    _require_exact_keys(provenance, PROVENANCE_KEYS, "provenance")
+    for field in (
+        "environment_sha256",
+        "worker_identity_sha256",
+        "pair_execution_id",
+        "execution_attempt_id",
+    ):
+        if not isinstance(provenance[field], str) or not SHA256.fullmatch(
+            provenance[field]
+        ):
+            raise CausalContractError(f"provenance.{field} must be SHA-256")
+    if not GIT_SHA.fullmatch(provenance["git_commit"]):
+        raise CausalContractError("provenance.git_commit must be a full commit hash")
+    if (
+        provenance["floatx"] != unit.floatx
+        or provenance["pytensor_floatx"] != unit.floatx
+    ):
+        raise CausalContractError("result precision differs from the planned regime")
+    if provenance["jax_enable_x64"] is not (unit.floatx == "float64"):
+        raise CausalContractError("JAX x64 state differs from the planned precision")
+    expected_backend = {
+        "pymc": ("pymc-nuts", "pytensor"),
+        "numpyro": ("numpyro-nuts-via-pymc", "pytensor-to-jax"),
+    }[unit.backend_id]
+    if (provenance["sampler"], provenance["compiler_path"]) != expected_backend:
+        raise CausalContractError("sampler/compiler provenance differs from the plan")
+    if provenance["device"] != "cpu":
+        raise CausalContractError("causal evidence must come from CPU execution")
+    expected_seed_input: int | list[int]
+    expected_chain_rng: list[dict[str, Any]]
+    if unit.backend_id == "pymc":
+        expected_seed_input = list(unit.chain_seeds)
+        expected_chain_rng = derive_pymc_chain_rng_provenance(
+            unit.chain_seeds, unit.chains
+        )
+    else:
+        if unit.sampler_seed is None:  # pragma: no cover - unit validation guards it
+            raise AssertionError("NumPyro unit without a sampler seed")
+        expected_seed_input = unit.sampler_seed
+        expected_chain_rng = [
+            {"chain": chain, "rng": "jax-prng-key", "key": key}
+            for chain, key in enumerate(
+                derive_numpyro_chain_keys(unit.sampler_seed, unit.chains)
+            )
+        ]
+    if provenance["sampler_seed_input"] != expected_seed_input:
+        raise CausalContractError("backend sampler seed input differs from the plan")
+    if provenance["chain_rng_provenance"] != expected_chain_rng:
+        raise CausalContractError("backend chain RNG provenance differs from the plan")
+    if context is not None:
+        validate_run_context(context)
+        if context.pair_id != unit.pair_id or unit.block_id not in context.block_ids:
+            raise CausalContractError("result context belongs to another backend pair")
+        position = context.cell_ids.index(unit.cell_id)
+        context_bindings = {
+            "environment_sha256": context.environment_sha256,
+            "git_commit": context.git_commit,
+            "worker_identity_sha256": context.worker_identity_sha256,
+            "pair_execution_id": context.pair_execution_id,
+            "execution_attempt_id": context.execution_attempt_ids[position],
+        }
+        for field, expected in context_bindings.items():
+            if provenance[field] != expected:
+                raise CausalContractError(
+                    f"result provenance.{field} is not parent-bound"
+                )
+    return record
+
+
+def _require_derived_metric(
+    record: Mapping[str, Any], name: str, observed: int | float | bool
+) -> None:
+    """Require a registered scalar to equal independently derived evidence."""
+    claimed = record["metrics"].get(name)
+    if isinstance(observed, bool) or isinstance(observed, int):
+        matches = claimed == observed and type(claimed) is type(observed)
+    else:
+        matches = isinstance(claimed, (int, float)) and not isinstance(claimed, bool)
+        matches = bool(
+            matches
+            and math.isclose(
+                float(claimed),
+                float(observed),
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+        )
+    if not matches:
+        raise CausalContractError(
+            f"metrics.{name} disagrees with hash-bound raw evidence"
+        )
+
+
+def _audit_diagnostic_evidence(
+    record: Mapping[str, Any],
+    unit: UnitSpec,
+    path: Path,
+    analysis_policy: Mapping[str, Any],
+) -> None:
+    """Recompute oracle metrics and ICDF gates from hash-bound raw arrays."""
+    try:
+        import numpy as np
+    except ImportError as error:  # pragma: no cover - NumPy is a frozen dependency.
+        raise CausalContractError(
+            "NumPy is required to audit diagnostic evidence"
+        ) from error
+    diagnostics = _load_json(path)
+    if not isinstance(diagnostics, Mapping):
+        raise CausalContractError("diagnostics artifact must contain an object")
+    identity = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+    }
+    if any(diagnostics.get(key) != value for key, value in identity.items()):
+        raise CausalContractError("diagnostics artifact identity differs from the plan")
+    runtime = diagnostics.get("runtime")
+    if not isinstance(runtime, Mapping):
+        raise CausalContractError("diagnostics artifact lacks child runtime evidence")
+    if (
+        runtime.get("pytensor_floatx") != record["provenance"]["pytensor_floatx"]
+        or runtime.get("jax_enable_x64") is not record["provenance"]["jax_enable_x64"]
+    ):
+        raise CausalContractError("diagnostic runtime differs from result provenance")
+    oracle = diagnostics.get("oracle")
+    has_registered_oracle = ORACLE_METRICS <= set(record["metrics"])
+    if not has_registered_oracle:
+        if oracle is not None:
+            raise CausalContractError(
+                "diagnostic oracle exists without registered oracle metrics"
+            )
+        return
+    if not isinstance(oracle, Mapping) or not isinstance(oracle.get("records"), list):
+        raise CausalContractError("diagnostics artifact lacks raw oracle records")
+    completed = record["execution_status"] == "completed"
+    failure = record.get("failure")
+    failure_stage = failure.get("stage") if isinstance(failure, Mapping) else None
+    expected_posterior = bool(completed or failure_stage == "summarize")
+    if oracle.get("posterior_trajectory_evaluated") is not expected_posterior:
+        raise CausalContractError("oracle phase does not match cell completion status")
+    records = oracle["records"]
+    expected_count = _expected_oracle_evaluation_count(
+        record,
+        unit.tier,
+        posterior_trajectory=expected_posterior,
+    )
+    if len(records) != expected_count:
+        raise CausalContractError("raw oracle record count differs from frozen design")
+
+    try:
+        gate = analysis_policy["oracle_gate"]
+        tolerances = gate["component_tolerances"][unit.floatx]
+        allowed_scaled_error = float(gate["scaled_error_max"])
+        roundtrip_limit = float(gate["roundtrip_absolute_error_max"][unit.floatx])
+    except (KeyError, TypeError, ValueError) as error:
+        raise CausalContractError("oracle analysis policy is incomplete") from error
+    component_tolerances = {
+        "value": tolerances["logp"],
+        "gradient": tolerances["gradient"],
+        "hessian": tolerances["hessian"],
+    }
+
+    def contains_boolean(value: Any) -> bool:
+        if isinstance(value, bool):
+            return True
+        if isinstance(value, list):
+            return any(contains_boolean(item) for item in value)
+        return False
+
+    def as_finite_array(value: Any, source: str) -> Any:
+        if value is None or contains_boolean(value):
+            raise CausalContractError(f"{source} is not a finite numeric array")
+        try:
+            array = np.asarray(value, dtype=np.float64)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise CausalContractError(
+                f"{source} is not a finite numeric array"
+            ) from error
+        if array.size == 0 or not np.all(np.isfinite(array)):
+            raise CausalContractError(f"{source} is not a finite numeric array")
+        return array
+
+    def scaled_error(
+        observed: Any,
+        expected: Any,
+        tolerance: Mapping[str, Any],
+        source: str,
+    ) -> tuple[dict[str, float], bool, Any | None, Any]:
+        expected_array = as_finite_array(expected, f"{source}.oracle")
+        if observed is None:
+            return (
+                {
+                    "absolute_max": sys.float_info.max,
+                    "scaled_max": allowed_scaled_error + 1.0,
+                },
+                False,
+                None,
+                expected_array,
+            )
+        observed_array = as_finite_array(observed, f"{source}.observed")
+        if observed_array.shape != expected_array.shape:
+            raise CausalContractError(f"{source} observed/oracle shapes differ")
+        absolute_tolerance = float(tolerance["absolute_tolerance"])
+        relative_tolerance = float(tolerance["relative_tolerance"])
+        difference = np.abs(observed_array - expected_array)
+        scale = absolute_tolerance + relative_tolerance * np.maximum(
+            np.abs(observed_array), np.abs(expected_array)
+        )
+        if absolute_tolerance <= 0 or relative_tolerance < 0 or np.any(scale <= 0):
+            raise CausalContractError(f"{source} has invalid frozen tolerances")
+        return (
+            {
+                "absolute_max": float(np.max(difference)),
+                "scaled_max": float(np.max(difference / scale)),
+            },
+            True,
+            observed_array,
+            expected_array,
+        )
+
+    def require_error_summary(
+        claimed: Any, observed: Mapping[str, float], source: str
+    ) -> None:
+        if not isinstance(claimed, Mapping):
+            raise CausalContractError(f"{source} must be an error summary")
+        _require_exact_keys(claimed, frozenset({"absolute_max", "scaled_max"}), source)
+        for name, expected in observed.items():
+            value = claimed[name]
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                or not math.isclose(
+                    float(value), expected, rel_tol=1e-12, abs_tol=1e-12
+                )
+            ):
+                raise CausalContractError(
+                    f"{source}.{name} disagrees with raw observed/oracle arrays"
+                )
+
+    audited_records: list[dict[str, Any]] = []
+    coordinate_size = int(unit.regime["n_groups"]) + 2
+    component_shapes = {
+        "value": (),
+        "gradient": (coordinate_size,),
+        "hessian": (coordinate_size, coordinate_size),
+    }
+    for index, item in enumerate(records):
+        source = f"oracle.records[{index}]"
+        if not isinstance(item, Mapping):
+            raise CausalContractError(f"{source} must be an object")
+        try:
+            observed_components = item["observed"]
+            oracle_components = item["oracle"]
+            claimed_errors = item["errors"]
+            claimed_finite = item["component_finite"]
+            roundtrip_error = float(item["roundtrip"]["absolute_error_max"])
+            kind = item["kind"]
+        except (KeyError, TypeError, ValueError) as error:
+            raise CausalContractError(
+                "raw oracle record schema is incomplete"
+            ) from error
+        if not all(
+            isinstance(value, Mapping)
+            for value in (
+                observed_components,
+                oracle_components,
+                claimed_errors,
+                claimed_finite,
+            )
+        ):
+            raise CausalContractError(f"{source} component mappings are malformed")
+        component_names = frozenset({"value", "gradient", "hessian"})
+        for mapping_name, value in (
+            ("observed", observed_components),
+            ("oracle", oracle_components),
+            ("errors", claimed_errors),
+            ("component_finite", claimed_finite),
+        ):
+            _require_exact_keys(value, component_names, f"{source}.{mapping_name}")
+        if (
+            not isinstance(kind, str)
+            or not kind
+            or not math.isfinite(roundtrip_error)
+            or roundtrip_error < 0
+        ):
+            raise CausalContractError(f"{source} kind/roundtrip is malformed")
+        component_errors: dict[str, dict[str, float]] = {}
+        finite_components: dict[str, bool] = {}
+        raw_arrays: dict[str, tuple[Any | None, Any]] = {}
+        for component in ("value", "gradient", "hessian"):
+            derived_error, finite, observed_array, oracle_array = scaled_error(
+                observed_components[component],
+                oracle_components[component],
+                component_tolerances[component],
+                f"{source}.{component}",
+            )
+            if oracle_array.shape != component_shapes[component]:
+                raise CausalContractError(
+                    f"{source}.{component} has the wrong coordinate shape"
+                )
+            require_error_summary(
+                claimed_errors[component],
+                derived_error,
+                f"{source}.errors.{component}",
+            )
+            if claimed_finite[component] is not finite:
+                raise CausalContractError(
+                    f"{source}.component_finite.{component} disagrees with raw arrays"
+                )
+            component_errors[component] = derived_error
+            finite_components[component] = finite
+            raw_arrays[component] = (observed_array, oracle_array)
+        finite = all(finite_components.values())
+        passed = bool(
+            finite
+            and roundtrip_error <= roundtrip_limit
+            and all(
+                error["scaled_max"] <= allowed_scaled_error
+                for error in component_errors.values()
+            )
+        )
+        if item.get("finite") is not finite or item.get("passed") is not passed:
+            raise CausalContractError(
+                f"{source} finite/passed summary disagrees with raw arrays"
+            )
+        audited_records.append(
+            {
+                "item": item,
+                "kind": kind,
+                "errors": component_errors,
+                "finite": finite,
+                "passed": passed,
+                "roundtrip_error": roundtrip_error,
+                "arrays": raw_arrays,
+            }
+        )
+
+    expected_points: dict[str, tuple[str, int | None]] = {}
+    if unit.replicate == 0:
+        expected_points["fixed-truth"] = ("fixed-grid", None)
+    for chain in range(unit.chains):
+        expected_points[f"start-chain-{chain:02d}"] = ("shared-natural-start", None)
+    expected_icdf_indices = {
+        "native-centered": (),
+        "manual-centered": (),
+        "group-icdf-noncentered": (2,),
+        "location-icdf-noncentered": (0,),
+        "full-icdf-noncentered": (0, 2),
+    }[unit.representation_id]
+    icdf_labels = (
+        "branch-left",
+        "branch-zero",
+        "branch-right",
+        "tail-low",
+        "tail-high",
+    )
+    for coordinate_index in expected_icdf_indices:
+        for label in icdf_labels:
+            expected_points[f"icdf-{coordinate_index}-{label}"] = (
+                f"icdf-{label}",
+                coordinate_index,
+            )
+    if expected_posterior:
+        for chain in range(unit.chains):
+            expected_points[f"trajectory-chain-{chain:02d}-selection-00"] = (
+                "hash-selected-posterior-trajectory",
+                None,
+            )
+    observed_points: dict[str, Mapping[str, Any]] = {}
+    for audited in audited_records:
+        item = audited["item"]
+        point_id = item.get("point_id")
+        if not isinstance(point_id, str) or not point_id or point_id in observed_points:
+            raise CausalContractError("oracle point IDs must be unique strings")
+        observed_points[point_id] = item
+    if set(observed_points) != set(expected_points):
+        raise CausalContractError(
+            "oracle point structure differs from the frozen static/ICDF/trajectory grid"
+        )
+    expected_branch_epsilon = float(
+        8.0 * math.sqrt(np.finfo(np.dtype(unit.floatx)).eps)
+    )
+    for point_id, (kind, expected_coordinate_index) in expected_points.items():
+        item = observed_points[point_id]
+        if item.get("kind") != kind:
+            raise CausalContractError(
+                "oracle point structure differs from the frozen point kinds"
+            )
+        if expected_coordinate_index is not None:
+            epsilon = item.get("branch_epsilon")
+            if (
+                item.get("coordinate_index") != expected_coordinate_index
+                or isinstance(epsilon, bool)
+                or not isinstance(epsilon, (int, float))
+                or not math.isclose(
+                    float(epsilon),
+                    expected_branch_epsilon,
+                    rel_tol=1e-12,
+                    abs_tol=1e-15,
+                )
+            ):
+                raise CausalContractError(
+                    "ICDF point coordinate/epsilon differs from the frozen grid"
+                )
+        if kind == "hash-selected-posterior-trajectory":
+            trajectory_chain = item.get("chain")
+            trajectory_draw = item.get("draw")
+            if (
+                not isinstance(trajectory_chain, int)
+                or isinstance(trajectory_chain, bool)
+                or not isinstance(trajectory_draw, int)
+                or isinstance(trajectory_draw, bool)
+                or trajectory_chain < 0
+                or trajectory_chain >= unit.chains
+                or trajectory_draw < 0
+                or trajectory_draw >= unit.draws
+                or point_id != f"trajectory-chain-{trajectory_chain:02d}-selection-00"
+            ):
+                raise CausalContractError(
+                    "posterior trajectory point differs from the frozen hash selection"
+                )
+            expected_draw = min(
+                range(unit.draws),
+                key=lambda draw: hashlib.sha256(
+                    f"{unit.cell_id}:trajectory:{trajectory_chain}:{draw}".encode()
+                ).digest(),
+            )
+            expected_selection_sha256 = hashlib.sha256(
+                (
+                    f"{unit.cell_id}:trajectory:{trajectory_chain}:{expected_draw}"
+                ).encode()
+            ).hexdigest()
+            if (
+                trajectory_draw != expected_draw
+                or item.get("selection_sha256") != expected_selection_sha256
+            ):
+                raise CausalContractError(
+                    "posterior trajectory point is not the frozen lowest-SHA draw"
+                )
+
+    tail_finite = all(
+        item["finite"]
+        for item in audited_records
+        if item["kind"].startswith("icdf-tail")
+    )
+    branch_groups: dict[int, dict[str, Mapping[str, Any]]] = {}
+    for item in audited_records:
+        if not item["kind"].startswith("icdf-branch"):
+            continue
+        coordinate_index = item["item"].get("coordinate_index")
+        if not _is_int(coordinate_index) or coordinate_index < 0:
+            raise CausalContractError("ICDF branch record lacks a coordinate index")
+        group = branch_groups.setdefault(coordinate_index, {})
+        if item["kind"] in group:
+            raise CausalContractError("ICDF branch diagnostic kind is duplicated")
+        group[item["kind"]] = item
+
+    branch_results: dict[int, bool] = {}
+    required_branch_kinds = {
+        "icdf-branch-left",
+        "icdf-branch-zero",
+        "icdf-branch-right",
+    }
+    for coordinate_index, group in branch_groups.items():
+        if set(group) != required_branch_kinds:
+            raise CausalContractError("ICDF branch diagnostic triplet is incomplete")
+        left = group["icdf-branch-left"]
+        zero = group["icdf-branch-zero"]
+        right = group["icdf-branch-right"]
+        branch_finite = bool(left["finite"] and zero["finite"] and right["finite"])
+        if branch_finite:
+            left_value, left_oracle_value = left["arrays"]["value"]
+            right_value, right_oracle_value = right["arrays"]["value"]
+            left_gradient, left_oracle_gradient = left["arrays"]["gradient"]
+            right_gradient, right_oracle_gradient = right["arrays"]["gradient"]
+            value_jump_error, _, _, _ = scaled_error(
+                right_value - left_value,
+                right_oracle_value - left_oracle_value,
+                component_tolerances["value"],
+                f"oracle.icdf_branch[{coordinate_index}].value_jump",
+            )
+            gradient_jump_error, _, _, _ = scaled_error(
+                right_gradient - left_gradient,
+                right_oracle_gradient - left_oracle_gradient,
+                component_tolerances["gradient"],
+                f"oracle.icdf_branch[{coordinate_index}].gradient_jump",
+            )
+            jump_passed = bool(
+                value_jump_error["scaled_max"] <= allowed_scaled_error
+                and gradient_jump_error["scaled_max"] <= allowed_scaled_error
+            )
+        else:
+            jump_passed = False
+        branch_results[coordinate_index] = bool(
+            left["passed"] and zero["passed"] and right["passed"] and jump_passed
+        )
+
+    branch_continuous = all(branch_results.values())
+    branch_checks = oracle.get("icdf_branch_checks")
+    if not isinstance(branch_checks, list) or len(branch_checks) != len(branch_results):
+        raise CausalContractError(
+            "ICDF branch-check summaries differ from raw triplets"
+        )
+    claimed_branch_results: dict[int, bool] = {}
+    for check in branch_checks:
+        if not isinstance(check, Mapping):
+            raise CausalContractError("ICDF branch-check summary must be an object")
+        claimed_index = check.get("coordinate_index")
+        claimed_passed = check.get("passed")
+        if (
+            not isinstance(claimed_index, int)
+            or isinstance(claimed_index, bool)
+            or not isinstance(claimed_passed, bool)
+            or claimed_index in claimed_branch_results
+        ):
+            raise CausalContractError("ICDF branch-check summary is malformed")
+        claimed_branch_results[claimed_index] = claimed_passed
+    if claimed_branch_results != branch_results:
+        raise CausalContractError(
+            "ICDF branch-check summaries disagree with raw diagnostic arrays"
+        )
+    if (
+        oracle.get("icdf_tail_finite") is not tail_finite
+        or oracle.get("icdf_branch_continuous") is not branch_continuous
+    ):
+        raise CausalContractError(
+            "ICDF summary flags disagree with raw diagnostic arrays"
+        )
+    oracle_passed = (
+        all(item["passed"] for item in audited_records) and branch_continuous
+    )
+    if oracle.get("passed") is not oracle_passed:
+        raise CausalContractError("oracle passed summary disagrees with raw arrays")
+
+    try:
+        derived: dict[str, int | float | bool] = {
+            "oracle_evaluation_count": len(records),
+            "oracle_logp_scaled_error_max": max(
+                item["errors"]["value"]["scaled_max"] for item in audited_records
+            ),
+            "oracle_gradient_scaled_error_max": max(
+                item["errors"]["gradient"]["scaled_max"] for item in audited_records
+            ),
+            "oracle_hessian_scaled_error_max": max(
+                item["errors"]["hessian"]["scaled_max"] for item in audited_records
+            ),
+            "roundtrip_absolute_error_max": max(
+                item["roundtrip_error"] for item in audited_records
+            ),
+            "icdf_tail_finite": tail_finite,
+            "icdf_branch_continuous": branch_continuous,
+        }
+    except (KeyError, TypeError, ValueError) as error:
+        raise CausalContractError("raw oracle record schema is incomplete") from error
+    for name, value in derived.items():
+        _require_derived_metric(record, name, value)
+
+
+def _audit_oracle_point_bindings(
+    record: Mapping[str, Any],
+    unit: UnitSpec,
+    diagnostics_path: Path,
+    data_path: Path,
+    natural_start_path: Path,
+    coordinate_start_path: Path,
+    chain_path: Path | None,
+    analysis_policy: Mapping[str, Any],
+) -> None:
+    """Bind every oracle coordinate to its immutable natural-scale source."""
+    if not ORACLE_METRICS <= set(record["metrics"]):
+        return
+    try:
+        import numpy as np
+        import xarray as xr
+
+        from scripts.truncated_hierarchy_causal_oracle import (
+            HierarchicalPosteriorSpec,
+            TruncationBounds,
+            hierarchical_natural_values,
+        )
+    except ImportError as error:  # pragma: no cover - frozen dependencies.
+        raise CausalContractError(
+            "NumPy, xarray, and the independent oracle are required to bind points"
+        ) from error
+
+    diagnostics = _load_json(diagnostics_path)
+    data = _load_json(data_path)
+    natural_starts = _load_json(natural_start_path)
+    coordinate_starts = _load_json(coordinate_start_path)
+    if not all(
+        isinstance(value, Mapping)
+        for value in (diagnostics, data, natural_starts, coordinate_starts)
+    ):
+        raise CausalContractError("oracle source artifacts must contain objects")
+    oracle = diagnostics.get("oracle")
+    if not isinstance(oracle, Mapping) or not isinstance(oracle.get("records"), list):
+        raise CausalContractError("diagnostics artifact lacks raw oracle records")
+
+    identities = (
+        (
+            data,
+            {
+                "schema_version": unit.schema_version,
+                "study_id": unit.study_id,
+                "manifest_sha256": unit.manifest_sha256,
+                "data_id": unit.data_id,
+                "tier": unit.tier,
+                "regime_id": unit.regime_id,
+                "replicate": unit.replicate,
+            },
+            "data",
+        ),
+        (
+            natural_starts,
+            {
+                "schema_version": unit.schema_version,
+                "study_id": unit.study_id,
+                "manifest_sha256": unit.manifest_sha256,
+                "start_id": unit.start_id,
+                "data_id": unit.data_id,
+                "tier": unit.tier,
+                "regime_id": unit.regime_id,
+                "replicate": unit.replicate,
+                "natural_start_seed": unit.natural_start_seed,
+                "natural_start_chain_seeds": list(unit.natural_start_chain_seeds),
+            },
+            "natural-start",
+        ),
+        (
+            coordinate_starts,
+            {
+                "schema_version": unit.schema_version,
+                "study_id": unit.study_id,
+                "manifest_sha256": unit.manifest_sha256,
+                "cell_id": unit.cell_id,
+                "start_id": unit.start_id,
+                "representation_id": unit.representation_id,
+                "backend_id": unit.backend_id,
+            },
+            "coordinate-start",
+        ),
+    )
+    for artifact, expected, source in identities:
+        if any(artifact.get(name) != value for name, value in expected.items()):
+            raise CausalContractError(
+                f"{source} artifact identity differs from the plan"
+            )
+
+    coordinate_size = int(unit.regime["n_groups"]) + 2
+
+    def finite_array(value: Any, shape: tuple[int, ...], source: str) -> Any:
+        if value is None or isinstance(value, bool):
+            raise CausalContractError(f"{source} is not a finite numeric array")
+        try:
+            array = np.asarray(value, dtype=np.float64)
+        except (TypeError, ValueError, OverflowError) as error:
+            raise CausalContractError(
+                f"{source} is not a finite numeric array"
+            ) from error
+        if array.shape != shape or not np.all(np.isfinite(array)):
+            raise CausalContractError(
+                f"{source} is not a finite numeric array with shape {shape}"
+            )
+        return array
+
+    def natural_vector(value: Mapping[str, Any], source: str) -> Any:
+        try:
+            location = float(value["group_location"])
+            scale = float(value["group_scale"])
+            groups = finite_array(
+                value["group_effect"],
+                (int(unit.regime["n_groups"]),),
+                f"{source}.group_effect",
+            )
+        except (KeyError, TypeError, ValueError, OverflowError) as error:
+            raise CausalContractError(f"{source} natural point is malformed") from error
+        if (
+            isinstance(value["group_location"], bool)
+            or isinstance(value["group_scale"], bool)
+            or not math.isfinite(location)
+            or not math.isfinite(scale)
+            or scale <= 0.0
+        ):
+            raise CausalContractError(f"{source} natural point is malformed")
+        return np.concatenate(([location, scale], groups))
+
+    def require_identity(observed: Any, expected: Any, source: str) -> None:
+        if observed.shape != expected.shape or not np.array_equal(observed, expected):
+            raise CausalContractError(
+                f"{source} differs from its hash-bound source artifact"
+            )
+
+    def require_roundtrip_summary(
+        summary: Any, restored: Any, source_natural: Any, source: str
+    ) -> float:
+        if not isinstance(summary, Mapping):
+            raise CausalContractError(f"{source}.roundtrip is malformed")
+        retained_natural = natural_vector(summary, f"{source}.roundtrip")
+        if not np.array_equal(retained_natural, restored):
+            raise CausalContractError(
+                f"{source} retained roundtrip differs from recomputed natural values"
+            )
+        recomputed_error = float(np.max(np.abs(restored - source_natural)))
+        claimed_error = summary.get("absolute_error_max")
+        if (
+            isinstance(claimed_error, bool)
+            or not isinstance(claimed_error, (int, float))
+            or not math.isclose(
+                float(claimed_error),
+                recomputed_error,
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+        ):
+            raise CausalContractError(
+                f"{source}.roundtrip error disagrees with retained coordinates"
+            )
+        return recomputed_error
+
+    data_spec = data.get("spec")
+    if not isinstance(data_spec, Mapping):
+        raise CausalContractError("data artifact lacks its natural-model spec")
+    expected_data_spec = {
+        "lower": unit.regime["lower"],
+        "upper": unit.regime["upper"],
+        "truth_group_location": unit.regime["truth_group_location"],
+        "truth_group_scale": unit.regime["truth_group_scale"],
+        "n_groups": unit.regime["n_groups"],
+        "n_per_group": unit.regime["n_per_group"],
+        "floatx": unit.floatx,
+        "observation_sigma": unit.natural_model["observation_sigma"],
+    }
+    if any(data_spec.get(name) != value for name, value in expected_data_spec.items()):
+        raise CausalContractError("data artifact natural-model spec differs from plan")
+    group_index = finite_array(
+        data.get("group_index"),
+        (int(unit.regime["n_groups"]) * int(unit.regime["n_per_group"]),),
+        "data.group_index",
+    )
+    if (
+        not np.all(group_index == np.floor(group_index))
+        or np.any(group_index < 0)
+        or np.any(group_index >= int(unit.regime["n_groups"]))
+    ):
+        raise CausalContractError("data.group_index contains an invalid group")
+    observations = finite_array(
+        data.get("observations"), group_index.shape, "data.observations"
+    )
+    truth = natural_vector(
+        {
+            "group_location": data_spec.get("truth_group_location"),
+            "group_scale": data_spec.get("truth_group_scale"),
+            "group_effect": data.get("group_effect"),
+        },
+        "data truth",
+    )
+    try:
+        oracle_spec = HierarchicalPosteriorSpec(
+            bounds=TruncationBounds(data_spec["lower"], data_spec["upper"]),
+            location_base_mean=float(unit.regime["prior_hyper_location"]),
+            location_prior_scale=float(unit.natural_model["location_prior_sigma"]),
+            scale_prior_shape=float(unit.natural_model["scale_prior_alpha"]),
+            scale_prior_scale=float(unit.natural_model["scale_prior_beta"]),
+            n_groups=int(unit.regime["n_groups"]),
+            group_index=group_index.astype(np.int64),
+            observations=observations,
+            observation_scale=float(unit.natural_model["observation_sigma"]),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise CausalContractError(
+            "data artifact cannot define the oracle model"
+        ) from error
+    parameterizations: Mapping[
+        str,
+        Literal[
+            "centered",
+            "location_icdf_noncentered",
+            "group_icdf_noncentered",
+            "full_icdf_noncentered",
+        ],
+    ] = {
+        "native-centered": "centered",
+        "manual-centered": "centered",
+        "group-icdf-noncentered": "group_icdf_noncentered",
+        "location-icdf-noncentered": "location_icdf_noncentered",
+        "full-icdf-noncentered": "full_icdf_noncentered",
+    }
+    parameterization = parameterizations[unit.representation_id]
+
+    natural_chain_rows = natural_starts.get("chains")
+    coordinate_chain_rows = coordinate_starts.get("chains")
+    if (
+        not isinstance(natural_chain_rows, list)
+        or not isinstance(coordinate_chain_rows, list)
+        or len(natural_chain_rows) != unit.chains
+        or len(coordinate_chain_rows) != unit.chains
+    ):
+        raise CausalContractError("start artifacts do not contain every planned chain")
+    natural_by_chain: dict[int, Any] = {}
+    coordinate_by_chain: dict[int, Any] = {}
+    for chain in range(unit.chains):
+        natural_row = natural_chain_rows[chain]
+        coordinate_row = coordinate_chain_rows[chain]
+        if not isinstance(natural_row, Mapping) or not isinstance(
+            coordinate_row, Mapping
+        ):
+            raise CausalContractError("start artifact chain row is malformed")
+        if (
+            natural_row.get("chain") != chain
+            or natural_row.get("seed") != unit.natural_start_chain_seeds[chain]
+            or coordinate_row.get("chain") != chain
+            or coordinate_row.get("natural_start_seed")
+            != unit.natural_start_chain_seeds[chain]
+        ):
+            raise CausalContractError("start artifact chain identity differs from plan")
+        natural = natural_vector(natural_row, f"natural start chain {chain}")
+        coordinate_natural = coordinate_row.get("natural")
+        if not isinstance(coordinate_natural, Mapping):
+            raise CausalContractError("coordinate start lacks its natural source")
+        require_identity(
+            natural_vector(coordinate_natural, f"coordinate start chain {chain}"),
+            natural,
+            f"coordinate start chain {chain} natural point",
+        )
+        coordinate = finite_array(
+            coordinate_row.get("coordinate_vector"),
+            (coordinate_size,),
+            f"coordinate start chain {chain}.coordinate_vector",
+        )
+        try:
+            restored = hierarchical_natural_values(
+                coordinate, oracle_spec, parameterization
+            )
+        except (TypeError, ValueError) as error:
+            raise CausalContractError(
+                "coordinate start cannot be mapped to the natural hierarchy"
+            ) from error
+        restored_vector = np.asarray(
+            [
+                restored.location.value,
+                restored.scale.value,
+                *(group.value for group in restored.group_effect),
+            ],
+            dtype=np.float64,
+        )
+        require_roundtrip_summary(
+            coordinate_row.get("roundtrip"),
+            restored_vector,
+            natural,
+            f"coordinate start chain {chain}",
+        )
+        natural_by_chain[chain] = natural
+        coordinate_by_chain[chain] = coordinate
+
+    chains = None
+    if chain_path is not None:
+        try:
+            chains = xr.load_dataset(chain_path, engine="scipy")
+        except Exception as error:
+            raise CausalContractError(
+                f"cannot decode chain artifact: {error}"
+            ) from error
+    try:
+        for index, item in enumerate(oracle["records"]):
+            source = f"oracle.records[{index}]"
+            if not isinstance(item, Mapping):
+                raise CausalContractError(f"{source} must be an object")
+            coordinate = finite_array(
+                item.get("coordinate_vector"),
+                (coordinate_size,),
+                f"{source}.coordinate_vector",
+            )
+            raw_natural = natural_vector(item, source)
+            try:
+                restored = hierarchical_natural_values(
+                    coordinate, oracle_spec, parameterization
+                )
+            except (TypeError, ValueError) as error:
+                raise CausalContractError(
+                    f"{source}.coordinate_vector cannot map to natural scale"
+                ) from error
+            restored_natural = np.asarray(
+                [
+                    restored.location.value,
+                    restored.scale.value,
+                    *(group.value for group in restored.group_effect),
+                ],
+                dtype=np.float64,
+            )
+            roundtrip = item.get("roundtrip")
+            require_roundtrip_summary(
+                roundtrip,
+                restored_natural,
+                raw_natural,
+                source,
+            )
+
+            kind = item.get("kind")
+            if kind == "fixed-grid":
+                require_identity(raw_natural, truth, f"{source} fixed truth")
+            elif kind == "shared-natural-start":
+                point_id = item.get("point_id")
+                try:
+                    chain = int(str(point_id).removeprefix("start-chain-"))
+                    expected_natural = natural_by_chain[chain]
+                    expected_coordinate = coordinate_by_chain[chain]
+                except (KeyError, TypeError, ValueError) as error:
+                    raise CausalContractError(
+                        f"{source} start identity is malformed"
+                    ) from error
+                require_identity(
+                    raw_natural, expected_natural, f"{source} natural start"
+                )
+                require_identity(
+                    coordinate,
+                    expected_coordinate,
+                    f"{source} coordinate start",
+                )
+            elif isinstance(kind, str) and kind.startswith("icdf-"):
+                coordinate_index = item.get("coordinate_index")
+                if not _is_int(coordinate_index):
+                    raise CausalContractError(f"{source} ICDF index is malformed")
+                expected_coordinate = np.array(
+                    coordinate_by_chain[0], dtype=np.dtype(unit.floatx), copy=True
+                )
+                label = kind.removeprefix("icdf-")
+                try:
+                    expected_coordinate[coordinate_index] = {
+                        "branch-left": -float(item["branch_epsilon"]),
+                        "branch-zero": 0.0,
+                        "branch-right": float(item["branch_epsilon"]),
+                        "tail-low": -6.0,
+                        "tail-high": 6.0,
+                    }[label]
+                except (KeyError, TypeError, ValueError, IndexError) as error:
+                    raise CausalContractError(
+                        f"{source} ICDF construction metadata is malformed"
+                    ) from error
+                require_identity(
+                    coordinate,
+                    expected_coordinate.astype(np.float64),
+                    f"{source} ICDF construction",
+                )
+            elif kind == "hash-selected-posterior-trajectory":
+                trajectory_chain = item.get("chain")
+                trajectory_draw = item.get("draw")
+                if (
+                    not isinstance(trajectory_chain, int)
+                    or isinstance(trajectory_chain, bool)
+                    or not isinstance(trajectory_draw, int)
+                    or isinstance(trajectory_draw, bool)
+                    or chains is None
+                    or chains.sizes.get("chain") != unit.chains
+                    or chains.sizes.get("draw") != unit.draws
+                ):
+                    raise CausalContractError(
+                        f"{source} lacks its planned natural chain draw"
+                    )
+                try:
+                    expected_natural = np.concatenate(
+                        (
+                            [
+                                float(
+                                    chains["group_location"][
+                                        trajectory_chain, trajectory_draw
+                                    ]
+                                ),
+                                float(
+                                    chains["group_scale"][
+                                        trajectory_chain, trajectory_draw
+                                    ]
+                                ),
+                            ],
+                            np.asarray(
+                                chains["group_effect"][
+                                    trajectory_chain, trajectory_draw
+                                ],
+                                dtype=np.float64,
+                            ),
+                        )
+                    )
+                except (KeyError, IndexError, TypeError, ValueError) as error:
+                    raise CausalContractError(
+                        f"{source} cannot be read from the natural chain"
+                    ) from error
+                if not np.all(np.isfinite(expected_natural)):
+                    raise CausalContractError(
+                        f"{source} selected natural chain draw is non-finite"
+                    )
+                require_identity(
+                    raw_natural,
+                    expected_natural,
+                    f"{source} selected natural chain draw",
+                )
+            else:  # pragma: no cover - point structure audit rejects this first.
+                raise CausalContractError(f"{source} has an unknown point kind")
+    finally:
+        if chains is not None:
+            chains.close()
+
+
+def _audit_chain_evidence(
+    record: Mapping[str, Any], unit: UnitSpec, path: Path
+) -> None:
+    """Recompute sampler health metrics from natural chains and per-draw stats."""
+    try:
+        import arviz as az
+        import numpy as np
+        import xarray as xr
+    except ImportError as error:  # pragma: no cover - all are frozen dependencies.
+        raise CausalContractError(
+            "ArviZ, NumPy, and xarray are required to audit chain evidence"
+        ) from error
+    try:
+        chains = xr.load_dataset(path, engine="scipy")
+    except Exception as error:
+        raise CausalContractError(f"cannot decode chain artifact: {error}") from error
+    try:
+        expected_attrs = {
+            "schema_version": unit.schema_version,
+            "study_id": unit.study_id,
+            "manifest_sha256": unit.manifest_sha256,
+            "cell_id": unit.cell_id,
+            "block_id": unit.block_id,
+            "tier": unit.tier,
+            "regime_id": unit.regime_id,
+            "backend_id": unit.backend_id,
+            "representation_id": unit.representation_id,
+        }
+        if any(chains.attrs.get(key) != value for key, value in expected_attrs.items()):
+            raise CausalContractError("chain artifact identity differs from the plan")
+        if (
+            chains.sizes.get("chain") != unit.chains
+            or chains.sizes.get("draw") != unit.draws
+        ):
+            raise CausalContractError("chain artifact dimensions differ from the plan")
+        natural_shapes = {
+            "group_location": (unit.chains, unit.draws),
+            "group_scale": (unit.chains, unit.draws),
+            "group_effect": (
+                unit.chains,
+                unit.draws,
+                int(unit.regime["n_groups"]),
+            ),
+        }
+        for name, shape in natural_shapes.items():
+            if name not in chains or chains[name].shape != shape:
+                raise CausalContractError(
+                    f"chain artifact natural variable {name!r} has wrong shape"
+                )
+            if not np.all(np.isfinite(np.asarray(chains[name]))):
+                raise CausalContractError(
+                    f"chain artifact natural variable {name!r} is non-finite"
+                )
+        required_stats = {
+            "acceptance_rate",
+            "diverging",
+            "energy",
+            "n_steps",
+            "step_size",
+            "tree_depth",
+        }
+
+        def statistic(name: str) -> Any:
+            variable = f"sample_stat__{name}"
+            if variable not in chains or chains[variable].dims != ("chain", "draw"):
+                raise CausalContractError(
+                    f"chain artifact lacks shaped per-draw statistic {name!r}"
+                )
+            array = np.asarray(chains[variable])
+            if array.shape != (unit.chains, unit.draws) or not np.all(
+                np.isfinite(array)
+            ):
+                raise CausalContractError(
+                    f"chain statistic {name!r} is non-finite or has wrong shape"
+                )
+            return chains[variable]
+
+        for name in required_stats:
+            statistic(name)
+        try:
+            seed_input = strict_json_loads(
+                chains.attrs["sampler_seed_input_json"], source="chain seed input"
+            )
+            chain_rng = strict_json_loads(
+                chains.attrs["chain_rng_provenance_json"],
+                source="chain RNG provenance",
+            )
+        except (KeyError, TypeError) as error:
+            raise CausalContractError("chain artifact lacks RNG provenance") from error
+        if (
+            seed_input != record["provenance"]["sampler_seed_input"]
+            or chain_rng != record["provenance"]["chain_rng_provenance"]
+        ):
+            raise CausalContractError("chain RNG provenance differs from result marker")
+
+        def flattened(dataset: Any) -> Any:
+            pieces = [
+                np.asarray(value).reshape(-1) for value in dataset.data_vars.values()
+            ]
+            return np.concatenate(pieces) if pieces else np.empty(0, dtype=np.float64)
+
+        divergences = np.asarray(statistic("diverging"), dtype=np.int64)
+        if "sample_stat__reached_max_treedepth" in chains:
+            saturated = np.asarray(statistic("reached_max_treedepth"), dtype=bool)
+        else:
+            saturated = (
+                np.asarray(statistic("tree_depth"), dtype=np.int64)
+                >= unit.max_treedepth
+            )
+        hyper = chains[["group_location", "group_scale"]]
+        group = chains[["group_effect"]]
+        hyper_rhat = flattened(az.rhat(hyper, method="rank"))
+        group_rhat = flattened(az.rhat(group, method="rank"))
+        hyper_bulk = flattened(az.ess(hyper, method="bulk"))
+        group_bulk = flattened(az.ess(group, method="bulk"))
+        hyper_tail = flattened(az.ess(hyper, method="tail"))
+        group_tail = flattened(az.ess(group, method="tail"))
+        hyper_mcse = flattened(az.mcse(hyper, method="mean"))
+        hyper_sd = np.asarray(
+            [float(chains[name].std(dim=("chain", "draw"), ddof=1)) for name in hyper]
+        )
+        mcse_over_sd = np.divide(
+            hyper_mcse,
+            hyper_sd,
+            out=np.full_like(hyper_mcse, np.inf),
+            where=hyper_sd > 0,
+        )
+        bfmi = np.asarray(
+            az.bfmi(np.asarray(statistic("energy"), dtype=np.float64)),
+            dtype=np.float64,
+        ).reshape(-1)
+        step_size = np.asarray(statistic("step_size"), dtype=np.float64)
+        n_steps = np.asarray(statistic("n_steps"), dtype=np.float64)
+        draws = unit.chains * unit.draws
+        divergence_count = int(np.sum(divergences))
+        derived = {
+            "divergence_count": divergence_count,
+            "posterior_draw_count": draws,
+            "divergence_rate": divergence_count / draws,
+            "hyper_rhat_max": float(np.max(hyper_rhat)),
+            "hyper_ess_bulk_min": float(np.min(hyper_bulk)),
+            "hyper_ess_tail_min": float(np.min(hyper_tail)),
+            "bfmi_min": float(np.min(bfmi)),
+            "treedepth_saturation_rate": float(np.mean(saturated)),
+            "hyper_mcse_over_sd_max": float(np.max(mcse_over_sd)),
+            "group_rhat_max": float(np.max(group_rhat)),
+            "group_ess_bulk_fraction_ge_400": float(np.mean(group_bulk >= 400.0)),
+            "group_ess_tail_fraction_ge_400": float(np.mean(group_tail >= 400.0)),
+            "step_size_final_min": float(np.min(step_size[:, -1])),
+            "step_size_final_max": float(np.max(step_size[:, -1])),
+            "leapfrog_step_count": float(np.sum(n_steps)),
+        }
+        for name, value in derived.items():
+            if name in record["metrics"]:
+                _require_derived_metric(record, name, value)
+    finally:
+        chains.close()
+
+
+def verify_result_artifacts(
+    record: Mapping[str, Any],
+    root: Path,
+    unit: UnitSpec | None = None,
+    manifest: Mapping[str, Any] | None = None,
+) -> None:
+    """Verify bytes and, with a unit, recompute oracle/sampler evidence."""
+    resolved_root = root.resolve()
+    resolved_paths: dict[str, Path] = {}
+    for name, reference in record["artifacts"].items():
+        if reference is None:
+            continue
+        relative = reference["path"]
+        _relative_contract_path(relative)
+        path = (resolved_root / relative).resolve()
+        if resolved_root not in path.parents:
+            raise CausalContractError(f"artifacts.{name} escapes the artifact root")
+        if sha256_file(path) != reference["sha256"]:
+            raise CausalContractError(f"artifacts.{name} exact-byte hash mismatch")
+        if path.stat().st_size != reference["size_bytes"]:
+            raise CausalContractError(f"artifacts.{name} byte count mismatch")
+        resolved_paths[name] = path
+    if unit is None:
+        return
+    diagnostics = record["artifacts"]["diagnostics"]
+    if diagnostics is not None:
+        effective_manifest = load_manifest() if manifest is None else manifest
+        validate_manifest(effective_manifest)
+        if manifest_digest(effective_manifest) != unit.manifest_sha256:
+            raise CausalContractError("artifact audit manifest differs from the plan")
+        _audit_diagnostic_evidence(
+            record,
+            unit,
+            resolved_root / diagnostics["path"],
+            effective_manifest["analysis_policy"],
+        )
+        if ORACLE_METRICS <= set(record["metrics"]):
+            missing_sources = {
+                name
+                for name in ("data", "natural_start", "coordinate_start")
+                if name not in resolved_paths
+            }
+            if missing_sources:
+                raise CausalContractError(
+                    f"oracle evidence lacks source artifacts: {sorted(missing_sources)}"
+                )
+            _audit_oracle_point_bindings(
+                record,
+                unit,
+                resolved_paths["diagnostics"],
+                resolved_paths["data"],
+                resolved_paths["natural_start"],
+                resolved_paths["coordinate_start"],
+                resolved_paths.get("chain"),
+                effective_manifest["analysis_policy"],
+            )
+    chain = record["artifacts"]["chain"]
+    if chain is not None:
+        _audit_chain_evidence(record, unit, resolved_paths["chain"])
+
+
+def load_result_records(directory: Path) -> dict[str, Mapping[str, Any]]:
+    """Load final cell markers; filenames must equal their cell identity."""
+    if not directory.is_dir():
+        return {}
+    records: dict[str, Mapping[str, Any]] = {}
+    for path in sorted(directory.glob("*.json")):
+        record = _load_json(path)
+        if not isinstance(record, Mapping):
+            raise CausalContractError(f"{path} must contain an object")
+        cell_id = record.get("cell_id")
+        if not isinstance(cell_id, str) or path.name != f"{cell_id}.json":
+            raise CausalContractError(f"result filename does not match cell_id: {path}")
+        if cell_id in records:
+            raise CausalContractError(f"duplicate result for {cell_id}")
+        records[cell_id] = record
+    return records
+
+
+def aggregate_results(
+    plan: Sequence[UnitSpec],
+    records: Mapping[str, Mapping[str, Any]],
+    *,
+    context_directory: Path | None = None,
+    artifact_root: Path | None = None,
+    manifest: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Order results by plan and materialize missing evidence explicitly."""
+    expected = {unit.cell_id for unit in plan}
+    extras = sorted(set(records) - expected)
+    if extras:
+        raise CausalContractError(f"unplanned result records: {extras}")
+    rows: list[dict[str, Any]] = []
+    for unit in plan:
+        record = records.get(unit.cell_id)
+        if record is None:
+            rows.append(
+                {
+                    "collection_status": "missing",
+                    "cell_id": unit.cell_id,
+                    "pair_id": unit.pair_id,
+                    "pair_position": unit.pair_position,
+                    "block_id": unit.block_id,
+                    "tier": unit.tier,
+                    "regime_id": unit.regime_id,
+                    "backend_id": unit.backend_id,
+                    "representation_id": unit.representation_id,
+                    "replicate": unit.replicate,
+                }
+            )
+            continue
+        context = None
+        if context_directory is not None:
+            context = load_run_context(context_directory / f"{unit.pair_id}.json")
+            validate_run_context(
+                context,
+                [candidate for candidate in plan if candidate.pair_id == unit.pair_id],
+                manifest,
+            )
+        validate_result_record(record, unit, context)
+        if artifact_root is not None:
+            verify_result_artifacts(record, artifact_root, unit, manifest)
+        rows.append({"collection_status": "present", **dict(record)})
+    return rows
+
+
+def _fit_health(row: Mapping[str, Any], tier: str, policy: Mapping[str, Any]) -> bool:
+    if row.get("collection_status") != "present":
+        return False
+    if row["execution_status"] != "completed":
+        return False
+    metrics = row["metrics"]
+    basic = (
+        all(
+            metrics[key]
+            for key in (
+                "compile_success",
+                "initialization_success",
+                "logp_finite",
+                "gradient_finite",
+                "sampling_success",
+            )
+        )
+        and metrics["divergence_rate"] < policy["divergence_rate_lt"]
+    )
+    if not basic or tier == "smoke":
+        return basic
+    return bool(
+        metrics["hyper_rhat_max"] < policy["hyper_rhat_max_lt"]
+        and metrics["hyper_ess_bulk_min"] >= policy["hyper_ess_bulk_min_ge"]
+        and metrics["hyper_ess_tail_min"] >= policy["hyper_ess_tail_min_ge"]
+        and metrics["bfmi_min"] >= policy["bfmi_min_ge"]
+        and metrics["treedepth_saturation_rate"]
+        < policy["treedepth_saturation_rate_lt"]
+        and metrics["hyper_mcse_over_sd_max"] <= policy["hyper_mcse_over_sd_max_le"]
+        and metrics["group_rhat_max"] < policy["group_rhat_max_lt"]
+        and metrics["group_ess_bulk_fraction_ge_400"]
+        >= policy["group_ess_bulk_fraction_ge_400_ge"]
+        and metrics["group_ess_tail_fraction_ge_400"]
+        >= policy["group_ess_tail_fraction_ge_400_ge"]
+    )
+
+
+def _expected_oracle_evaluation_count(
+    row: Mapping[str, Any], tier: str, *, posterior_trajectory: bool
+) -> int:
+    """Return the frozen number of oracle points for one cell and phase."""
+    chains = 2 if tier == "smoke" else 4
+    layers = {
+        "native-centered": 0,
+        "manual-centered": 0,
+        "group-icdf-noncentered": 1,
+        "location-icdf-noncentered": 1,
+        "full-icdf-noncentered": 2,
+    }[row["representation_id"]]
+    static = (
+        chains + int(row["replicate"] == 0) + ICDF_DIAGNOSTIC_POINTS_PER_LAYER * layers
+    )
+    if posterior_trajectory:
+        return static + TRAJECTORY_POINTS_PER_CHAIN * chains
+    return static
+
+
+def _oracle_metrics_health(
+    row: Mapping[str, Any],
+    floatx: str,
+    tier: str,
+    *,
+    require_posterior_trajectory: bool,
+) -> bool:
+    if row.get("collection_status") != "present":
+        return False
+    metrics = row.get("metrics", {})
+    if not ORACLE_METRICS <= set(metrics):
+        return False
+    completed = row.get("execution_status") == "completed"
+    if require_posterior_trajectory and not completed:
+        return False
+    failure = row.get("failure")
+    failure_stage = failure.get("stage") if isinstance(failure, Mapping) else None
+    posterior_trajectory = completed or failure_stage == "summarize"
+    expected_count = _expected_oracle_evaluation_count(
+        row,
+        tier,
+        posterior_trajectory=posterior_trajectory,
+    )
+    tolerance = 1e-10 if floatx == "float64" else 2e-5
+    return bool(
+        metrics["oracle_evaluation_count"] == expected_count
+        and metrics["oracle_logp_scaled_error_max"] <= 1
+        and metrics["oracle_gradient_scaled_error_max"] <= 1
+        and metrics["oracle_hessian_scaled_error_max"] <= 1
+        and metrics["roundtrip_absolute_error_max"] <= tolerance
+        and metrics["icdf_tail_finite"]
+        and metrics["icdf_branch_continuous"]
+    )
+
+
+def _pre_sampling_oracle_health(row: Mapping[str, Any], floatx: str, tier: str) -> bool:
+    """Check fixed/start/ICDF evidence, whether or not sampling later succeeded."""
+    return _oracle_metrics_health(
+        row,
+        floatx,
+        tier,
+        require_posterior_trajectory=False,
+    )
+
+
+def _full_oracle_health(row: Mapping[str, Any], floatx: str, tier: str) -> bool:
+    """Check the complete oracle, including posterior-trajectory points."""
+    return _oracle_metrics_health(
+        row,
+        floatx,
+        tier,
+        require_posterior_trajectory=True,
+    )
+
+
+def _native_density_derivative_mismatch(row: Mapping[str, Any], tier: str) -> bool:
+    """Identify an explicit native value/gradient/Hessian oracle disagreement."""
+    if row.get("collection_status") != "present":
+        return False
+    metrics = row.get("metrics", {})
+    if not ORACLE_METRICS <= set(metrics):
+        return False
+    if row.get("execution_status") not in {"completed", "failed"}:
+        return False
+    completed = row.get("execution_status") == "completed"
+    failure = row.get("failure")
+    failure_stage = failure.get("stage") if isinstance(failure, Mapping) else None
+    expected_count = _expected_oracle_evaluation_count(
+        row,
+        tier,
+        posterior_trajectory=completed or failure_stage == "summarize",
+    )
+    return bool(
+        metrics["oracle_evaluation_count"] == expected_count
+        and any(
+            metrics[metric] > 1.0
+            for metric in (
+                "oracle_logp_scaled_error_max",
+                "oracle_gradient_scaled_error_max",
+                "oracle_hessian_scaled_error_max",
+            )
+        )
+    )
+
+
+def _family_health(
+    rows: Sequence[Mapping[str, Any]],
+    tier: str,
+    policy: Mapping[str, Any],
+    per_fit_policy: Mapping[str, Any],
+) -> bool:
+    if not rows or any(row.get("collection_status") != "present" for row in rows):
+        return False
+    completed = [row for row in rows if row["execution_status"] == "completed"]
+    if len(completed) != len(rows):
+        return False
+    fit_passes = sum(_fit_health(row, tier, per_fit_policy) for row in rows)
+    pass_fraction = fit_passes / len(rows)
+    divergences = sum(row["metrics"]["divergence_count"] for row in rows)
+    draws = sum(row["metrics"]["posterior_draw_count"] for row in rows)
+    return bool(
+        pass_fraction >= policy["per_fit_pass_fraction_ge"]
+        and len(rows) - fit_passes <= policy["maximum_failed_replicates"]
+        and draws > 0
+        and divergences / draws < policy["aggregate_divergence_rate_lt"]
+    )
+
+
+def _exact_two_sided_sign_p(left: int, right: int) -> float:
+    """Return the exact two-sided sign-test p-value for discordant pairs."""
+    discordant = left + right
+    if discordant == 0:
+        return 1.0
+    tail = min(left, right)
+    probability = sum(math.comb(discordant, k) for k in range(tail + 1)) / (
+        2**discordant
+    )
+    return min(1.0, 2.0 * probability)
+
+
+def _paired_health_contrast(
+    rows: Sequence[Mapping[str, Any]],
+    tier: str,
+    left_representation: str,
+    right_representation: str,
+    per_fit_policy: Mapping[str, Any],
+    alpha: float,
+) -> dict[str, Any]:
+    """Compare paired fit health, where left-unhealthy/right-healthy is directional."""
+    left = {
+        row["replicate"]: _fit_health(row, tier, per_fit_policy)
+        for row in rows
+        if row["representation_id"] == left_representation
+    }
+    right = {
+        row["replicate"]: _fit_health(row, tier, per_fit_policy)
+        for row in rows
+        if row["representation_id"] == right_representation
+    }
+    complete = bool(left) and set(left) == set(right)
+    left_bad_right_good = 0
+    left_good_right_bad = 0
+    ties = 0
+    if complete:
+        for replicate in sorted(left):
+            if not left[replicate] and right[replicate]:
+                left_bad_right_good += 1
+            elif left[replicate] and not right[replicate]:
+                left_good_right_bad += 1
+            else:
+                ties += 1
+    p_value = _exact_two_sided_sign_p(left_bad_right_good, left_good_right_bad)
+    return {
+        "left": left_representation,
+        "right": right_representation,
+        "complete": complete,
+        "pairs": len(left) if complete else 0,
+        "left_unhealthy_right_healthy": left_bad_right_good,
+        "left_healthy_right_unhealthy": left_good_right_bad,
+        "ties": ties,
+        "two_sided_exact_p": p_value,
+        "supports_direction": bool(
+            complete
+            and len(left) == 8
+            and left_bad_right_good > left_good_right_bad
+            and p_value <= alpha
+        ),
+    }
+
+
+def _paired_backend_health_contrast(
+    rows: Sequence[Mapping[str, Any]],
+    tier: str,
+    per_fit_policy: Mapping[str, Any],
+    alpha: float,
+) -> dict[str, Any]:
+    """Describe one representation's backend contrast; never classify from it."""
+    pymc = {
+        row["replicate"]: _fit_health(row, tier, per_fit_policy)
+        for row in rows
+        if row["backend_id"] == "pymc"
+    }
+    numpyro = {
+        row["replicate"]: _fit_health(row, tier, per_fit_policy)
+        for row in rows
+        if row["backend_id"] == "numpyro"
+    }
+    complete = bool(pymc) and set(pymc) == set(numpyro)
+    pymc_bad_numpyro_good = 0
+    pymc_good_numpyro_bad = 0
+    ties = 0
+    if complete:
+        for replicate in sorted(pymc):
+            if not pymc[replicate] and numpyro[replicate]:
+                pymc_bad_numpyro_good += 1
+            elif pymc[replicate] and not numpyro[replicate]:
+                pymc_good_numpyro_bad += 1
+            else:
+                ties += 1
+    p_value = _exact_two_sided_sign_p(pymc_bad_numpyro_good, pymc_good_numpyro_bad)
+    return {
+        "complete": complete,
+        "pairs": len(pymc) if complete else 0,
+        "pymc_unhealthy_numpyro_healthy": pymc_bad_numpyro_good,
+        "pymc_healthy_numpyro_unhealthy": pymc_good_numpyro_bad,
+        "ties": ties,
+        "two_sided_exact_p": p_value,
+        "all_directional_at_threshold": bool(
+            complete
+            and len(pymc) == 8
+            and pymc_bad_numpyro_good != pymc_good_numpyro_bad
+            and p_value <= alpha
+        ),
+        "descriptive_only": True,
+    }
+
+
+def _backend_omnibus_health_contrast(
+    rows: Sequence[Mapping[str, Any]],
+    tier: str,
+    per_fit_policy: Mapping[str, Any],
+    alpha: float,
+) -> dict[str, Any]:
+    """Compare the number of healthy forms in each paired backend block."""
+    counts: dict[str, dict[int, int]] = {}
+    complete = True
+    for backend in BACKEND_IDS:
+        counts[backend] = {}
+        backend_rows = [row for row in rows if row["backend_id"] == backend]
+        for replicate in range(8):
+            selected = [row for row in backend_rows if row["replicate"] == replicate]
+            identities = {row["representation_id"] for row in selected}
+            if len(selected) != 5 or identities != set(REPRESENTATION_IDS):
+                complete = False
+                continue
+            counts[backend][replicate] = sum(
+                _fit_health(row, tier, per_fit_policy) for row in selected
+            )
+    complete = complete and all(
+        set(counts[backend]) == set(range(8)) for backend in BACKEND_IDS
+    )
+    pymc_less_healthy = 0
+    pymc_more_healthy = 0
+    ties = 0
+    differences: list[int] = []
+    if complete:
+        for replicate in range(8):
+            difference = counts["pymc"][replicate] - counts["numpyro"][replicate]
+            differences.append(difference)
+            if difference < 0:
+                pymc_less_healthy += 1
+            elif difference > 0:
+                pymc_more_healthy += 1
+            else:
+                ties += 1
+    p_value = _exact_two_sided_sign_p(pymc_less_healthy, pymc_more_healthy)
+    supports = bool(
+        complete and pymc_less_healthy != pymc_more_healthy and p_value <= alpha
+    )
+    direction = None
+    if supports:
+        direction = "pymc-less-healthy" if pymc_less_healthy else "pymc-more-healthy"
+    return {
+        "complete": complete,
+        "pairs": 8 if complete else 0,
+        "statistic": "pymc-healthy-form-count-minus-numpyro-healthy-form-count",
+        "differences": differences,
+        "pymc_less_healthy": pymc_less_healthy,
+        "pymc_more_healthy": pymc_more_healthy,
+        "ties": ties,
+        "two_sided_exact_p": p_value,
+        "supports_either_direction": supports,
+        "direction": direction,
+    }
+
+
+def _every_paired_fit_matches(
+    rows: Sequence[Mapping[str, Any]],
+    tier: str,
+    expected_health: Mapping[str, bool],
+    per_fit_policy: Mapping[str, Any],
+) -> bool:
+    """Require one exact health pattern for every replicate on both backends."""
+    for backend in BACKEND_IDS:
+        backend_rows = [row for row in rows if row["backend_id"] == backend]
+        replicate_ids = {row["replicate"] for row in backend_rows}
+        if not replicate_ids:
+            return False
+        for replicate in replicate_ids:
+            replicate_rows = {
+                row["representation_id"]: row
+                for row in backend_rows
+                if row["replicate"] == replicate
+            }
+            if not set(expected_health) <= set(replicate_rows):
+                return False
+            if any(
+                _fit_health(replicate_rows[representation], tier, per_fit_policy)
+                is not expected
+                for representation, expected in expected_health.items()
+            ):
+                return False
+    return True
+
+
+def _family_pattern_matches(
+    family: Mapping[str, bool], expected_health: Mapping[str, bool]
+) -> bool:
+    """Require exact aggregate health states for named forms on both backends."""
+    return all(
+        family[f"{backend}/{representation}"] is expected
+        for backend in BACKEND_IDS
+        for representation, expected in expected_health.items()
+    )
+
+
+def _backend_family_direction_matches(
+    family: Mapping[str, bool], omnibus: Mapping[str, Any]
+) -> bool:
+    """Require the aggregate family counts to corroborate the omnibus direction."""
+    counts = {
+        backend: sum(
+            family[f"{backend}/{representation}"]
+            for representation in REPRESENTATION_IDS
+        )
+        for backend in BACKEND_IDS
+    }
+    if omnibus["direction"] == "pymc-less-healthy":
+        return counts["pymc"] < counts["numpyro"]
+    if omnibus["direction"] == "pymc-more-healthy":
+        return counts["pymc"] > counts["numpyro"]
+    return False
+
+
+def _classify_regime(
+    rows: Sequence[Mapping[str, Any]],
+    regime: Mapping[str, Any],
+    tier: str,
+    analysis_policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    regime_rows = [row for row in rows if row["regime_id"] == regime["regime_id"]]
+    if any(row.get("collection_status") != "present" for row in regime_rows):
+        return {
+            "regime_id": regime["regime_id"],
+            "classification": "incomplete",
+            "family_health": {},
+        }
+    family: dict[str, bool] = {}
+    oracle: dict[str, bool] = {}
+    pre_oracle: dict[str, bool] = {}
+    paired: dict[str, dict[str, Any]] = {}
+    family_policy = analysis_policy["family_health"]
+    per_fit_policy = analysis_policy["per_fit_health"]
+    alpha = analysis_policy["paired_inference"]["per_comparison_alpha"]
+    for backend in BACKEND_IDS:
+        backend_rows = [row for row in regime_rows if row["backend_id"] == backend]
+        for representation in REPRESENTATION_IDS:
+            selected = [
+                row
+                for row in regime_rows
+                if row["backend_id"] == backend
+                and row["representation_id"] == representation
+            ]
+            key = f"{backend}/{representation}"
+            family[key] = _family_health(selected, tier, family_policy, per_fit_policy)
+            oracle[key] = all(
+                _full_oracle_health(row, regime["floatx"], tier) for row in selected
+            )
+            pre_oracle[key] = all(
+                _pre_sampling_oracle_health(row, regime["floatx"], tier)
+                for row in selected
+            )
+        if tier == "smoke":
+            continue
+        contrast_pairs = {
+            "native-to-manual": ("native-centered", "manual-centered"),
+            "group-effect-at-location-c": (
+                "manual-centered",
+                "group-icdf-noncentered",
+            ),
+            "group-effect-at-location-nc": (
+                "location-icdf-noncentered",
+                "full-icdf-noncentered",
+            ),
+            "location-effect-at-groups-c": (
+                "manual-centered",
+                "location-icdf-noncentered",
+            ),
+            "location-effect-at-groups-nc": (
+                "group-icdf-noncentered",
+                "full-icdf-noncentered",
+            ),
+        }
+        for contrast_id, (left, right) in contrast_pairs.items():
+            paired[f"{backend}/{contrast_id}"] = _paired_health_contrast(
+                backend_rows,
+                tier,
+                left,
+                right,
+                per_fit_policy,
+                alpha,
+            )
+
+    if tier == "smoke":
+        return {
+            "regime_id": regime["regime_id"],
+            "classification": "screening-only",
+            "causal_classification": None,
+            "family_health": family,
+            "oracle_health": oracle,
+            "pre_sampling_oracle_health": pre_oracle,
+            "paired_health_contrasts": {},
+        }
+
+    for representation in REPRESENTATION_IDS:
+        representation_rows = [
+            row for row in regime_rows if row["representation_id"] == representation
+        ]
+        paired[f"backend/{representation}/pymc-to-numpyro"] = (
+            _paired_backend_health_contrast(
+                representation_rows,
+                tier,
+                per_fit_policy,
+                alpha,
+            )
+        )
+    backend_omnibus = _backend_omnibus_health_contrast(
+        regime_rows,
+        tier,
+        per_fit_policy,
+        alpha,
+    )
+    paired["backend/five-form-health-count-omnibus"] = backend_omnibus
+
+    manual_rows = {
+        (row["replicate"], row["backend_id"]): row
+        for row in regime_rows
+        if row["representation_id"] == "manual-centered"
+    }
+    native_mismatch_replicates = sorted(
+        {
+            row["replicate"]
+            for row in regime_rows
+            if row["representation_id"] == "native-centered"
+            and _native_density_derivative_mismatch(row, tier)
+            and (manual := manual_rows.get((row["replicate"], row["backend_id"])))
+            is not None
+            and _pre_sampling_oracle_health(manual, regime["floatx"], tier)
+        }
+    )
+    all_oracle_ok = all(oracle.values())
+    classification = "mixed-inconclusive"
+    if len(native_mismatch_replicates) >= 2:
+        classification = "native-pymc-correctness-defect"
+    elif (
+        all(
+            paired[f"{backend}/native-to-manual"]["supports_direction"]
+            for backend in BACKEND_IDS
+        )
+        and _family_pattern_matches(
+            family,
+            {"native-centered": False, "manual-centered": True},
+        )
+        and all_oracle_ok
+    ):
+        classification = "native-graph-or-adaptation"
+    elif (
+        all(
+            paired[f"{backend}/group-effect-at-location-c"]["supports_direction"]
+            and paired[f"{backend}/group-effect-at-location-nc"]["supports_direction"]
+            for backend in BACKEND_IDS
+        )
+        and _family_pattern_matches(
+            family,
+            {
+                "manual-centered": False,
+                "group-icdf-noncentered": True,
+                "location-icdf-noncentered": False,
+                "full-icdf-noncentered": True,
+            },
+        )
+        and all_oracle_ok
+    ):
+        classification = "group-conditional-centering"
+    elif (
+        all(
+            paired[f"{backend}/location-effect-at-groups-c"]["supports_direction"]
+            and paired[f"{backend}/location-effect-at-groups-nc"]["supports_direction"]
+            for backend in BACKEND_IDS
+        )
+        and _family_pattern_matches(
+            family,
+            {
+                "manual-centered": False,
+                "group-icdf-noncentered": False,
+                "location-icdf-noncentered": True,
+                "full-icdf-noncentered": True,
+            },
+        )
+        and all_oracle_ok
+    ):
+        classification = "location-centering"
+    elif (
+        _every_paired_fit_matches(
+            regime_rows,
+            tier,
+            {
+                "manual-centered": False,
+                "group-icdf-noncentered": False,
+                "location-icdf-noncentered": False,
+                "full-icdf-noncentered": True,
+            },
+            per_fit_policy,
+        )
+        and _family_pattern_matches(
+            family,
+            {
+                "manual-centered": False,
+                "group-icdf-noncentered": False,
+                "location-icdf-noncentered": False,
+                "full-icdf-noncentered": True,
+            },
+        )
+        and all_oracle_ok
+    ):
+        classification = "joint-centering-interaction"
+    elif (
+        backend_omnibus["supports_either_direction"]
+        and _backend_family_direction_matches(family, backend_omnibus)
+        and all_oracle_ok
+    ):
+        classification = "backend-path-specific"
+    elif (
+        _every_paired_fit_matches(
+            regime_rows,
+            tier,
+            {representation: False for representation in REPRESENTATION_IDS},
+            per_fit_policy,
+        )
+        and not any(family.values())
+        and all_oracle_ok
+    ):
+        classification = "residual-tn-or-scale-geometry"
+    elif all(family.values()) and all_oracle_ok:
+        classification = "all-representations-healthy"
+    return {
+        "regime_id": regime["regime_id"],
+        "classification": classification,
+        "family_health": family,
+        "oracle_health": oracle,
+        "pre_sampling_oracle_health": pre_oracle,
+        "native_mismatch_replicates": native_mismatch_replicates,
+        "paired_health_contrasts": paired,
+    }
+
+
+def assess_results(
+    rows: Sequence[Mapping[str, Any]],
+    plan: Sequence[UnitSpec],
+    manifest: Mapping[str, Any],
+    tier: str,
+) -> dict[str, Any]:
+    """Apply the frozen health gates and classifier without sampling."""
+    validate_manifest(manifest)
+    if len(rows) != len(plan):
+        raise CausalContractError("assessment rows do not match plan length")
+    for row, unit in zip(rows, plan, strict=True):
+        if row.get("cell_id") != unit.cell_id:
+            raise CausalContractError("assessment rows are not in canonical plan order")
+        if row.get("collection_status") == "present":
+            validate_result_record(
+                {
+                    key: value
+                    for key, value in row.items()
+                    if key != "collection_status"
+                },
+                unit,
+            )
+        elif row.get("collection_status") != "missing":
+            raise CausalContractError("collection_status must be present or missing")
+    missing = sum(row.get("collection_status") == "missing" for row in rows)
+    failed = sum(
+        row.get("collection_status") == "present"
+        and row.get("execution_status") == "failed"
+        for row in rows
+    )
+    regime_results = [
+        _classify_regime(
+            rows,
+            regime,
+            tier,
+            manifest["analysis_policy"],
+        )
+        for regime in manifest["regimes"]
+    ]
+    if missing:
+        outcome = "incomplete"
+    elif tier == "smoke":
+        outcome = (
+            "screening-pass"
+            if all(
+                _fit_health(
+                    row,
+                    tier,
+                    manifest["analysis_policy"]["per_fit_health"],
+                )
+                and _full_oracle_health(
+                    row,
+                    next(
+                        regime["floatx"]
+                        for regime in manifest["regimes"]
+                        if regime["regime_id"] == row["regime_id"]
+                    ),
+                    tier,
+                )
+                for row in rows
+            )
+            else "screening-fail"
+        )
+    elif any(
+        item["classification"] in {"incomplete", "mixed-inconclusive"}
+        for item in regime_results
+    ):
+        outcome = "inconclusive"
+    elif any(
+        item["classification"] == "native-pymc-correctness-defect"
+        for item in regime_results
+    ):
+        outcome = "correctness-defect"
+    else:
+        outcome = "classified"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "study_id": manifest["study_id"],
+        "manifest_sha256": manifest_digest(manifest),
+        "tier": tier,
+        "planned_cells": len(plan),
+        "present_cells": len(plan) - missing,
+        "missing_cells": missing,
+        "failed_cells": failed,
+        "outcome": outcome,
+        "contract_valid": True,
+        "evidence_complete": missing == 0,
+        "proceed_to_confirmation": bool(tier == "smoke" and missing == 0),
+        "qualifies_causal_conclusion": bool(
+            tier == "confirmation" and outcome in {"classified", "correctness-defect"}
+        ),
+        "regimes": regime_results,
+    }
+
+
+def _write_plan(plan: Sequence[UnitSpec], output_dir: Path) -> tuple[Path, Path]:
+    jsonl_path = output_dir / "plan.jsonl"
+    csv_path = output_dir / "matrix.csv"
+    jsonl = b"".join(canonical_json_bytes(unit.as_dict()) for unit in plan)
+    _atomic_write(jsonl_path, jsonl)
+    fields = (
+        "pair_id",
+        "pair_position",
+        "block_id",
+        "block_position",
+        "cell_id",
+        "tier",
+        "regime_id",
+        "backend_id",
+        "representation_id",
+        "replicate",
+        "chains",
+        "tune",
+        "draws",
+        "floatx",
+    )
+    buffer = io.StringIO(newline="")
+    writer = csv.DictWriter(buffer, fieldnames=fields, lineterminator="\n")
+    writer.writeheader()
+    for unit in plan:
+        value = unit.as_dict()
+        writer.writerow({field: value[field] for field in fields})
+    _atomic_write(csv_path, buffer.getvalue().encode())
+    return jsonl_path, csv_path
+
+
+def _write_aggregate(rows: Sequence[Mapping[str, Any]], path: Path) -> Path:
+    _atomic_write(path, b"".join(canonical_json_bytes(row) for row in rows))
+    return path
+
+
+def _load_jsonl(path: Path) -> list[Mapping[str, Any]]:
+    try:
+        lines = path.read_text().splitlines()
+    except OSError as error:
+        raise CausalContractError(f"cannot read {path}: {error}") from error
+    records: list[Mapping[str, Any]] = []
+    for number, line in enumerate(lines, 1):
+        value = strict_json_loads(line, source=f"{path}:{number}")
+        if not isinstance(value, Mapping):
+            raise CausalContractError(f"{path}:{number} must contain an object")
+        records.append(value)
+    return records
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("validate", help="validate the frozen v3 and v2 byte anchor")
+    plan = commands.add_parser("plan", help="write deterministic JSONL/CSV plans")
+    plan.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    plan.add_argument("--output-dir", type=Path, required=True)
+    matrix = commands.add_parser(
+        "matrix", help="print the GitHub matrix of backend-paired workers"
+    )
+    matrix.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    environment = commands.add_parser(
+        "environment", help="collect an environment attestation"
+    )
+    environment.add_argument("--output", type=Path)
+    aggregate = commands.add_parser("aggregate", help="aggregate final cell markers")
+    aggregate.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    aggregate.add_argument("--run-dir", type=Path, required=True)
+    aggregate.add_argument("--output", type=Path, required=True)
+    assess = commands.add_parser(
+        "assess", help="apply health gates and causal classifier"
+    )
+    assess.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    assess.add_argument("--results", type=Path, required=True)
+    assess.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the no-sampling v3 contract CLI."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        digest = manifest_digest(manifest)
+        if args.command == "validate":
+            summary = {
+                "study_id": manifest["study_id"],
+                "manifest_sha256": digest,
+                "status": manifest["status"],
+                "smoke_fits": manifest["tiers"]["smoke"]["expected_fit_count"],
+                "confirmation_fits": manifest["tiers"]["confirmation"][
+                    "expected_fit_count"
+                ],
+            }
+            print(canonical_json_bytes(summary).decode(), end="")
+            return 0
+        if args.command == "environment":
+            record = collect_environment(manifest)
+            payload = canonical_json_bytes(record)
+            if args.output is None:
+                print(payload.decode(), end="")
+            else:
+                _atomic_write(args.output, payload)
+                print(args.output)
+            return 0
+        plan = build_plan(manifest, args.tier)
+        if args.command == "plan":
+            paths = _write_plan(plan, args.output_dir)
+            print("\n".join(str(path) for path in paths))
+            return 0
+        if args.command == "matrix":
+            pairs = []
+            for unit in plan:
+                if unit.pair_position == 0:
+                    pairs.append(
+                        {
+                            "pair_id": unit.pair_id,
+                            "tier": unit.tier,
+                            "regime_id": unit.regime_id,
+                            "replicate": unit.replicate,
+                        }
+                    )
+            print(canonical_json_bytes({"include": pairs}).decode(), end="")
+            return 0
+        if args.command == "aggregate":
+            records = load_result_records(args.run_dir / "cells")
+            rows = aggregate_results(
+                plan,
+                records,
+                context_directory=args.run_dir / "contexts",
+                artifact_root=args.run_dir,
+                manifest=manifest,
+            )
+            _write_aggregate(rows, args.output)
+            print(args.output)
+            return 0
+        assessment_rows = _load_jsonl(args.results)
+        assessment = assess_results(assessment_rows, plan, manifest, args.tier)
+        payload = (
+            json.dumps(assessment, allow_nan=False, indent=2, sort_keys=True).encode()
+            + b"\n"
+        )
+        if args.output is None:
+            print(payload.decode(), end="")
+        else:
+            _atomic_write(args.output, payload)
+            print(args.output)
+        return 0 if assessment["evidence_complete"] else 1
+    except CausalContractError as error:
+        parser.exit(2, f"causal contract error: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/truncated_hierarchy_causal_models.py
+++ b/scripts/truncated_hierarchy_causal_models.py
@@ -123,7 +123,12 @@ def _standard_normal_lower_icdf(
     else:
         log_p = pt.as_tensor_variable(log_probability)
         p = pt.exp(log_p)
-    log_p = pt.minimum(log_p, _constant(math.log(0.5)))
+    log_half = _constant(math.log(0.5))
+    # The lower-tail approximation is defined only through probability 0.5.
+    # Use an explicit branch that selects ``log_p`` at equality: JAX assigns a
+    # 1/2 subgradient to ``minimum(x, c)`` at x == c, which would halve the
+    # central inverse-CDF derivative used by NumPyro.
+    log_p = pt.switch(pt.le(log_p, log_half), log_p, log_half)
 
     tail_argument = pt.sqrt(-_constant(2.0) * log_p)
     tail = _polyval(_ACKLAM_C, tail_argument) / (

--- a/scripts/truncated_hierarchy_causal_runner.py
+++ b/scripts/truncated_hierarchy_causal_runner.py
@@ -44,6 +44,7 @@ import xarray as xr
 from pymc.initial_point import make_initial_point_fns_per_chain
 from pymc.sampling.jax import get_jaxified_graph, sample_numpyro_nuts
 from pymc.util import get_random_generator
+from pytensor.compile.mode import Mode
 from pytensor.link.c.exceptions import CompileError
 from scipy.special import log_ndtr, ndtri_exp
 
@@ -1348,14 +1349,26 @@ def _make_graph_evaluator(
     """Compile the exact scalar value/gradient/Hessian path used by a backend."""
     model_logp = model.logp(jacobian=True)
     if backend_id == "pymc":
-        outputs: list[Any] = [
+        value_and_gradient_outputs: list[Any] = [
             model_logp,
             model.dlogp(jacobian=True),
-            model.d2logp(jacobian=True, negate_output=False),
         ]
-        function = model.compile_fn(
-            outputs,
+        value_and_gradient_function = model.compile_fn(
+            value_and_gradient_outputs,
             inputs=model.value_vars,
+            on_unused_input="ignore",
+            point_fn=False,
+        )
+        # The ICDF parameterizations create a large symbolic second-order graph.
+        # PyTensor's default FAST_RUN/C compilation can spend unbounded time and
+        # memory optimizing that diagnostic-only graph.  Keep the sampler's exact
+        # default optimized value/gradient path, but evaluate the same symbolic
+        # Hessian with the bounded Python/no-optimizer mode already used by the B1
+        # independent-oracle tests.
+        hessian_function = model.compile_fn(
+            model.d2logp(jacobian=True, negate_output=False),
+            inputs=model.value_vars,
+            mode=Mode(linker="py", optimizer="None"),
             on_unused_input="ignore",
             point_fn=False,
         )
@@ -1363,7 +1376,9 @@ def _make_graph_evaluator(
         def evaluate_pymc(
             vector: np.ndarray,
         ) -> tuple[float, np.ndarray, np.ndarray]:
-            value, gradient, hessian = function(*_model_arguments(model, vector))
+            arguments = _model_arguments(model, vector)
+            value, gradient = value_and_gradient_function(*arguments)
+            hessian = hessian_function(*arguments)
             return (
                 float(value),
                 np.asarray(gradient, dtype=np.float64),

--- a/scripts/truncated_hierarchy_causal_runner.py
+++ b/scripts/truncated_hierarchy_causal_runner.py
@@ -21,6 +21,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -2797,19 +2798,42 @@ def _run_observed_cell_process(
     if not math.isfinite(heartbeat_seconds) or heartbeat_seconds <= 0.0:
         raise ValueError("heartbeat_seconds must be finite and positive")
     started = time.monotonic()
-    process = subprocess.Popen(
-        command,
-        cwd=cwd,
-        env=environment,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=os.name == "posix",
-        creationflags=(
-            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) if os.name == "nt" else 0
-        ),
+    process: subprocess.Popen[str] | None = None
+    pending_sigterm: int | None = None
+    cleanup_started = False
+    primary_exception = False
+    install_sigterm_handler = threading.current_thread() is threading.main_thread()
+    previous_sigterm_handler: Any = (
+        signal.getsignal(signal.SIGTERM) if install_sigterm_handler else None
     )
+
+    def handle_parent_sigterm(signum: int, _frame: Any) -> None:
+        nonlocal pending_sigterm
+        if cleanup_started:
+            return
+        pending_sigterm = signum
+        if process is not None:
+            raise SystemExit(128 + signum)
+
     try:
+        if install_sigterm_handler:
+            signal.signal(signal.SIGTERM, handle_parent_sigterm)
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=os.name == "posix",
+            creationflags=(
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                if os.name == "nt"
+                else 0
+            ),
+        )
+        if pending_sigterm is not None:
+            raise SystemExit(128 + pending_sigterm)
         _emit_cell_observation(
             unit,
             "cell-start",
@@ -2835,31 +2859,41 @@ def _run_observed_cell_process(
                     elapsed_seconds=round(time.monotonic() - started, 3),
                     **resources,
                 )
+        returncode = cast("int", process.returncode)
+        _emit_cell_observation(
+            unit,
+            "cell-end",
+            child_pid=process.pid,
+            elapsed_seconds=round(time.monotonic() - started, 3),
+            returncode=returncode,
+            termination="child-exited",
+        )
+        return subprocess.CompletedProcess(command, returncode, stdout, stderr)
     except BaseException:
-        _cleanup_interrupted_cell_process(process)
+        primary_exception = True
+        cleanup_started = True
+        if process is not None:
+            _cleanup_interrupted_cell_process(process)
         try:
-            _emit_cell_observation(
-                unit,
-                "cell-end",
-                child_pid=process.pid,
-                elapsed_seconds=round(time.monotonic() - started, 3),
-                returncode=process.returncode,
-                termination="observer-interrupted",
-            )
+            if process is not None:
+                _emit_cell_observation(
+                    unit,
+                    "cell-end",
+                    child_pid=process.pid,
+                    elapsed_seconds=round(time.monotonic() - started, 3),
+                    returncode=process.returncode,
+                    termination="observer-interrupted",
+                )
         except BaseException:
             pass
         raise
-
-    returncode = cast("int", process.returncode)
-    _emit_cell_observation(
-        unit,
-        "cell-end",
-        child_pid=process.pid,
-        elapsed_seconds=round(time.monotonic() - started, 3),
-        returncode=returncode,
-        termination="child-exited",
-    )
-    return subprocess.CompletedProcess(command, returncode, stdout, stderr)
+    finally:
+        if install_sigterm_handler:
+            try:
+                signal.signal(signal.SIGTERM, previous_sigterm_handler)
+            except BaseException:
+                if not primary_exception:
+                    raise
 
 
 def _subprocess_cell_executor(

--- a/scripts/truncated_hierarchy_causal_runner.py
+++ b/scripts/truncated_hierarchy_causal_runner.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import math
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -120,6 +121,9 @@ BUILDER_TO_PARAMETERIZATION: dict[str, Parameterization] = {
     "full_icdf_noncentered": "full_icdf_noncentered",
 }
 TRAJECTORY_POINTS_PER_CHAIN = 1
+CELL_HEARTBEAT_SECONDS = 30.0
+CELL_CLEANUP_SECONDS = 2.0
+CELL_OBSERVATION_PREFIX = "hssm-causal-observation "
 
 
 class CausalRunnerError(RuntimeError):
@@ -2614,6 +2618,250 @@ def _private_materialize_unit(
     return 0
 
 
+def _process_resource_snapshot(child_pid: int) -> dict[str, Any]:
+    """Return best-effort process and host telemetry for one active child."""
+    try:
+        import psutil
+    except ImportError:
+        return {
+            "resource_status": "unavailable",
+            "resource_error_types": ["ImportError"],
+        }
+
+    error_types: set[str] = set()
+    snapshot: dict[str, Any] = {}
+    try:
+        snapshot["parent_rss_bytes"] = psutil.Process(os.getpid()).memory_info().rss
+    except (psutil.Error, OSError) as error:
+        error_types.add(type(error).__name__)
+
+    processes: list[Any] = []
+    try:
+        child = psutil.Process(child_pid)
+        processes.append(child)
+        try:
+            processes.extend(child.children(recursive=True))
+        except (psutil.Error, OSError) as error:
+            error_types.add(type(error).__name__)
+    except (psutil.Error, OSError) as error:
+        error_types.add(type(error).__name__)
+
+    process_count = 0
+    rss_bytes = 0
+    vms_bytes = 0
+    thread_count = 0
+    cpu_user_seconds = 0.0
+    cpu_system_seconds = 0.0
+    for process in processes:
+        try:
+            with process.oneshot():
+                memory = process.memory_info()
+                cpu = process.cpu_times()
+                threads = process.num_threads()
+        except (psutil.Error, OSError) as error:
+            error_types.add(type(error).__name__)
+            continue
+        process_count += 1
+        rss_bytes += int(memory.rss)
+        vms_bytes += int(memory.vms)
+        thread_count += int(threads)
+        cpu_user_seconds += float(cpu.user)
+        cpu_system_seconds += float(cpu.system)
+    snapshot.update(
+        {
+            "child_process_count": process_count,
+            "child_tree_rss_bytes": rss_bytes,
+            "child_tree_vms_bytes": vms_bytes,
+            "child_tree_thread_count": thread_count,
+            "child_tree_cpu_user_seconds": cpu_user_seconds,
+            "child_tree_cpu_system_seconds": cpu_system_seconds,
+        }
+    )
+
+    try:
+        host_memory = psutil.virtual_memory()
+        host_swap = psutil.swap_memory()
+        snapshot.update(
+            {
+                "host_available_memory_bytes": int(host_memory.available),
+                "host_memory_percent": float(host_memory.percent),
+                "host_swap_used_bytes": int(host_swap.used),
+            }
+        )
+    except (psutil.Error, OSError) as error:
+        error_types.add(type(error).__name__)
+
+    snapshot["resource_status"] = "partial" if error_types else "available"
+    snapshot["resource_error_types"] = sorted(error_types)
+    return snapshot
+
+
+def _emit_cell_observation(unit: UnitSpec, event: str, **values: Any) -> None:
+    """Write one fail-soft operational record outside the evidence contract."""
+    payload = {
+        "event": event,
+        "cell_id": unit.cell_id,
+        "pair_id": unit.pair_id,
+        "pair_position": unit.pair_position,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "replicate": unit.replicate,
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        **values,
+    }
+    try:
+        encoded = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        print(CELL_OBSERVATION_PREFIX + encoded, file=sys.stderr, flush=True)
+    except Exception:
+        # Broken log pipes and telemetry serialization must never alter a cell.
+        return
+
+
+def _kill_cell_process_tree(process: subprocess.Popen[str]) -> None:
+    """Best-effort kill of the isolated child session or non-POSIX tree."""
+    if os.name == "posix":
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        except OSError:
+            pass
+    else:
+        try:
+            import psutil
+
+            root = psutil.Process(process.pid)
+            descendants = root.children(recursive=True)
+            for descendant in reversed(descendants):
+                try:
+                    descendant.kill()
+                except (psutil.Error, OSError):
+                    pass
+        except (ImportError, OSError):
+            pass
+        except Exception:
+            # psutil is optional; direct-child cleanup remains the fallback.
+            pass
+    try:
+        process.kill()
+    except OSError:
+        pass
+
+
+def _cleanup_interrupted_cell_process(process: subprocess.Popen[str]) -> None:
+    """Bound cleanup so inherited pipes cannot mask the original interrupt."""
+    try:
+        _kill_cell_process_tree(process)
+    except BaseException:
+        pass
+    try:
+        process.communicate(timeout=CELL_CLEANUP_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    except BaseException:
+        pass
+
+    for pipe in (process.stdout, process.stderr):
+        if pipe is None:
+            continue
+        try:
+            pipe.close()
+        except BaseException:
+            pass
+    try:
+        process.kill()
+    except BaseException:
+        pass
+    try:
+        process.wait(timeout=CELL_CLEANUP_SECONDS)
+    except BaseException:
+        pass
+
+
+def _run_observed_cell_process(
+    unit: UnitSpec,
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    environment: Mapping[str, str],
+    heartbeat_seconds: float = CELL_HEARTBEAT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    """Run one captured child while emitting fail-soft operational heartbeats."""
+    if not math.isfinite(heartbeat_seconds) or heartbeat_seconds <= 0.0:
+        raise ValueError("heartbeat_seconds must be finite and positive")
+    started = time.monotonic()
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=os.name == "posix",
+        creationflags=(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) if os.name == "nt" else 0
+        ),
+    )
+    try:
+        _emit_cell_observation(
+            unit,
+            "cell-start",
+            child_pid=process.pid,
+            elapsed_seconds=0.0,
+        )
+        while True:
+            try:
+                stdout, stderr = process.communicate(timeout=heartbeat_seconds)
+                break
+            except subprocess.TimeoutExpired:
+                try:
+                    resources = _process_resource_snapshot(process.pid)
+                except Exception as error:
+                    resources = {
+                        "resource_status": "unavailable",
+                        "resource_error_types": [type(error).__name__],
+                    }
+                _emit_cell_observation(
+                    unit,
+                    "cell-heartbeat",
+                    child_pid=process.pid,
+                    elapsed_seconds=round(time.monotonic() - started, 3),
+                    **resources,
+                )
+    except BaseException:
+        _cleanup_interrupted_cell_process(process)
+        try:
+            _emit_cell_observation(
+                unit,
+                "cell-end",
+                child_pid=process.pid,
+                elapsed_seconds=round(time.monotonic() - started, 3),
+                returncode=process.returncode,
+                termination="observer-interrupted",
+            )
+        except BaseException:
+            pass
+        raise
+
+    returncode = cast("int", process.returncode)
+    _emit_cell_observation(
+        unit,
+        "cell-end",
+        child_pid=process.pid,
+        elapsed_seconds=round(time.monotonic() - started, 3),
+        returncode=returncode,
+        termination="child-exited",
+    )
+    return subprocess.CompletedProcess(command, returncode, stdout, stderr)
+
+
 def _subprocess_cell_executor(
     unit: UnitSpec,
     *,
@@ -2676,13 +2924,11 @@ def _subprocess_cell_executor(
             "--output-dir",
             str(output_directory),
         ]
-        completed = subprocess.run(
+        completed = _run_observed_cell_process(
+            unit,
             command,
             cwd=Path(__file__).resolve().parents[1],
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=False,
+            environment=environment,
         )
         if completed.returncode not in {0, 10}:
             stderr = completed.stderr[-4000:]

--- a/scripts/truncated_hierarchy_causal_runner.py
+++ b/scripts/truncated_hierarchy_causal_runner.py
@@ -1,0 +1,2908 @@
+"""Execute backend-paired five-form blocks for the #1282 causal experiment.
+
+This runner is intentionally separate from the frozen v2 qualification harness.
+Its unit of scheduling is a backend pair containing two five-representation
+blocks for one tier, regime, and replicate.  A parent process mints a run
+context, materializes byte-identical data and natural starts, launches all ten
+cells in isolated processes/caches, and publishes each cell JSON last.
+Scientific failures are evidence and do not suppress paired controls; contract,
+environment, artifact, programming, and interrupt failures leave the pair
+incomplete instead of manufacturing scientific evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+# Public CI commands historically invoke scripts by file path.  Preserve that
+# surface while child workers use module mode, which otherwise has the more
+# reliable package import semantics.
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import arviz as az
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pymc as pm
+import pytensor
+import xarray as xr
+from pymc.initial_point import make_initial_point_fns_per_chain
+from pymc.sampling.jax import get_jaxified_graph, sample_numpyro_nuts
+from pymc.util import get_random_generator
+from pytensor.link.c.exceptions import CompileError
+from scipy.special import log_ndtr, ndtri_exp
+
+from scripts.truncated_hierarchy_causal_artifacts import (
+    ArtifactRef,
+    ArtifactStore,
+    CausalArtifactError,
+    canonical_json_bytes,
+    decode_canonical_json,
+    merge_run_directories,
+    sha256_bytes,
+)
+from scripts.truncated_hierarchy_causal_contract import (
+    ALLOWED_TIERS,
+    DEFAULT_MANIFEST,
+    ORACLE_METRICS,
+    RUNNER_VERSION,
+    CausalContractError,
+    RunContext,
+    UnitSpec,
+    build_plan,
+    collect_environment,
+    environment_digest,
+    load_manifest,
+    manifest_digest,
+    pair_units,
+    plan_unit_by_id,
+    validate_environment,
+    validate_manifest,
+    validate_result_record,
+    validate_run_context,
+)
+from scripts.truncated_hierarchy_causal_models import (
+    Parameterization,
+    build_causal_model,
+)
+from scripts.truncated_hierarchy_causal_oracle import (
+    CausalParameterization,
+    HierarchicalPosteriorSpec,
+    TruncationBounds,
+    hierarchical_natural_values,
+    hierarchical_posterior_components,
+    positive_inverse,
+    support_inverse,
+)
+from scripts.truncated_hierarchy_models import (
+    Bounds,
+    NativeTruncatedPrior,
+    SyntheticHierarchyData,
+    ToyDataSpec,
+    generate_synthetic_data,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+ScientificStage = Literal[
+    "data", "build", "initialize", "compile", "sample", "summarize", "diagnose"
+]
+
+SCIENTIFIC_STAGES: frozenset[str] = frozenset(
+    {"data", "build", "initialize", "compile", "sample", "summarize", "diagnose"}
+)
+REPRESENTATION_TO_PARAMETERIZATION: dict[str, CausalParameterization] = {
+    "native-centered": "centered",
+    "manual-centered": "centered",
+    "group-icdf-noncentered": "group_icdf_noncentered",
+    "location-icdf-noncentered": "location_icdf_noncentered",
+    "full-icdf-noncentered": "full_icdf_noncentered",
+}
+BUILDER_TO_PARAMETERIZATION: dict[str, Parameterization] = {
+    "native_centered": "native_centered",
+    "manual_centered": "manual_centered",
+    "group_icdf_noncentered": "group_icdf_noncentered",
+    "location_icdf_noncentered": "location_icdf_noncentered",
+    "full_icdf_noncentered": "full_icdf_noncentered",
+}
+TRAJECTORY_POINTS_PER_CHAIN = 1
+
+
+class CausalRunnerError(RuntimeError):
+    """Base class for runner contract and infrastructure failures."""
+
+
+class IncompleteBlockError(CausalRunnerError):
+    """Raised when infrastructure prevents a complete ten-cell backend pair."""
+
+
+class ScientificCellFailure(RuntimeError):
+    """A deliberately classified model/compiler/sampler failure."""
+
+    def __init__(
+        self,
+        stage: ScientificStage,
+        message: str,
+        *,
+        error_type: str | None = None,
+    ) -> None:
+        if stage not in SCIENTIFIC_STAGES:
+            raise ValueError(f"unknown scientific failure stage {stage!r}")
+        if not isinstance(message, str) or not message.strip():
+            raise ValueError("scientific failure message must be non-empty")
+        super().__init__(message)
+        self.stage = stage
+        self.error_type = error_type or type(self).__name__
+
+    def as_dict(self) -> dict[str, str]:
+        """Return the exact failure evidence included in a cell record."""
+        return {
+            "stage": self.stage,
+            "error_type": self.error_type,
+            "message": str(self),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CellExecution:
+    """In-memory evidence returned by one isolated cell execution."""
+
+    status: Literal["completed", "failed"]
+    coordinate_starts: Mapping[str, Any] | None = None
+    chain_dataset: xr.Dataset | None = None
+    diagnostics: Mapping[str, Any] | None = None
+    metrics: Mapping[str, Any] | None = None
+    parameter_summaries: Sequence[Mapping[str, Any]] | None = None
+    failure: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        """Enforce completed-versus-failed evidence separation."""
+        if self.status == "completed":
+            if (
+                self.coordinate_starts is None
+                or self.chain_dataset is None
+                or self.diagnostics is None
+                or self.metrics is None
+                or self.parameter_summaries is None
+                or self.failure is not None
+            ):
+                raise CausalRunnerError("completed cell lacks required evidence")
+        elif self.status == "failed":
+            if self.failure is None:
+                raise CausalRunnerError("failed cell lacks classified failure")
+            stage = self.failure.get("stage")
+            if stage in {"summarize", "diagnose"} and self.chain_dataset is None:
+                raise CausalRunnerError(
+                    "late scientific failure must preserve the completed chain"
+                )
+            if (
+                stage not in {"summarize", "diagnose"}
+                and self.chain_dataset is not None
+            ):
+                raise CausalRunnerError(
+                    "pre-summary scientific failure cannot publish a chain"
+                )
+            if self.parameter_summaries:
+                raise CausalRunnerError(
+                    "failed cell cannot publish posterior summaries"
+                )
+        else:
+            raise CausalRunnerError(f"unknown cell status {self.status!r}")
+
+
+def _regime_bounds(unit: UnitSpec) -> Bounds:
+    return Bounds(unit.regime["lower"], unit.regime["upper"])
+
+
+def _toy_spec(unit: UnitSpec) -> ToyDataSpec:
+    """Construct the public B1 data specification from one planned unit."""
+    return ToyDataSpec(
+        bounds=_regime_bounds(unit),
+        group_location=float(unit.regime["truth_group_location"]),
+        group_scale=float(unit.regime["truth_group_scale"]),
+        n_groups=int(unit.regime["n_groups"]),
+        n_per_group=int(unit.regime["n_per_group"]),
+        floatx=cast("Literal['float32', 'float64']", unit.floatx),
+        observation_sigma=float(unit.natural_model["observation_sigma"]),
+    )
+
+
+def _prior(unit: UnitSpec) -> NativeTruncatedPrior:
+    """Construct the one common natural prior from the frozen plan entry."""
+    return NativeTruncatedPrior(
+        bounds=_regime_bounds(unit),
+        location_base_mean=float(unit.regime["prior_hyper_location"]),
+        location_prior_sigma=float(unit.natural_model["location_prior_sigma"]),
+        scale_prior_alpha=float(unit.natural_model["scale_prior_alpha"]),
+        scale_prior_beta=float(unit.natural_model["scale_prior_beta"]),
+    )
+
+
+def _oracle_spec(
+    unit: UnitSpec, prior: NativeTruncatedPrior, data: SyntheticHierarchyData
+) -> HierarchicalPosteriorSpec:
+    return HierarchicalPosteriorSpec(
+        bounds=TruncationBounds(prior.bounds.lower, prior.bounds.upper),
+        location_base_mean=prior.location_base_mean,
+        location_prior_scale=prior.location_prior_sigma,
+        scale_prior_shape=prior.scale_prior_alpha,
+        scale_prior_scale=prior.scale_prior_beta,
+        n_groups=int(unit.regime["n_groups"]),
+        group_index=data.group_index,
+        observations=data.y,
+        observation_scale=data.spec.observation_sigma,
+    )
+
+
+def _data_payload(unit: UnitSpec, data: SyntheticHierarchyData) -> dict[str, Any]:
+    """Serialize every generated byte needed to rebuild a dataset exactly."""
+    return {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "data_id": unit.data_id,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "replicate": unit.replicate,
+        "seeds": {
+            "data_seed": unit.data_seed,
+            "truth_seed": unit.truth_seed,
+            "group_seed": unit.group_seed,
+            "observation_seed": unit.observation_seed,
+        },
+        "spec": {
+            "lower": data.spec.bounds.lower,
+            "upper": data.spec.bounds.upper,
+            "truth_group_location": data.spec.group_location,
+            "truth_group_scale": data.spec.group_scale,
+            "n_groups": data.spec.n_groups,
+            "n_per_group": data.spec.n_per_group,
+            "floatx": data.spec.floatx,
+            "observation_sigma": data.spec.observation_sigma,
+        },
+        "group_labels": list(data.group_labels),
+        "group_index": [int(value) for value in data.group_index],
+        "group_effect": [float(value) for value in data.group_effect],
+        "observations": [float(value) for value in data.y],
+    }
+
+
+def _data_from_payload(
+    payload: Mapping[str, Any], unit: UnitSpec
+) -> SyntheticHierarchyData:
+    """Strictly reconstruct and re-derive a shared input artifact."""
+    if payload.get("data_id") != unit.data_id:
+        raise CausalRunnerError("data artifact identity does not match the plan")
+    expected = generate_synthetic_data(
+        _toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    if canonical_json_bytes(_data_payload(unit, expected)) != canonical_json_bytes(
+        payload
+    ):
+        raise CausalRunnerError(
+            "data artifact does not match deterministic regeneration"
+        )
+    return expected
+
+
+def _pack_model_point(model: pm.Model, point: Mapping[str, Any]) -> np.ndarray:
+    """Pack B1 value variables in their frozen location/scale/groups order."""
+    pieces: list[np.ndarray] = []
+    for variable in model.value_vars:
+        if variable.name not in point:
+            raise CausalRunnerError(f"point lacks value variable {variable.name!r}")
+        pieces.append(np.asarray(point[variable.name]).reshape(-1))
+    vector = np.concatenate(pieces).astype(model.value_vars[0].dtype, copy=False)
+    if not np.all(np.isfinite(vector)):
+        raise ScientificCellFailure("initialize", "initial coordinate is non-finite")
+    return vector
+
+
+def _point_from_vector(model: pm.Model, vector: np.ndarray) -> dict[str, np.ndarray]:
+    """Split one canonical coordinate vector into a concrete PyMC point."""
+    initial = model.initial_point()
+    cursor = 0
+    result: dict[str, np.ndarray] = {}
+    for variable in model.value_vars:
+        shape = np.asarray(initial[variable.name]).shape
+        size = int(np.prod(shape, dtype=int)) if shape else 1
+        result[variable.name] = np.asarray(
+            vector[cursor : cursor + size], dtype=variable.dtype
+        ).reshape(shape)
+        cursor += size
+    if cursor != vector.size:
+        raise CausalRunnerError("coordinate dimension does not match model graph")
+    return result
+
+
+def _logdiffexp(larger: float, smaller: float) -> float:
+    if not larger > smaller:
+        raise ScientificCellFailure("initialize", "degenerate truncated probability")
+    return larger + math.log(-math.expm1(smaller - larger))
+
+
+def _normal_interval_logmass(lower: float, upper: float) -> float:
+    """Return log(Phi(upper)-Phi(lower)) without tail cancellation."""
+    if not lower < upper:
+        raise ScientificCellFailure("initialize", "truncated interval is empty")
+    if lower >= 0.0:
+        return _logdiffexp(float(log_ndtr(-lower)), float(log_ndtr(-upper)))
+    return _logdiffexp(float(log_ndtr(upper)), float(log_ndtr(lower)))
+
+
+def _truncated_offset_from_natural(
+    value: float,
+    *,
+    location: float,
+    scale: float,
+    bounds: Bounds,
+) -> float:
+    """Invert the B1 TN-ICDF map using stable interval probabilities."""
+    if not bounds.contains(value) or not math.isfinite(scale) or scale <= 0.0:
+        raise ScientificCellFailure("initialize", "natural start is outside support")
+    lower = -math.inf if bounds.lower is None else (bounds.lower - location) / scale
+    upper = math.inf if bounds.upper is None else (bounds.upper - location) / scale
+    standardized = (value - location) / scale
+    total = _normal_interval_logmass(lower, upper)
+    log_quantile = _normal_interval_logmass(lower, standardized) - total
+    log_survival = _normal_interval_logmass(standardized, upper) - total
+    offset = (
+        float(ndtri_exp(log_quantile))
+        if log_quantile <= log_survival
+        else -float(ndtri_exp(log_survival))
+    )
+    if not math.isfinite(offset):
+        raise ScientificCellFailure("initialize", "TN inverse start is non-finite")
+    return offset
+
+
+def natural_to_coordinate(
+    natural: Mapping[str, Any],
+    *,
+    prior: NativeTruncatedPrior,
+    oracle_spec: HierarchicalPosteriorSpec,
+    representation_id: str,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    """Map one common natural hierarchy into a representation and round-trip it."""
+    try:
+        parameterization = REPRESENTATION_TO_PARAMETERIZATION[representation_id]
+    except KeyError as error:
+        raise CausalRunnerError(
+            f"unknown representation {representation_id!r}"
+        ) from error
+    location = float(natural["group_location"])
+    scale = float(natural["group_scale"])
+    groups = np.asarray(natural["group_effect"], dtype=np.float64)
+    if groups.shape != (oracle_spec.n_groups,):
+        raise CausalRunnerError("natural group start has the wrong shape")
+    location_noncentered = parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    group_noncentered = parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }
+    if location_noncentered:
+        location_coordinate = _truncated_offset_from_natural(
+            location,
+            location=prior.location_base_mean,
+            scale=prior.location_prior_sigma,
+            bounds=prior.bounds,
+        )
+    else:
+        location_coordinate = support_inverse(location, oracle_spec.bounds)
+    if group_noncentered:
+        group_coordinates = [
+            _truncated_offset_from_natural(
+                float(group), location=location, scale=scale, bounds=prior.bounds
+            )
+            for group in groups
+        ]
+    else:
+        group_coordinates = [
+            support_inverse(float(group), oracle_spec.bounds) for group in groups
+        ]
+    vector = np.asarray(
+        [location_coordinate, positive_inverse(scale), *group_coordinates],
+        dtype=np.float64,
+    )
+
+    return vector, _natural_coordinate_roundtrip(
+        natural,
+        vector,
+        oracle_spec=oracle_spec,
+        parameterization=parameterization,
+    )
+
+
+def _natural_coordinate_roundtrip(
+    natural: Mapping[str, Any],
+    vector: np.ndarray,
+    *,
+    oracle_spec: HierarchicalPosteriorSpec,
+    parameterization: CausalParameterization,
+) -> dict[str, Any]:
+    """Round-trip the exact graph-representable coordinate to natural scale."""
+    location = float(natural["group_location"])
+    scale = float(natural["group_scale"])
+    groups = np.asarray(natural["group_effect"], dtype=np.float64)
+    restored = hierarchical_natural_values(vector, oracle_spec, parameterization)
+    restored_groups = np.asarray(
+        [group.value for group in restored.group_effect], dtype=np.float64
+    )
+    differences = np.concatenate(
+        [
+            [abs(restored.location.value - location)],
+            [abs(restored.scale.value - scale)],
+            np.abs(restored_groups - groups),
+        ]
+    )
+    roundtrip = {
+        "group_location": restored.location.value,
+        "group_scale": restored.scale.value,
+        "group_effect": restored_groups.tolist(),
+        "absolute_error_max": float(np.max(differences)),
+    }
+    return roundtrip
+
+
+def _natural_start_payload(
+    unit: UnitSpec,
+    data: SyntheticHierarchyData,
+    prior: NativeTruncatedPrior,
+) -> dict[str, Any]:
+    """Generate the common starts once from native-centered PyMC jitter.
+
+    This makes the previously implicit ``jitter+adapt_diag`` initialization
+    explicit and inspectable.  Only the starting point generation is reused;
+    sampling receives the resulting exact points with ``init='adapt_diag'`` so
+    neither backend adds a second, representation-specific jitter.
+    """
+    if pytensor.config.floatX != unit.floatx:
+        raise CausalRunnerError(
+            "natural-start source process floatX differs from the planned regime"
+        )
+    model = build_causal_model("native_centered", prior, data)
+    value_variable_dtypes = [str(variable.dtype) for variable in model.value_vars]
+    if not value_variable_dtypes or any(
+        dtype != unit.floatx for dtype in value_variable_dtypes
+    ):
+        raise CausalRunnerError(
+            "natural-start source graph contains an unplanned value-variable dtype"
+        )
+    functions = make_initial_point_fns_per_chain(
+        model=model,
+        overrides=None,
+        jitter_rvs=set(model.free_RVs),
+        chains=unit.chains,
+    )
+    oracle_spec = _oracle_spec(unit, prior, data)
+    chains: list[dict[str, Any]] = []
+    for chain, (function, seed) in enumerate(
+        zip(functions, unit.natural_start_chain_seeds, strict=True)
+    ):
+        point = function(seed)
+        vector = _pack_model_point(model, point).astype(np.float64)
+        natural = hierarchical_natural_values(vector, oracle_spec, "centered")
+        groups = [float(item.value) for item in natural.group_effect]
+        chains.append(
+            {
+                "chain": chain,
+                "seed": seed,
+                "group_location": float(natural.location.value),
+                "group_scale": float(natural.scale.value),
+                "group_effect": groups,
+            }
+        )
+    return {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "start_id": unit.start_id,
+        "data_id": unit.data_id,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "replicate": unit.replicate,
+        "policy": "native-centered-support-point-plus-uniform-jitter-v3",
+        "source_graph": {
+            "builder": "native_centered",
+            "pytensor_floatx": pytensor.config.floatX,
+            "value_variable_dtypes": value_variable_dtypes,
+        },
+        "natural_start_seed": unit.natural_start_seed,
+        "natural_start_chain_seeds": list(unit.natural_start_chain_seeds),
+        "chains": chains,
+    }
+
+
+def _validate_natural_start_payload(
+    payload: Mapping[str, Any],
+    unit: UnitSpec,
+    prior: NativeTruncatedPrior,
+    data: SyntheticHierarchyData,
+) -> None:
+    """Validate identity, seeds, shapes, support, and finite natural values."""
+    identity = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "start_id": unit.start_id,
+        "data_id": unit.data_id,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "replicate": unit.replicate,
+    }
+    for name, expected in identity.items():
+        if payload.get(name) != expected:
+            raise CausalRunnerError(f"natural start {name} does not match the plan")
+    if payload.get("natural_start_chain_seeds") != list(unit.natural_start_chain_seeds):
+        raise CausalRunnerError("natural start chain seeds do not match the plan")
+    source_graph = payload.get("source_graph")
+    if not isinstance(source_graph, dict) or set(source_graph) != {
+        "builder",
+        "pytensor_floatx",
+        "value_variable_dtypes",
+    }:
+        raise CausalRunnerError("natural start source graph attestation is malformed")
+    if (
+        source_graph["builder"] != "native_centered"
+        or source_graph["pytensor_floatx"] != unit.floatx
+        or not isinstance(source_graph["value_variable_dtypes"], list)
+        or not source_graph["value_variable_dtypes"]
+        or any(dtype != unit.floatx for dtype in source_graph["value_variable_dtypes"])
+    ):
+        raise CausalRunnerError("natural start source graph precision is wrong")
+    chains = payload.get("chains")
+    if not isinstance(chains, list) or len(chains) != unit.chains:
+        raise CausalRunnerError("natural start artifact has the wrong chain count")
+    for index, chain in enumerate(chains):
+        if not isinstance(chain, dict):
+            raise CausalRunnerError("natural start chain must be an object")
+        if chain.get("chain") != index:
+            raise CausalRunnerError("natural start chains are out of order")
+        if chain.get("seed") != unit.natural_start_chain_seeds[index]:
+            raise CausalRunnerError("natural start seed does not match the plan")
+        location = float(chain.get("group_location", math.nan))
+        scale = float(chain.get("group_scale", math.nan))
+        groups = np.asarray(chain.get("group_effect", []), dtype=np.float64)
+        if not prior.bounds.contains(location) or not scale > 0.0:
+            raise CausalRunnerError("natural start hyperparameters are invalid")
+        if groups.shape != (data.spec.n_groups,) or not prior.bounds.contains(groups):
+            raise CausalRunnerError("natural group start is invalid")
+    expected = _natural_start_payload(unit, data, prior)
+    if canonical_json_bytes(expected) != canonical_json_bytes(payload):
+        raise CausalRunnerError(
+            "natural start artifact does not match deterministic regeneration"
+        )
+
+
+def _materialize_inputs_for_unit_current_process(
+    unit: UnitSpec, store: ArtifactStore
+) -> tuple[ArtifactRef, ArtifactRef]:
+    """Publish one pair after the caller has activated its planned precision."""
+    if pytensor.config.floatX != unit.floatx:
+        raise CausalRunnerError(
+            "input materialization process floatX differs from the planned regime"
+        )
+    data = generate_synthetic_data(
+        _toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    data_payload = _data_payload(unit, data)
+    data_reference = store.ensure_json(f"data/{unit.data_id}.json", data_payload)
+    prior = _prior(unit)
+    start_payload = _natural_start_payload(unit, data, prior)
+    _validate_natural_start_payload(start_payload, unit, prior, data)
+    start_reference = store.ensure_json(
+        f"starts/natural/{unit.start_id}.json", start_payload
+    )
+    return data_reference, start_reference
+
+
+def _materialize_inputs_subprocess(
+    unit: UnitSpec,
+    store: ArtifactStore,
+    *,
+    manifest_path: Path,
+) -> tuple[ArtifactRef, ArtifactRef]:
+    """Materialize one shared pair in a fresh precision-specific interpreter."""
+    with tempfile.TemporaryDirectory(
+        prefix="hssm-causal-materialize-"
+    ) as temporary_name:
+        temporary = Path(temporary_name)
+        (temporary / "pytensor").mkdir()
+        (temporary / "jax").mkdir()
+        (temporary / "matplotlib").mkdir()
+        (temporary / "xdg-cache").mkdir()
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PYTENSOR_FLAGS": (
+                    f"base_compiledir={temporary / 'pytensor'},floatX={unit.floatx}"
+                ),
+                "JAX_COMPILATION_CACHE_DIR": str(temporary / "jax"),
+                "JAX_ENABLE_X64": "true" if unit.floatx == "float64" else "false",
+                "JAX_PLATFORMS": "cpu",
+                "MPLCONFIGDIR": str(temporary / "matplotlib"),
+                "XDG_CACHE_HOME": str(temporary / "xdg-cache"),
+                "OMP_NUM_THREADS": "1",
+                "OPENBLAS_NUM_THREADS": "1",
+                "MKL_NUM_THREADS": "1",
+                "NUMEXPR_NUM_THREADS": "1",
+            }
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "scripts.truncated_hierarchy_causal_runner",
+            "--manifest",
+            str(manifest_path.resolve()),
+            "_materialize-unit",
+            "--tier",
+            unit.tier,
+            "--cell-id",
+            unit.cell_id,
+            "--run-dir",
+            str(store.root),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=Path(__file__).resolve().parents[1],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    if completed.returncode != 0:
+        raise IncompleteBlockError(
+            f"precision-specific input materialization failed for {unit.data_id}: "
+            f"{completed.stderr[-4000:]}"
+        )
+    try:
+        payload = decode_canonical_json(completed.stdout.encode("utf-8"))
+        if not isinstance(payload, dict) or set(payload) != {"data", "natural_start"}:
+            raise CausalArtifactError("materialization response has unexpected fields")
+        data_reference = ArtifactRef.from_dict(payload["data"])
+        start_reference = ArtifactRef.from_dict(payload["natural_start"])
+    except (CausalArtifactError, TypeError, UnicodeError) as error:
+        raise IncompleteBlockError(
+            "precision-specific materialization returned invalid evidence"
+        ) from error
+    if (
+        data_reference.path != f"data/{unit.data_id}.json"
+        or start_reference.path != f"starts/natural/{unit.start_id}.json"
+    ):
+        raise IncompleteBlockError("materialization returned unplanned artifact paths")
+    store.verify(data_reference)
+    store.verify(start_reference)
+    return data_reference, start_reference
+
+
+def materialize_inputs_for_unit(
+    unit: UnitSpec,
+    store: ArtifactStore,
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+) -> tuple[ArtifactRef, ArtifactRef]:
+    """Publish inputs directly only when this process has the planned floatX."""
+    if pytensor.config.floatX == unit.floatx:
+        return _materialize_inputs_for_unit_current_process(unit, store)
+    return _materialize_inputs_subprocess(unit, store, manifest_path=manifest_path)
+
+
+def materialize_inputs(
+    manifest: Mapping[str, Any],
+    tier: str,
+    store: ArtifactStore,
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+) -> tuple[tuple[ArtifactRef, ArtifactRef], ...]:
+    """Materialize each distinct data/start pair in a tier exactly once."""
+    representatives: dict[str, UnitSpec] = {}
+    for unit in build_plan(manifest, tier):
+        representatives.setdefault(unit.data_id, unit)
+    return tuple(
+        materialize_inputs_for_unit(unit, store, manifest_path=manifest_path)
+        for unit in representatives.values()
+    )
+
+
+def _coordinate_start_payload(
+    unit: UnitSpec,
+    model: pm.Model,
+    starts: Mapping[str, Any],
+    prior: NativeTruncatedPrior,
+    oracle_spec: HierarchicalPosteriorSpec,
+) -> tuple[dict[str, Any], list[dict[str, np.ndarray]]]:
+    """Map every shared natural chain start into one graph's coordinates."""
+    _, chain_rng_provenance = _sampler_rng_provenance(unit)
+    records: list[dict[str, Any]] = []
+    initvals: list[dict[str, np.ndarray]] = []
+    for chain in starts["chains"]:
+        natural = {
+            "group_location": chain["group_location"],
+            "group_scale": chain["group_scale"],
+            "group_effect": chain["group_effect"],
+        }
+        candidate_vector, _ = natural_to_coordinate(
+            natural,
+            prior=prior,
+            oracle_spec=oracle_spec,
+            representation_id=unit.representation_id,
+        )
+        point = _point_from_vector(model, candidate_vector)
+        vector = _pack_model_point(model, point)
+        roundtrip = _natural_coordinate_roundtrip(
+            natural,
+            vector,
+            oracle_spec=oracle_spec,
+            parameterization=REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id],
+        )
+        initvals.append(point)
+        records.append(
+            {
+                "chain": chain["chain"],
+                "natural_start_seed": chain["seed"],
+                "chain_rng_provenance": chain_rng_provenance[chain["chain"]],
+                "natural": natural,
+                "coordinate_vector": vector.tolist(),
+                "value_variables": {
+                    name: np.asarray(value).tolist() for name, value in point.items()
+                },
+                "roundtrip": roundtrip,
+            }
+        )
+    return (
+        {
+            "schema_version": unit.schema_version,
+            "study_id": unit.study_id,
+            "manifest_sha256": unit.manifest_sha256,
+            "cell_id": unit.cell_id,
+            "start_id": unit.start_id,
+            "representation_id": unit.representation_id,
+            "backend_id": unit.backend_id,
+            "chains": records,
+        },
+        initvals,
+    )
+
+
+def _sampler_rng_provenance(unit: UnitSpec) -> tuple[Any, list[dict[str, Any]]]:
+    """Describe exact backend RNG inputs and chain streams on the pinned stack."""
+    if unit.backend_id == "pymc":
+        if unit.sampler_seed is not None or len(unit.chain_seeds) != unit.chains:
+            raise CausalRunnerError("PyMC seed shape differs from the plan")
+        # PyMC 6.3.1 treats this sequence as SeedSequence entropy, spawns one
+        # Generator per chain, draws one init/step integer, and hands the advanced
+        # Generator to the sampler.  Record both the draw and exact handoff state.
+        generators = get_random_generator(list(unit.chain_seeds)).spawn(unit.chains)
+        records: list[dict[str, Any]] = []
+        for chain, generator in enumerate(generators):
+            init_step_seed = int(generator.integers(2**30))
+            seed_sequence = generator.bit_generator.seed_seq
+            records.append(
+                {
+                    "chain": chain,
+                    "rng": "numpy.random.Generator(PCG64)",
+                    "spawn_key": list(getattr(seed_sequence, "spawn_key")),
+                    "seed_sequence_pool_size": getattr(seed_sequence, "pool_size"),
+                    "init_step_seed": init_step_seed,
+                    "post_init_draw_state_sha256": sha256_bytes(
+                        canonical_json_bytes(generator.bit_generator.state)
+                    ),
+                }
+            )
+        return list(unit.chain_seeds), records
+    if unit.backend_id == "numpyro":
+        if unit.sampler_seed is None or unit.chain_seeds:
+            raise CausalRunnerError("NumPyro seed shape differs from the plan")
+        key = jax.random.PRNGKey(unit.sampler_seed)
+        keys = key[None, :] if unit.chains == 1 else jax.random.split(key, unit.chains)
+        key_lists = np.asarray(keys, dtype=np.uint32).astype(np.uint64).tolist()
+        return unit.sampler_seed, [
+            {"chain": chain, "rng": "jax-prng-key", "key": chain_key}
+            for chain, chain_key in enumerate(key_lists)
+        ]
+    raise CausalRunnerError(f"unknown backend {unit.backend_id!r}")
+
+
+def _finite_initial_evidence(
+    model: pm.Model, initvals: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    """Evaluate log density and gradient at every exact sampler start."""
+    try:
+        outputs: list[Any] = [model.logp(jacobian=True), model.dlogp(jacobian=True)]
+        function = model.compile_fn(
+            outputs,
+            inputs=model.value_vars,
+            on_unused_input="ignore",
+            point_fn=False,
+        )
+    except (CompileError, NotImplementedError) as error:
+        raise ScientificCellFailure(
+            "compile", str(error), error_type=type(error).__name__
+        ) from error
+    records: list[dict[str, Any]] = []
+    for chain, point in enumerate(initvals):
+        arguments = [point[variable.name] for variable in model.value_vars]
+        value_raw, derivative_raw = function(*arguments)
+        value = float(value_raw)
+        derivative = np.asarray(derivative_raw, dtype=np.float64)
+        finite = bool(math.isfinite(value) and np.all(np.isfinite(derivative)))
+        records.append(
+            {
+                "chain": chain,
+                "logp": value,
+                "gradient_finite": bool(np.all(np.isfinite(derivative))),
+                "gradient_absolute_max": float(np.max(np.abs(derivative))),
+                "finite": finite,
+            }
+        )
+    if not all(record["finite"] for record in records):
+        raise ScientificCellFailure(
+            "initialize", "at least one exact shared start has non-finite logp/gradient"
+        )
+    return {"chains": records, "all_finite": True}
+
+
+def _sample_model(
+    unit: UnitSpec,
+    model: pm.Model,
+    initvals: Sequence[Mapping[str, Any]],
+) -> tuple[Any, float]:
+    """Sample one graph with exact starts and frozen backend-specific RNG input."""
+    started = time.perf_counter()
+    exact_initvals = cast("Any", [dict(point) for point in initvals])
+    try:
+        with cast("Any", model):
+            if unit.backend_id == "pymc":
+                if (
+                    unit.sampler_seed is not None
+                    or len(unit.chain_seeds) != unit.chains
+                ):
+                    raise CausalRunnerError("PyMC seed shape differs from the plan")
+                inference = pm.sample(
+                    draws=unit.draws,
+                    tune=unit.tune,
+                    chains=unit.chains,
+                    cores=1,
+                    random_seed=list(unit.chain_seeds),
+                    nuts_sampler="pymc",
+                    initvals=exact_initvals,
+                    init="adapt_diag",
+                    progressbar=False,
+                    compute_convergence_checks=False,
+                    discard_tuned_samples=False,
+                    return_inferencedata=True,
+                    nuts={
+                        "target_accept": unit.target_accept,
+                        "max_treedepth": unit.max_treedepth,
+                    },
+                )
+            elif unit.backend_id == "numpyro":
+                if unit.sampler_seed is None or unit.chain_seeds:
+                    raise CausalRunnerError("NumPyro seed shape differs from the plan")
+                inference = sample_numpyro_nuts(
+                    draws=unit.draws,
+                    tune=unit.tune,
+                    chains=unit.chains,
+                    target_accept=unit.target_accept,
+                    random_seed=unit.sampler_seed,
+                    initvals=exact_initvals,
+                    jitter=False,
+                    model=model,
+                    progressbar=False,
+                    quiet=True,
+                    chain_method="sequential",  # type: ignore[arg-type]
+                    nuts_kwargs={"max_tree_depth": unit.max_treedepth},
+                    compute_convergence_checks=False,
+                )
+            else:
+                raise CausalRunnerError(f"unknown backend {unit.backend_id!r}")
+    except (CompileError, NotImplementedError) as error:
+        raise ScientificCellFailure(
+            "compile", str(error), error_type=type(error).__name__
+        ) from error
+    except (
+        FloatingPointError,
+        np.linalg.LinAlgError,
+        pm.exceptions.SamplingError,
+    ) as error:
+        raise ScientificCellFailure(
+            "sample", str(error), error_type=type(error).__name__
+        ) from error
+    elapsed = time.perf_counter() - started
+    return inference, elapsed
+
+
+def _dataset_view(group: Any) -> xr.Dataset:
+    """Normalize an ArviZ DataTree group or xarray dataset."""
+    if isinstance(group, xr.Dataset):
+        return group
+    if hasattr(group, "to_dataset"):
+        return group.to_dataset()
+    if hasattr(group, "dataset"):
+        return xr.Dataset(group.dataset)
+    raise CausalRunnerError("inference output lacks an xarray dataset group")
+
+
+def _chain_identity_attributes(unit: UnitSpec) -> dict[str, Any]:
+    """Return the exact plan and RNG identity carried by every chain artifact."""
+    sampler_seed_input, chain_rng_provenance = _sampler_rng_provenance(unit)
+    return {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+        "pair_id": unit.pair_id,
+        "pair_position": unit.pair_position,
+        "block_id": unit.block_id,
+        "block_position": unit.block_position,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "replicate": unit.replicate,
+        "chains": unit.chains,
+        "draws": unit.draws,
+        "pymc_seed_entropy_words_json": json.dumps(
+            list(unit.chain_seeds), separators=(",", ":")
+        ),
+        "sampler_seed_input_json": json.dumps(
+            sampler_seed_input, separators=(",", ":")
+        ),
+        "chain_rng_provenance_json": json.dumps(
+            chain_rng_provenance, separators=(",", ":"), sort_keys=True
+        ),
+    }
+
+
+def _validate_standardized_natural_chains(unit: UnitSpec, chains: xr.Dataset) -> None:
+    """Fail closed unless a canonical chain is complete and plan-bound."""
+    expected_attrs = _chain_identity_attributes(unit)
+    for name, expected in expected_attrs.items():
+        if chains.attrs.get(name) != expected:
+            raise CausalRunnerError(
+                f"standardized chain attribute {name!r} is not plan-bound"
+            )
+    expected_sizes = {
+        "chain": unit.chains,
+        "draw": unit.draws,
+        "group": int(unit.regime["n_groups"]),
+    }
+    for dimension, size in expected_sizes.items():
+        if chains.sizes.get(dimension) != size:
+            raise CausalRunnerError(
+                f"standardized chain dimension {dimension!r} has the wrong size"
+            )
+        if not np.array_equal(
+            np.asarray(chains.coords[dimension]), np.arange(size, dtype=np.int64)
+        ):
+            raise CausalRunnerError(
+                f"standardized chain coordinate {dimension!r} is not canonical"
+            )
+    expected_natural_dims = {
+        "group_location": ("chain", "draw"),
+        "group_scale": ("chain", "draw"),
+        "group_effect": ("chain", "draw", "group"),
+    }
+    required_stats = {
+        "acceptance_rate",
+        "diverging",
+        "energy",
+        "n_steps",
+        "step_size",
+        "tree_depth",
+    }
+    for name, dimensions in expected_natural_dims.items():
+        if name not in chains or chains[name].dims != dimensions:
+            raise CausalRunnerError(
+                f"standardized chain variable {name!r} has the wrong dimensions"
+            )
+        if not np.all(np.isfinite(np.asarray(chains[name]))):
+            raise CausalRunnerError(
+                f"standardized chain variable {name!r} is non-finite"
+            )
+    for name in required_stats:
+        variable = f"sample_stat__{name}"
+        if variable not in chains or chains[variable].dims != ("chain", "draw"):
+            raise CausalRunnerError(
+                f"standardized chain lacks canonical statistic {name!r}"
+            )
+        if not np.all(np.isfinite(np.asarray(chains[variable]))):
+            raise CausalRunnerError(
+                f"standardized chain statistic {name!r} is non-finite"
+            )
+    warmup_retained = chains.attrs.get("warmup_sample_stats_retained")
+    if warmup_retained not in {0, 1}:
+        raise CausalRunnerError("standardized chain warmup attestation is invalid")
+    warmup_variables = [
+        name
+        for name in chains.data_vars
+        if isinstance(name, str) and name.startswith("warmup_sample_stat__")
+    ]
+    if warmup_retained:
+        if chains.sizes.get("warmup_draw") != unit.tune or not warmup_variables:
+            raise CausalRunnerError("standardized warmup evidence is incomplete")
+        if not np.array_equal(
+            np.asarray(chains.coords["warmup_draw"]),
+            np.arange(unit.tune, dtype=np.int64),
+        ):
+            raise CausalRunnerError("standardized warmup coordinate is not canonical")
+        if any(
+            chains[name].dims != ("chain", "warmup_draw") for name in warmup_variables
+        ):
+            raise CausalRunnerError(
+                "standardized warmup statistic has wrong dimensions"
+            )
+    elif warmup_variables or "warmup_draw" in chains.dims:
+        raise CausalRunnerError("standardized chain has unattested warmup evidence")
+
+
+def _standardize_natural_chains(unit: UnitSpec, inference: Any) -> xr.Dataset:
+    """Retain canonical natural draws and auditable per-draw sampler evidence."""
+    try:
+        posterior = _dataset_view(inference.posterior)
+    except AttributeError as error:
+        raise ScientificCellFailure(
+            "summarize", "sampler output lacks posterior chains"
+        ) from error
+    required = {"group_location", "group_scale", "group_effect"}
+    missing = required.difference(posterior.data_vars)
+    if missing:
+        raise ScientificCellFailure(
+            "summarize", f"posterior lacks natural variables: {sorted(missing)}"
+        )
+    location = posterior["group_location"].transpose("chain", "draw")
+    scale = posterior["group_scale"].transpose("chain", "draw")
+    effect = posterior["group_effect"].transpose("chain", "draw", "group")
+    expected_shapes = {
+        "location": (unit.chains, unit.draws),
+        "scale": (unit.chains, unit.draws),
+        "effect": (unit.chains, unit.draws, int(unit.regime["n_groups"])),
+    }
+    observed_shapes = {
+        "location": location.shape,
+        "scale": scale.shape,
+        "effect": effect.shape,
+    }
+    if observed_shapes != expected_shapes:
+        message = (
+            f"posterior natural-chain shapes are {observed_shapes}, "
+            f"expected {expected_shapes}"
+        )
+        raise ScientificCellFailure(
+            "summarize",
+            message,
+        )
+    values = np.concatenate(
+        [
+            np.asarray(location).reshape(-1),
+            np.asarray(scale).reshape(-1),
+            np.asarray(effect).reshape(-1),
+        ]
+    )
+    if not np.all(np.isfinite(values)):
+        raise ScientificCellFailure("summarize", "posterior contains non-finite values")
+    try:
+        sample_stats = _dataset_view(inference.sample_stats)
+    except AttributeError as error:
+        raise ScientificCellFailure(
+            "sample", "sampler output lacks per-draw statistics"
+        ) from error
+    required_stats = {
+        "acceptance_rate",
+        "diverging",
+        "energy",
+        "n_steps",
+        "step_size",
+        "tree_depth",
+    }
+    missing_stats = required_stats.difference(sample_stats.data_vars)
+    if missing_stats:
+        raise ScientificCellFailure(
+            "sample", f"sample_stats lacks required fields: {sorted(missing_stats)}"
+        )
+    data_vars: dict[str, Any] = {
+        "group_location": (("chain", "draw"), np.asarray(location)),
+        "group_scale": (("chain", "draw"), np.asarray(scale)),
+        "group_effect": (("chain", "draw", "group"), np.asarray(effect)),
+    }
+
+    def retain_stats(
+        source: xr.Dataset,
+        *,
+        prefix: str,
+        draw_dimension: str,
+        expected_draws: int,
+    ) -> None:
+        for raw_name in sorted(source.data_vars, key=str):
+            if not isinstance(raw_name, str):
+                raise ScientificCellFailure(
+                    "sample", "sample statistic names must be strings"
+                )
+            name = raw_name
+            value = source[name]
+            if set(value.dims) != {"chain", "draw"} or len(value.dims) != 2:
+                raise ScientificCellFailure(
+                    "sample", f"sample statistic {name!r} has unsupported dimensions"
+                )
+            ordered = value.transpose("chain", "draw")
+            if ordered.shape != (unit.chains, expected_draws):
+                raise ScientificCellFailure(
+                    "sample", f"sample statistic {name!r} has the wrong shape"
+                )
+            array = np.asarray(ordered)
+            if array.dtype.kind not in "biuf":
+                raise ScientificCellFailure(
+                    "sample", f"sample statistic {name!r} is not numeric"
+                )
+            if name in required_stats and not np.all(np.isfinite(array)):
+                raise ScientificCellFailure(
+                    "sample", f"required sample statistic {name!r} is non-finite"
+                )
+            data_vars[f"{prefix}{name}"] = (
+                ("chain", draw_dimension),
+                array,
+            )
+
+    retain_stats(
+        sample_stats,
+        prefix="sample_stat__",
+        draw_dimension="draw",
+        expected_draws=unit.draws,
+    )
+    warmup_retained = False
+    if hasattr(inference, "warmup_sample_stats"):
+        warmup_stats = _dataset_view(inference.warmup_sample_stats)
+        retain_stats(
+            warmup_stats,
+            prefix="warmup_sample_stat__",
+            draw_dimension="warmup_draw",
+            expected_draws=unit.tune,
+        )
+        warmup_retained = True
+    group_index = np.arange(int(unit.regime["n_groups"]), dtype=np.int64)
+    result = xr.Dataset(
+        data_vars=data_vars,
+        coords={
+            "chain": np.arange(unit.chains, dtype=np.int64),
+            "draw": np.arange(unit.draws, dtype=np.int64),
+            "group": group_index,
+            **(
+                {"warmup_draw": np.arange(unit.tune, dtype=np.int64)}
+                if warmup_retained
+                else {}
+            ),
+        },
+        attrs={
+            **_chain_identity_attributes(unit),
+            "warmup_sample_stats_retained": int(warmup_retained),
+        },
+    )
+    _validate_standardized_natural_chains(unit, result)
+    return result
+
+
+def _dataarray_values(dataset: xr.Dataset) -> np.ndarray:
+    """Flatten all values in an ArviZ diagnostic dataset."""
+    pieces = [np.asarray(value).reshape(-1) for value in dataset.data_vars.values()]
+    return np.concatenate(pieces) if pieces else np.empty(0, dtype=np.float64)
+
+
+def _sampler_metrics(
+    unit: UnitSpec,
+    chains: xr.Dataset,
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    """Recompute every registered sampler metric from the retained chain artifact."""
+    _validate_standardized_natural_chains(unit, chains)
+
+    def statistic(name: str) -> xr.DataArray:
+        variable = f"sample_stat__{name}"
+        if variable not in chains:
+            raise ScientificCellFailure(
+                "summarize", f"retained chain lacks sample statistic {name!r}"
+            )
+        value = chains[variable]
+        if value.dims != ("chain", "draw") or value.shape != (
+            unit.chains,
+            unit.draws,
+        ):
+            raise ScientificCellFailure(
+                "summarize", f"retained sample statistic {name!r} has wrong shape"
+            )
+        return value
+
+    divergences = np.asarray(statistic("diverging"), dtype=np.int64)
+    draws_total = int(unit.chains * unit.draws)
+    divergence_count = int(np.sum(divergences))
+    if "sample_stat__reached_max_treedepth" in chains:
+        saturated = np.asarray(statistic("reached_max_treedepth"), dtype=bool)
+    else:
+        saturated = np.asarray(statistic("tree_depth")) >= unit.max_treedepth
+
+    hyper = chains[["group_location", "group_scale"]]
+    group = chains[["group_effect"]]
+    hyper_rhat = _dataarray_values(az.rhat(hyper, method="rank"))
+    group_rhat = _dataarray_values(az.rhat(group, method="rank"))
+    hyper_bulk = _dataarray_values(az.ess(hyper, method="bulk"))
+    group_bulk = _dataarray_values(az.ess(group, method="bulk"))
+    hyper_tail = _dataarray_values(az.ess(hyper, method="tail"))
+    group_tail = _dataarray_values(az.ess(group, method="tail"))
+    hyper_mcse = _dataarray_values(az.mcse(hyper, method="mean"))
+    hyper_sd = np.asarray(
+        [float(chains[name].std(dim=("chain", "draw"), ddof=1)) for name in hyper]
+    )
+    mcse_over_sd = np.divide(
+        hyper_mcse,
+        hyper_sd,
+        out=np.full_like(hyper_mcse, np.inf),
+        where=hyper_sd > 0,
+    )
+    try:
+        bfmi_result = az.bfmi(np.asarray(statistic("energy"), dtype=np.float64))
+        bfmi_values = np.asarray(bfmi_result, dtype=np.float64).reshape(-1)
+    except Exception as error:  # ArviZ adapters differ across InferenceData/DataTree.
+        raise ScientificCellFailure(
+            "summarize",
+            f"BFMI calculation failed: {error}",
+            error_type=type(error).__name__,
+        ) from error
+
+    def optional_stat(name: str) -> list[float] | None:
+        if f"sample_stat__{name}" not in chains:
+            return None
+        array = np.asarray(statistic(name), dtype=np.float64)
+        return [float(value) for value in np.mean(array, axis=1)]
+
+    step_size = np.asarray(statistic("step_size"), dtype=np.float64)
+    n_steps = np.asarray(statistic("n_steps"), dtype=np.float64)
+    if step_size.shape != (unit.chains, unit.draws):
+        raise ScientificCellFailure("summarize", "step_size has the wrong shape")
+    if n_steps.shape != (unit.chains, unit.draws):
+        raise ScientificCellFailure("summarize", "n_steps has the wrong shape")
+    result = {
+        "wall_seconds": float(elapsed_seconds),
+        "chains": unit.chains,
+        "draws_per_chain": unit.draws,
+        "draws_total": draws_total,
+        "divergence_count": divergence_count,
+        "divergence_count_by_chain": [
+            int(value) for value in np.sum(divergences, axis=1)
+        ],
+        "divergence_rate": divergence_count / draws_total,
+        "treedepth_saturation_count": int(np.sum(saturated)),
+        "treedepth_saturation_rate": float(np.mean(saturated)),
+        "hyper_rhat": hyper_rhat.tolist(),
+        "hyper_rhat_max": float(np.max(hyper_rhat)),
+        "group_rhat": group_rhat.tolist(),
+        "group_rhat_max": float(np.max(group_rhat)),
+        "hyper_ess_bulk": hyper_bulk.tolist(),
+        "hyper_ess_bulk_min": float(np.min(hyper_bulk)),
+        "group_ess_bulk": group_bulk.tolist(),
+        "group_ess_bulk_fraction_ge_400": float(np.mean(group_bulk >= 400.0)),
+        "hyper_ess_tail": hyper_tail.tolist(),
+        "hyper_ess_tail_min": float(np.min(hyper_tail)),
+        "group_ess_tail": group_tail.tolist(),
+        "group_ess_tail_fraction_ge_400": float(np.mean(group_tail >= 400.0)),
+        "bfmi_by_chain": bfmi_values.tolist(),
+        "bfmi_min": float(np.min(bfmi_values)),
+        "hyper_mcse_over_sd": mcse_over_sd.tolist(),
+        "hyper_mcse_over_sd_max": float(np.max(mcse_over_sd)),
+        "mean_step_size_by_chain": optional_stat("step_size"),
+        "final_step_size_by_chain": [float(value) for value in step_size[:, -1]],
+        "step_size_final_min": float(np.min(step_size[:, -1])),
+        "step_size_final_max": float(np.max(step_size[:, -1])),
+        "leapfrog_step_count": float(np.sum(n_steps)),
+        "mean_acceptance_rate_by_chain": optional_stat("acceptance_rate"),
+        "mean_n_steps_by_chain": optional_stat("n_steps"),
+        "mean_energy_by_chain": optional_stat("energy"),
+    }
+    numeric_values = [
+        float(item)
+        for value in result.values()
+        if value is not None
+        for item in (value if isinstance(value, list) else [value])
+        if not isinstance(item, bool)
+    ]
+    if not all(math.isfinite(value) for value in numeric_values):
+        raise ScientificCellFailure(
+            "summarize", "at least one sampler diagnostic is non-finite"
+        )
+    return result
+
+
+def _model_arguments(model: pm.Model, vector: np.ndarray) -> list[np.ndarray]:
+    """Split a canonical vector into arguments ordered like ``model.value_vars``."""
+    point = _point_from_vector(model, vector)
+    return [point[variable.name] for variable in model.value_vars]
+
+
+def _make_graph_evaluator(
+    model: pm.Model, backend_id: str
+) -> Callable[[np.ndarray], tuple[float, np.ndarray, np.ndarray]]:
+    """Compile the exact scalar value/gradient/Hessian path used by a backend."""
+    model_logp = model.logp(jacobian=True)
+    if backend_id == "pymc":
+        outputs: list[Any] = [
+            model_logp,
+            model.dlogp(jacobian=True),
+            model.d2logp(jacobian=True, negate_output=False),
+        ]
+        function = model.compile_fn(
+            outputs,
+            inputs=model.value_vars,
+            on_unused_input="ignore",
+            point_fn=False,
+        )
+
+        def evaluate_pymc(
+            vector: np.ndarray,
+        ) -> tuple[float, np.ndarray, np.ndarray]:
+            value, gradient, hessian = function(*_model_arguments(model, vector))
+            return (
+                float(value),
+                np.asarray(gradient, dtype=np.float64),
+                np.asarray(hessian, dtype=np.float64),
+            )
+
+        return evaluate_pymc
+    if backend_id != "numpyro":
+        raise CausalRunnerError(f"unknown backend {backend_id!r}")
+    jaxified = get_jaxified_graph(
+        inputs=model.value_vars, outputs=cast("Any", [model_logp])
+    )
+    initial = model.initial_point()
+    layouts: list[tuple[int, int, tuple[int, ...]]] = []
+    cursor = 0
+    for variable in model.value_vars:
+        shape = np.asarray(initial[variable.name]).shape
+        size = int(np.prod(shape, dtype=int)) if shape else 1
+        layouts.append((cursor, cursor + size, shape))
+        cursor += size
+
+    def scalar(vector: Any) -> Any:
+        arguments = [
+            vector[start:stop].reshape(shape) for start, stop, shape in layouts
+        ]
+        return jaxified(*arguments)[0]
+
+    value_and_gradient = jax.jit(jax.value_and_grad(scalar))
+    hessian_function = jax.jit(jax.hessian(scalar))
+
+    def evaluate_numpyro(
+        vector: np.ndarray,
+    ) -> tuple[float, np.ndarray, np.ndarray]:
+        point = jnp.asarray(vector)
+        value, gradient = value_and_gradient(point)
+        hessian = hessian_function(point)
+        return (
+            float(value),
+            np.asarray(gradient, dtype=np.float64),
+            np.asarray(hessian, dtype=np.float64),
+        )
+
+    return evaluate_numpyro
+
+
+def _scaled_error(
+    observed: np.ndarray | float,
+    expected: np.ndarray | float,
+    *,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+) -> dict[str, float]:
+    """Return raw and combined-tolerance errors for one diagnostic component."""
+    observed_array = np.asarray(observed, dtype=np.float64)
+    expected_array = np.asarray(expected, dtype=np.float64)
+    difference = np.abs(observed_array - expected_array)
+    scale = absolute_tolerance + relative_tolerance * np.maximum(
+        np.abs(observed_array), np.abs(expected_array)
+    )
+    return {
+        "absolute_max": float(np.max(difference)),
+        "scaled_max": float(np.max(difference / scale)),
+    }
+
+
+def _oracle_tolerances(
+    analysis_policy: Mapping[str, Any], floatx: str
+) -> Mapping[str, Mapping[str, float]]:
+    """Read the frozen component tolerances, rejecting an undefined gate."""
+    gate = analysis_policy["oracle_gate"]
+    tolerances = gate.get("component_tolerances")
+    if not isinstance(tolerances, dict) or floatx not in tolerances:
+        raise CausalRunnerError(
+            f"manifest lacks oracle component tolerances for {floatx}"
+        )
+    result = tolerances[floatx]
+    if set(result) != {"logp", "gradient", "hessian"}:
+        raise CausalRunnerError("oracle tolerances must cover logp/gradient/Hessian")
+    for component in result.values():
+        if set(component) != {"absolute_tolerance", "relative_tolerance"}:
+            raise CausalRunnerError("oracle component tolerance is malformed")
+    return result
+
+
+def _diagnostic_natural_points(
+    unit: UnitSpec,
+    prior: NativeTruncatedPrior,
+    data: SyntheticHierarchyData,
+    starts: Mapping[str, Any],
+    chains: xr.Dataset | None,
+    *,
+    include_static: bool,
+) -> list[dict[str, Any]]:
+    """Select fixed, every-start, and hash-selected trajectory points."""
+    points: list[dict[str, Any]] = []
+    if include_static and unit.replicate == 0:
+        points.append(
+            {
+                "point_id": "fixed-truth",
+                "kind": "fixed-grid",
+                "group_location": data.spec.group_location,
+                "group_scale": data.spec.group_scale,
+                "group_effect": [float(value) for value in data.group_effect],
+            }
+        )
+    if include_static:
+        for chain in starts["chains"]:
+            points.append(
+                {
+                    "point_id": f"start-chain-{int(chain['chain']):02d}",
+                    "kind": "shared-natural-start",
+                    "group_location": chain["group_location"],
+                    "group_scale": chain["group_scale"],
+                    "group_effect": chain["group_effect"],
+                }
+            )
+    if chains is not None:
+        for chain in range(unit.chains):
+            ranked = sorted(
+                range(unit.draws),
+                key=lambda draw: hashlib.sha256(
+                    f"{unit.cell_id}:trajectory:{chain}:{draw}".encode()
+                ).digest(),
+            )
+            for selection, draw in enumerate(ranked[:TRAJECTORY_POINTS_PER_CHAIN]):
+                point_id = f"trajectory-chain-{chain:02d}-selection-{selection:02d}"
+                points.append(
+                    {
+                        "point_id": point_id,
+                        "kind": "hash-selected-posterior-trajectory",
+                        "chain": chain,
+                        "draw": draw,
+                        "selection_sha256": hashlib.sha256(
+                            f"{unit.cell_id}:trajectory:{chain}:{draw}".encode()
+                        ).hexdigest(),
+                        "group_location": float(chains["group_location"][chain, draw]),
+                        "group_scale": float(chains["group_scale"][chain, draw]),
+                        "group_effect": np.asarray(
+                            chains["group_effect"][chain, draw], dtype=np.float64
+                        ).tolist(),
+                    }
+                )
+    parameterization = REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+    nc_indices: list[int] = []
+    if include_static and parameterization in {
+        "location_icdf_noncentered",
+        "full_icdf_noncentered",
+    }:
+        nc_indices.append(0)
+    if include_static and parameterization in {
+        "group_icdf_noncentered",
+        "full_icdf_noncentered",
+    }:
+        nc_indices.append(2)
+    if nc_indices:
+        spec = _oracle_spec(unit, prior, data)
+        base, _ = natural_to_coordinate(
+            starts["chains"][0],
+            prior=prior,
+            oracle_spec=spec,
+            representation_id=unit.representation_id,
+        )
+        branch_epsilon = 8.0 * math.sqrt(np.finfo(unit.floatx).eps)
+        for coordinate_index in nc_indices:
+            for label, value in (
+                ("branch-left", -branch_epsilon),
+                ("branch-zero", 0.0),
+                ("branch-right", branch_epsilon),
+                ("tail-low", -6.0),
+                ("tail-high", 6.0),
+            ):
+                coordinate = base.copy()
+                coordinate[coordinate_index] = value
+                natural = hierarchical_natural_values(
+                    coordinate, spec, parameterization
+                )
+                points.append(
+                    {
+                        "point_id": f"icdf-{coordinate_index}-{label}",
+                        "kind": f"icdf-{label}",
+                        "group_location": natural.location.value,
+                        "group_scale": natural.scale.value,
+                        "group_effect": [item.value for item in natural.group_effect],
+                        "diagnostic_coordinate_vector": coordinate.tolist(),
+                        "branch_epsilon": branch_epsilon,
+                        "coordinate_index": coordinate_index,
+                    }
+                )
+    return points
+
+
+def _oracle_diagnostics(
+    unit: UnitSpec,
+    model: pm.Model,
+    prior: NativeTruncatedPrior,
+    data: SyntheticHierarchyData,
+    starts: Mapping[str, Any],
+    chains: xr.Dataset | None,
+    analysis_policy: Mapping[str, Any],
+    *,
+    evaluator: Callable[[np.ndarray], tuple[float, np.ndarray, np.ndarray]]
+    | None = None,
+    prior_records: Sequence[Mapping[str, Any]] = (),
+    include_static: bool = True,
+) -> dict[str, Any]:
+    """Evaluate backend graphs against the independent oracle through order two."""
+    parameterization = REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+    spec = _oracle_spec(unit, prior, data)
+    tolerances = _oracle_tolerances(analysis_policy, unit.floatx)
+    graph_evaluator = (
+        _make_graph_evaluator(model, unit.backend_id)
+        if evaluator is None
+        else evaluator
+    )
+    allowed_scaled_error = float(analysis_policy["oracle_gate"]["scaled_error_max"])
+    roundtrip_limit = float(
+        analysis_policy["oracle_gate"]["roundtrip_absolute_error_max"][unit.floatx]
+    )
+    failed_scaled_error = {
+        "absolute_max": float(np.finfo(np.float64).max),
+        "scaled_max": allowed_scaled_error + 1.0,
+    }
+    records = [dict(record) for record in prior_records]
+    for point in _diagnostic_natural_points(
+        unit, prior, data, starts, chains, include_static=include_static
+    ):
+        if "diagnostic_coordinate_vector" in point:
+            candidate_vector = np.asarray(
+                point["diagnostic_coordinate_vector"], dtype=np.float64
+            )
+        else:
+            candidate_vector, _ = natural_to_coordinate(
+                point,
+                prior=prior,
+                oracle_spec=spec,
+                representation_id=unit.representation_id,
+            )
+        graph_point = _point_from_vector(model, candidate_vector)
+        vector = _pack_model_point(model, graph_point)
+        roundtrip = _natural_coordinate_roundtrip(
+            point,
+            vector,
+            oracle_spec=spec,
+            parameterization=parameterization,
+        )
+        observed_value, observed_gradient, observed_hessian = graph_evaluator(vector)
+        expected = hierarchical_posterior_components(
+            vector, spec, parameterization
+        ).total
+        expected_finite = bool(
+            math.isfinite(expected.value)
+            and np.all(np.isfinite(expected.gradient))
+            and np.all(np.isfinite(expected.hessian))
+        )
+        if not expected_finite:
+            raise CausalRunnerError("independent oracle is non-finite at a valid point")
+        component_finite = {
+            "value": math.isfinite(observed_value),
+            "gradient": bool(np.all(np.isfinite(observed_gradient))),
+            "hessian": bool(np.all(np.isfinite(observed_hessian))),
+        }
+        finite = all(component_finite.values())
+        errors = {
+            "value": (
+                _scaled_error(
+                    observed_value,
+                    expected.value,
+                    absolute_tolerance=float(tolerances["logp"]["absolute_tolerance"]),
+                    relative_tolerance=float(tolerances["logp"]["relative_tolerance"]),
+                )
+                if component_finite["value"]
+                else dict(failed_scaled_error)
+            ),
+            "gradient": (
+                _scaled_error(
+                    observed_gradient,
+                    expected.gradient,
+                    absolute_tolerance=float(
+                        tolerances["gradient"]["absolute_tolerance"]
+                    ),
+                    relative_tolerance=float(
+                        tolerances["gradient"]["relative_tolerance"]
+                    ),
+                )
+                if component_finite["gradient"]
+                else dict(failed_scaled_error)
+            ),
+            "hessian": (
+                _scaled_error(
+                    observed_hessian,
+                    expected.hessian,
+                    absolute_tolerance=float(
+                        tolerances["hessian"]["absolute_tolerance"]
+                    ),
+                    relative_tolerance=float(
+                        tolerances["hessian"]["relative_tolerance"]
+                    ),
+                )
+                if component_finite["hessian"]
+                else dict(failed_scaled_error)
+            ),
+        }
+        passed = bool(
+            finite
+            and roundtrip["absolute_error_max"] <= roundtrip_limit
+            and all(
+                component["scaled_max"] <= allowed_scaled_error
+                for component in errors.values()
+            )
+        )
+        records.append(
+            {
+                **{
+                    name: value
+                    for name, value in point.items()
+                    if name
+                    in {
+                        "point_id",
+                        "kind",
+                        "chain",
+                        "draw",
+                        "selection_sha256",
+                        "branch_epsilon",
+                        "coordinate_index",
+                        "group_location",
+                        "group_scale",
+                        "group_effect",
+                    }
+                },
+                "coordinate_vector": vector.tolist(),
+                "roundtrip": roundtrip,
+                "observed": {
+                    "value": observed_value if component_finite["value"] else None,
+                    "gradient": (
+                        observed_gradient.tolist()
+                        if component_finite["gradient"]
+                        else None
+                    ),
+                    "hessian": (
+                        observed_hessian.tolist()
+                        if component_finite["hessian"]
+                        else None
+                    ),
+                },
+                "oracle": {
+                    "value": expected.value,
+                    "gradient": expected.gradient.tolist(),
+                    "hessian": expected.hessian.tolist(),
+                },
+                "errors": errors,
+                "component_finite": component_finite,
+                "finite": finite,
+                "passed": passed,
+            }
+        )
+    tail_records = [
+        record for record in records if record["kind"].startswith("icdf-tail")
+    ]
+    branch_checks: list[dict[str, Any]] = []
+    coordinate_indices = sorted(
+        {
+            int(record["coordinate_index"])
+            for record in records
+            if record["kind"].startswith("icdf-branch")
+        }
+    )
+    for coordinate_index in coordinate_indices:
+        by_kind = {
+            record["kind"]: record
+            for record in records
+            if record.get("coordinate_index") == coordinate_index
+            and record["kind"].startswith("icdf-branch")
+        }
+        required_kinds = {
+            "icdf-branch-left",
+            "icdf-branch-zero",
+            "icdf-branch-right",
+        }
+        if set(by_kind) != required_kinds:
+            raise CausalRunnerError("ICDF branch diagnostic triplet is incomplete")
+        left = by_kind["icdf-branch-left"]
+        zero = by_kind["icdf-branch-zero"]
+        right = by_kind["icdf-branch-right"]
+        branch_finite = bool(left["finite"] and zero["finite"] and right["finite"])
+        oracle_value_jump = right["oracle"]["value"] - left["oracle"]["value"]
+        oracle_gradient_jump = np.asarray(
+            right["oracle"]["gradient"], dtype=np.float64
+        ) - np.asarray(left["oracle"]["gradient"], dtype=np.float64)
+        if branch_finite:
+            observed_value_jump = right["observed"]["value"] - left["observed"]["value"]
+            observed_gradient_jump = np.asarray(
+                right["observed"]["gradient"], dtype=np.float64
+            ) - np.asarray(left["observed"]["gradient"], dtype=np.float64)
+            value_jump_error = _scaled_error(
+                observed_value_jump,
+                oracle_value_jump,
+                absolute_tolerance=float(tolerances["logp"]["absolute_tolerance"]),
+                relative_tolerance=float(tolerances["logp"]["relative_tolerance"]),
+            )
+            gradient_jump_error = _scaled_error(
+                observed_gradient_jump,
+                oracle_gradient_jump,
+                absolute_tolerance=float(tolerances["gradient"]["absolute_tolerance"]),
+                relative_tolerance=float(tolerances["gradient"]["relative_tolerance"]),
+            )
+        else:
+            observed_value_jump = None
+            observed_gradient_jump = None
+            value_jump_error = dict(failed_scaled_error)
+            gradient_jump_error = dict(failed_scaled_error)
+        branch_checks.append(
+            {
+                "coordinate_index": coordinate_index,
+                "epsilon": left["branch_epsilon"],
+                "left_point_id": left["point_id"],
+                "zero_point_id": zero["point_id"],
+                "right_point_id": right["point_id"],
+                "observed_value_jump": observed_value_jump,
+                "oracle_value_jump": oracle_value_jump,
+                "observed_gradient_jump": (
+                    None
+                    if observed_gradient_jump is None
+                    else observed_gradient_jump.tolist()
+                ),
+                "oracle_gradient_jump": oracle_gradient_jump.tolist(),
+                "value_jump_error": value_jump_error,
+                "gradient_jump_error": gradient_jump_error,
+                "passed": bool(
+                    left["passed"]
+                    and zero["passed"]
+                    and right["passed"]
+                    and value_jump_error["scaled_max"] <= allowed_scaled_error
+                    and gradient_jump_error["scaled_max"] <= allowed_scaled_error
+                ),
+            }
+        )
+    return {
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "parameterization": parameterization,
+        "point_selection": {
+            "fixed_grid": "replicate-zero-truth",
+            "starts": "every-shared-natural-chain-start",
+            "trajectory": "lowest-sha256-per-chain",
+            "trajectory_points_per_chain": TRAJECTORY_POINTS_PER_CHAIN,
+        },
+        "posterior_trajectory_evaluated": chains is not None,
+        "records": records,
+        "icdf_tail_finite": all(record["finite"] for record in tail_records),
+        "icdf_branch_checks": branch_checks,
+        "icdf_branch_continuous": all(record["passed"] for record in branch_checks),
+        "passed": all(record["passed"] for record in records)
+        and all(record["passed"] for record in branch_checks),
+    }
+
+
+def _parameter_summaries(chains: xr.Dataset) -> list[dict[str, Any]]:
+    """Summarize every natural parameter used for cross-form agreement."""
+    summaries: list[dict[str, Any]] = []
+
+    def append(parameter_id: str, values: xr.DataArray, index: int | None) -> None:
+        flattened = np.asarray(values, dtype=np.float64).reshape(-1)
+        mcse = az.mcse(values, method="mean")
+        mcse_value = float(np.asarray(mcse).reshape(-1)[0])
+        summaries.append(
+            {
+                "parameter_id": parameter_id,
+                "index": index,
+                "mean": float(np.mean(flattened)),
+                "sd": float(np.std(flattened, ddof=1)),
+                "mcse_mean": mcse_value,
+            }
+        )
+
+    append("group_location", chains["group_location"], None)
+    append("group_scale", chains["group_scale"], None)
+    for index in range(chains.sizes["group"]):
+        append("group_effect", chains["group_effect"].isel(group=index), index)
+    if any(
+        not math.isfinite(float(summary[field]))
+        for summary in summaries
+        for field in ("mean", "sd", "mcse_mean")
+    ):
+        raise ScientificCellFailure("summarize", "parameter summary is non-finite")
+    return summaries
+
+
+def _registered_metrics(
+    unit: UnitSpec,
+    raw: Mapping[str, Any],
+    oracle: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Project detailed evidence onto the contract's flat registered metrics."""
+    result: dict[str, Any] = {
+        "compile_success": True,
+        "initialization_success": True,
+        "logp_finite": True,
+        "gradient_finite": True,
+        "sampling_success": True,
+        "divergence_count": raw["divergence_count"],
+        "posterior_draw_count": raw["draws_total"],
+        "divergence_rate": raw["divergence_rate"],
+        "sampling_elapsed_seconds": raw["wall_seconds"],
+        "step_size_final_min": raw["step_size_final_min"],
+        "step_size_final_max": raw["step_size_final_max"],
+        "leapfrog_step_count": raw["leapfrog_step_count"],
+        **_registered_oracle_metrics(oracle),
+    }
+    if unit.tier == "confirmation":
+        result.update(
+            {
+                "hyper_rhat_max": raw["hyper_rhat_max"],
+                "hyper_ess_bulk_min": raw["hyper_ess_bulk_min"],
+                "hyper_ess_tail_min": raw["hyper_ess_tail_min"],
+                "bfmi_min": raw["bfmi_min"],
+                "treedepth_saturation_rate": raw["treedepth_saturation_rate"],
+                "hyper_mcse_over_sd_max": raw["hyper_mcse_over_sd_max"],
+                "group_rhat_max": raw["group_rhat_max"],
+                "group_ess_bulk_fraction_ge_400": raw["group_ess_bulk_fraction_ge_400"],
+                "group_ess_tail_fraction_ge_400": raw["group_ess_tail_fraction_ge_400"],
+            }
+        )
+    return result
+
+
+def _registered_oracle_metrics(oracle: Mapping[str, Any]) -> dict[str, Any]:
+    """Project deterministic oracle evidence without requiring sampler output."""
+    records = oracle["records"]
+    if not records:
+        raise CausalRunnerError("oracle diagnostics contain no evaluation records")
+    return {
+        "oracle_evaluation_count": len(records),
+        "oracle_logp_scaled_error_max": max(
+            record["errors"]["value"]["scaled_max"] for record in records
+        ),
+        "oracle_gradient_scaled_error_max": max(
+            record["errors"]["gradient"]["scaled_max"] for record in records
+        ),
+        "oracle_hessian_scaled_error_max": max(
+            record["errors"]["hessian"]["scaled_max"] for record in records
+        ),
+        "roundtrip_absolute_error_max": max(
+            record["roundtrip"]["absolute_error_max"] for record in records
+        ),
+        "icdf_tail_finite": oracle["icdf_tail_finite"],
+        "icdf_branch_continuous": oracle["icdf_branch_continuous"],
+    }
+
+
+def _runtime_evidence() -> dict[str, Any]:
+    """Capture observed child runtime state for every completed or failed cell."""
+    return {
+        "process_id": os.getpid(),
+        "cache_identity_sha256": os.environ.get("HSSM_CAUSAL_CACHE_ID"),
+        "pytensor_floatx": pytensor.config.floatX,
+        "jax_enable_x64": bool(jax.config.jax_enable_x64),
+        "jax_platform": jax.default_backend(),
+    }
+
+
+def _diagnostics_payload(
+    unit: UnitSpec,
+    *,
+    initial_points: Mapping[str, Any] | None = None,
+    oracle: Mapping[str, Any] | None = None,
+    sampler: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one identity-bound diagnostics payload with observed runtime state."""
+    result: dict[str, Any] = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+        "runtime": _runtime_evidence(),
+    }
+    if initial_points is not None:
+        result["initial_points"] = dict(initial_points)
+    if oracle is not None:
+        result["oracle"] = dict(oracle)
+    if sampler is not None:
+        result["sampler"] = dict(sampler)
+    return result
+
+
+def _validate_execution_oracle_coherence(
+    unit: UnitSpec, execution: CellExecution
+) -> None:
+    """Bind every registered oracle claim to the retained diagnostic phase."""
+    metric_names = set(execution.metrics or {})
+    observed_metric_names = metric_names.intersection(ORACLE_METRICS)
+    if observed_metric_names and observed_metric_names != ORACLE_METRICS:
+        raise CausalRunnerError("cell contains a partial registered oracle metric set")
+    oracle = (
+        execution.diagnostics.get("oracle")
+        if isinstance(execution.diagnostics, Mapping)
+        else None
+    )
+    has_metrics = observed_metric_names == ORACLE_METRICS
+    if (oracle is not None) != has_metrics:
+        raise CausalRunnerError(
+            "retained raw oracle diagnostics and registered metrics disagree"
+        )
+    if oracle is None:
+        return
+    if not isinstance(oracle, Mapping) or not isinstance(oracle.get("records"), list):
+        raise CausalRunnerError("retained oracle diagnostics are malformed")
+    trajectory = oracle.get("posterior_trajectory_evaluated")
+    if not isinstance(trajectory, bool):
+        raise CausalRunnerError("retained oracle phase is malformed")
+    layers = {
+        "native-centered": 0,
+        "manual-centered": 0,
+        "group-icdf-noncentered": 1,
+        "location-icdf-noncentered": 1,
+        "full-icdf-noncentered": 2,
+    }[unit.representation_id]
+    expected_count = (
+        unit.chains
+        + int(unit.replicate == 0)
+        + 5 * layers
+        + (TRAJECTORY_POINTS_PER_CHAIN * unit.chains if trajectory else 0)
+    )
+    if (
+        len(oracle["records"]) != expected_count
+        or (execution.metrics or {}).get("oracle_evaluation_count") != expected_count
+    ):
+        raise CausalRunnerError("retained oracle phase has the wrong evaluation count")
+    if execution.status == "completed":
+        if not trajectory:
+            raise CausalRunnerError("completed cell lacks trajectory oracle evidence")
+        return
+    stage = (execution.failure or {}).get("stage")
+    if not isinstance(stage, str):
+        raise CausalRunnerError("failed cell lacks a classified oracle stage")
+    expected_trajectory = {
+        "compile": False,
+        "sample": False,
+        "diagnose": False,
+        "summarize": True,
+    }.get(stage)
+    if expected_trajectory is None or trajectory is not expected_trajectory:
+        raise CausalRunnerError(
+            "failed cell retains an oracle phase inconsistent with its stage"
+        )
+
+
+def execute_cell(
+    unit: UnitSpec,
+    data_payload: Mapping[str, Any],
+    start_payload: Mapping[str, Any],
+    analysis_policy: Mapping[str, Any],
+) -> CellExecution:
+    """Build, initialize, sample, summarize, and diagnose one planned cell."""
+    try:
+        data = _data_from_payload(data_payload, unit)
+    except (FloatingPointError, np.linalg.LinAlgError) as error:
+        raise ScientificCellFailure(
+            "data", str(error), error_type=type(error).__name__
+        ) from error
+    prior = _prior(unit)
+    _validate_natural_start_payload(start_payload, unit, prior, data)
+    try:
+        builder = BUILDER_TO_PARAMETERIZATION[unit.builder]
+    except KeyError as error:
+        raise CausalRunnerError(f"unsupported builder {unit.builder!r}") from error
+    try:
+        model = build_causal_model(builder, prior, data)
+    except (
+        FloatingPointError,
+        np.linalg.LinAlgError,
+        NotImplementedError,
+        pm.exceptions.DtypeError,
+        pm.exceptions.ShapeError,
+        pm.exceptions.TruncationError,
+    ) as error:
+        raise ScientificCellFailure(
+            "build", str(error), error_type=type(error).__name__
+        ) from error
+    oracle_spec = _oracle_spec(unit, prior, data)
+    coordinate_payload, initvals = _coordinate_start_payload(
+        unit, model, start_payload, prior, oracle_spec
+    )
+    roundtrip_limit = float(
+        analysis_policy["oracle_gate"]["roundtrip_absolute_error_max"][unit.floatx]
+    )
+    if any(
+        chain["roundtrip"]["absolute_error_max"] > roundtrip_limit
+        for chain in coordinate_payload["chains"]
+    ):
+        failure = ScientificCellFailure(
+            "initialize", "natural-coordinate-natural round-trip exceeded tolerance"
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=_diagnostics_payload(unit),
+            metrics={"initialization_success": False},
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    try:
+        initial_evidence = _finite_initial_evidence(model, initvals)
+    except ScientificCellFailure as failure:
+        metrics = (
+            {"compile_success": False}
+            if failure.stage == "compile"
+            else {"compile_success": True, "initialization_success": False}
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=_diagnostics_payload(unit),
+            metrics=metrics,
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    try:
+        evaluator = _make_graph_evaluator(model, unit.backend_id)
+        pre_oracle = _oracle_diagnostics(
+            unit,
+            model,
+            prior,
+            data,
+            start_payload,
+            None,
+            analysis_policy,
+            evaluator=evaluator,
+        )
+    except (CompileError, NotImplementedError) as error:
+        classified_failure = ScientificCellFailure(
+            "compile", str(error), error_type=type(error).__name__
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=_diagnostics_payload(unit, initial_points=initial_evidence),
+            metrics={
+                "compile_success": False,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+            },
+            parameter_summaries=[],
+            failure=classified_failure.as_dict(),
+        )
+    except ScientificCellFailure as error:
+        classified_failure = ScientificCellFailure(
+            "initialize", str(error), error_type=error.error_type
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=_diagnostics_payload(unit, initial_points=initial_evidence),
+            metrics={
+                "compile_success": True,
+                "initialization_success": False,
+                "logp_finite": True,
+                "gradient_finite": True,
+            },
+            parameter_summaries=[],
+            failure=classified_failure.as_dict(),
+        )
+    pre_oracle_metrics = _registered_oracle_metrics(pre_oracle)
+    pre_diagnostics = _diagnostics_payload(
+        unit,
+        initial_points=initial_evidence,
+        oracle=pre_oracle,
+    )
+    try:
+        inference, elapsed = _sample_model(unit, model, initvals)
+    except ScientificCellFailure as failure:
+        metrics = (
+            {
+                "compile_success": False,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                **pre_oracle_metrics,
+            }
+            if failure.stage == "compile"
+            else {
+                "compile_success": True,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                "sampling_success": False,
+                **pre_oracle_metrics,
+            }
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=pre_diagnostics,
+            metrics=metrics,
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    try:
+        natural_chains = _standardize_natural_chains(unit, inference)
+    except ScientificCellFailure as error:
+        # The sampler has not produced the experiment's canonical chain artifact
+        # until this projection succeeds.  A malformed or non-finite posterior is
+        # therefore a sample-stage failure, not a summarize-stage failure with a
+        # missing chain.
+        classified_failure = ScientificCellFailure(
+            "sample", str(error), error_type=error.error_type
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            diagnostics=pre_diagnostics,
+            metrics={
+                "compile_success": True,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                "sampling_success": False,
+                "sampling_elapsed_seconds": elapsed,
+                **pre_oracle_metrics,
+            },
+            parameter_summaries=[],
+            failure=classified_failure.as_dict(),
+        )
+    try:
+        oracle = _oracle_diagnostics(
+            unit,
+            model,
+            prior,
+            data,
+            start_payload,
+            natural_chains,
+            analysis_policy,
+            evaluator=evaluator,
+            prior_records=pre_oracle["records"],
+            include_static=False,
+        )
+    except (CompileError, NotImplementedError, ScientificCellFailure) as error:
+        error_type = (
+            error.error_type
+            if isinstance(error, ScientificCellFailure)
+            else type(error).__name__
+        )
+        classified_failure = ScientificCellFailure(
+            "diagnose", str(error), error_type=error_type
+        )
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            chain_dataset=natural_chains,
+            diagnostics=pre_diagnostics,
+            metrics={
+                "compile_success": True,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                "sampling_success": True,
+                "sampling_elapsed_seconds": elapsed,
+                **pre_oracle_metrics,
+            },
+            parameter_summaries=[],
+            failure=classified_failure.as_dict(),
+        )
+    try:
+        raw_metrics = _sampler_metrics(unit, natural_chains, elapsed)
+    except ScientificCellFailure as failure:
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            chain_dataset=natural_chains,
+            diagnostics=_diagnostics_payload(
+                unit, initial_points=initial_evidence, oracle=oracle
+            ),
+            metrics={
+                "compile_success": True,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                "sampling_success": True,
+                "sampling_elapsed_seconds": elapsed,
+                **_registered_oracle_metrics(oracle),
+            },
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    diagnostics = _diagnostics_payload(
+        unit,
+        initial_points=initial_evidence,
+        oracle=oracle,
+        sampler=raw_metrics,
+    )
+    try:
+        summaries = _parameter_summaries(natural_chains)
+    except ScientificCellFailure as failure:
+        return CellExecution(
+            status="failed",
+            coordinate_starts=coordinate_payload,
+            chain_dataset=natural_chains,
+            diagnostics=diagnostics,
+            metrics=_registered_metrics(unit, raw_metrics, oracle),
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    metrics = _registered_metrics(unit, raw_metrics, oracle)
+    return CellExecution(
+        status="completed",
+        coordinate_starts=coordinate_payload,
+        chain_dataset=natural_chains,
+        diagnostics=diagnostics,
+        metrics=metrics,
+        parameter_summaries=summaries,
+    )
+
+
+def mint_run_context(
+    manifest: Mapping[str, Any],
+    units: Sequence[UnitSpec],
+    *,
+    worker_identity: str,
+    environment: Mapping[str, Any] | None = None,
+    expected_git_commit: str | None = None,
+) -> tuple[RunContext, Mapping[str, Any]]:
+    """Validate the runtime and mint one parent identity for ten child attempts."""
+    if len(units) != 10 or len({unit.pair_id for unit in units}) != 1:
+        raise CausalRunnerError(
+            "a run context requires exactly one ten-cell backend pair"
+        )
+    if not isinstance(worker_identity, str) or not worker_identity.strip():
+        raise CausalRunnerError("worker identity must be a non-empty opaque string")
+    record = collect_environment(manifest) if environment is None else environment
+    validate_environment(record, manifest)
+    git_commit = str(record["git"]["commit"])
+    if expected_git_commit is not None and git_commit != expected_git_commit:
+        raise CausalRunnerError("runtime git commit differs from the expected commit")
+    worker_digest = sha256_bytes(worker_identity.encode("utf-8"))
+    pair_execution_id = sha256_bytes(
+        canonical_json_bytes(
+            {
+                "domain": "hssm-causal-pair-execution-v3",
+                "pair_id": units[0].pair_id,
+                "manifest_sha256": manifest_digest(manifest),
+                "environment_sha256": environment_digest(record),
+                "git_commit": git_commit,
+                "worker_identity_sha256": worker_digest,
+            }
+        )
+    )
+    attempt_ids = tuple(
+        sha256_bytes(
+            canonical_json_bytes(
+                {
+                    "domain": "hssm-causal-cell-attempt-v3",
+                    "pair_execution_id": pair_execution_id,
+                    "cell_id": unit.cell_id,
+                    "position": unit.pair_position,
+                }
+            )
+        )
+        for unit in units
+    )
+    context = RunContext(
+        schema_version=units[0].schema_version,
+        study_id=units[0].study_id,
+        manifest_sha256=units[0].manifest_sha256,
+        pair_id=units[0].pair_id,
+        block_ids=tuple(dict.fromkeys(unit.block_id for unit in units)),
+        cell_ids=tuple(unit.cell_id for unit in units),
+        execution_order=tuple(unit.cell_id for unit in units),
+        environment=dict(record),
+        environment_sha256=environment_digest(record),
+        git_commit=git_commit,
+        worker_identity_sha256=worker_digest,
+        pair_execution_id=pair_execution_id,
+        execution_attempt_ids=attempt_ids,
+    )
+    validate_run_context(context, units, manifest)
+    return context, record
+
+
+def _netcdf_bytes(dataset: xr.Dataset) -> bytes:
+    """Serialize a standardized natural chain to portable NetCDF3 bytes."""
+    payload = dataset.to_netcdf(path=None, engine="scipy", format="NETCDF3_64BIT")
+    return bytes(payload)
+
+
+def _backend_metadata(
+    manifest: Mapping[str, Any], backend_id: str
+) -> Mapping[str, Any]:
+    matches = [
+        item for item in manifest["backends"] if item["backend_id"] == backend_id
+    ]
+    if len(matches) != 1:
+        raise CausalRunnerError(f"manifest backend {backend_id!r} is not unique")
+    return matches[0]
+
+
+def _result_provenance(
+    unit: UnitSpec,
+    context: RunContext,
+    manifest: Mapping[str, Any],
+    execution: CellExecution,
+) -> dict[str, Any]:
+    backend = _backend_metadata(manifest, unit.backend_id)
+    sampler_seed_input, chain_rng_provenance = _sampler_rng_provenance(unit)
+    if execution.diagnostics is None:
+        raise CausalRunnerError("cell lacks observed runtime diagnostics")
+    runtime = execution.diagnostics.get("runtime")
+    if not isinstance(runtime, Mapping):
+        raise CausalRunnerError("cell runtime diagnostics are malformed")
+    required_runtime = {
+        "process_id",
+        "cache_identity_sha256",
+        "pytensor_floatx",
+        "jax_enable_x64",
+        "jax_platform",
+    }
+    if set(runtime) != required_runtime:
+        raise CausalRunnerError("cell runtime diagnostics have unexpected fields")
+    if runtime["pytensor_floatx"] != unit.floatx:
+        raise CausalRunnerError("cell runtime PyTensor precision differs from plan")
+    if runtime["jax_enable_x64"] is not (unit.floatx == "float64"):
+        raise CausalRunnerError("cell runtime JAX precision differs from plan")
+    if runtime["jax_platform"] != backend["device"]:
+        raise CausalRunnerError("cell runtime device differs from plan")
+    cache_identity = runtime["cache_identity_sha256"]
+    if (
+        not isinstance(cache_identity, str)
+        or len(cache_identity) != 64
+        or any(character not in "0123456789abcdef" for character in cache_identity)
+    ):
+        raise CausalRunnerError("cell runtime lacks a valid cache identity")
+    position = context.cell_ids.index(unit.cell_id)
+    return {
+        "environment_sha256": context.environment_sha256,
+        "git_commit": context.git_commit,
+        "worker_identity_sha256": context.worker_identity_sha256,
+        "pair_execution_id": context.pair_execution_id,
+        "execution_attempt_id": context.execution_attempt_ids[position],
+        "sampler": backend["sampler"],
+        "compiler_path": backend["compiler_path"],
+        "device": runtime["jax_platform"],
+        "floatx": unit.floatx,
+        "pytensor_floatx": runtime["pytensor_floatx"],
+        "jax_enable_x64": runtime["jax_enable_x64"],
+        "sampler_seed_input": sampler_seed_input,
+        "chain_rng_provenance": chain_rng_provenance,
+    }
+
+
+def publish_cell_execution(
+    unit: UnitSpec,
+    context: RunContext,
+    manifest: Mapping[str, Any],
+    store: ArtifactStore,
+    execution: CellExecution,
+    *,
+    context_reference: ArtifactRef,
+    data_reference: ArtifactRef,
+    natural_start_reference: ArtifactRef,
+) -> ArtifactRef:
+    """Publish all evidence first and the validated result JSON last."""
+    _validate_execution_oracle_coherence(unit, execution)
+    if execution.chain_dataset is not None:
+        _validate_standardized_natural_chains(unit, execution.chain_dataset)
+    coordinate_reference = (
+        store.write_json(
+            f"starts/coordinates/{unit.cell_id}.json", execution.coordinate_starts
+        )
+        if execution.coordinate_starts is not None
+        else None
+    )
+    chain_reference = (
+        store.write_bytes(
+            f"chains/{unit.cell_id}.nc", _netcdf_bytes(execution.chain_dataset)
+        )
+        if execution.chain_dataset is not None
+        else None
+    )
+    diagnostic_reference = (
+        store.write_json(f"diagnostics/{unit.cell_id}.json", execution.diagnostics)
+        if execution.diagnostics is not None
+        else None
+    )
+    artifacts = {
+        "context": context_reference.as_dict(),
+        "data": data_reference.as_dict(),
+        "natural_start": natural_start_reference.as_dict(),
+        "coordinate_start": (
+            None if coordinate_reference is None else coordinate_reference.as_dict()
+        ),
+        "chain": None if chain_reference is None else chain_reference.as_dict(),
+        "diagnostics": (
+            None if diagnostic_reference is None else diagnostic_reference.as_dict()
+        ),
+    }
+    record = {
+        "schema_version": unit.schema_version,
+        "runner_version": RUNNER_VERSION,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "replicate": unit.replicate,
+        "pair_id": unit.pair_id,
+        "pair_position": unit.pair_position,
+        "block_id": unit.block_id,
+        "block_position": unit.block_position,
+        "cell_id": unit.cell_id,
+        "execution_status": execution.status,
+        "metrics": dict(execution.metrics or {}),
+        "parameter_summaries": [
+            dict(summary) for summary in (execution.parameter_summaries or [])
+        ],
+        "artifacts": artifacts,
+        "failure": None if execution.failure is None else dict(execution.failure),
+        "provenance": _result_provenance(unit, context, manifest, execution),
+    }
+    validate_result_record(record, unit, context)
+    return store.write_json(f"cells/{unit.cell_id}.json", record)
+
+
+def _write_staged_execution(directory: Path, execution: CellExecution) -> None:
+    directory.mkdir(parents=True, exist_ok=False)
+    files: dict[str, str | None] = {
+        "coordinate_starts": None,
+        "chain": None,
+        "diagnostics": None,
+    }
+    if execution.coordinate_starts is not None:
+        (directory / "coordinate-start.json").write_bytes(
+            canonical_json_bytes(execution.coordinate_starts)
+        )
+        files["coordinate_starts"] = "coordinate-start.json"
+    if execution.chain_dataset is not None:
+        (directory / "chain.nc").write_bytes(_netcdf_bytes(execution.chain_dataset))
+        files["chain"] = "chain.nc"
+    if execution.diagnostics is not None:
+        (directory / "diagnostics.json").write_bytes(
+            canonical_json_bytes(execution.diagnostics)
+        )
+        files["diagnostics"] = "diagnostics.json"
+    outcome = {
+        "status": execution.status,
+        "metrics": dict(execution.metrics or {}),
+        "parameter_summaries": [
+            dict(summary) for summary in (execution.parameter_summaries or [])
+        ],
+        "failure": None if execution.failure is None else dict(execution.failure),
+        "files": files,
+    }
+    (directory / "outcome.json").write_bytes(canonical_json_bytes(outcome))
+
+
+def _load_staged_execution(directory: Path) -> CellExecution:
+    outcome = decode_canonical_json((directory / "outcome.json").read_bytes())
+    files = outcome["files"]
+
+    def json_file(name: str) -> Any | None:
+        relative = files[name]
+        return (
+            None
+            if relative is None
+            else decode_canonical_json((directory / relative).read_bytes())
+        )
+
+    chain = (
+        None
+        if files["chain"] is None
+        else xr.load_dataset(directory / files["chain"], engine="scipy")
+    )
+    return CellExecution(
+        status=outcome["status"],
+        coordinate_starts=json_file("coordinate_starts"),
+        chain_dataset=chain,
+        diagnostics=json_file("diagnostics"),
+        metrics=outcome["metrics"],
+        parameter_summaries=outcome["parameter_summaries"],
+        failure=outcome["failure"],
+    )
+
+
+def _load_context(
+    path: Path, units: Sequence[UnitSpec], manifest: Mapping[str, Any]
+) -> RunContext:
+    """Load a canonical context and bind it to the exact ten planned units."""
+    try:
+        payload = decode_canonical_json(path.read_bytes())
+    except OSError as error:
+        raise CausalRunnerError(f"cannot read parent context {path}") from error
+    if not isinstance(payload, Mapping):
+        raise CausalRunnerError("parent context must be a JSON object")
+    context = RunContext.from_dict(payload)
+    return validate_run_context(context, units, manifest)
+
+
+def _private_sample_cell(
+    manifest_path: Path,
+    tier: str,
+    cell_id: str,
+    run_dir: Path,
+    context_file: Path,
+    output_directory: Path,
+) -> int:
+    """Private fresh-process entry point; write staging, never final evidence."""
+    manifest = load_manifest(manifest_path)
+    unit = plan_unit_by_id(manifest, tier, cell_id)
+    units = pair_units(manifest, tier, unit.pair_id)
+    _load_context(context_file, units, manifest)
+    store = ArtifactStore(run_dir)
+    try:
+        data_reference, start_reference = materialize_inputs_for_unit(
+            unit, store, manifest_path=manifest_path
+        )
+        data_payload = store.read_json(data_reference)
+        start_payload = store.read_json(start_reference)
+        execution = execute_cell(
+            unit, data_payload, start_payload, manifest["analysis_policy"]
+        )
+    except ScientificCellFailure as failure:
+        execution = CellExecution(
+            status="failed",
+            diagnostics=_diagnostics_payload(unit),
+            metrics={},
+            parameter_summaries=[],
+            failure=failure.as_dict(),
+        )
+    _write_staged_execution(output_directory, execution)
+    return 0 if execution.status == "completed" else 10
+
+
+def _private_materialize_unit(
+    manifest_path: Path,
+    tier: str,
+    cell_id: str,
+    run_dir: Path,
+) -> int:
+    """Private precision-activated input materializer."""
+    manifest = load_manifest(manifest_path)
+    unit = plan_unit_by_id(manifest, tier, cell_id)
+    data_reference, start_reference = _materialize_inputs_for_unit_current_process(
+        unit, ArtifactStore(run_dir)
+    )
+    print(
+        canonical_json_bytes(
+            {
+                "data": data_reference.as_dict(),
+                "natural_start": start_reference.as_dict(),
+            }
+        ).decode(),
+        end="",
+    )
+    return 0
+
+
+def _subprocess_cell_executor(
+    unit: UnitSpec,
+    *,
+    manifest_path: Path,
+    run_dir: Path,
+    context_path: Path,
+    context: RunContext,
+) -> CellExecution:
+    """Run one cell in a fresh interpreter and uniquely scoped compiler caches."""
+    position = context.cell_ids.index(unit.cell_id)
+    cache_identity = sha256_bytes(
+        canonical_json_bytes(
+            {
+                "domain": "hssm-causal-fresh-cache-v3",
+                "attempt": context.execution_attempt_ids[position],
+            }
+        )
+    )
+    with tempfile.TemporaryDirectory(prefix="hssm-causal-cell-") as temporary_name:
+        temporary = Path(temporary_name)
+        output_directory = temporary / "result"
+        cache = temporary / "cache"
+        (cache / "pytensor").mkdir(parents=True)
+        (cache / "jax").mkdir(parents=True)
+        (cache / "matplotlib").mkdir(parents=True)
+        (cache / "xdg").mkdir(parents=True)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "HSSM_CAUSAL_CACHE_ID": cache_identity,
+                "PYTENSOR_FLAGS": (
+                    f"base_compiledir={cache / 'pytensor'},floatX={unit.floatx}"
+                ),
+                "JAX_COMPILATION_CACHE_DIR": str(cache / "jax"),
+                "JAX_ENABLE_X64": "true" if unit.floatx == "float64" else "false",
+                "JAX_PLATFORMS": "cpu",
+                "MPLCONFIGDIR": str(cache / "matplotlib"),
+                "XDG_CACHE_HOME": str(cache / "xdg"),
+                "OMP_NUM_THREADS": "1",
+                "OPENBLAS_NUM_THREADS": "1",
+                "MKL_NUM_THREADS": "1",
+                "NUMEXPR_NUM_THREADS": "1",
+            }
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "scripts.truncated_hierarchy_causal_runner",
+            "--manifest",
+            str(manifest_path),
+            "_sample-cell",
+            "--tier",
+            unit.tier,
+            "--cell-id",
+            unit.cell_id,
+            "--run-dir",
+            str(run_dir),
+            "--context",
+            str(context_path),
+            "--output-dir",
+            str(output_directory),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=Path(__file__).resolve().parents[1],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode not in {0, 10}:
+            stderr = completed.stderr[-4000:]
+            message = (
+                f"fresh child for {unit.cell_id} exited "
+                f"{completed.returncode}: {stderr}"
+            )
+            raise IncompleteBlockError(message)
+        execution = _load_staged_execution(output_directory)
+        expected_status = "completed" if completed.returncode == 0 else "failed"
+        if execution.status != expected_status:
+            raise IncompleteBlockError("child exit status contradicts staged outcome")
+        runtime = (
+            execution.diagnostics.get("runtime", {})
+            if execution.diagnostics is not None
+            else {}
+        )
+        if runtime.get("cache_identity_sha256") != cache_identity:
+            raise IncompleteBlockError("child did not attest its unique compiler cache")
+        if runtime.get("pytensor_floatx") != unit.floatx:
+            raise IncompleteBlockError("child attested the wrong PyTensor floatX")
+        if runtime.get("jax_enable_x64") is not (unit.floatx == "float64"):
+            raise IncompleteBlockError("child attested the wrong JAX precision")
+        if runtime.get("jax_platform") != "cpu":
+            raise IncompleteBlockError("child did not attest the required CPU backend")
+        return execution
+
+
+def run_pair(
+    manifest: Mapping[str, Any],
+    manifest_path: Path,
+    units: Sequence[UnitSpec],
+    store: ArtifactStore,
+    context: RunContext,
+    *,
+    context_reference: ArtifactRef,
+    executor: Callable[[UnitSpec], CellExecution] | None = None,
+) -> tuple[ArtifactRef, ...]:
+    """Attempt all ten paired members, then publish independent final markers."""
+    validate_run_context(context, units, manifest)
+    representative = units[0]
+    data_reference, start_reference = materialize_inputs_for_unit(
+        representative, store, manifest_path=manifest_path
+    )
+    executions: list[CellExecution] = []
+    for unit in units:
+        try:
+            execution = (
+                _subprocess_cell_executor(
+                    unit,
+                    manifest_path=manifest_path,
+                    run_dir=store.root,
+                    context_path=store.root / context_reference.path,
+                    context=context,
+                )
+                if executor is None
+                else executor(unit)
+            )
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as error:
+            raise IncompleteBlockError(
+                f"infrastructure aborted {unit.cell_id}; no cell markers published"
+            ) from error
+        executions.append(execution)
+    if len(executions) != 10:
+        raise IncompleteBlockError("pair did not attempt all ten planned cells")
+    return tuple(
+        publish_cell_execution(
+            unit,
+            context,
+            manifest,
+            store,
+            execution,
+            context_reference=context_reference,
+            data_reference=data_reference,
+            natural_start_reference=start_reference,
+        )
+        for unit, execution in zip(units, executions, strict=True)
+    )
+
+
+def run_unit_parent(
+    manifest: Mapping[str, Any],
+    manifest_path: Path,
+    *,
+    tier: str,
+    pair_id: str,
+    run_dir: Path,
+    worker_identity: str,
+    expected_git_commit: str | None = None,
+) -> tuple[tuple[ArtifactRef, ...], bool]:
+    """Mint context and execute the selected backend-paired unit."""
+    units = pair_units(manifest, tier, pair_id)
+    context, _environment = mint_run_context(
+        manifest,
+        units,
+        worker_identity=worker_identity,
+        expected_git_commit=expected_git_commit,
+    )
+    store = ArtifactStore(run_dir)
+    context_reference = store.write_json(f"contexts/{pair_id}.json", context.as_dict())
+    results = run_pair(
+        manifest,
+        manifest_path,
+        units,
+        store,
+        context,
+        context_reference=context_reference,
+    )
+    any_failed = any(
+        store.read_json(reference)["execution_status"] == "failed"
+        for reference in results
+    )
+    return results, any_failed
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    commands = parser.add_subparsers(dest="command", required=True)
+    materialize = commands.add_parser(
+        "materialize-inputs", help="publish deterministic shared data and starts"
+    )
+    materialize.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    materialize.add_argument("--run-dir", type=Path, required=True)
+    run = commands.add_parser(
+        "run-unit", help="run one indivisible ten-cell backend pair"
+    )
+    run.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    run.add_argument("--pair-id", required=True)
+    run.add_argument("--run-dir", type=Path, required=True)
+    run.add_argument("--worker-identity", required=True)
+    run.add_argument("--expected-git-commit")
+    merge = commands.add_parser(
+        "merge-runs", help="merge downloaded pair roots by exact bytes"
+    )
+    merge.add_argument("--source-dir", type=Path, required=True)
+    merge.add_argument("--run-dir", type=Path, required=True)
+    private = commands.add_parser("_sample-cell", help=argparse.SUPPRESS)
+    private.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    private.add_argument("--cell-id", required=True)
+    private.add_argument("--run-dir", type=Path, required=True)
+    private.add_argument("--context", type=Path, required=True)
+    private.add_argument("--output-dir", type=Path, required=True)
+    private_materialize = commands.add_parser(
+        "_materialize-unit", help=argparse.SUPPRESS
+    )
+    private_materialize.add_argument("--tier", choices=ALLOWED_TIERS, required=True)
+    private_materialize.add_argument("--cell-id", required=True)
+    private_materialize.add_argument("--run-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the causal execution CLI with fail-safe exit semantics."""
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "merge-runs":
+            summary = merge_run_directories(args.source_dir, args.run_dir)
+            print(canonical_json_bytes(summary).decode(), end="")
+            return 0
+        manifest = load_manifest(args.manifest)
+        validate_manifest(manifest, manifest_path=args.manifest)
+        if args.command == "materialize-inputs":
+            input_references = materialize_inputs(
+                manifest,
+                args.tier,
+                ArtifactStore(args.run_dir),
+                manifest_path=args.manifest,
+            )
+            print(
+                canonical_json_bytes(
+                    {"tier": args.tier, "input_pairs": len(input_references)}
+                ).decode(),
+                end="",
+            )
+            return 0
+        if args.command == "_materialize-unit":
+            return _private_materialize_unit(
+                args.manifest,
+                args.tier,
+                args.cell_id,
+                args.run_dir,
+            )
+        if args.command == "_sample-cell":
+            return _private_sample_cell(
+                args.manifest,
+                args.tier,
+                args.cell_id,
+                args.run_dir,
+                args.context,
+                args.output_dir,
+            )
+        result_references, any_failed = run_unit_parent(
+            manifest,
+            args.manifest,
+            tier=args.tier,
+            pair_id=args.pair_id,
+            run_dir=args.run_dir,
+            worker_identity=args.worker_identity,
+            expected_git_commit=args.expected_git_commit,
+        )
+        print(
+            canonical_json_bytes(
+                {
+                    "pair_id": args.pair_id,
+                    "cell_results": [
+                        reference.as_dict() for reference in result_references
+                    ],
+                    "scientific_failures": any_failed,
+                }
+            ).decode(),
+            end="",
+        )
+        return 1 if any_failed else 0
+    except (CausalArtifactError, CausalContractError, CausalRunnerError) as error:
+        parser.exit(2, f"causal runner error: {error}\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_truncated_hierarchy_causal_artifacts.py
+++ b/tests/test_truncated_hierarchy_causal_artifacts.py
@@ -1,0 +1,156 @@
+"""Tests for immutable causal-experiment artifact publication."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from scripts.truncated_hierarchy_causal_artifacts import (
+    ArtifactRef,
+    ArtifactStore,
+    CausalArtifactError,
+    canonical_json_bytes,
+    decode_canonical_json,
+    merge_run_directories,
+)
+
+
+def test_canonical_json_is_finite_sorted_and_round_trips() -> None:
+    """Canonical encoding fixes ordering, whitespace, Unicode, and newline."""
+    payload = {"z": [3, True, None], "a": {"unicode": "μ", "value": 1.25}}
+    encoded = canonical_json_bytes(payload)
+
+    assert encoded == (b'{"a":{"unicode":"\xce\xbc","value":1.25},"z":[3,true,null]}\n')
+    assert decode_canonical_json(encoded) == payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"x": float("nan")},
+        {"x": float("inf")},
+        {"x": Path("not-json")},
+        {1: "non-string-key"},
+    ],
+)
+def test_canonical_json_rejects_ambiguous_values(payload) -> None:
+    """Non-finite, non-string-keyed, and non-JSON values are invalid."""
+    with pytest.raises(CausalArtifactError):
+        canonical_json_bytes(payload)
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        b'{"x":NaN}\n',
+        b'{"x":1,"x":2}\n',
+        b'{ "x": 1 }\n',
+        b'{"x":1}',
+    ],
+)
+def test_decoder_rejects_noncanonical_or_nonstrict_json(encoded: bytes) -> None:
+    """Reading enforces the same strict byte representation as writing."""
+    with pytest.raises(CausalArtifactError):
+        decode_canonical_json(encoded)
+
+
+def test_store_publishes_without_overwrite_and_verifies_bytes(tmp_path: Path) -> None:
+    """An artifact path is an immutable commit rather than a mutable filename."""
+    store = ArtifactStore(tmp_path.resolve())
+    reference = store.write_json("data/example.json", {"seed": 1282})
+
+    assert reference == ArtifactRef(
+        path="data/example.json",
+        sha256=hashlib.sha256(b'{"seed":1282}\n').hexdigest(),
+        size_bytes=len(b'{"seed":1282}\n'),
+    )
+    assert store.read_json(reference) == {"seed": 1282}
+    with pytest.raises(CausalArtifactError, match="overwrite"):
+        store.write_json("data/example.json", {"seed": 1283})
+
+
+def test_store_detects_tampering_before_decode(tmp_path: Path) -> None:
+    """Verification rejects changed bytes before their payload is trusted."""
+    store = ArtifactStore(tmp_path.resolve())
+    reference = store.write_json("cells/cell.json", {"status": "completed"})
+    (tmp_path / reference.path).write_bytes(b'{"status":"failed"}\n')
+
+    with pytest.raises(CausalArtifactError, match="wrong"):
+        store.read_json(reference)
+
+
+def test_ensure_accepts_only_an_identical_concurrent_input(tmp_path: Path) -> None:
+    """Idempotent input materialization never silently reuses different bytes."""
+    store = ArtifactStore(tmp_path.resolve())
+    first = store.ensure_json("data/shared.json", {"seed": 1282})
+
+    assert store.ensure_json("data/shared.json", {"seed": 1282}) == first
+    with pytest.raises(CausalArtifactError, match="overwrite"):
+        store.ensure_json("data/shared.json", {"seed": 1283})
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["", "/absolute.json", "../escape.json", "a/../escape.json", "a\\b.json"],
+)
+def test_store_rejects_unsafe_paths(tmp_path: Path, path: str) -> None:
+    """Recorded paths cannot be absolute, traversing, or platform-dependent."""
+    store = ArtifactStore(tmp_path.resolve())
+    with pytest.raises(CausalArtifactError):
+        store.write_bytes(path, b"payload")
+
+
+def test_store_rejects_symlink_escape(tmp_path: Path) -> None:
+    """A symlinked parent cannot redirect an artifact outside the run root."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "linked").symlink_to(outside, target_is_directory=True)
+    store = ArtifactStore(root.resolve())
+
+    with pytest.raises(CausalArtifactError, match="escapes"):
+        store.write_bytes("linked/payload.bin", b"payload")
+
+
+def test_merge_accepts_identical_shared_inputs_and_rejects_conflicts(
+    tmp_path: Path,
+) -> None:
+    """Downloaded block roots merge only when duplicate bytes are identical."""
+    downloads = tmp_path / "downloads"
+    first = downloads / "block-a"
+    second = downloads / "block-b"
+    (first / "data").mkdir(parents=True)
+    (second / "data").mkdir(parents=True)
+    (first / "cells").mkdir()
+    (second / "cells").mkdir()
+    (first / "data/shared.json").write_bytes(b'{"seed":1282}\n')
+    (second / "data/shared.json").write_bytes(b'{"seed":1282}\n')
+    (first / "cells/a.json").write_bytes(b'{"cell":"a"}\n')
+    (second / "cells/b.json").write_bytes(b'{"cell":"b"}\n')
+
+    summary = merge_run_directories(downloads, tmp_path / "merged")
+
+    assert summary == {"published": 3, "identical": 1}
+    assert (tmp_path / "merged/cells/a.json").is_file()
+    (second / "data/shared.json").write_bytes(b'{"seed":1283}\n')
+    with pytest.raises(CausalArtifactError, match="overwrite"):
+        merge_run_directories(downloads, tmp_path / "conflicting")
+
+
+def test_merge_rejects_symlinks_and_unexpected_roots(tmp_path: Path) -> None:
+    """A download cannot smuggle links or non-contract paths into the run root."""
+    downloads = tmp_path / "downloads"
+    block = downloads / "block"
+    block.mkdir(parents=True)
+    (block / "unknown.txt").write_text("no")
+    with pytest.raises(CausalArtifactError, match="unexpected"):
+        merge_run_directories(downloads, tmp_path / "merged")
+
+    (block / "unknown.txt").unlink()
+    (block / "data").mkdir()
+    (block / "data/link.json").symlink_to(tmp_path / "outside")
+    with pytest.raises(CausalArtifactError, match="symlink"):
+        merge_run_directories(downloads, tmp_path / "merged-links")

--- a/tests/test_truncated_hierarchy_causal_contract.py
+++ b/tests/test_truncated_hierarchy_causal_contract.py
@@ -1,0 +1,1325 @@
+# ruff: noqa: D103
+"""Contract tests for the no-sampling TruncatedNormal causal experiment."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import scripts.truncated_hierarchy_causal_contract as contract
+from scripts.truncated_hierarchy_causal_contract import (
+    BACKEND_IDS,
+    REPRESENTATION_IDS,
+    CausalContractError,
+    RunContext,
+    UnitSpec,
+    aggregate_results,
+    assess_results,
+    block_units,
+    build_plan,
+    canonical_json_bytes,
+    derive_seed,
+    load_manifest,
+    manifest_digest,
+    pair_units,
+    plan_unit_by_id,
+    strict_json_loads,
+    validate_manifest,
+    validate_result_record,
+    validate_run_context,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def manifest() -> Mapping[str, Any]:
+    """Load the repository's frozen causal manifest."""
+    return load_manifest()
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _metrics(unit: UnitSpec, *, healthy: bool = True) -> dict[str, Any]:
+    divergence_count = 0 if healthy else unit.chains * unit.draws
+    metrics: dict[str, Any] = {
+        "compile_success": True,
+        "initialization_success": True,
+        "logp_finite": True,
+        "gradient_finite": True,
+        "sampling_success": True,
+        "divergence_count": divergence_count,
+        "posterior_draw_count": unit.chains * unit.draws,
+        "divergence_rate": divergence_count / (unit.chains * unit.draws),
+        "oracle_evaluation_count": contract._expected_oracle_evaluation_count(
+            unit.as_dict(), unit.tier, posterior_trajectory=True
+        ),
+        "oracle_logp_scaled_error_max": 0.1,
+        "oracle_gradient_scaled_error_max": 0.1,
+        "oracle_hessian_scaled_error_max": 0.1,
+        "roundtrip_absolute_error_max": 0.0,
+        "icdf_tail_finite": True,
+        "icdf_branch_continuous": True,
+    }
+    if unit.tier == "confirmation":
+        metrics.update(
+            {
+                "hyper_rhat_max": 1.0,
+                "hyper_ess_bulk_min": 500.0,
+                "hyper_ess_tail_min": 500.0,
+                "bfmi_min": 0.5,
+                "treedepth_saturation_rate": 0.0,
+                "hyper_mcse_over_sd_max": 0.01,
+                "group_rhat_max": 1.0,
+                "group_ess_bulk_fraction_ge_400": 1.0,
+                "group_ess_tail_fraction_ge_400": 1.0,
+            }
+        )
+    return metrics
+
+
+def _artifact(path: str) -> dict[str, Any]:
+    return {"path": path, "sha256": _digest(path), "size_bytes": 12}
+
+
+def _context(unit_pair: tuple[UnitSpec, ...]) -> RunContext:
+    environment: dict[str, Any] = {"git": {"commit": "a" * 40}}
+    environment_sha256 = contract.environment_digest(environment)
+    environment["environment_sha256"] = environment_sha256
+    return RunContext(
+        schema_version=3,
+        study_id="truncated_hierarchy_causal_v3",
+        manifest_sha256=unit_pair[0].manifest_sha256,
+        pair_id=unit_pair[0].pair_id,
+        block_ids=tuple(dict.fromkeys(unit.block_id for unit in unit_pair)),
+        cell_ids=tuple(unit.cell_id for unit in unit_pair),
+        execution_order=tuple(unit.cell_id for unit in unit_pair),
+        environment=environment,
+        environment_sha256=environment_sha256,
+        git_commit="a" * 40,
+        worker_identity_sha256=_digest("worker"),
+        pair_execution_id=_digest("pair"),
+        execution_attempt_ids=tuple(
+            _digest(f"attempt-{unit.cell_id}") for unit in unit_pair
+        ),
+    )
+
+
+def _record(
+    unit: UnitSpec,
+    context: RunContext,
+    *,
+    healthy: bool = True,
+    status: str = "completed",
+) -> dict[str, Any]:
+    position = context.cell_ids.index(unit.cell_id)
+    if unit.backend_id == "pymc":
+        sampler_seed_input: int | list[int] = list(unit.chain_seeds)
+        chain_rng = contract.derive_pymc_chain_rng_provenance(
+            unit.chain_seeds, unit.chains
+        )
+        sampler = "pymc-nuts"
+        compiler = "pytensor"
+    else:
+        assert unit.sampler_seed is not None
+        sampler_seed_input = unit.sampler_seed
+        chain_rng = [
+            {"chain": chain, "rng": "jax-prng-key", "key": key}
+            for chain, key in enumerate(
+                contract.derive_numpyro_chain_keys(unit.sampler_seed, unit.chains)
+            )
+        ]
+        sampler = "numpyro-nuts-via-pymc"
+        compiler = "pytensor-to-jax"
+    artifacts: dict[str, dict[str, Any] | None] = {
+        "context": _artifact(f"contexts/{unit.pair_id}.json"),
+        "data": _artifact(f"data/{unit.data_id}.json"),
+        "natural_start": _artifact(f"starts/natural/{unit.start_id}.json"),
+        "coordinate_start": _artifact(f"starts/coordinates/{unit.cell_id}.json"),
+        "chain": _artifact(f"chains/{unit.cell_id}.nc"),
+        "diagnostics": _artifact(f"diagnostics/{unit.cell_id}.json"),
+    }
+    failure = None
+    metrics = _metrics(unit, healthy=healthy)
+    if status == "failed":
+        artifacts["chain"] = None
+        artifacts["diagnostics"] = None
+        failure = {
+            "stage": "sample",
+            "error_type": "RuntimeError",
+            "message": "sampler failed",
+        }
+        metrics = {}
+    return {
+        "schema_version": 3,
+        "runner_version": 3,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "tier": unit.tier,
+        "regime_id": unit.regime_id,
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "replicate": unit.replicate,
+        "pair_id": unit.pair_id,
+        "pair_position": unit.pair_position,
+        "block_id": unit.block_id,
+        "block_position": unit.block_position,
+        "cell_id": unit.cell_id,
+        "execution_status": status,
+        "metrics": metrics,
+        "parameter_summaries": [],
+        "artifacts": artifacts,
+        "failure": failure,
+        "provenance": {
+            "environment_sha256": context.environment_sha256,
+            "git_commit": context.git_commit,
+            "worker_identity_sha256": context.worker_identity_sha256,
+            "pair_execution_id": context.pair_execution_id,
+            "execution_attempt_id": context.execution_attempt_ids[position],
+            "sampler": sampler,
+            "compiler_path": compiler,
+            "device": "cpu",
+            "floatx": unit.floatx,
+            "pytensor_floatx": unit.floatx,
+            "jax_enable_x64": unit.floatx == "float64",
+            "sampler_seed_input": sampler_seed_input,
+            "chain_rng_provenance": chain_rng,
+        },
+    }
+
+
+def _classifier_rows(
+    *,
+    left_bad_replicates: int,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for backend in BACKEND_IDS:
+        for replicate in range(8):
+            for representation in REPRESENTATION_IDS:
+                healthy = representation in {
+                    "group-icdf-noncentered",
+                    "full-icdf-noncentered",
+                }
+                if representation in {
+                    "native-centered",
+                    "manual-centered",
+                    "location-icdf-noncentered",
+                }:
+                    healthy = replicate >= left_bad_replicates
+                metrics = {
+                    "compile_success": True,
+                    "initialization_success": True,
+                    "logp_finite": True,
+                    "gradient_finite": True,
+                    "sampling_success": True,
+                    "divergence_count": 0 if healthy else 4000,
+                    "posterior_draw_count": 4000,
+                    "divergence_rate": 0.0 if healthy else 1.0,
+                    "hyper_rhat_max": 1.0,
+                    "hyper_ess_bulk_min": 500.0,
+                    "hyper_ess_tail_min": 500.0,
+                    "bfmi_min": 0.5,
+                    "treedepth_saturation_rate": 0.0,
+                    "hyper_mcse_over_sd_max": 0.01,
+                    "group_rhat_max": 1.0,
+                    "group_ess_bulk_fraction_ge_400": 1.0,
+                    "group_ess_tail_fraction_ge_400": 1.0,
+                    "oracle_evaluation_count": (
+                        4
+                        + int(replicate == 0)
+                        + 5
+                        * {
+                            "native-centered": 0,
+                            "manual-centered": 0,
+                            "group-icdf-noncentered": 1,
+                            "location-icdf-noncentered": 1,
+                            "full-icdf-noncentered": 2,
+                        }[representation]
+                        + 4
+                    ),
+                    "oracle_logp_scaled_error_max": 0.1,
+                    "oracle_gradient_scaled_error_max": 0.1,
+                    "oracle_hessian_scaled_error_max": 0.1,
+                    "roundtrip_absolute_error_max": 0.0,
+                    "icdf_tail_finite": True,
+                    "icdf_branch_continuous": True,
+                }
+                rows.append(
+                    {
+                        "collection_status": "present",
+                        "execution_status": "completed",
+                        "regime_id": "lower-outside-weak",
+                        "backend_id": backend,
+                        "representation_id": representation,
+                        "replicate": replicate,
+                        "metrics": metrics,
+                    }
+                )
+    return rows
+
+
+def test_manifest_is_frozen_to_v2_and_complete(manifest) -> None:
+    """Bind the new study to exact v2 bytes and the complete five-form design."""
+    assert manifest["frozen_v2"]["file_sha256"] == contract.sha256_file(
+        contract.DEFAULT_FROZEN_V2
+    )
+    assert (
+        tuple(item["representation_id"] for item in manifest["representations"])
+        == REPRESENTATION_IDS
+    )
+    assert manifest["tiers"]["smoke"]["expected_fit_count"] == 20
+    assert manifest["tiers"]["confirmation"]["expected_fit_count"] == 160
+    assert (
+        manifest["failure_policy"]["block_failure"]
+        == "one-member-failure-does-not-suppress-the-other-nine-attempts"
+    )
+    assert (
+        manifest["analysis_policy"]["family_health"]["maximum_failed_replicates"] == 0
+    )
+    assert manifest_digest(manifest) == manifest_digest(load_manifest())
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda value: value["representations"].pop(),
+            "exactly five",
+        ),
+        (
+            lambda value: value["tiers"]["confirmation"].update(replicates=5),
+            "budget changed",
+        ),
+        (
+            lambda value: value["analysis_policy"]["family_health"].update(
+                maximum_failed_replicates=1
+            ),
+            "require 8/8",
+        ),
+        (
+            lambda value: value["execution_policy"].update(order="random"),
+            "counterbalancing",
+        ),
+        (
+            lambda value: value["natural_model"].update(observation_sigma=0.6),
+            "natural_model",
+        ),
+        (
+            lambda value: value["backends"][0].update(sampler="other"),
+            "backend sampler/compiler",
+        ),
+        (
+            lambda value: value["analysis_policy"]["per_fit_health"].update(
+                divergence_rate_lt=0.02
+            ),
+            "semantic digest",
+        ),
+        (
+            lambda value: value["analysis_policy"]["family_health"].update(
+                aggregate_divergence_rate_lt=0.002
+            ),
+            "semantic digest",
+        ),
+        (
+            lambda value: value["analysis_policy"]["oracle_gate"].update(
+                evaluation_points=["fixed-grid"]
+            ),
+            "evaluation-point",
+        ),
+        (
+            lambda value: value["analysis_policy"]["oracle_gate"].update(
+                scaled_error_max=2.0
+            ),
+            "semantic digest",
+        ),
+        (
+            lambda value: value["analysis_policy"]["classifier_precedence"].reverse(),
+            "classifier precedence",
+        ),
+        (
+            lambda value: value["tiers"]["smoke"].update(role="changed"),
+            "semantic digest",
+        ),
+        (
+            lambda value: value["artifact_policy"].update(hash="changed"),
+            "semantic digest",
+        ),
+        (
+            lambda value: value["failure_policy"].update(
+                missing_result="silently-pass"
+            ),
+            "semantic digest",
+        ),
+    ],
+)
+def test_manifest_rejects_design_drift(manifest, mutation, message) -> None:
+    changed = copy.deepcopy(manifest)
+    mutation(changed)
+    with pytest.raises(CausalContractError, match=message):
+        validate_manifest(changed)
+
+
+def test_strict_json_and_seed_domain() -> None:
+    with pytest.raises(CausalContractError, match="duplicate"):
+        strict_json_loads('{"a":1,"a":2}')
+    with pytest.raises(CausalContractError, match="invalid constant"):
+        strict_json_loads('{"a":NaN}')
+    assert canonical_json_bytes({"b": 1, "a": 2}) == b'{"a":2,"b":1}\n'
+    assert derive_seed(1282, "data", "lower-outside-weak", 1) == derive_seed(
+        1282, "data", "lower-outside-weak", 1
+    )
+    assert derive_seed(1282, "data", "lower-outside-weak", 1) != derive_seed(
+        1282, "sampler", "lower-outside-weak", 1
+    )
+    pymc_rng = contract.derive_pymc_chain_rng_provenance(
+        [943009182, 939311901, 1620816411, 1994453597], 4
+    )
+    assert [item["init_step_seed"] for item in pymc_rng] == [
+        1019536840,
+        896392474,
+        417781057,
+        822370369,
+    ]
+    assert [item["spawn_key"] for item in pymc_rng] == [[0], [1], [2], [3]]
+
+
+def test_plan_counts_counterbalancing_and_shared_inputs(manifest) -> None:
+    smoke = build_plan(manifest, "smoke")
+    confirmation = build_plan(manifest, "confirmation")
+    assert len(smoke) == 20
+    assert len(confirmation) == 160
+    assert [unit.representation_id for unit in smoke if unit.block_position == 0] == [
+        "native-centered",
+        "manual-centered",
+        "location-icdf-noncentered",
+        "group-icdf-noncentered",
+    ]
+    starts = [
+        unit.representation_id
+        for unit in confirmation
+        if unit.regime_id == "lower-outside-weak"
+        and unit.backend_id == "pymc"
+        and unit.block_position == 0
+    ]
+    assert starts == [
+        "native-centered",
+        "full-icdf-noncentered",
+        "location-icdf-noncentered",
+        "group-icdf-noncentered",
+        "manual-centered",
+        "native-centered",
+        "full-icdf-noncentered",
+        "location-icdf-noncentered",
+    ]
+    first_pair = pair_units(manifest, "smoke", smoke[0].pair_id)
+    assert len(first_pair) == 10
+    assert len({unit.data_seed for unit in first_pair}) == 1
+    assert len({unit.natural_start_chain_seeds for unit in first_pair}) == 1
+    assert [unit.backend_id for unit in first_pair[:5]] == ["pymc"] * 5
+    assert [unit.backend_id for unit in first_pair[5:]] == ["numpyro"] * 5
+    second_pair = pair_units(manifest, "smoke", smoke[10].pair_id)
+    assert [unit.backend_id for unit in second_pair[:5]] == ["numpyro"] * 5
+    assert [unit.backend_id for unit in second_pair[5:]] == ["pymc"] * 5
+    for chain, seed in enumerate(first_pair[0].natural_start_chain_seeds):
+        assert seed == derive_seed(first_pair[0].natural_start_seed, "chain", chain)
+    assert first_pair[0].data_seed == 1818466647
+    assert first_pair[0].truth_seed == 746768835
+    assert all(unit.sampler_seed is None for unit in first_pair[:5])
+    numpyro = block_units(manifest, "smoke", smoke[5].block_id)
+    assert all(
+        unit.sampler_seed is not None and not unit.chain_seeds for unit in numpyro
+    )
+
+
+def test_plan_roundtrip_and_exact_lookup(manifest) -> None:
+    unit = build_plan(manifest, "smoke")[0]
+    assert UnitSpec.from_dict(unit.as_dict()) == unit
+    assert plan_unit_by_id(manifest, "smoke", unit.cell_id) == unit
+    with pytest.raises(CausalContractError, match="not planned"):
+        plan_unit_by_id(manifest, "smoke", f"{unit.cell_id}--unknown")
+
+
+def test_run_context_binds_both_backend_blocks_and_ten_attempts(manifest) -> None:
+    plan = build_plan(manifest, "smoke")
+    units = pair_units(manifest, "smoke", plan[0].pair_id)
+    context = _context(units)
+    assert RunContext.from_dict(context.as_dict()) == context
+    assert validate_run_context(context, units) == context
+    changed = context.as_dict()
+    changed["execution_order"] = list(reversed(changed["execution_order"]))
+    with pytest.raises(CausalContractError, match="execution_order"):
+        RunContext.from_dict(changed)
+    changed = context.as_dict()
+    changed["environment"]["git"]["commit"] = "b" * 40
+    with pytest.raises(CausalContractError, match="environment"):
+        RunContext.from_dict(changed)
+
+
+def test_result_identity_artifacts_failure_and_seed_provenance(manifest) -> None:
+    plan = build_plan(manifest, "smoke")
+    units = pair_units(manifest, "smoke", plan[0].pair_id)
+    context = _context(units)
+    good = _record(units[0], context)
+    assert validate_result_record(good, units[0], context) == good
+    forged = copy.deepcopy(good)
+    forged["artifacts"]["data"]["path"] = "data/another.json"
+    with pytest.raises(CausalContractError, match="does not match the plan"):
+        validate_result_record(forged, units[0], context)
+    forged = copy.deepcopy(good)
+    forged["provenance"]["chain_rng_provenance"][0]["init_step_seed"] += 1
+    with pytest.raises(CausalContractError, match="chain RNG provenance"):
+        validate_result_record(forged, units[0], context)
+    failed = _record(units[0], context, status="failed")
+    assert validate_result_record(failed, units[0], context) == failed
+    failed["failure"]["stage"] = "infrastructure"
+    with pytest.raises(CausalContractError, match="scientific stage"):
+        validate_result_record(failed, units[0], context)
+
+
+def test_failed_sample_accepts_only_complete_auditable_pre_oracle(manifest) -> None:
+    plan = build_plan(manifest, "smoke")
+    units = pair_units(manifest, "smoke", plan[0].pair_id)
+    context = _context(units)
+    unit = units[0]
+    failed = _record(unit, context, status="failed")
+    complete = _metrics(unit)
+    failed["metrics"] = {
+        key: complete[key]
+        for key in (
+            "compile_success",
+            "initialization_success",
+            "logp_finite",
+            "gradient_finite",
+            *sorted(contract.ORACLE_METRICS),
+        )
+    }
+    failed["metrics"]["sampling_success"] = False
+    failed["metrics"]["oracle_evaluation_count"] = (
+        contract._expected_oracle_evaluation_count(
+            unit.as_dict(), "smoke", posterior_trajectory=False
+        )
+    )
+    failed["artifacts"]["diagnostics"] = _artifact(f"diagnostics/{unit.cell_id}.json")
+    assert validate_result_record(failed, unit, context) == failed
+
+    no_diagnostics = copy.deepcopy(failed)
+    no_diagnostics["artifacts"]["diagnostics"] = None
+    with pytest.raises(CausalContractError, match="requires diagnostics"):
+        validate_result_record(no_diagnostics, unit, context)
+    missing_point = copy.deepcopy(failed)
+    missing_point["metrics"]["oracle_evaluation_count"] -= 1
+    with pytest.raises(CausalContractError, match="frozen evidence phase"):
+        validate_result_record(missing_point, unit, context)
+
+
+def test_completed_oracle_requires_every_static_and_trajectory_point(manifest) -> None:
+    plan = build_plan(manifest, "smoke")
+    units = pair_units(manifest, "smoke", plan[0].pair_id)
+    context = _context(units)
+    record = _record(units[0], context)
+    record["metrics"]["oracle_evaluation_count"] -= 1
+    with pytest.raises(CausalContractError, match="trajectory/static evidence"):
+        validate_result_record(record, units[0], context)
+
+
+def test_raw_diagnostics_recompute_registered_oracle_metrics(
+    manifest, tmp_path: Path
+) -> None:
+    unit = build_plan(manifest, "smoke")[0]
+    context = _context(pair_units(manifest, "smoke", unit.pair_id))
+    record = _record(unit, context)
+    count = record["metrics"]["oracle_evaluation_count"]
+    coordinate_size = int(unit.regime["n_groups"]) + 2
+    gradient = [float(index + 1) for index in range(coordinate_size)]
+    hessian = [
+        [float(row == column) for column in range(coordinate_size)]
+        for row in range(coordinate_size)
+    ]
+    raw_record: dict[str, Any] = {
+        "observed": {
+            "value": 1.0,
+            "gradient": list(gradient),
+            "hessian": copy.deepcopy(hessian),
+        },
+        "oracle": {
+            "value": 1.0,
+            "gradient": list(gradient),
+            "hessian": copy.deepcopy(hessian),
+        },
+        "errors": {
+            "value": {"absolute_max": 0.0, "scaled_max": 0.0},
+            "gradient": {"absolute_max": 0.0, "scaled_max": 0.0},
+            "hessian": {"absolute_max": 0.0, "scaled_max": 0.0},
+        },
+        "roundtrip": {"absolute_error_max": 0.0},
+        "component_finite": {"value": True, "gradient": True, "hessian": True},
+        "finite": True,
+        "passed": True,
+    }
+    records: list[dict[str, Any]] = []
+    fixed = copy.deepcopy(raw_record)
+    fixed.update(point_id="fixed-truth", kind="fixed-grid")
+    records.append(fixed)
+    for chain in range(unit.chains):
+        start = copy.deepcopy(raw_record)
+        start.update(point_id=f"start-chain-{chain:02d}", kind="shared-natural-start")
+        records.append(start)
+    for chain in range(unit.chains):
+        draw = min(
+            range(unit.draws),
+            key=lambda candidate: hashlib.sha256(
+                f"{unit.cell_id}:trajectory:{chain}:{candidate}".encode()
+            ).digest(),
+        )
+        trajectory = copy.deepcopy(raw_record)
+        trajectory.update(
+            point_id=f"trajectory-chain-{chain:02d}-selection-00",
+            kind="hash-selected-posterior-trajectory",
+            chain=chain,
+            draw=draw,
+            selection_sha256=hashlib.sha256(
+                f"{unit.cell_id}:trajectory:{chain}:{draw}".encode()
+            ).hexdigest(),
+        )
+        records.append(trajectory)
+    assert len(records) == count
+    for name in (
+        "oracle_logp_scaled_error_max",
+        "oracle_gradient_scaled_error_max",
+        "oracle_hessian_scaled_error_max",
+    ):
+        record["metrics"][name] = 0.0
+    diagnostics: dict[str, Any] = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+        "runtime": {
+            "pytensor_floatx": unit.floatx,
+            "jax_enable_x64": unit.floatx == "float64",
+        },
+        "oracle": {
+            "posterior_trajectory_evaluated": True,
+            "records": records,
+            "icdf_tail_finite": True,
+            "icdf_branch_checks": [],
+            "icdf_branch_continuous": True,
+            "passed": True,
+        },
+    }
+    path = tmp_path / "diagnostics.json"
+    path.write_bytes(canonical_json_bytes(diagnostics))
+    contract._audit_diagnostic_evidence(record, unit, path, manifest["analysis_policy"])
+    forged = copy.deepcopy(record)
+    forged["metrics"]["oracle_gradient_scaled_error_max"] = 0.2
+    with pytest.raises(CausalContractError, match="hash-bound raw evidence"):
+        contract._audit_diagnostic_evidence(
+            forged, unit, path, manifest["analysis_policy"]
+        )
+
+    forged_diagnostics: dict[str, Any] = copy.deepcopy(diagnostics)
+    forged_diagnostics["oracle"]["records"][0]["observed"]["gradient"][0] = 9.0
+    forged_path = tmp_path / "forged-diagnostics.json"
+    forged_path.write_bytes(canonical_json_bytes(forged_diagnostics))
+    with pytest.raises(CausalContractError, match="raw observed/oracle arrays"):
+        contract._audit_diagnostic_evidence(
+            record, unit, forged_path, manifest["analysis_policy"]
+        )
+
+    nonminimal: dict[str, Any] = copy.deepcopy(diagnostics)
+    trajectory = next(
+        item
+        for item in nonminimal["oracle"]["records"]
+        if item["kind"] == "hash-selected-posterior-trajectory" and item["chain"] == 0
+    )
+    nonminimal_draw = next(
+        draw for draw in range(unit.draws) if draw != trajectory["draw"]
+    )
+    trajectory["draw"] = nonminimal_draw
+    trajectory["selection_sha256"] = hashlib.sha256(
+        f"{unit.cell_id}:trajectory:0:{nonminimal_draw}".encode()
+    ).hexdigest()
+    nonminimal_path = tmp_path / "nonminimal-trajectory.json"
+    nonminimal_path.write_bytes(canonical_json_bytes(nonminimal))
+    with pytest.raises(CausalContractError, match="lowest-SHA draw"):
+        contract._audit_diagnostic_evidence(
+            record, unit, nonminimal_path, manifest["analysis_policy"]
+        )
+
+
+def test_raw_diagnostics_recompute_icdf_tail_and_branch_flags(
+    manifest, tmp_path: Path
+) -> None:
+    import numpy as np
+
+    unit = next(
+        item
+        for item in build_plan(manifest, "smoke")
+        if item.representation_id == "full-icdf-noncentered"
+        and item.backend_id == "pymc"
+        and item.regime_id == "lower-outside-weak"
+    )
+    context = _context(pair_units(manifest, "smoke", unit.pair_id))
+    result = _record(unit, context)
+    for name in (
+        "oracle_logp_scaled_error_max",
+        "oracle_gradient_scaled_error_max",
+        "oracle_hessian_scaled_error_max",
+    ):
+        result["metrics"][name] = 0.0
+    gate = manifest["analysis_policy"]["oracle_gate"]
+    tolerances = gate["component_tolerances"][unit.floatx]
+    coordinate_size = int(unit.regime["n_groups"]) + 2
+    zero_gradient = np.zeros(coordinate_size, dtype=np.float64)
+    zero_hessian = np.zeros((coordinate_size, coordinate_size), dtype=np.float64)
+    branch_epsilon = float(8.0 * np.sqrt(np.finfo(np.dtype(unit.floatx)).eps))
+
+    def error_summary(observed: Any, expected: Any, component: str) -> dict[str, float]:
+        if observed is None:
+            return {
+                "absolute_max": float(np.finfo(np.float64).max),
+                "scaled_max": float(gate["scaled_error_max"]) + 1.0,
+            }
+        observed_array = np.asarray(observed, dtype=np.float64)
+        expected_array = np.asarray(expected, dtype=np.float64)
+        tolerance = tolerances[component]
+        difference = np.abs(observed_array - expected_array)
+        scale = float(tolerance["absolute_tolerance"]) + float(
+            tolerance["relative_tolerance"]
+        ) * np.maximum(np.abs(observed_array), np.abs(expected_array))
+        return {
+            "absolute_max": float(np.max(difference)),
+            "scaled_max": float(np.max(difference / scale)),
+        }
+
+    def raw_record(
+        point_id: str,
+        kind: str,
+        *,
+        coordinate_index: int | None = None,
+        observed_value: float | None = 0.0,
+        observed_gradient: list[float] | None = None,
+    ) -> dict[str, Any]:
+        gradient = (
+            zero_gradient.tolist() if observed_gradient is None else observed_gradient
+        )
+        observed = {
+            "value": observed_value,
+            "gradient": gradient,
+            "hessian": zero_hessian.tolist(),
+        }
+        expected = {
+            "value": 0.0,
+            "gradient": zero_gradient.tolist(),
+            "hessian": zero_hessian.tolist(),
+        }
+        finite = {
+            component: observed[component] is not None
+            for component in ("value", "gradient", "hessian")
+        }
+        errors = {
+            "value": error_summary(observed["value"], expected["value"], "logp"),
+            "gradient": error_summary(
+                observed["gradient"], expected["gradient"], "gradient"
+            ),
+            "hessian": error_summary(
+                observed["hessian"], expected["hessian"], "hessian"
+            ),
+        }
+        passed = bool(
+            all(finite.values())
+            and all(
+                summary["scaled_max"] <= float(gate["scaled_error_max"])
+                for summary in errors.values()
+            )
+        )
+        return {
+            "point_id": point_id,
+            "kind": kind,
+            **(
+                {
+                    "coordinate_index": coordinate_index,
+                    "branch_epsilon": branch_epsilon,
+                }
+                if coordinate_index is not None
+                else {}
+            ),
+            "observed": observed,
+            "oracle": expected,
+            "errors": errors,
+            "roundtrip": {"absolute_error_max": 0.0},
+            "component_finite": finite,
+            "finite": all(finite.values()),
+            "passed": passed,
+        }
+
+    count = result["metrics"]["oracle_evaluation_count"]
+    records = [raw_record("fixed-truth", "fixed-grid")]
+    records.extend(
+        raw_record(f"start-chain-{chain:02d}", "shared-natural-start")
+        for chain in range(unit.chains)
+    )
+    for coordinate_index in (0, 2):
+        records.extend(
+            raw_record(
+                f"icdf-{coordinate_index}-{label}",
+                f"icdf-{label}",
+                coordinate_index=coordinate_index,
+            )
+            for label in (
+                "branch-left",
+                "branch-zero",
+                "branch-right",
+                "tail-low",
+                "tail-high",
+            )
+        )
+    for chain in range(unit.chains):
+        draw = min(
+            range(unit.draws),
+            key=lambda candidate: hashlib.sha256(
+                f"{unit.cell_id}:trajectory:{chain}:{candidate}".encode()
+            ).digest(),
+        )
+        trajectory = raw_record(
+            f"trajectory-chain-{chain:02d}-selection-00",
+            "hash-selected-posterior-trajectory",
+        )
+        trajectory.update(
+            chain=chain,
+            draw=draw,
+            selection_sha256=hashlib.sha256(
+                f"{unit.cell_id}:trajectory:{chain}:{draw}".encode()
+            ).hexdigest(),
+        )
+        records.append(trajectory)
+    assert len(records) == count
+    diagnostics: dict[str, Any] = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+        "runtime": {
+            "pytensor_floatx": unit.floatx,
+            "jax_enable_x64": True,
+        },
+        "oracle": {
+            "posterior_trajectory_evaluated": True,
+            "records": records,
+            "icdf_tail_finite": True,
+            "icdf_branch_checks": [
+                {"coordinate_index": coordinate_index, "passed": True}
+                for coordinate_index in (0, 2)
+            ],
+            "icdf_branch_continuous": True,
+            "passed": True,
+        },
+    }
+    path = tmp_path / "valid-icdf.json"
+    path.write_bytes(canonical_json_bytes(diagnostics))
+    contract._audit_diagnostic_evidence(result, unit, path, manifest["analysis_policy"])
+
+    missing_tail: dict[str, Any] = copy.deepcopy(diagnostics)
+    missing_tail["oracle"]["records"] = [
+        item
+        for item in missing_tail["oracle"]["records"]
+        if not (item["kind"] == "icdf-tail-high" and item["coordinate_index"] == 2)
+    ]
+    missing_tail_path = tmp_path / "missing-tail.json"
+    missing_tail_path.write_bytes(canonical_json_bytes(missing_tail))
+    with pytest.raises(CausalContractError, match="record count"):
+        contract._audit_diagnostic_evidence(
+            result,
+            unit,
+            missing_tail_path,
+            manifest["analysis_policy"],
+        )
+
+    relabelled_branch: dict[str, Any] = copy.deepcopy(diagnostics)
+    next(
+        item
+        for item in relabelled_branch["oracle"]["records"]
+        if item["kind"] == "icdf-branch-left" and item["coordinate_index"] == 2
+    )["kind"] = "fixed-grid"
+    relabelled_branch_path = tmp_path / "relabelled-branch.json"
+    relabelled_branch_path.write_bytes(canonical_json_bytes(relabelled_branch))
+    with pytest.raises(CausalContractError, match="point kinds"):
+        contract._audit_diagnostic_evidence(
+            result,
+            unit,
+            relabelled_branch_path,
+            manifest["analysis_policy"],
+        )
+
+    forged_tail: dict[str, Any] = copy.deepcopy(diagnostics)
+    tail = next(
+        item
+        for item in forged_tail["oracle"]["records"]
+        if item["kind"] == "icdf-tail-low"
+    )
+    tail["observed"]["gradient"] = None
+    tail["errors"]["gradient"] = error_summary(None, zero_gradient, "gradient")
+    tail["component_finite"]["gradient"] = False
+    tail["finite"] = False
+    tail["passed"] = False
+    forged_tail_path = tmp_path / "forged-tail.json"
+    forged_tail_path.write_bytes(canonical_json_bytes(forged_tail))
+    with pytest.raises(CausalContractError, match="ICDF summary flags"):
+        contract._audit_diagnostic_evidence(
+            result,
+            unit,
+            forged_tail_path,
+            manifest["analysis_policy"],
+        )
+
+    forged_branch: dict[str, Any] = copy.deepcopy(diagnostics)
+    logp_absolute_tolerance = float(tolerances["logp"]["absolute_tolerance"])
+    for kind, direction in (
+        ("icdf-branch-left", -1.0),
+        ("icdf-branch-right", 1.0),
+    ):
+        branch = next(
+            item
+            for item in forged_branch["oracle"]["records"]
+            if item["kind"] == kind and item["coordinate_index"] == 0
+        )
+        branch["observed"]["value"] = direction * 0.75 * logp_absolute_tolerance
+        branch["errors"]["value"] = error_summary(
+            branch["observed"]["value"], 0.0, "logp"
+        )
+    forged_branch_path = tmp_path / "forged-branch.json"
+    forged_branch_path.write_bytes(canonical_json_bytes(forged_branch))
+    with pytest.raises(CausalContractError, match="branch-check summaries"):
+        contract._audit_diagnostic_evidence(
+            result,
+            unit,
+            forged_branch_path,
+            manifest["analysis_policy"],
+        )
+
+
+def test_raw_chain_stats_recompute_registered_sampler_metrics(
+    manifest, tmp_path: Path
+) -> None:
+    import numpy as np
+    import xarray as xr
+
+    unit = build_plan(manifest, "smoke")[0]
+    context = _context(pair_units(manifest, "smoke", unit.pair_id))
+    record = _record(unit, context)
+    shape = (unit.chains, unit.draws)
+    generator = np.random.default_rng(41)
+    chain_rng = record["provenance"]["chain_rng_provenance"]
+    dataset = xr.Dataset(
+        {
+            "group_location": (("chain", "draw"), generator.normal(size=shape)),
+            "group_scale": (("chain", "draw"), generator.lognormal(size=shape)),
+            "group_effect": (
+                ("chain", "draw", "group"),
+                generator.normal(size=(*shape, unit.regime["n_groups"])),
+            ),
+            "sample_stat__acceptance_rate": (
+                ("chain", "draw"),
+                np.full(shape, 0.9),
+            ),
+            "sample_stat__diverging": (
+                ("chain", "draw"),
+                np.zeros(shape, dtype=bool),
+            ),
+            "sample_stat__energy": (
+                ("chain", "draw"),
+                generator.normal(size=shape),
+            ),
+            "sample_stat__n_steps": (("chain", "draw"), np.full(shape, 7)),
+            "sample_stat__step_size": (
+                ("chain", "draw"),
+                np.full(shape, 0.125),
+            ),
+            "sample_stat__tree_depth": (("chain", "draw"), np.full(shape, 3)),
+        },
+        attrs={
+            "schema_version": unit.schema_version,
+            "study_id": unit.study_id,
+            "manifest_sha256": unit.manifest_sha256,
+            "cell_id": unit.cell_id,
+            "block_id": unit.block_id,
+            "tier": unit.tier,
+            "regime_id": unit.regime_id,
+            "backend_id": unit.backend_id,
+            "representation_id": unit.representation_id,
+            "sampler_seed_input_json": json.dumps(
+                record["provenance"]["sampler_seed_input"], separators=(",", ":")
+            ),
+            "chain_rng_provenance_json": json.dumps(
+                chain_rng, separators=(",", ":"), sort_keys=True
+            ),
+        },
+    )
+    path = tmp_path / "chains.nc"
+    dataset.to_netcdf(path, engine="scipy", format="NETCDF3_64BIT")
+    contract._audit_chain_evidence(record, unit, path)
+    forged = copy.deepcopy(record)
+    forged["metrics"]["divergence_count"] = 1
+    with pytest.raises(CausalContractError, match="hash-bound raw evidence"):
+        contract._audit_chain_evidence(forged, unit, path)
+
+
+def test_family_health_requires_eight_of_eight() -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    selected = [
+        row
+        for row in rows
+        if row["backend_id"] == "pymc"
+        and row["representation_id"] == "group-icdf-noncentered"
+    ]
+    policy = {
+        "aggregate_divergence_rate_lt": 0.001,
+        "per_fit_pass_fraction_ge": 0.95,
+        "maximum_failed_replicates": 0,
+    }
+    per_fit_policy = load_manifest()["analysis_policy"]["per_fit_health"]
+    assert contract._family_health(selected, "confirmation", policy, per_fit_policy)
+    selected[-1] = copy.deepcopy(selected[-1])
+    selected[-1]["metrics"]["divergence_count"] = 4000
+    selected[-1]["metrics"]["divergence_rate"] = 1.0
+    assert not contract._family_health(selected, "confirmation", policy, per_fit_policy)
+
+
+@pytest.mark.parametrize(
+    ("bad_replicates", "expected"),
+    [
+        (1, "mixed-inconclusive"),
+        (7, "mixed-inconclusive"),
+        (8, "group-conditional-centering"),
+    ],
+)
+def test_classifier_requires_all_eight_directional_pairs(
+    manifest, bad_replicates, expected
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=bad_replicates)
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == expected
+    contrast = result["paired_health_contrasts"]["pymc/group-effect-at-location-c"]
+    assert contrast["supports_direction"] is (bad_replicates == 8)
+    if bad_replicates == 8:
+        assert contrast["two_sided_exact_p"] == 0.0078125
+
+
+def test_sampling_classification_requires_aggregate_family_health(manifest) -> None:
+    rows = _classifier_rows(left_bad_replicates=8)
+    for row in rows:
+        if row["representation_id"] in {
+            "group-icdf-noncentered",
+            "full-icdf-noncentered",
+        }:
+            row["metrics"]["divergence_count"] = 8
+            row["metrics"]["divergence_rate"] = 0.002
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "mixed-inconclusive"
+    assert result["paired_health_contrasts"]["pymc/group-effect-at-location-c"][
+        "supports_direction"
+    ]
+    assert not result["family_health"]["pymc/group-icdf-noncentered"]
+
+
+@pytest.mark.parametrize(
+    ("bad_replicates", "expected"),
+    [
+        (1, "mixed-inconclusive"),
+        (7, "mixed-inconclusive"),
+        (8, "joint-centering-interaction"),
+    ],
+)
+def test_joint_classifier_requires_the_pattern_in_every_pair(
+    manifest, bad_replicates, expected
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    for row in rows:
+        if row["replicate"] < bad_replicates and row["representation_id"] in {
+            "manual-centered",
+            "group-icdf-noncentered",
+            "location-icdf-noncentered",
+        }:
+            row["metrics"]["divergence_count"] = 4000
+            row["metrics"]["divergence_rate"] = 1.0
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == expected
+
+
+@pytest.mark.parametrize(
+    ("bad_replicates", "expected"),
+    [
+        (1, "mixed-inconclusive"),
+        (7, "mixed-inconclusive"),
+        (8, "residual-tn-or-scale-geometry"),
+    ],
+)
+def test_residual_classifier_requires_every_fit_to_be_unhealthy(
+    manifest, bad_replicates, expected
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    for row in rows:
+        if row["replicate"] < bad_replicates:
+            row["metrics"]["divergence_count"] = 4000
+            row["metrics"]["divergence_rate"] = 1.0
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == expected
+
+
+def test_sampling_classifier_fails_closed_on_non_native_oracle_failure(
+    manifest,
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=8)
+    affected = next(
+        row for row in rows if row["representation_id"] == "group-icdf-noncentered"
+    )
+    affected["metrics"]["oracle_hessian_scaled_error_max"] = 1.01
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "mixed-inconclusive"
+
+
+@pytest.mark.parametrize(
+    ("bad_replicates", "expected"),
+    [
+        (1, "mixed-inconclusive"),
+        (7, "mixed-inconclusive"),
+        (8, "backend-path-specific"),
+    ],
+)
+def test_backend_label_uses_one_block_health_count_omnibus(
+    manifest, bad_replicates, expected
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    for row in rows:
+        if (
+            row["backend_id"] == "pymc"
+            and row["representation_id"] == "native-centered"
+            and row["replicate"] < bad_replicates
+        ):
+            row["metrics"]["divergence_count"] = 4000
+            row["metrics"]["divergence_rate"] = 1.0
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == expected
+    omnibus = result["paired_health_contrasts"][
+        "backend/five-form-health-count-omnibus"
+    ]
+    assert omnibus["supports_either_direction"] is (bad_replicates == 8)
+    if bad_replicates == 8:
+        assert omnibus["two_sided_exact_p"] == 0.0078125
+
+
+def test_opposite_representation_backend_effects_are_descriptive_only(
+    manifest,
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    for row in rows:
+        unhealthy = (
+            row["backend_id"] == "pymc"
+            and row["representation_id"] == "native-centered"
+        ) or (
+            row["backend_id"] == "numpyro"
+            and row["representation_id"] == "manual-centered"
+        )
+        if unhealthy:
+            row["metrics"]["divergence_count"] = 4000
+            row["metrics"]["divergence_rate"] = 1.0
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "mixed-inconclusive"
+    assert result["paired_health_contrasts"]["backend/native-centered/pymc-to-numpyro"][
+        "all_directional_at_threshold"
+    ]
+    assert result["paired_health_contrasts"]["backend/manual-centered/pymc-to-numpyro"][
+        "all_directional_at_threshold"
+    ]
+    assert not result["paired_health_contrasts"][
+        "backend/five-form-health-count-omnibus"
+    ]["supports_either_direction"]
+
+
+@pytest.mark.parametrize("failure_kind", ["sampling", "roundtrip"])
+def test_native_non_density_failures_are_not_correctness_defects(
+    manifest, failure_kind
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    affected = [
+        row
+        for row in rows
+        if row["representation_id"] == "native-centered" and row["replicate"] == 0
+    ]
+    assert len(affected) == 2
+    for row in affected:
+        if failure_kind == "sampling":
+            row["execution_status"] = "failed"
+        else:
+            row["metrics"]["roundtrip_absolute_error_max"] = 1.0
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "mixed-inconclusive"
+
+
+def test_one_dataset_seen_on_both_backends_is_not_reproducible_native_defect(
+    manifest,
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    affected = [
+        row
+        for row in rows
+        if row["representation_id"] == "native-centered" and row["replicate"] == 0
+    ]
+    assert len(affected) == 2
+    for row in affected:
+        row["metrics"]["oracle_gradient_scaled_error_max"] = 1.01
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "mixed-inconclusive"
+    assert result["native_mismatch_replicates"] == [0]
+
+
+def test_two_dataset_native_derivative_mismatch_is_correctness_defect(
+    manifest,
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    affected = [
+        row
+        for row in rows
+        if row["backend_id"] == "pymc"
+        and row["representation_id"] == "native-centered"
+        and row["replicate"] in {0, 1}
+    ]
+    assert len(affected) == 2
+    for row in affected:
+        row["metrics"]["oracle_gradient_scaled_error_max"] = 1.01
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "native-pymc-correctness-defect"
+    assert result["native_mismatch_replicates"] == [0, 1]
+
+
+def test_native_correctness_can_use_pre_oracle_when_sampling_later_fails(
+    manifest,
+) -> None:
+    rows = _classifier_rows(left_bad_replicates=0)
+    for row in rows:
+        if (
+            row["backend_id"] == "pymc"
+            and row["representation_id"] in {"native-centered", "manual-centered"}
+            and row["replicate"] in {0, 1}
+        ):
+            row["execution_status"] = "failed"
+            row["metrics"]["sampling_success"] = False
+            row["metrics"]["oracle_evaluation_count"] -= 4
+            if row["representation_id"] == "native-centered":
+                row["metrics"]["oracle_hessian_scaled_error_max"] = 1.01
+    result = contract._classify_regime(
+        rows,
+        manifest["regimes"][0],
+        "confirmation",
+        manifest["analysis_policy"],
+    )
+    assert result["classification"] == "native-pymc-correctness-defect"
+    assert result["native_mismatch_replicates"] == [0, 1]
+
+
+def test_aggregate_materializes_missing_and_assessment_allows_scientific_failures(
+    manifest,
+) -> None:
+    plan = build_plan(manifest, "smoke")
+    contexts = {
+        unit.pair_id: _context(pair_units(manifest, "smoke", unit.pair_id))
+        for unit in plan
+    }
+    records = {
+        unit.cell_id: _record(
+            unit,
+            contexts[unit.pair_id],
+            healthy=unit.representation_id != "native-centered",
+        )
+        for unit in plan
+    }
+    rows = aggregate_results(plan, records)
+    assessment = assess_results(rows, plan, manifest, "smoke")
+    assert assessment["outcome"] == "screening-fail"
+    assert assessment["contract_valid"] is True
+    assert assessment["evidence_complete"] is True
+    assert assessment["proceed_to_confirmation"] is True
+    assert {item["classification"] for item in assessment["regimes"]} == {
+        "screening-only"
+    }
+    assert all(item["causal_classification"] is None for item in assessment["regimes"])
+    missing_rows = aggregate_results(
+        plan, {key: value for key, value in records.items() if key != plan[0].cell_id}
+    )
+    incomplete = assess_results(missing_rows, plan, manifest, "smoke")
+    assert incomplete["outcome"] == "incomplete"
+    assert incomplete["evidence_complete"] is False
+    assert incomplete["proceed_to_confirmation"] is False
+
+
+def test_cli_validate_plan_and_matrix(manifest, tmp_path: Path, capsys) -> None:
+    assert contract.main(["validate"]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["manifest_sha256"] == manifest_digest(manifest)
+    assert contract.main(["matrix", "--tier", "smoke"]) == 0
+    matrix = json.loads(capsys.readouterr().out)
+    assert len(matrix["include"]) == 2
+    assert set(matrix["include"][0]) == {"pair_id", "tier", "regime_id", "replicate"}
+    output = tmp_path / "plan"
+    assert contract.main(["plan", "--tier", "smoke", "--output-dir", str(output)]) == 0
+    capsys.readouterr()
+    assert len((output / "plan.jsonl").read_text().splitlines()) == 20
+    assert len((output / "matrix.csv").read_text().splitlines()) == 21

--- a/tests/test_truncated_hierarchy_causal_heartbeat.py
+++ b/tests/test_truncated_hierarchy_causal_heartbeat.py
@@ -5,17 +5,15 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import sys
 import time
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
 import scripts.truncated_hierarchy_causal_runner as runner
 from scripts.truncated_hierarchy_causal_contract import build_plan, load_manifest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture(scope="module")
@@ -52,10 +50,53 @@ def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
 
 
 def _pid_file_ready(path: Path) -> bool:
+    return _read_pid_file(path) is not None
+
+
+def _read_pid_file(path: Path) -> int | None:
     try:
-        return int(path.read_text()) > 0
+        pid = int(path.read_text())
     except (OSError, ValueError):
-        return False
+        return None
+    return pid if pid > 0 else None
+
+
+def _cleanup_recorded_processes(
+    child_pid_path: Path, grandchild_pid_path: Path
+) -> None:
+    """Best-effort cleanup even when readiness failed after one PID appeared."""
+    child_pid = _read_pid_file(child_pid_path)
+    grandchild_pid = _read_pid_file(grandchild_pid_path)
+    recorded_pids = [pid for pid in (child_pid, grandchild_pid) if pid is not None]
+    if child_pid is not None and any(_pid_exists(pid) for pid in recorded_pids):
+        try:
+            os.killpg(child_pid, signal.SIGKILL)
+        except OSError:
+            pass
+    for pid in recorded_pids:
+        if _pid_exists(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+
+def _pipe_holding_tree_program(child_pid_path: Path, grandchild_pid_path: Path) -> str:
+    grandchild_program = (
+        "import os,time; "
+        "from pathlib import Path; "
+        f"Path({str(grandchild_pid_path)!r}).write_text(str(os.getpid())); "
+        "print('grandchild-ready', flush=True); "
+        "time.sleep(60)"
+    )
+    return (
+        "import os,subprocess,sys,time; "
+        "from pathlib import Path; "
+        f"Path({str(child_pid_path)!r}).write_text(str(os.getpid())); "
+        f"subprocess.Popen([sys.executable, '-c', {grandchild_program!r}]); "
+        "print('child-ready', flush=True); "
+        "time.sleep(60)"
+    )
 
 
 def test_observed_process_emits_live_heartbeat_and_preserves_capture(
@@ -71,13 +112,21 @@ def test_observed_process_emits_live_heartbeat_and_preserves_capture(
         "print('stderr-after', file=sys.stderr)"
     )
 
-    completed = runner._run_observed_cell_process(
-        unit,
-        [sys.executable, "-c", program],
-        cwd=tmp_path,
-        environment=os.environ.copy(),
-        heartbeat_seconds=0.02,
-    )
+    def prior_sigterm_handler(_signum: int, _frame: object) -> None:
+        return
+
+    original_sigterm_handler = signal.signal(signal.SIGTERM, prior_sigterm_handler)
+    try:
+        completed = runner._run_observed_cell_process(
+            unit,
+            [sys.executable, "-c", program],
+            cwd=tmp_path,
+            environment=os.environ.copy(),
+            heartbeat_seconds=0.02,
+        )
+        assert signal.getsignal(signal.SIGTERM) is prior_sigterm_handler
+    finally:
+        signal.signal(signal.SIGTERM, original_sigterm_handler)
 
     captured = capsys.readouterr()
     observations = _observations(captured.err)
@@ -171,21 +220,7 @@ def test_interrupt_kills_child_and_pipe_holding_grandchild_before_propagating(
     """An inherited pipe cannot strand cleanup or leave either process alive."""
     child_pid_path = tmp_path / "child.pid"
     grandchild_pid_path = tmp_path / "grandchild.pid"
-    grandchild_program = (
-        "import os,time; "
-        "from pathlib import Path; "
-        f"Path({str(grandchild_pid_path)!r}).write_text(str(os.getpid())); "
-        "print('grandchild-ready', flush=True); "
-        "time.sleep(15)"
-    )
-    child_program = (
-        "import os,subprocess,sys,time; "
-        "from pathlib import Path; "
-        f"Path({str(child_pid_path)!r}).write_text(str(os.getpid())); "
-        f"subprocess.Popen([sys.executable, '-c', {grandchild_program!r}]); "
-        "print('child-ready', flush=True); "
-        "time.sleep(15)"
-    )
+    child_program = _pipe_holding_tree_program(child_pid_path, grandchild_pid_path)
 
     def interrupt_after_tree_starts(_child_pid: int) -> dict[str, object]:
         deadline = time.monotonic() + 3.0
@@ -199,31 +234,26 @@ def test_interrupt_kills_child_and_pipe_holding_grandchild_before_propagating(
         runner, "_process_resource_snapshot", interrupt_after_tree_starts
     )
     started = time.monotonic()
-    with pytest.raises(KeyboardInterrupt):
-        runner._run_observed_cell_process(
-            unit,
-            [sys.executable, "-c", child_program],
-            cwd=tmp_path,
-            environment=os.environ.copy(),
-            heartbeat_seconds=0.02,
-        )
-    elapsed = time.monotonic() - started
-
-    assert child_pid_path.is_file()
-    assert grandchild_pid_path.is_file()
-    child_pid = int(child_pid_path.read_text())
-    grandchild_pid = int(grandchild_pid_path.read_text())
     try:
+        with pytest.raises(KeyboardInterrupt):
+            runner._run_observed_cell_process(
+                unit,
+                [sys.executable, "-c", child_program],
+                cwd=tmp_path,
+                environment=os.environ.copy(),
+                heartbeat_seconds=0.02,
+            )
+        elapsed = time.monotonic() - started
+
+        child_pid = _read_pid_file(child_pid_path)
+        grandchild_pid = _read_pid_file(grandchild_pid_path)
+        assert child_pid is not None
+        assert grandchild_pid is not None
         assert elapsed < runner.CELL_CLEANUP_SECONDS + 2.0
         assert _wait_for_pid_exit(child_pid)
         assert _wait_for_pid_exit(grandchild_pid)
     finally:
-        for pid in (child_pid, grandchild_pid):
-            if _pid_exists(pid):
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
+        _cleanup_recorded_processes(child_pid_path, grandchild_pid_path)
 
     observations = _observations(capsys.readouterr().err)
     assert [record["event"] for record in observations] == [
@@ -232,3 +262,75 @@ def test_interrupt_kills_child_and_pipe_holding_grandchild_before_propagating(
     ]
     assert observations[-1]["returncode"] == -signal.SIGKILL
     assert observations[-1]["termination"] == "observer-interrupted"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX signal-session regression")
+def test_sigterm_observer_exits_143_and_reaps_pipe_holding_process_tree(
+    tmp_path: Path,
+) -> None:
+    """External SIGTERM reaches bounded group cleanup before observer exit."""
+    child_pid_path = tmp_path / "child.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    child_program = _pipe_holding_tree_program(child_pid_path, grandchild_pid_path)
+    repository = Path(runner.__file__).resolve().parents[1]
+    observer_program = (
+        "import os,sys; "
+        "from pathlib import Path; "
+        "from scripts.truncated_hierarchy_causal_contract import "
+        "build_plan,load_manifest; "
+        "from scripts.truncated_hierarchy_causal_runner import "
+        "_run_observed_cell_process; "
+        "unit=build_plan(load_manifest(), 'smoke')[0]; "
+        f"_run_observed_cell_process(unit, [sys.executable, '-c', {child_program!r}], "
+        f"cwd=Path({str(tmp_path)!r}), environment=os.environ.copy(), "
+        "heartbeat_seconds=30.0)"
+    )
+    observer = subprocess.Popen(
+        [sys.executable, "-c", observer_program],
+        cwd=repository,
+        env=os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            if _pid_file_ready(child_pid_path) and _pid_file_ready(grandchild_pid_path):
+                break
+            if observer.poll() is not None:
+                break
+            time.sleep(0.01)
+        child_pid = _read_pid_file(child_pid_path)
+        grandchild_pid = _read_pid_file(grandchild_pid_path)
+        assert child_pid is not None
+        assert grandchild_pid is not None
+        assert observer.poll() is None
+
+        started = time.monotonic()
+        os.kill(observer.pid, signal.SIGTERM)
+        _stdout, stderr = observer.communicate(
+            timeout=runner.CELL_CLEANUP_SECONDS + 5.0
+        )
+        elapsed = time.monotonic() - started
+
+        assert observer.returncode == 128 + signal.SIGTERM
+        assert elapsed < runner.CELL_CLEANUP_SECONDS + 4.0
+        assert _wait_for_pid_exit(child_pid)
+        assert _wait_for_pid_exit(grandchild_pid)
+        observations = _observations(stderr)
+        assert [record["event"] for record in observations] == [
+            "cell-start",
+            "cell-end",
+        ]
+        assert observations[-1]["returncode"] == -signal.SIGKILL
+        assert observations[-1]["termination"] == "observer-interrupted"
+    finally:
+        if observer.poll() is None:
+            observer.terminate()
+            try:
+                observer.communicate(timeout=runner.CELL_CLEANUP_SECONDS + 1.0)
+            except subprocess.TimeoutExpired:
+                observer.kill()
+                observer.communicate(timeout=runner.CELL_CLEANUP_SECONDS + 1.0)
+        _cleanup_recorded_processes(child_pid_path, grandchild_pid_path)

--- a/tests/test_truncated_hierarchy_causal_heartbeat.py
+++ b/tests/test_truncated_hierarchy_causal_heartbeat.py
@@ -1,0 +1,234 @@
+"""Operational heartbeat tests for the causal-study cell subprocess."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+import scripts.truncated_hierarchy_causal_runner as runner
+from scripts.truncated_hierarchy_causal_contract import build_plan, load_manifest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def unit():
+    """Return one real planned unit for operational identity fields."""
+    return build_plan(load_manifest(), "smoke")[0]
+
+
+def _observations(stderr: str) -> list[dict[str, object]]:
+    return [
+        json.loads(line.removeprefix(runner.CELL_OBSERVATION_PREFIX))
+        for line in stderr.splitlines()
+        if line.startswith(runner.CELL_OBSERVATION_PREFIX)
+    ]
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _pid_exists(pid):
+            return True
+        time.sleep(0.01)
+    return not _pid_exists(pid)
+
+
+def _pid_file_ready(path: Path) -> bool:
+    try:
+        return int(path.read_text()) > 0
+    except (OSError, ValueError):
+        return False
+
+
+def test_observed_process_emits_live_heartbeat_and_preserves_capture(
+    unit, tmp_path: Path, capsys
+) -> None:
+    """Heartbeat logging never enters either captured child stream."""
+    program = (
+        "import sys,time; "
+        "print('stdout-before', flush=True); "
+        "print('stderr-before', file=sys.stderr, flush=True); "
+        "time.sleep(0.12); "
+        "print('stdout-after'); "
+        "print('stderr-after', file=sys.stderr)"
+    )
+
+    completed = runner._run_observed_cell_process(
+        unit,
+        [sys.executable, "-c", program],
+        cwd=tmp_path,
+        environment=os.environ.copy(),
+        heartbeat_seconds=0.02,
+    )
+
+    captured = capsys.readouterr()
+    observations = _observations(captured.err)
+    assert completed.returncode == 0
+    assert completed.stdout == "stdout-before\nstdout-after\n"
+    assert completed.stderr == "stderr-before\nstderr-after\n"
+    assert captured.out == ""
+    assert [record["event"] for record in observations][0] == "cell-start"
+    assert [record["event"] for record in observations][-1] == "cell-end"
+    heartbeats = [
+        record for record in observations if record["event"] == "cell-heartbeat"
+    ]
+    assert heartbeats
+    assert all(record["cell_id"] == unit.cell_id for record in observations)
+    assert all(
+        record["child_pid"] == observations[0]["child_pid"] for record in observations
+    )
+    assert all(
+        record["resource_status"] in {"available", "partial", "unavailable"}
+        for record in heartbeats
+    )
+    assert observations[-1]["returncode"] == 0
+    assert observations[-1]["termination"] == "child-exited"
+
+
+def test_observed_process_preserves_scientific_failure_returncode_and_streams(
+    unit, tmp_path: Path, capsys
+) -> None:
+    """The runner still receives return code 10 and exact child diagnostics."""
+    program = (
+        "import sys; "
+        "print('failed-out', end=''); "
+        "print('failed-err', end='', file=sys.stderr); "
+        "raise SystemExit(10)"
+    )
+
+    completed = runner._run_observed_cell_process(
+        unit,
+        [sys.executable, "-c", program],
+        cwd=tmp_path,
+        environment=os.environ.copy(),
+        heartbeat_seconds=1.0,
+    )
+
+    observations = _observations(capsys.readouterr().err)
+    assert completed.returncode == 10
+    assert completed.stdout == "failed-out"
+    assert completed.stderr == "failed-err"
+    assert [record["event"] for record in observations] == [
+        "cell-start",
+        "cell-end",
+    ]
+    assert observations[-1]["returncode"] == 10
+
+
+def test_resource_telemetry_failure_cannot_change_child_result(
+    unit, tmp_path: Path, capsys, monkeypatch
+) -> None:
+    """A failed optional resource probe degrades to heartbeat-only logging."""
+
+    def fail_resource_probe(_child_pid: int) -> dict[str, object]:
+        raise PermissionError("resource access denied")
+
+    monkeypatch.setattr(runner, "_process_resource_snapshot", fail_resource_probe)
+    completed = runner._run_observed_cell_process(
+        unit,
+        [sys.executable, "-c", "import time; print('ok'); time.sleep(0.08)"],
+        cwd=tmp_path,
+        environment=os.environ.copy(),
+        heartbeat_seconds=0.01,
+    )
+
+    observations = _observations(capsys.readouterr().err)
+    heartbeats = [
+        record for record in observations if record["event"] == "cell-heartbeat"
+    ]
+    assert completed.returncode == 0
+    assert completed.stdout == "ok\n"
+    assert completed.stderr == ""
+    assert heartbeats
+    assert all(record["resource_status"] == "unavailable" for record in heartbeats)
+    assert all(
+        record["resource_error_types"] == ["PermissionError"] for record in heartbeats
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-session regression")
+def test_interrupt_kills_child_and_pipe_holding_grandchild_before_propagating(
+    unit, tmp_path: Path, capsys, monkeypatch
+) -> None:
+    """An inherited pipe cannot strand cleanup or leave either process alive."""
+    child_pid_path = tmp_path / "child.pid"
+    grandchild_pid_path = tmp_path / "grandchild.pid"
+    grandchild_program = (
+        "import os,time; "
+        "from pathlib import Path; "
+        f"Path({str(grandchild_pid_path)!r}).write_text(str(os.getpid())); "
+        "print('grandchild-ready', flush=True); "
+        "time.sleep(15)"
+    )
+    child_program = (
+        "import os,subprocess,sys,time; "
+        "from pathlib import Path; "
+        f"Path({str(child_pid_path)!r}).write_text(str(os.getpid())); "
+        f"subprocess.Popen([sys.executable, '-c', {grandchild_program!r}]); "
+        "print('child-ready', flush=True); "
+        "time.sleep(15)"
+    )
+
+    def interrupt_after_tree_starts(_child_pid: int) -> dict[str, object]:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if _pid_file_ready(child_pid_path) and _pid_file_ready(grandchild_pid_path):
+                break
+            time.sleep(0.01)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        runner, "_process_resource_snapshot", interrupt_after_tree_starts
+    )
+    started = time.monotonic()
+    with pytest.raises(KeyboardInterrupt):
+        runner._run_observed_cell_process(
+            unit,
+            [sys.executable, "-c", child_program],
+            cwd=tmp_path,
+            environment=os.environ.copy(),
+            heartbeat_seconds=0.02,
+        )
+    elapsed = time.monotonic() - started
+
+    assert child_pid_path.is_file()
+    assert grandchild_pid_path.is_file()
+    child_pid = int(child_pid_path.read_text())
+    grandchild_pid = int(grandchild_pid_path.read_text())
+    try:
+        assert elapsed < runner.CELL_CLEANUP_SECONDS + 2.0
+        assert _wait_for_pid_exit(child_pid)
+        assert _wait_for_pid_exit(grandchild_pid)
+    finally:
+        for pid in (child_pid, grandchild_pid):
+            if _pid_exists(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+    observations = _observations(capsys.readouterr().err)
+    assert [record["event"] for record in observations] == [
+        "cell-start",
+        "cell-end",
+    ]
+    assert observations[-1]["returncode"] == -signal.SIGKILL
+    assert observations[-1]["termination"] == "observer-interrupted"

--- a/tests/test_truncated_hierarchy_causal_models.py
+++ b/tests/test_truncated_hierarchy_causal_models.py
@@ -522,6 +522,58 @@ def test_extreme_tail_icdf_and_density_match_scipy_in_pytensor_and_jax(
     assert jax_derivative > 0.0
 
 
+@pytest.mark.parametrize("floatx", ["float32", "float64"])
+def test_symmetric_finite_icdf_central_jax_derivatives_match_oracle(floatx) -> None:
+    """The exact half-probability branch must retain its one-sided derivative."""
+    bounds = Bounds(0.1, 0.9)
+    base_mean = 0.5
+    scale = 0.3
+    with (
+        pytensor.config.change_flags(floatX=floatx),
+        jax.enable_x64(floatx == "float64"),
+    ):
+        offset = pt.scalar("offset", dtype=floatx)
+        natural = _truncated_normal_from_standard_normal(
+            offset,
+            mu=base_mean,
+            sigma=scale,
+            bounds=bounds,
+        )
+        jaxified = get_jaxified_graph(inputs=[offset], outputs=[natural])
+        jax_offset = jnp.asarray(0.0, dtype=floatx)
+
+        def scalar_jax_offset(value):
+            return jaxified(value)[0]
+
+        observed_value, observed_gradient = jax.value_and_grad(scalar_jax_offset)(
+            jax_offset
+        )
+        observed_hessian = jax.hessian(scalar_jax_offset)(jax_offset)
+
+    expected = truncated_normal_from_standard_normal(
+        Jet2.variable(0.0, index=0, dimension=1),
+        base_mean,
+        scale,
+        TruncationBounds(bounds.lower, bounds.upper),
+    )
+    tolerance = 2e-5 if floatx == "float32" else 2e-10
+    np.testing.assert_allclose(
+        observed_value, expected.value, rtol=tolerance, atol=tolerance
+    )
+    np.testing.assert_allclose(
+        observed_gradient,
+        expected.gradient[0],
+        rtol=tolerance,
+        atol=tolerance,
+    )
+    np.testing.assert_allclose(
+        observed_hessian,
+        expected.hessian[0, 0],
+        rtol=tolerance,
+        atol=tolerance,
+    )
+
+
 @pytest.mark.parametrize(("bounds", "base_mean", "_location"), BOUND_CASES)
 def test_standard_normal_offset_induces_the_target_natural_density(
     bounds, base_mean, _location

--- a/tests/test_truncated_hierarchy_causal_runner.py
+++ b/tests/test_truncated_hierarchy_causal_runner.py
@@ -1504,6 +1504,25 @@ def test_oracle_points_are_bound_to_exact_source_artifacts(
             path.write_bytes(original)
             record["artifacts"][name] = reference
 
+    one_ulp_roundtrip = copy.deepcopy(execution.diagnostics)
+    retained = one_ulp_roundtrip["oracle"]["records"][0]["roundtrip"]
+    retained["group_location"] = float(np.nextafter(retained["group_location"], np.inf))
+    diagnostics_reference = copy.deepcopy(record["artifacts"]["diagnostics"])
+    diagnostics_path = store.root / diagnostics_reference["path"]
+    original_diagnostics = diagnostics_path.read_bytes()
+    try:
+        one_ulp_bytes = canonical_json_bytes(one_ulp_roundtrip)
+        diagnostics_path.write_bytes(one_ulp_bytes)
+        record["artifacts"]["diagnostics"] = {
+            "path": diagnostics_reference["path"],
+            "sha256": sha256_bytes(one_ulp_bytes),
+            "size_bytes": len(one_ulp_bytes),
+        }
+        verify_result_artifacts(record, store.root, unit, manifest)
+    finally:
+        diagnostics_path.write_bytes(original_diagnostics)
+        record["artifacts"]["diagnostics"] = diagnostics_reference
+
     diagnostics = copy.deepcopy(execution.diagnostics)
     trajectory = next(
         item

--- a/tests/test_truncated_hierarchy_causal_runner.py
+++ b/tests/test_truncated_hierarchy_causal_runner.py
@@ -921,6 +921,220 @@ def test_initial_evidence_uses_positional_binding_with_unnamed_inputs(
     assert evidence["all_finite"] is True
 
 
+def test_pymc_graph_evaluator_splits_default_first_order_from_bounded_hessian(
+    manifest, monkeypatch
+) -> None:
+    """Keep sampler-relevant derivatives optimized without optimizing the Hessian."""
+    unit = next(
+        item
+        for item in build_plan(manifest, "smoke")
+        if item.floatx == "float64"
+        and item.backend_id == "pymc"
+        and item.representation_id == "group-icdf-noncentered"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    model = build_causal_model(unit.builder, prior, data)
+    starts = runner._natural_start_payload(unit, data, prior)
+    _, initvals = runner._coordinate_start_payload(
+        unit, model, starts, prior, runner._oracle_spec(unit, prior, data)
+    )
+    vector = runner._pack_model_point(model, initvals[0])
+
+    bounded_mode = object()
+    mode_requests: list[tuple[str, str]] = []
+    compile_requests: list[dict[str, object]] = []
+    evaluated_arguments: list[tuple[np.ndarray, ...]] = []
+    expected_value = 1.25
+    expected_gradient = np.arange(vector.size, dtype=np.float64)
+    expected_hessian = np.arange(vector.size**2, dtype=np.float64).reshape(
+        vector.size, vector.size
+    )
+
+    def bounded_mode_factory(*, linker, optimizer):
+        mode_requests.append((linker, optimizer))
+        return bounded_mode
+
+    def compile_spy(
+        outputs,
+        *,
+        inputs=None,
+        on_unused_input=None,
+        point_fn=True,
+        **kwargs,
+    ):
+        compile_requests.append(
+            {
+                "outputs": outputs,
+                "inputs": inputs,
+                "on_unused_input": on_unused_input,
+                "point_fn": point_fn,
+                "mode_present": "mode" in kwargs,
+                "mode": kwargs.get("mode"),
+            }
+        )
+        if isinstance(outputs, list):
+            assert len(outputs) == 2
+
+            def evaluate_first_order(*arguments):
+                evaluated_arguments.append(tuple(arguments))
+                return expected_value, expected_gradient
+
+            return evaluate_first_order
+
+        def evaluate_hessian(*arguments):
+            evaluated_arguments.append(tuple(arguments))
+            return expected_hessian
+
+        return evaluate_hessian
+
+    monkeypatch.setattr(runner, "Mode", bounded_mode_factory)
+    monkeypatch.setattr(model, "compile_fn", compile_spy)
+
+    evaluator = runner._make_graph_evaluator(model, "pymc")
+    value, gradient, hessian = evaluator(vector)
+
+    assert mode_requests == [("py", "None")]
+    assert len(compile_requests) == 2
+    first_order, second_order = compile_requests
+    assert first_order["mode_present"] is False
+    assert first_order["mode"] is None
+    assert second_order["mode_present"] is True
+    assert second_order["mode"] is bounded_mode
+    for request in compile_requests:
+        assert request["inputs"] == model.value_vars
+        assert request["on_unused_input"] == "ignore"
+        assert request["point_fn"] is False
+    assert len(evaluated_arguments) == 2
+    for arguments in evaluated_arguments:
+        reconstructed = np.concatenate(
+            [np.asarray(argument).reshape(-1) for argument in arguments]
+        )
+        np.testing.assert_array_equal(reconstructed, vector)
+    assert value == expected_value
+    np.testing.assert_array_equal(gradient, expected_gradient)
+    np.testing.assert_array_equal(hessian, expected_hessian)
+
+
+@pytest.mark.slow
+def test_group_icdf_pymc_oracle_evaluator_completes_without_sampling(
+    tmp_path: Path,
+) -> None:
+    """Compile the exact group-ICDF oracle path in a bounded fresh process."""
+    cache = tmp_path / "graph-evaluator-cache"
+    for name in ("pytensor", "jax", "matplotlib", "xdg"):
+        (cache / name).mkdir(parents=True, exist_ok=True)
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.update(
+        {
+            "PYTENSOR_FLAGS": (f"base_compiledir={cache / 'pytensor'},floatX=float64"),
+            "JAX_COMPILATION_CACHE_DIR": str(cache / "jax"),
+            "JAX_ENABLE_X64": "true",
+            "JAX_PLATFORMS": "cpu",
+            "MPLCONFIGDIR": str(cache / "matplotlib"),
+            "XDG_CACHE_HOME": str(cache / "xdg"),
+            "OMP_NUM_THREADS": "1",
+            "OPENBLAS_NUM_THREADS": "1",
+            "MKL_NUM_THREADS": "1",
+            "NUMEXPR_NUM_THREADS": "1",
+        }
+    )
+    program = textwrap.dedent(
+        """
+        import resource
+        import sys
+        import time
+
+        import numpy as np
+
+        from scripts import truncated_hierarchy_causal_runner as runner
+        from scripts.truncated_hierarchy_causal_contract import (
+            DEFAULT_MANIFEST,
+            build_plan,
+            load_manifest,
+        )
+
+        manifest = load_manifest(DEFAULT_MANIFEST)
+        unit = next(
+            item for item in build_plan(manifest, "smoke")
+            if item.floatx == "float64"
+            and item.backend_id == "pymc"
+            and item.representation_id == "group-icdf-noncentered"
+        )
+        data = runner.generate_synthetic_data(
+            runner._toy_spec(unit),
+            group_seed=unit.group_seed,
+            observation_seed=unit.observation_seed,
+        )
+        prior = runner._prior(unit)
+        model = runner.build_causal_model(unit.builder, prior, data)
+        starts = runner._natural_start_payload(unit, data, prior)
+        spec = runner._oracle_spec(unit, prior, data)
+        _, initvals = runner._coordinate_start_payload(
+            unit, model, starts, prior, spec
+        )
+        vector = runner._pack_model_point(model, initvals[0])
+        started = time.perf_counter()
+        observed = runner._make_graph_evaluator(model, "pymc")(vector)
+        elapsed = time.perf_counter() - started
+        parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[
+            unit.representation_id
+        ]
+        expected = runner.hierarchical_posterior_components(
+            vector, spec, parameterization
+        ).total
+        tolerances = manifest["analysis_policy"]["oracle_gate"][
+            "component_tolerances"
+        ][unit.floatx]
+        for actual, reference, component in zip(
+            observed,
+            (expected.value, expected.gradient, expected.hessian),
+            ("logp", "gradient", "hessian"),
+            strict=True,
+        ):
+            tolerance = tolerances[component]
+            np.testing.assert_allclose(
+                actual,
+                reference,
+                rtol=tolerance["relative_tolerance"],
+                atol=tolerance["absolute_tolerance"],
+            )
+        maximum_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        maximum_rss_bytes = int(
+            maximum_rss if sys.platform == "darwin" else maximum_rss * 1024
+        )
+        print(
+            runner.canonical_json_bytes(
+                {
+                    "elapsed_seconds": elapsed,
+                    "maximum_rss_bytes": maximum_rss_bytes,
+                }
+            ).decode(),
+            end="",
+        )
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=DEFAULT_MANIFEST.parents[2],
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=240,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = decode_canonical_json((completed.stdout.splitlines()[-1] + "\n").encode())
+    assert 0.0 < result["elapsed_seconds"] < 240.0
+    assert 0 < result["maximum_rss_bytes"] < 5 * 1024**3
+
+
 def _mock_execute_cell_prefix(monkeypatch, *, roundtrip_error: float = 0.0) -> None:
     """Replace the build/start prefix while retaining execute_cell state logic."""
     sentinel = object()

--- a/tests/test_truncated_hierarchy_causal_runner.py
+++ b/tests/test_truncated_hierarchy_causal_runner.py
@@ -1,0 +1,1863 @@
+"""Tests for the isolated backend-paired causal sampling runner."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import math
+import os
+import subprocess
+import sys
+import textwrap
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import jax
+import numpy as np
+import pytest
+import xarray as xr
+
+import scripts.truncated_hierarchy_causal_runner as runner
+from scripts.truncated_hierarchy_causal_artifacts import (
+    ArtifactRef,
+    ArtifactStore,
+    CausalArtifactError,
+    decode_canonical_json,
+)
+from scripts.truncated_hierarchy_causal_contract import (
+    DEFAULT_MANIFEST,
+    RUNNER_VERSION,
+    CausalContractError,
+    RunContext,
+    aggregate_results,
+    build_plan,
+    canonical_json_bytes,
+    environment_digest,
+    load_manifest,
+    manifest_digest,
+    pair_units,
+    sha256_bytes,
+    validate_result_record,
+    verify_result_artifacts,
+)
+from scripts.truncated_hierarchy_causal_models import build_causal_model
+from scripts.truncated_hierarchy_models import generate_synthetic_data
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    """Load the real frozen causal contract once for focused runner tests."""
+    return load_manifest(DEFAULT_MANIFEST)
+
+
+def _context(units, manifest) -> RunContext:
+    profile = manifest["dependency_profile"]
+    environment = {
+        "schema_version": 3,
+        "study_id": manifest["study_id"],
+        "manifest_sha256": manifest_digest(manifest),
+        "runner_version": RUNNER_VERSION,
+        "dependency_profile": profile["name"],
+        "git": {"commit": "2" * 40, "branch": "test", "dirty": False},
+        "project": {
+            "path": profile["project_path"],
+            "sha256": profile["project_sha256"],
+            "lock_path": profile["lock_path"],
+            "lock_sha256": profile["lock_sha256"],
+        },
+        "runtime": {
+            "python": "3.12.0",
+            "implementation": "CPython",
+            "executable": "/test/python",
+            "platform": "test",
+        },
+        "packages": dict(profile["required_versions"]),
+    }
+    environment["environment_sha256"] = environment_digest(environment)
+    return RunContext(
+        schema_version=3,
+        study_id=units[0].study_id,
+        manifest_sha256=units[0].manifest_sha256,
+        pair_id=units[0].pair_id,
+        block_ids=tuple(dict.fromkeys(unit.block_id for unit in units)),
+        cell_ids=tuple(unit.cell_id for unit in units),
+        execution_order=tuple(unit.cell_id for unit in units),
+        environment=environment,
+        environment_sha256=environment["environment_sha256"],
+        git_commit="2" * 40,
+        worker_identity_sha256="3" * 64,
+        pair_execution_id="4" * 64,
+        execution_attempt_ids=tuple(f"{index + 5:064x}" for index in range(10)),
+    )
+
+
+def _natural_dataset(unit) -> xr.Dataset:
+    rng = np.random.default_rng(1282)
+    shape = (unit.chains, unit.draws)
+    lower = float(unit.regime["lower"])
+    upper = unit.regime["upper"]
+    location = lower + 0.2 + 0.01 * rng.normal(size=shape)
+    if upper is not None:
+        location = np.clip(location, lower + 0.01, float(upper) - 0.01)
+    scale = np.exp(-1.2 + 0.02 * rng.normal(size=shape))
+    effects = np.repeat(location[..., None], int(unit.regime["n_groups"]), axis=2)
+    posterior = xr.Dataset(
+        {
+            "group_location": (("chain", "draw"), location),
+            "group_scale": (("chain", "draw"), scale),
+            "group_effect": (("chain", "draw", "group"), effects),
+        },
+        coords={
+            "chain": np.arange(unit.chains),
+            "draw": np.arange(unit.draws),
+            "group": np.arange(int(unit.regime["n_groups"])),
+        },
+    )
+    sequence = np.arange(np.prod(shape), dtype=np.float64).reshape(shape)
+    sample_stats = xr.Dataset(
+        {
+            "acceptance_rate": (("chain", "draw"), np.full(shape, 0.91)),
+            "diverging": (("chain", "draw"), np.zeros(shape, dtype=bool)),
+            "energy": (("chain", "draw"), np.sin(sequence / 11.0)),
+            "n_steps": (("chain", "draw"), np.full(shape, 7)),
+            "step_size": (("chain", "draw"), np.full(shape, 0.125)),
+            "tree_depth": (("chain", "draw"), np.full(shape, 3)),
+        }
+    )
+    return runner._standardize_natural_chains(
+        unit, SimpleNamespace(posterior=posterior, sample_stats=sample_stats)
+    )
+
+
+@pytest.fixture(scope="module")
+def native_oracle_artifacts(manifest):
+    """Build one exact, no-sampling artifact set for provenance audits."""
+    unit = next(
+        item
+        for item in build_plan(manifest, "smoke")
+        if item.backend_id == "pymc"
+        and item.representation_id == "native-centered"
+        and item.floatx == "float64"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    data_payload = runner._data_payload(unit, data)
+    start_payload = runner._natural_start_payload(unit, data, prior)
+    model = build_causal_model(unit.builder, prior, data)
+    oracle_spec = runner._oracle_spec(unit, prior, data)
+    coordinate_payload, _ = runner._coordinate_start_payload(
+        unit, model, start_payload, prior, oracle_spec
+    )
+    parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+
+    def exact_evaluator(vector):
+        expected = runner.hierarchical_posterior_components(
+            vector, oracle_spec, parameterization
+        ).total
+        return expected.value, expected.gradient, expected.hessian
+
+    pre_oracle = runner._oracle_diagnostics(
+        unit,
+        model,
+        prior,
+        data,
+        start_payload,
+        None,
+        manifest["analysis_policy"],
+        evaluator=exact_evaluator,
+    )
+    chains = _natural_dataset(unit)
+    full_oracle = runner._oracle_diagnostics(
+        unit,
+        model,
+        prior,
+        data,
+        start_payload,
+        chains,
+        manifest["analysis_policy"],
+        evaluator=exact_evaluator,
+        prior_records=pre_oracle["records"],
+        include_static=False,
+    )
+    return {
+        "unit": unit,
+        "data": data,
+        "prior": prior,
+        "model": model,
+        "oracle_spec": oracle_spec,
+        "data_payload": data_payload,
+        "start_payload": start_payload,
+        "coordinate_payload": coordinate_payload,
+        "chains": chains,
+        "pre_oracle": pre_oracle,
+        "full_oracle": full_oracle,
+    }
+
+
+def _completed_metrics(unit) -> dict[str, object]:
+    layers = {
+        "native-centered": 0,
+        "manual-centered": 0,
+        "group-icdf-noncentered": 1,
+        "location-icdf-noncentered": 1,
+        "full-icdf-noncentered": 2,
+    }[unit.representation_id]
+    oracle_count = unit.chains + int(unit.replicate == 0) + 5 * layers + unit.chains
+    return {
+        "compile_success": True,
+        "initialization_success": True,
+        "logp_finite": True,
+        "gradient_finite": True,
+        "sampling_success": True,
+        "divergence_count": 0,
+        "posterior_draw_count": unit.chains * unit.draws,
+        "divergence_rate": 0.0,
+        "sampling_elapsed_seconds": 1.0,
+        "step_size_final_min": 0.01,
+        "step_size_final_max": 0.02,
+        "leapfrog_step_count": 1000.0,
+        "oracle_evaluation_count": oracle_count,
+        "oracle_logp_scaled_error_max": 0.0,
+        "oracle_gradient_scaled_error_max": 0.0,
+        "oracle_hessian_scaled_error_max": 0.0,
+        "roundtrip_absolute_error_max": 0.0,
+        "icdf_tail_finite": True,
+        "icdf_branch_continuous": True,
+    }
+
+
+def _synthetic_oracle(unit, *, trajectory: bool) -> dict[str, object]:
+    size = int(unit.regime["n_groups"]) + 2
+    zeros = [0.0] * size
+    zero_hessian = [[0.0] * size for _ in range(size)]
+    zero_error = {"absolute_max": 0.0, "scaled_max": 0.0}
+
+    def record(
+        point_id,
+        kind,
+        *,
+        coordinate_index=None,
+        epsilon=None,
+        chain=None,
+        draw=None,
+        selection_sha256=None,
+    ):
+        value = {
+            "point_id": point_id,
+            "kind": kind,
+            "coordinate_vector": zeros,
+            "roundtrip": {"absolute_error_max": 0.0},
+            "observed": {
+                "value": 0.0,
+                "gradient": zeros,
+                "hessian": zero_hessian,
+            },
+            "oracle": {
+                "value": 0.0,
+                "gradient": zeros,
+                "hessian": zero_hessian,
+            },
+            "errors": {
+                "value": dict(zero_error),
+                "gradient": dict(zero_error),
+                "hessian": dict(zero_error),
+            },
+            "component_finite": {
+                "value": True,
+                "gradient": True,
+                "hessian": True,
+            },
+            "finite": True,
+            "passed": True,
+        }
+        if coordinate_index is not None:
+            value["coordinate_index"] = coordinate_index
+        if epsilon is not None:
+            value["branch_epsilon"] = epsilon
+        if chain is not None:
+            value["chain"] = chain
+        if draw is not None:
+            value["draw"] = draw
+        if selection_sha256 is not None:
+            value["selection_sha256"] = selection_sha256
+        return value
+
+    records = []
+    if unit.replicate == 0:
+        records.append(record("fixed-truth", "fixed-grid"))
+    records.extend(
+        record(f"start-chain-{chain:02d}", "shared-natural-start")
+        for chain in range(unit.chains)
+    )
+    parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+    indices = []
+    if parameterization in {"location_icdf_noncentered", "full_icdf_noncentered"}:
+        indices.append(0)
+    if parameterization in {"group_icdf_noncentered", "full_icdf_noncentered"}:
+        indices.append(2)
+    epsilon = float(8.0 * math.sqrt(np.finfo(np.dtype(unit.floatx)).eps))
+    branch_checks = []
+    for coordinate_index in indices:
+        for label in ("branch-left", "branch-zero", "branch-right"):
+            records.append(
+                record(
+                    f"icdf-{coordinate_index}-{label}",
+                    f"icdf-{label}",
+                    coordinate_index=coordinate_index,
+                    epsilon=epsilon,
+                )
+            )
+        for label in ("tail-low", "tail-high"):
+            records.append(
+                record(
+                    f"icdf-{coordinate_index}-{label}",
+                    f"icdf-{label}",
+                    coordinate_index=coordinate_index,
+                    epsilon=epsilon,
+                )
+            )
+        branch_checks.append(
+            {
+                "coordinate_index": coordinate_index,
+                "epsilon": epsilon,
+                "left_point_id": f"icdf-{coordinate_index}-branch-left",
+                "zero_point_id": f"icdf-{coordinate_index}-branch-zero",
+                "right_point_id": f"icdf-{coordinate_index}-branch-right",
+                "observed_value_jump": 0.0,
+                "oracle_value_jump": 0.0,
+                "observed_gradient_jump": zeros,
+                "oracle_gradient_jump": zeros,
+                "value_jump_error": dict(zero_error),
+                "gradient_jump_error": dict(zero_error),
+                "passed": True,
+            }
+        )
+    if trajectory:
+        for chain in range(unit.chains):
+            draw = min(
+                range(unit.draws),
+                key=lambda candidate: hashlib.sha256(
+                    f"{unit.cell_id}:trajectory:{chain}:{candidate}".encode()
+                ).digest(),
+            )
+            selection_sha256 = hashlib.sha256(
+                f"{unit.cell_id}:trajectory:{chain}:{draw}".encode()
+            ).hexdigest()
+            records.append(
+                record(
+                    f"trajectory-chain-{chain:02d}-selection-00",
+                    "hash-selected-posterior-trajectory",
+                    chain=chain,
+                    draw=draw,
+                    selection_sha256=selection_sha256,
+                )
+            )
+    return {
+        "backend_id": unit.backend_id,
+        "representation_id": unit.representation_id,
+        "parameterization": parameterization,
+        "point_selection": {
+            "fixed_grid": "replicate-zero-truth",
+            "starts": "every-shared-natural-chain-start",
+            "trajectory": "lowest-sha256-per-chain",
+            "trajectory_points_per_chain": 1,
+        },
+        "posterior_trajectory_evaluated": trajectory,
+        "records": records,
+        "icdf_tail_finite": True,
+        "icdf_branch_checks": branch_checks,
+        "icdf_branch_continuous": True,
+        "passed": True,
+    }
+
+
+def _runtime_diagnostics(unit, *, oracle=None) -> dict[str, object]:
+    result = {
+        "schema_version": unit.schema_version,
+        "study_id": unit.study_id,
+        "manifest_sha256": unit.manifest_sha256,
+        "cell_id": unit.cell_id,
+        "runtime": {
+            "process_id": 1282,
+            "cache_identity_sha256": "5" * 64,
+            "pytensor_floatx": unit.floatx,
+            "jax_enable_x64": unit.floatx == "float64",
+            "jax_platform": "cpu",
+        },
+    }
+    if oracle is not None:
+        result["oracle"] = oracle
+    return result
+
+
+def test_shared_natural_starts_roundtrip_through_all_five_forms(manifest) -> None:
+    """One byte-identical start maps bijectively into the complete 2x2 panel."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    reference = units[0]
+    data = generate_synthetic_data(
+        runner._toy_spec(reference),
+        group_seed=reference.group_seed,
+        observation_seed=reference.observation_seed,
+    )
+    prior = runner._prior(reference)
+    starts = runner._natural_start_payload(reference, data, prior)
+
+    for unit in units:
+        model = build_causal_model(
+            runner.BUILDER_TO_PARAMETERIZATION[unit.builder], prior, data
+        )
+        payload, initvals = runner._coordinate_start_payload(
+            unit, model, starts, prior, runner._oracle_spec(unit, prior, data)
+        )
+        assert len(initvals) == unit.chains
+        assert (
+            max(chain["roundtrip"]["absolute_error_max"] for chain in payload["chains"])
+            < 1e-10
+        )
+
+
+def test_natural_start_validation_rejects_support_valid_forgery(manifest) -> None:
+    """Support checks cannot substitute for the exact seeded intervention."""
+    unit = next(
+        item for item in build_plan(manifest, "smoke") if item.floatx == "float64"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    payload = runner._natural_start_payload(unit, data, prior)
+    forged = copy.deepcopy(payload)
+    forged["chains"][0]["group_location"] += 1e-6
+
+    with pytest.raises(runner.CausalRunnerError, match="deterministic regeneration"):
+        runner._validate_natural_start_payload(forged, unit, prior, data)
+
+
+def test_icdf_branch_gate_uses_symmetric_neighbors_and_detects_jump(manifest) -> None:
+    """Continuity is an explicit left/zero/right comparison, not a zero probe."""
+    unit = next(
+        item
+        for item in build_plan(manifest, "smoke")
+        if item.floatx == "float64"
+        and item.backend_id == "pymc"
+        and item.representation_id == "group-icdf-noncentered"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    model = build_causal_model(unit.builder, prior, data)
+    starts = runner._natural_start_payload(unit, data, prior)
+    spec = runner._oracle_spec(unit, prior, data)
+    parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+
+    def discontinuous_evaluator(vector):
+        expected = runner.hierarchical_posterior_components(
+            vector, spec, parameterization
+        ).total
+        value = expected.value
+        gradient = np.asarray(expected.gradient).copy()
+        if vector[2] > 0:
+            value += 1.0
+            gradient[2] += 1.0
+        return value, gradient, np.asarray(expected.hessian)
+
+    diagnostics = runner._oracle_diagnostics(
+        unit,
+        model,
+        prior,
+        data,
+        starts,
+        None,
+        manifest["analysis_policy"],
+        evaluator=discontinuous_evaluator,
+    )
+
+    branch_records = [
+        record
+        for record in diagnostics["records"]
+        if record["kind"].startswith("icdf-branch")
+    ]
+    coordinates = {
+        record["kind"]: record["coordinate_vector"][2] for record in branch_records
+    }
+    assert set(coordinates) == {
+        "icdf-branch-left",
+        "icdf-branch-zero",
+        "icdf-branch-right",
+    }
+    assert coordinates["icdf-branch-left"] == pytest.approx(
+        -coordinates["icdf-branch-right"], abs=1e-15
+    )
+    assert coordinates["icdf-branch-zero"] == 0.0
+    assert diagnostics["icdf_branch_checks"][0]["passed"] is False
+    assert diagnostics["icdf_branch_continuous"] is False
+
+
+def test_nonfinite_backend_oracle_is_finite_publishable_evidence(manifest) -> None:
+    """NaN backend derivatives become explicit failed evidence, never JSON NaN."""
+    unit = next(
+        item
+        for item in build_plan(manifest, "smoke")
+        if item.floatx == "float64"
+        and item.backend_id == "pymc"
+        and item.representation_id == "native-centered"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    model = build_causal_model(unit.builder, prior, data)
+    starts = runner._natural_start_payload(unit, data, prior)
+    spec = runner._oracle_spec(unit, prior, data)
+    parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id]
+
+    def nonfinite_evaluator(vector):
+        expected = runner.hierarchical_posterior_components(
+            vector, spec, parameterization
+        ).total
+        return (
+            float("nan"),
+            np.full_like(expected.gradient, np.nan),
+            np.full_like(expected.hessian, np.nan),
+        )
+
+    diagnostics = runner._oracle_diagnostics(
+        unit,
+        model,
+        prior,
+        data,
+        starts,
+        None,
+        manifest["analysis_policy"],
+        evaluator=nonfinite_evaluator,
+    )
+    metrics = runner._registered_oracle_metrics(diagnostics)
+
+    assert all(record["finite"] is False for record in diagnostics["records"])
+    assert all(record["observed"]["value"] is None for record in diagnostics["records"])
+    assert metrics["oracle_logp_scaled_error_max"] > 1
+    assert metrics["oracle_gradient_scaled_error_max"] > 1
+    assert metrics["oracle_hessian_scaled_error_max"] > 1
+    runner.canonical_json_bytes(diagnostics)
+
+
+def test_shared_input_artifacts_are_byte_exact_across_forms_and_backends(
+    manifest, tmp_path: Path
+) -> None:
+    """Every candidate and backend consumes one immutable intervention pair."""
+    cohort = [
+        unit
+        for unit in build_plan(manifest, "smoke")
+        if unit.regime_id == "lower-outside-weak"
+    ]
+    store = ArtifactStore(tmp_path.resolve())
+
+    references = [runner.materialize_inputs_for_unit(unit, store) for unit in cohort]
+
+    assert len({data.sha256 for data, _start in references}) == 1
+    assert len({start.sha256 for _data, start in references}) == 1
+    assert len({data.path for data, _start in references}) == 1
+    assert len({start.path for _data, start in references}) == 1
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("ambient_floatx", ["float64", "float32"])
+def test_public_materialization_uses_each_regimes_planned_source_precision(
+    manifest, tmp_path: Path, ambient_floatx: str
+) -> None:
+    """Mixed-precision tiers re-exec the opposite regime in a fresh process."""
+    repository = DEFAULT_MANIFEST.parents[2]
+    run_dir = (tmp_path / "run").resolve()
+    cache = tmp_path / "cache"
+    for name in ("pytensor", "jax", "matplotlib", "xdg"):
+        (cache / name).mkdir(parents=True, exist_ok=True)
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.update(
+        {
+            "PYTENSOR_FLAGS": (
+                f"base_compiledir={cache / 'pytensor'},floatX={ambient_floatx}"
+            ),
+            "JAX_COMPILATION_CACHE_DIR": str(cache / "jax"),
+            "JAX_ENABLE_X64": "true" if ambient_floatx == "float64" else "false",
+            "JAX_PLATFORMS": "cpu",
+            "MPLCONFIGDIR": str(cache / "matplotlib"),
+            "XDG_CACHE_HOME": str(cache / "xdg"),
+            "OMP_NUM_THREADS": "1",
+            "OPENBLAS_NUM_THREADS": "1",
+            "MKL_NUM_THREADS": "1",
+            "NUMEXPR_NUM_THREADS": "1",
+        }
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/truncated_hierarchy_causal_runner.py",
+            "--manifest",
+            str(DEFAULT_MANIFEST),
+            "materialize-inputs",
+            "--tier",
+            "smoke",
+            "--run-dir",
+            str(run_dir),
+        ],
+        cwd=repository,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    representatives: dict[str, runner.UnitSpec] = {}
+    for unit in build_plan(manifest, "smoke"):
+        representatives.setdefault(unit.data_id, unit)
+    for unit in representatives.values():
+        start = decode_canonical_json(
+            (run_dir / "starts" / "natural" / f"{unit.start_id}.json").read_bytes()
+        )
+        data = decode_canonical_json(
+            (run_dir / "data" / f"{unit.data_id}.json").read_bytes()
+        )
+        assert start["source_graph"]["pytensor_floatx"] == unit.floatx
+        assert set(start["source_graph"]["value_variable_dtypes"]) == {unit.floatx}
+        assert data["spec"]["floatx"] == unit.floatx
+
+
+@pytest.mark.slow
+def test_float32_coordinate_payload_uses_graph_representable_vector(
+    tmp_path: Path,
+) -> None:
+    """Recorded round trips use the float32 point actually passed to the graph."""
+    cache = tmp_path / "cache"
+    for name in ("pytensor", "jax", "matplotlib", "xdg"):
+        (cache / name).mkdir(parents=True, exist_ok=True)
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.update(
+        {
+            "PYTENSOR_FLAGS": f"base_compiledir={cache / 'pytensor'},floatX=float32",
+            "JAX_COMPILATION_CACHE_DIR": str(cache / "jax"),
+            "JAX_ENABLE_X64": "false",
+            "JAX_PLATFORMS": "cpu",
+            "MPLCONFIGDIR": str(cache / "matplotlib"),
+            "XDG_CACHE_HOME": str(cache / "xdg"),
+        }
+    )
+    program = textwrap.dedent(
+        """
+        import numpy as np
+        from scripts import truncated_hierarchy_causal_runner as runner
+        from scripts.truncated_hierarchy_causal_contract import (
+            DEFAULT_MANIFEST,
+            build_plan,
+            load_manifest,
+        )
+
+        manifest = load_manifest(DEFAULT_MANIFEST)
+        unit = next(
+            item for item in build_plan(manifest, "smoke")
+            if item.floatx == "float32"
+            and item.backend_id == "pymc"
+            and item.representation_id == "full-icdf-noncentered"
+        )
+        data = runner.generate_synthetic_data(
+            runner._toy_spec(unit),
+            group_seed=unit.group_seed,
+            observation_seed=unit.observation_seed,
+        )
+        prior = runner._prior(unit)
+        model = runner.build_causal_model(unit.builder, prior, data)
+        starts = runner._natural_start_payload(unit, data, prior)
+        spec = runner._oracle_spec(unit, prior, data)
+        payload, initvals = runner._coordinate_start_payload(
+            unit, model, starts, prior, spec
+        )
+        parameterization = runner.REPRESENTATION_TO_PARAMETERIZATION[
+            unit.representation_id
+        ]
+        maximum = 0.0
+        for record, point in zip(payload["chains"], initvals, strict=True):
+            graph_vector = runner._pack_model_point(model, point)
+            if graph_vector.dtype != np.dtype("float32"):
+                raise AssertionError(graph_vector.dtype)
+            np.testing.assert_array_equal(
+                graph_vector,
+                np.asarray(record["coordinate_vector"], dtype=np.float32),
+            )
+            roundtrip = runner._natural_coordinate_roundtrip(
+                record["natural"],
+                graph_vector,
+                oracle_spec=spec,
+                parameterization=parameterization,
+            )
+            if roundtrip != record["roundtrip"]:
+                raise AssertionError("stored roundtrip differs from graph point")
+            maximum = max(maximum, roundtrip["absolute_error_max"])
+        print(runner.canonical_json_bytes({"maximum": maximum}).decode(), end="")
+        """
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=DEFAULT_MANIFEST.parents[2],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = decode_canonical_json(completed.stdout.encode())
+    assert 0.0 <= result["maximum"] <= 2e-5
+
+
+def test_backend_seed_shapes_and_numpyro_split_keys_are_exact(manifest) -> None:
+    """Record PyMC spawned integers and NumPyro split keys, not seed inputs."""
+    plan = build_plan(manifest, "confirmation")
+    pymc_unit = next(unit for unit in plan if unit.backend_id == "pymc")
+    numpyro_unit = next(unit for unit in plan if unit.backend_id == "numpyro")
+
+    sampler_input, pymc_streams = runner._sampler_rng_provenance(pymc_unit)
+    assert sampler_input == [943009182, 939311901, 1620816411, 1994453597]
+    assert [stream["init_step_seed"] for stream in pymc_streams] == [
+        1019536840,
+        896392474,
+        417781057,
+        822370369,
+    ]
+    assert [stream["spawn_key"] for stream in pymc_streams] == [
+        [0],
+        [1],
+        [2],
+        [3],
+    ]
+    assert [stream["post_init_draw_state_sha256"] for stream in pymc_streams] == [
+        "68ed6b06d0544f5ee8e81dbdaaef0fcadfb2ada704e93f21e6c662b9ab117ed5",
+        "9f48f6b2865cff458c5d73a80e41a9b3bc3b47cbc26c1837adedf50911657fdb",
+        "f63f284505c3e569d75bb43480a8b3a3dd2e54c469973d5dee90c338c897a826",
+        "4140b920ccbddae64419e03cb21ce599b81cecfe500c1f3ab2f5a976f1f76238",
+    ]
+    master, numpyro_streams = runner._sampler_rng_provenance(numpyro_unit)
+    expected = np.asarray(
+        jax.random.split(jax.random.PRNGKey(numpyro_unit.sampler_seed), 4),
+        dtype=np.uint32,
+    ).astype(np.uint64)
+    assert master == numpyro_unit.sampler_seed
+    assert [stream["key"] for stream in numpyro_streams] == expected.tolist()
+
+
+def test_sample_dispatch_preserves_backend_specific_seeds_and_starts(
+    manifest, monkeypatch
+) -> None:
+    """Dispatch adds no second jitter and keeps the reviewed backend paths."""
+    plan = build_plan(manifest, "smoke")
+    calls: dict[str, dict] = {}
+    sentinel = object()
+
+    def fake_pymc(**kwargs):
+        calls["pymc"] = kwargs
+        return sentinel
+
+    def fake_numpyro(**kwargs):
+        calls["numpyro"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(runner.pm, "sample", fake_pymc)
+    monkeypatch.setattr(runner, "sample_numpyro_nuts", fake_numpyro)
+    with runner.pm.Model() as model:
+        runner.pm.Normal("x")
+    initvals = [{"x": np.array(0.0)}, {"x": np.array(0.1)}]
+    pymc_unit = next(unit for unit in plan if unit.backend_id == "pymc")
+    numpyro_unit = next(unit for unit in plan if unit.backend_id == "numpyro")
+
+    assert runner._sample_model(pymc_unit, model, initvals)[0] is sentinel
+    assert runner._sample_model(numpyro_unit, model, initvals)[0] is sentinel
+    assert calls["pymc"]["random_seed"] == list(pymc_unit.chain_seeds)
+    assert calls["pymc"]["init"] == "adapt_diag"
+    assert calls["pymc"]["initvals"] == initvals
+    assert calls["numpyro"]["random_seed"] == numpyro_unit.sampler_seed
+    assert calls["numpyro"]["jitter"] is False
+    assert calls["numpyro"]["chain_method"] == "sequential"
+    assert calls["numpyro"]["initvals"] == initvals
+
+
+def test_sampler_jaxification_incompatibility_is_a_compile_failure(
+    manifest, monkeypatch
+) -> None:
+    """A known unsupported JAX lowering is evidence, not an incomplete block."""
+    unit = next(
+        item for item in build_plan(manifest, "smoke") if item.backend_id == "numpyro"
+    )
+
+    def fail_jaxification(**_kwargs):
+        raise NotImplementedError("unsupported PyTensor Op")
+
+    monkeypatch.setattr(runner, "sample_numpyro_nuts", fail_jaxification)
+    with runner.pm.Model() as model:
+        runner.pm.Normal("x")
+    initvals = [{"x": np.array(0.0)}, {"x": np.array(0.1)}]
+
+    with pytest.raises(runner.ScientificCellFailure) as captured:
+        runner._sample_model(unit, model, initvals)
+
+    assert captured.value.stage == "compile"
+    assert captured.value.error_type == "NotImplementedError"
+
+
+def test_chain_artifact_retains_stats_and_metrics_are_recomputed(
+    manifest, tmp_path: Path
+) -> None:
+    """Hash-bound per-draw statistics, rather than scalar claims, drive metrics."""
+    unit = build_plan(manifest, "smoke")[0]
+    shape = (unit.chains, unit.draws)
+    sequence = np.arange(np.prod(shape), dtype=np.float64).reshape(shape)
+    divergences = np.zeros(shape, dtype=bool)
+    divergences[0, 3] = True
+    divergences[1, 7] = True
+    inference = SimpleNamespace(
+        posterior=_natural_dataset(unit),
+        sample_stats=xr.Dataset(
+            {
+                "acceptance_rate": (("chain", "draw"), np.full(shape, 0.91)),
+                "diverging": (("chain", "draw"), divergences),
+                "energy": (("chain", "draw"), np.sin(sequence / 11.0)),
+                "energy_error": (("chain", "draw"), np.cos(sequence / 13.0)),
+                "n_steps": (("chain", "draw"), np.full(shape, 7)),
+                "step_size": (("chain", "draw"), np.full(shape, 0.125)),
+                "tree_depth": (("chain", "draw"), np.full(shape, 3)),
+            }
+        ),
+    )
+
+    chains = runner._standardize_natural_chains(unit, inference)
+    metrics = runner._sampler_metrics(unit, chains, 1.25)
+
+    assert "sample_stat__energy_error" in chains
+    assert chains["sample_stat__diverging"].shape == shape
+    assert chains.attrs["pair_id"] == unit.pair_id
+    assert chains.attrs["pair_position"] == unit.pair_position
+    assert chains.attrs["cell_id"] == unit.cell_id
+    assert chains.attrs["sampler_seed_input_json"]
+    assert chains.attrs["chain_rng_provenance_json"]
+    assert metrics["divergence_count"] == 2
+    assert metrics["leapfrog_step_count"] == 7 * np.prod(shape)
+    assert metrics["step_size_final_min"] == pytest.approx(0.125)
+
+    tampered = chains.copy(deep=True)
+    tampered["sample_stat__diverging"][0, 0] = True
+    assert runner._sampler_metrics(unit, tampered, 1.25)["divergence_count"] == 3
+
+    store = ArtifactStore(tmp_path.resolve())
+    reference = store.write_bytes("chains/test.nc", runner._netcdf_bytes(chains))
+    chain_path = store.verify(reference)
+    changed_bytes = bytearray(chain_path.read_bytes())
+    changed_bytes[-1] ^= 1
+    chain_path.write_bytes(changed_bytes)
+    with pytest.raises(CausalArtifactError, match="wrong SHA-256"):
+        store.verify(reference)
+
+
+def test_initial_evidence_uses_positional_binding_with_unnamed_inputs(
+    manifest, monkeypatch
+) -> None:
+    """Hosted linkers may drop names without breaking start diagnostics."""
+    unit = build_plan(manifest, "smoke")[0]
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    model = build_causal_model("native_centered", runner._prior(unit), data)
+    original = model.compile_fn
+    observed_point_fn: list[bool] = []
+
+    def compile_unnamed(outputs, *, inputs=None, point_fn=True, **kwargs):
+        assert inputs is not None
+        names = [variable.name for variable in inputs]
+        try:
+            for variable in inputs:
+                variable.name = None
+            function = original(outputs, inputs=inputs, point_fn=point_fn, **kwargs)
+        finally:
+            for variable, name in zip(inputs, names, strict=True):
+                variable.name = name
+        observed_point_fn.append(point_fn)
+        return function
+
+    monkeypatch.setattr(model, "compile_fn", compile_unnamed)
+    point = model.initial_point()
+    evidence = runner._finite_initial_evidence(model, [point])
+
+    assert observed_point_fn == [False]
+    assert evidence["all_finite"] is True
+
+
+def _mock_execute_cell_prefix(monkeypatch, *, roundtrip_error: float = 0.0) -> None:
+    """Replace the build/start prefix while retaining execute_cell state logic."""
+    sentinel = object()
+    monkeypatch.setattr(runner, "_data_from_payload", lambda *_args: sentinel)
+    monkeypatch.setattr(runner, "_prior", lambda *_args: sentinel)
+    monkeypatch.setattr(runner, "_validate_natural_start_payload", lambda *_args: None)
+    monkeypatch.setattr(runner, "build_causal_model", lambda *_args: sentinel)
+    monkeypatch.setattr(runner, "_oracle_spec", lambda *_args: sentinel)
+    monkeypatch.setattr(
+        runner,
+        "_coordinate_start_payload",
+        lambda *_args: (
+            {"chains": [{"roundtrip": {"absolute_error_max": roundtrip_error}}]},
+            [{"x": np.array(0.0)}],
+        ),
+    )
+    monkeypatch.setattr(runner, "_make_graph_evaluator", lambda *_args: sentinel)
+    monkeypatch.setattr(
+        runner,
+        "_oracle_diagnostics",
+        lambda *_args, **_kwargs: {
+            "records": [
+                {
+                    "errors": {
+                        "value": {"scaled_max": 0.0},
+                        "gradient": {"scaled_max": 0.0},
+                        "hessian": {"scaled_max": 0.0},
+                    },
+                    "roundtrip": {"absolute_error_max": 0.0},
+                }
+            ],
+            "icdf_tail_finite": True,
+            "icdf_branch_continuous": True,
+        },
+    )
+
+
+def test_precompile_roundtrip_failure_does_not_claim_compile_success(
+    manifest, monkeypatch
+) -> None:
+    """A coordinate mapping failure reports no compiler evidence."""
+    unit = build_plan(manifest, "smoke")[0]
+    _mock_execute_cell_prefix(monkeypatch, roundtrip_error=1.0)
+
+    execution = runner.execute_cell(unit, {}, {}, manifest["analysis_policy"])
+
+    assert execution.failure["stage"] == "initialize"
+    assert execution.metrics == {"initialization_success": False}
+    assert execution.chain_dataset is None
+
+
+def test_compile_failure_is_distinct_from_nonfinite_initialization(
+    manifest, monkeypatch
+) -> None:
+    """A classified compiler failure records compile_success=False only."""
+    unit = build_plan(manifest, "smoke")[0]
+    _mock_execute_cell_prefix(monkeypatch)
+
+    def fail_compile(*_args):
+        raise runner.ScientificCellFailure(
+            "compile", "compiler rejected graph", error_type="CompileError"
+        )
+
+    monkeypatch.setattr(runner, "_finite_initial_evidence", fail_compile)
+    execution = runner.execute_cell(unit, {}, {}, manifest["analysis_policy"])
+
+    assert execution.failure["stage"] == "compile"
+    assert execution.metrics == {"compile_success": False}
+    assert execution.chain_dataset is None
+
+
+@pytest.mark.parametrize("failure_stage", ["sample", "compile"])
+def test_pre_sampling_oracle_evidence_obeys_failure_contract(
+    manifest, tmp_path: Path, monkeypatch, failure_stage: str
+) -> None:
+    """Static oracle evidence survives sampling failure but not a compile claim."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    unit = next(
+        item
+        for item in units
+        if item.backend_id == "pymc" and item.representation_id == "native-centered"
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    data_payload = runner._data_payload(unit, data)
+    start_payload = runner._natural_start_payload(unit, data, prior)
+    monkeypatch.setenv("HSSM_CAUSAL_CACHE_ID", "5" * 64)
+
+    def fail_after_oracle(*_args, **_kwargs):
+        raise runner.ScientificCellFailure(
+            failure_stage,
+            "controlled backend failure",
+            error_type="ControlledBackendError",
+        )
+
+    monkeypatch.setattr(runner, "_sample_model", fail_after_oracle)
+    execution = runner.execute_cell(
+        unit, data_payload, start_payload, manifest["analysis_policy"]
+    )
+
+    assert execution.status == "failed"
+    assert execution.failure["stage"] == failure_stage
+    assert execution.chain_dataset is None
+    assert execution.diagnostics["oracle"]["posterior_trajectory_evaluated"] is False
+    assert execution.metrics["oracle_evaluation_count"] == unit.chains + 1
+    if failure_stage == "sample":
+        assert execution.metrics["sampling_success"] is False
+    else:
+        assert execution.metrics["compile_success"] is False
+
+    context = _context(units, manifest)
+    store = ArtifactStore(tmp_path.resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    data_ref = store.write_json(f"data/{unit.data_id}.json", data_payload)
+    start_ref = store.write_json(f"starts/natural/{unit.start_id}.json", start_payload)
+    result_ref = runner.publish_cell_execution(
+        unit,
+        context,
+        manifest,
+        store,
+        execution,
+        context_reference=context_ref,
+        data_reference=data_ref,
+        natural_start_reference=start_ref,
+    )
+    record = store.read_json(result_ref)
+    validate_result_record(record, unit, context)
+    rows = aggregate_results(
+        units,
+        {unit.cell_id: record},
+        context_directory=store.root / "contexts",
+        artifact_root=store.root,
+        manifest=manifest,
+    )
+    assert rows[unit.pair_position]["collection_status"] == "present"
+
+
+def test_failed_chain_standardization_is_sample_failure_without_chain(
+    manifest, monkeypatch
+) -> None:
+    """Malformed sampler output cannot masquerade as a late chain-bearing failure."""
+    unit = build_plan(manifest, "smoke")[0]
+    _mock_execute_cell_prefix(monkeypatch)
+    monkeypatch.setattr(
+        runner,
+        "_finite_initial_evidence",
+        lambda *_args: {"chains": [], "all_finite": True},
+    )
+    monkeypatch.setattr(runner, "_sample_model", lambda *_args: (object(), 0.25))
+
+    def fail_standardization(*_args):
+        raise runner.ScientificCellFailure(
+            "summarize", "posterior lacks natural variables"
+        )
+
+    monkeypatch.setattr(runner, "_standardize_natural_chains", fail_standardization)
+    execution = runner.execute_cell(unit, {}, {}, manifest["analysis_policy"])
+
+    assert execution.failure["stage"] == "sample"
+    assert execution.metrics["sampling_success"] is False
+    assert execution.chain_dataset is None
+
+
+@pytest.mark.parametrize(
+    ("failure_point", "expected_stage", "posterior_trajectory"),
+    [
+        ("diagnose", "diagnose", False),
+        ("sampler_metrics", "summarize", True),
+        ("parameter_summary", "summarize", True),
+    ],
+)
+def test_late_failures_retain_auditable_stage_appropriate_oracle_evidence(
+    manifest,
+    native_oracle_artifacts,
+    tmp_path: Path,
+    monkeypatch,
+    failure_point: str,
+    expected_stage: str,
+    posterior_trajectory: bool,
+) -> None:
+    """Late scientific failures keep exactly the oracle phase already completed."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    unit = next(
+        item
+        for item in units
+        if item.backend_id == "pymc" and item.representation_id == "native-centered"
+    )
+    _mock_execute_cell_prefix(monkeypatch)
+    monkeypatch.setattr(
+        runner,
+        "_runtime_evidence",
+        lambda: _runtime_diagnostics(unit)["runtime"],
+    )
+    monkeypatch.setattr(
+        runner,
+        "_finite_initial_evidence",
+        lambda *_args: {"chains": [], "all_finite": True},
+    )
+    monkeypatch.setattr(runner, "_sample_model", lambda *_args: (object(), 0.25))
+    assert unit == native_oracle_artifacts["unit"]
+    natural_chains = native_oracle_artifacts["chains"]
+    monkeypatch.setattr(
+        runner, "_standardize_natural_chains", lambda *_args: natural_chains
+    )
+
+    def oracle_diagnostics(*args, **_kwargs):
+        has_trajectory = args[5] is not None
+        if failure_point == "diagnose" and has_trajectory:
+            raise runner.ScientificCellFailure(
+                "diagnose", "controlled trajectory diagnostic failure"
+            )
+        return _synthetic_oracle(unit, trajectory=has_trajectory)
+
+    monkeypatch.setattr(runner, "_oracle_diagnostics", oracle_diagnostics)
+    if failure_point == "sampler_metrics":
+
+        def fail_sampler_metrics(*_args):
+            raise runner.ScientificCellFailure(
+                "summarize", "controlled sampler metric failure"
+            )
+
+        monkeypatch.setattr(runner, "_sampler_metrics", fail_sampler_metrics)
+    elif failure_point == "parameter_summary":
+
+        def fail_parameter_summary(*_args):
+            raise runner.ScientificCellFailure(
+                "summarize", "controlled parameter summary failure"
+            )
+
+        monkeypatch.setattr(runner, "_parameter_summaries", fail_parameter_summary)
+
+    execution = runner.execute_cell(unit, {}, {}, manifest["analysis_policy"])
+
+    assert execution.status == "failed"
+    assert execution.failure["stage"] == expected_stage
+    assert execution.chain_dataset is natural_chains
+    oracle = execution.diagnostics["oracle"]
+    assert oracle["posterior_trajectory_evaluated"] is posterior_trajectory
+    expected_count = unit.chains + 1 + (unit.chains if posterior_trajectory else 0)
+    assert len(oracle["records"]) == expected_count
+    assert execution.metrics["oracle_evaluation_count"] == expected_count
+    assert runner.ORACLE_METRICS <= set(execution.metrics)
+    assert execution.metrics["sampling_success"] is True
+
+    retained_oracle = native_oracle_artifacts[
+        "full_oracle" if posterior_trajectory else "pre_oracle"
+    ]
+    execution = replace(
+        execution,
+        coordinate_starts=native_oracle_artifacts["coordinate_payload"],
+        diagnostics=_runtime_diagnostics(unit, oracle=retained_oracle),
+        metrics={
+            **execution.metrics,
+            **runner._registered_oracle_metrics(retained_oracle),
+        },
+    )
+
+    context = _context(units, manifest)
+    store = ArtifactStore(tmp_path.resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    data_ref = store.write_json(
+        f"data/{unit.data_id}.json", native_oracle_artifacts["data_payload"]
+    )
+    start_ref = store.write_json(
+        f"starts/natural/{unit.start_id}.json",
+        native_oracle_artifacts["start_payload"],
+    )
+    result_ref = runner.publish_cell_execution(
+        unit,
+        context,
+        manifest,
+        store,
+        execution,
+        context_reference=context_ref,
+        data_reference=data_ref,
+        natural_start_reference=start_ref,
+    )
+    record = store.read_json(result_ref)
+    rows = aggregate_results(
+        units,
+        {unit.cell_id: record},
+        context_directory=store.root / "contexts",
+        artifact_root=store.root,
+        manifest=manifest,
+    )
+    assert rows[unit.pair_position]["collection_status"] == "present"
+
+    if failure_point == "parameter_summary":
+        tampered = copy.deepcopy(record)
+        tampered["metrics"]["oracle_logp_scaled_error_max"] = 0.5
+        with pytest.raises(CausalContractError, match="hash-bound raw evidence"):
+            aggregate_results(
+                units,
+                {unit.cell_id: tampered},
+                context_directory=store.root / "contexts",
+                artifact_root=store.root,
+                manifest=manifest,
+            )
+
+
+def test_oracle_points_are_bound_to_exact_source_artifacts(
+    manifest, native_oracle_artifacts, tmp_path: Path
+) -> None:
+    """Every retained coordinate is tied to its planned natural-scale source."""
+    unit = native_oracle_artifacts["unit"]
+    units = pair_units(manifest, "smoke", unit.pair_id)
+    context = _context(units, manifest)
+    store = ArtifactStore(tmp_path.resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    data_ref = store.write_json(
+        f"data/{unit.data_id}.json", native_oracle_artifacts["data_payload"]
+    )
+    start_ref = store.write_json(
+        f"starts/natural/{unit.start_id}.json",
+        native_oracle_artifacts["start_payload"],
+    )
+    chains = native_oracle_artifacts["chains"]
+    oracle = native_oracle_artifacts["full_oracle"]
+    raw_metrics = runner._sampler_metrics(unit, chains, 1.0)
+    execution = runner.CellExecution(
+        status="completed",
+        coordinate_starts=native_oracle_artifacts["coordinate_payload"],
+        chain_dataset=chains,
+        diagnostics=_runtime_diagnostics(unit, oracle=oracle),
+        metrics=runner._registered_metrics(unit, raw_metrics, oracle),
+        parameter_summaries=runner._parameter_summaries(chains),
+    )
+    result_ref = runner.publish_cell_execution(
+        unit,
+        context,
+        manifest,
+        store,
+        execution,
+        context_reference=context_ref,
+        data_reference=data_ref,
+        natural_start_reference=start_ref,
+    )
+    record = store.read_json(result_ref)
+    verify_result_artifacts(record, store.root, unit, manifest)
+
+    def assert_forged_artifact_rejected(
+        name: str, payload: bytes, message: str
+    ) -> None:
+        reference = copy.deepcopy(record["artifacts"][name])
+        path = store.root / reference["path"]
+        original = path.read_bytes()
+        try:
+            path.write_bytes(payload)
+            record["artifacts"][name] = {
+                "path": reference["path"],
+                "sha256": sha256_bytes(payload),
+                "size_bytes": len(payload),
+            }
+            with pytest.raises(CausalContractError, match=message):
+                verify_result_artifacts(record, store.root, unit, manifest)
+        finally:
+            path.write_bytes(original)
+            record["artifacts"][name] = reference
+
+    diagnostics = copy.deepcopy(execution.diagnostics)
+    trajectory = next(
+        item
+        for item in diagnostics["oracle"]["records"]
+        if item["kind"] == "hash-selected-posterior-trajectory" and item["chain"] == 0
+    )
+    nonminimal_draw = next(
+        draw for draw in range(unit.draws) if draw != trajectory["draw"]
+    )
+    alternative_natural = {
+        "group_location": float(chains["group_location"][0, nonminimal_draw]),
+        "group_scale": float(chains["group_scale"][0, nonminimal_draw]),
+        "group_effect": np.asarray(
+            chains["group_effect"][0, nonminimal_draw], dtype=np.float64
+        ).tolist(),
+    }
+    candidate_vector, _ = runner.natural_to_coordinate(
+        alternative_natural,
+        prior=native_oracle_artifacts["prior"],
+        oracle_spec=native_oracle_artifacts["oracle_spec"],
+        representation_id=unit.representation_id,
+    )
+    vector = runner._pack_model_point(
+        native_oracle_artifacts["model"],
+        runner._point_from_vector(native_oracle_artifacts["model"], candidate_vector),
+    )
+    expected = runner.hierarchical_posterior_components(
+        vector,
+        native_oracle_artifacts["oracle_spec"],
+        runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id],
+    ).total
+    trajectory.update(
+        draw=nonminimal_draw,
+        selection_sha256=hashlib.sha256(
+            f"{unit.cell_id}:trajectory:0:{nonminimal_draw}".encode()
+        ).hexdigest(),
+        coordinate_vector=vector.tolist(),
+        roundtrip=runner._natural_coordinate_roundtrip(
+            alternative_natural,
+            vector,
+            oracle_spec=native_oracle_artifacts["oracle_spec"],
+            parameterization=runner.REPRESENTATION_TO_PARAMETERIZATION[
+                unit.representation_id
+            ],
+        ),
+        observed={
+            "value": expected.value,
+            "gradient": expected.gradient.tolist(),
+            "hessian": expected.hessian.tolist(),
+        },
+        oracle={
+            "value": expected.value,
+            "gradient": expected.gradient.tolist(),
+            "hessian": expected.hessian.tolist(),
+        },
+        group_location=alternative_natural["group_location"],
+        group_scale=alternative_natural["group_scale"],
+        group_effect=alternative_natural["group_effect"],
+    )
+    assert_forged_artifact_rejected(
+        "diagnostics",
+        canonical_json_bytes(diagnostics),
+        "lowest-SHA draw",
+    )
+
+    wrong_coordinate = copy.deepcopy(execution.diagnostics)
+    start_record = next(
+        item
+        for item in wrong_coordinate["oracle"]["records"]
+        if item["kind"] == "shared-natural-start"
+    )
+    start_record["coordinate_vector"][0] += 0.1
+    assert_forged_artifact_rejected(
+        "diagnostics",
+        canonical_json_bytes(wrong_coordinate),
+        "retained roundtrip differs",
+    )
+
+    unhealthy_roundtrip = copy.deepcopy(execution.diagnostics)
+    fixed_record = next(
+        item
+        for item in unhealthy_roundtrip["oracle"]["records"]
+        if item["kind"] == "fixed-grid"
+    )
+    shifted_vector = np.asarray(fixed_record["coordinate_vector"], dtype=np.float64)
+    shifted_vector[0] += 0.1
+    source_natural = {
+        "group_location": fixed_record["group_location"],
+        "group_scale": fixed_record["group_scale"],
+        "group_effect": fixed_record["group_effect"],
+    }
+    shifted_roundtrip = runner._natural_coordinate_roundtrip(
+        source_natural,
+        shifted_vector,
+        oracle_spec=native_oracle_artifacts["oracle_spec"],
+        parameterization=runner.REPRESENTATION_TO_PARAMETERIZATION[
+            unit.representation_id
+        ],
+    )
+    shifted_expected = runner.hierarchical_posterior_components(
+        shifted_vector,
+        native_oracle_artifacts["oracle_spec"],
+        runner.REPRESENTATION_TO_PARAMETERIZATION[unit.representation_id],
+    ).total
+    assert shifted_roundtrip["absolute_error_max"] > float(
+        manifest["analysis_policy"]["oracle_gate"]["roundtrip_absolute_error_max"][
+            unit.floatx
+        ]
+    )
+    fixed_record.update(
+        coordinate_vector=shifted_vector.tolist(),
+        roundtrip=shifted_roundtrip,
+        observed={
+            "value": shifted_expected.value,
+            "gradient": shifted_expected.gradient.tolist(),
+            "hessian": shifted_expected.hessian.tolist(),
+        },
+        oracle={
+            "value": shifted_expected.value,
+            "gradient": shifted_expected.gradient.tolist(),
+            "hessian": shifted_expected.hessian.tolist(),
+        },
+        passed=False,
+    )
+    unhealthy_roundtrip["oracle"]["passed"] = False
+    unhealthy_bytes = canonical_json_bytes(unhealthy_roundtrip)
+    diagnostics_reference = copy.deepcopy(record["artifacts"]["diagnostics"])
+    diagnostics_path = store.root / diagnostics_reference["path"]
+    original_diagnostics = diagnostics_path.read_bytes()
+    original_roundtrip_metric = record["metrics"]["roundtrip_absolute_error_max"]
+    try:
+        diagnostics_path.write_bytes(unhealthy_bytes)
+        record["artifacts"]["diagnostics"] = {
+            "path": diagnostics_reference["path"],
+            "sha256": sha256_bytes(unhealthy_bytes),
+            "size_bytes": len(unhealthy_bytes),
+        }
+        record["metrics"]["roundtrip_absolute_error_max"] = shifted_roundtrip[
+            "absolute_error_max"
+        ]
+        verify_result_artifacts(record, store.root, unit, manifest)
+        rows = aggregate_results(
+            units,
+            {unit.cell_id: record},
+            context_directory=store.root / "contexts",
+            artifact_root=store.root,
+            manifest=manifest,
+        )
+        assert rows[unit.pair_position]["collection_status"] == "present"
+    finally:
+        diagnostics_path.write_bytes(original_diagnostics)
+        record["artifacts"]["diagnostics"] = diagnostics_reference
+        record["metrics"]["roundtrip_absolute_error_max"] = original_roundtrip_metric
+
+    forged_roundtrip = copy.deepcopy(execution.diagnostics)
+    forged_roundtrip["oracle"]["records"][0]["roundtrip"]["absolute_error_max"] = 5e-11
+    original_roundtrip_metric = record["metrics"]["roundtrip_absolute_error_max"]
+    record["metrics"]["roundtrip_absolute_error_max"] = 5e-11
+    try:
+        assert_forged_artifact_rejected(
+            "diagnostics",
+            canonical_json_bytes(forged_roundtrip),
+            "roundtrip error disagrees",
+        )
+    finally:
+        record["metrics"]["roundtrip_absolute_error_max"] = original_roundtrip_metric
+
+    forged_roundtrip_component = copy.deepcopy(execution.diagnostics)
+    forged_roundtrip_component["oracle"]["records"][0]["roundtrip"][
+        "group_location"
+    ] += 0.01
+    assert_forged_artifact_rejected(
+        "diagnostics",
+        canonical_json_bytes(forged_roundtrip_component),
+        "retained roundtrip",
+    )
+
+    wrong_coordinate_start = copy.deepcopy(
+        native_oracle_artifacts["coordinate_payload"]
+    )
+    wrong_coordinate_start["chains"][0]["coordinate_vector"][0] += 0.1
+    assert_forged_artifact_rejected(
+        "coordinate_start",
+        canonical_json_bytes(wrong_coordinate_start),
+        "coordinate start chain 0 retained roundtrip",
+    )
+
+    wrong_natural_start = copy.deepcopy(native_oracle_artifacts["start_payload"])
+    wrong_natural_start["chains"][0]["group_location"] += 0.01
+    assert_forged_artifact_rejected(
+        "natural_start",
+        canonical_json_bytes(wrong_natural_start),
+        "coordinate start chain 0 natural point",
+    )
+
+    wrong_data = copy.deepcopy(native_oracle_artifacts["data_payload"])
+    wrong_data["group_effect"][0] += 0.01
+    assert_forged_artifact_rejected(
+        "data", canonical_json_bytes(wrong_data), "fixed truth"
+    )
+
+    wrong_chain = chains.copy(deep=True)
+    selected = next(
+        item
+        for item in execution.diagnostics["oracle"]["records"]
+        if item["kind"] == "hash-selected-posterior-trajectory" and item["chain"] == 0
+    )
+    wrong_chain["group_location"][0, selected["draw"]] += 0.01
+    assert_forged_artifact_rejected(
+        "chain",
+        runner._netcdf_bytes(wrong_chain),
+        "selected natural chain draw",
+    )
+
+
+def test_completed_and_late_failure_records_validate_with_exact_artifacts(
+    manifest, tmp_path: Path
+) -> None:
+    """Completed and post-sampling failures satisfy the strict result schema."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    context = _context(units, manifest)
+    store = ArtifactStore(tmp_path.resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    data_ref = store.write_json(f"data/{units[0].data_id}.json", {"data": True})
+    start_ref = store.write_json(
+        f"starts/natural/{units[0].start_id}.json", {"starts": True}
+    )
+    completed = runner.CellExecution(
+        status="completed",
+        coordinate_starts={"cell": units[0].cell_id},
+        chain_dataset=_natural_dataset(units[0]),
+        diagnostics=_runtime_diagnostics(
+            units[0], oracle=_synthetic_oracle(units[0], trajectory=True)
+        ),
+        metrics=_completed_metrics(units[0]),
+        parameter_summaries=[
+            {
+                "parameter_id": "group_location",
+                "index": None,
+                "mean": 0.3,
+                "sd": 0.1,
+                "mcse_mean": 0.01,
+            }
+        ],
+    )
+    result_ref = runner.publish_cell_execution(
+        units[0],
+        context,
+        manifest,
+        store,
+        completed,
+        context_reference=context_ref,
+        data_reference=data_ref,
+        natural_start_reference=start_ref,
+    )
+    validate_result_record(store.read_json(result_ref), units[0], context)
+
+    for unit, stage in zip(units[1:3], ("summarize", "diagnose"), strict=True):
+        failure = runner.CellExecution(
+            status="failed",
+            coordinate_starts={"cell": unit.cell_id},
+            chain_dataset=_natural_dataset(unit),
+            diagnostics=_runtime_diagnostics(
+                unit,
+                oracle=_synthetic_oracle(unit, trajectory=stage == "summarize"),
+            ),
+            metrics={
+                "compile_success": True,
+                "initialization_success": True,
+                "logp_finite": True,
+                "gradient_finite": True,
+                "sampling_success": True,
+                **runner._registered_oracle_metrics(
+                    _synthetic_oracle(unit, trajectory=stage == "summarize")
+                ),
+            },
+            parameter_summaries=[],
+            failure={"stage": stage, "error_type": "NumericalError", "message": "x"},
+        )
+        reference = runner.publish_cell_execution(
+            unit,
+            context,
+            manifest,
+            store,
+            failure,
+            context_reference=context_ref,
+            data_reference=data_ref,
+            natural_start_reference=start_ref,
+        )
+        validate_result_record(store.read_json(reference), unit, context)
+
+
+def test_run_pair_attempts_all_ten_after_scientific_failure(
+    manifest, tmp_path: Path, monkeypatch
+) -> None:
+    """One scientific failure cannot suppress either backend's paired controls."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    context = _context(units, manifest)
+    store = ArtifactStore(tmp_path.resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    data_ref = store.write_json(f"data/{units[0].data_id}.json", {"data": True})
+    start_ref = store.write_json(
+        f"starts/natural/{units[0].start_id}.json", {"starts": True}
+    )
+    monkeypatch.setattr(
+        runner,
+        "materialize_inputs_for_unit",
+        lambda _unit, _store, **_kwargs: (data_ref, start_ref),
+    )
+    attempted: list[str] = []
+    published: list[str] = []
+
+    def execute(unit):
+        attempted.append(unit.cell_id)
+        return runner.CellExecution(
+            status="failed",
+            metrics={},
+            parameter_summaries=[],
+            failure={"stage": "build", "error_type": "SamplingError", "message": "x"},
+        )
+
+    def publish(unit, *_args, **_kwargs):
+        assert len(attempted) == 10
+        published.append(unit.cell_id)
+        return ArtifactRef(f"cells/{unit.cell_id}.json", "a" * 64, 1)
+
+    monkeypatch.setattr(runner, "publish_cell_execution", publish)
+    runner.run_pair(
+        manifest,
+        DEFAULT_MANIFEST,
+        units,
+        store,
+        context,
+        context_reference=context_ref,
+        executor=execute,
+    )
+
+    assert attempted == [unit.cell_id for unit in units]
+    assert published == attempted
+
+
+def test_subprocess_builder_failure_publishes_one_marker_after_all_ten_attempts(
+    manifest, tmp_path: Path
+) -> None:
+    """A real child build failure remains evidence and cannot suppress controls."""
+    units = pair_units(manifest, "smoke", build_plan(manifest, "smoke")[0].pair_id)
+    target = next(
+        unit
+        for unit in units
+        if unit.backend_id == "pymc" and unit.representation_id == "manual-centered"
+    )
+    context = _context(units, manifest)
+    store = ArtifactStore((tmp_path / "run").resolve())
+    context_ref = store.write_json(
+        f"contexts/{context.pair_id}.json", context.as_dict()
+    )
+    context_path = store.root / context_ref.path
+    attempted: list[str] = []
+    child_output = (tmp_path / "child-result").resolve()
+    child_cache = (tmp_path / "child-cache").resolve()
+    for name in ("pytensor", "jax", "matplotlib", "xdg"):
+        (child_cache / name).mkdir(parents=True, exist_ok=True)
+
+    def completed_control(unit):
+        return runner.CellExecution(
+            status="completed",
+            coordinate_starts={"cell": unit.cell_id},
+            chain_dataset=_natural_dataset(unit),
+            diagnostics=_runtime_diagnostics(
+                unit, oracle=_synthetic_oracle(unit, trajectory=True)
+            ),
+            metrics=_completed_metrics(unit),
+            parameter_summaries=[
+                {
+                    "parameter_id": "group_location",
+                    "index": None,
+                    "mean": 0.3,
+                    "sd": 0.1,
+                    "mcse_mean": 0.01,
+                }
+            ],
+        )
+
+    def execute(unit):
+        attempted.append(unit.cell_id)
+        if unit.cell_id != target.cell_id:
+            return completed_control(unit)
+        program = textwrap.dedent(
+            """
+            import sys
+            from pathlib import Path
+            from scripts import truncated_hierarchy_causal_runner as runner
+
+            original_builder = runner.build_causal_model
+
+            def fail_manual_builder(parameterization, *args, **kwargs):
+                if parameterization == "manual_centered":
+                    raise FloatingPointError("controlled builder failure")
+                return original_builder(parameterization, *args, **kwargs)
+
+            runner.build_causal_model = fail_manual_builder
+            raise SystemExit(
+                runner._private_sample_cell(
+                    Path(sys.argv[1]),
+                    sys.argv[2],
+                    sys.argv[3],
+                    Path(sys.argv[4]),
+                    Path(sys.argv[5]),
+                    Path(sys.argv[6]),
+                )
+            )
+            """
+        )
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        environment.update(
+            {
+                "HSSM_CAUSAL_CACHE_ID": "6" * 64,
+                "PYTENSOR_FLAGS": (
+                    f"base_compiledir={child_cache / 'pytensor'},floatX={unit.floatx}"
+                ),
+                "JAX_COMPILATION_CACHE_DIR": str(child_cache / "jax"),
+                "JAX_ENABLE_X64": "true",
+                "JAX_PLATFORMS": "cpu",
+                "MPLCONFIGDIR": str(child_cache / "matplotlib"),
+                "XDG_CACHE_HOME": str(child_cache / "xdg"),
+                "OMP_NUM_THREADS": "1",
+                "OPENBLAS_NUM_THREADS": "1",
+                "MKL_NUM_THREADS": "1",
+                "NUMEXPR_NUM_THREADS": "1",
+            }
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                program,
+                str(DEFAULT_MANIFEST),
+                unit.tier,
+                unit.cell_id,
+                str(store.root),
+                str(context_path),
+                str(child_output),
+            ],
+            cwd=DEFAULT_MANIFEST.parents[2],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 10, completed.stderr
+        return runner._load_staged_execution(child_output)
+
+    references = runner.run_pair(
+        manifest,
+        DEFAULT_MANIFEST,
+        units,
+        store,
+        context,
+        context_reference=context_ref,
+        executor=execute,
+    )
+
+    assert attempted == [unit.cell_id for unit in units]
+    records = [store.read_json(reference) for reference in references]
+    failed = [record for record in records if record["execution_status"] == "failed"]
+    assert len(failed) == 1
+    assert failed[0]["cell_id"] == target.cell_id
+    assert failed[0]["failure"] == {
+        "stage": "build",
+        "error_type": "FloatingPointError",
+        "message": "controlled builder failure",
+    }
+
+
+@pytest.mark.parametrize(
+    "invocation",
+    [
+        ("-m", "scripts.truncated_hierarchy_causal_runner"),
+        ("scripts/truncated_hierarchy_causal_runner.py",),
+    ],
+)
+def test_runner_starts_in_clean_subprocess_without_pythonpath(
+    invocation: tuple[str, ...],
+) -> None:
+    """Module-mode children and the public file-path CLI resolve imports."""
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    completed = subprocess.run(
+        [sys.executable, *invocation, "--help"],
+        cwd=DEFAULT_MANIFEST.parents[2],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "run-unit" in completed.stdout
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("backend_id", ["pymc", "numpyro"])
+def test_tiny_actual_backend_sampling_uses_exact_mapped_start(
+    manifest, backend_id: str
+) -> None:
+    """Exercise each locked sampler path with one short real chain."""
+    original = next(
+        unit
+        for unit in build_plan(manifest, "smoke")
+        if unit.backend_id == backend_id and unit.representation_id == "native-centered"
+    )
+    unit = replace(
+        original,
+        chains=1,
+        tune=5,
+        draws=5,
+        natural_start_chain_seeds=(12821,),
+        chain_seeds=(12822,) if backend_id == "pymc" else (),
+        sampler_seed=12823 if backend_id == "numpyro" else None,
+    )
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    model = build_causal_model("native_centered", prior, data)
+    starts = runner._natural_start_payload(unit, data, prior)
+    _, initvals = runner._coordinate_start_payload(
+        unit, model, starts, prior, runner._oracle_spec(unit, prior, data)
+    )
+
+    inference, elapsed = runner._sample_model(unit, model, initvals)
+    chains = runner._standardize_natural_chains(unit, inference)
+
+    assert elapsed >= 0
+    assert chains["group_effect"].shape == (1, 5, 4)
+    assert np.all(
+        np.isfinite(
+            chains[["group_location", "group_scale", "group_effect"]].to_array()
+        )
+    )
+    for name in (
+        "acceptance_rate",
+        "diverging",
+        "energy",
+        "n_steps",
+        "step_size",
+        "tree_depth",
+    ):
+        assert np.all(np.isfinite(chains[f"sample_stat__{name}"]))
+
+
+@pytest.mark.slow
+def test_tiny_real_execution_applies_manifest_oracle_tolerances(manifest) -> None:
+    """Run sampling plus trajectory value/gradient/Hessian oracle diagnostics."""
+    original = next(
+        unit
+        for unit in build_plan(manifest, "smoke")
+        if unit.backend_id == "pymc" and unit.representation_id == "native-centered"
+    )
+    unit = replace(original, tune=10, draws=10)
+    data = generate_synthetic_data(
+        runner._toy_spec(unit),
+        group_seed=unit.group_seed,
+        observation_seed=unit.observation_seed,
+    )
+    prior = runner._prior(unit)
+    data_payload = runner._data_payload(unit, data)
+    start_payload = runner._natural_start_payload(unit, data, prior)
+
+    execution = runner.execute_cell(
+        unit, data_payload, start_payload, manifest["analysis_policy"]
+    )
+
+    assert execution.status == "completed"
+    assert execution.metrics["oracle_evaluation_count"] >= 5
+    assert execution.metrics["oracle_logp_scaled_error_max"] <= 1
+    assert execution.metrics["oracle_gradient_scaled_error_max"] <= 1
+    assert execution.metrics["oracle_hessian_scaled_error_max"] <= 1

--- a/tests/test_truncated_hierarchy_causal_runner.py
+++ b/tests/test_truncated_hierarchy_causal_runner.py
@@ -54,6 +54,20 @@ def manifest():
     return load_manifest(DEFAULT_MANIFEST)
 
 
+@pytest.fixture(autouse=True)
+def _pin_float64_precision():
+    """Isolate this module's direct graphs from global precision mutations."""
+    previous_floatx = str(runner.pytensor.config.floatX)
+    previous_jax_x64 = bool(runner.jax.config.x64_enabled)
+    runner.pytensor.config.floatX = "float64"
+    runner.jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        runner.pytensor.config.floatX = previous_floatx
+        runner.jax.config.update("jax_enable_x64", previous_jax_x64)
+
+
 def _context(units, manifest) -> RunContext:
     profile = manifest["dependency_profile"]
     environment = {
@@ -133,8 +147,8 @@ def _natural_dataset(unit) -> xr.Dataset:
     )
 
 
-@pytest.fixture(scope="module")
-def native_oracle_artifacts(manifest):
+@pytest.fixture
+def native_oracle_artifacts(manifest, _pin_float64_precision):
     """Build one exact, no-sampling artifact set for provenance audits."""
     unit = next(
         item

--- a/tests/test_truncated_hierarchy_causal_workflow.py
+++ b/tests/test_truncated_hierarchy_causal_workflow.py
@@ -1,0 +1,390 @@
+"""No-sampling contract tests for the isolated causal-study workflow."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from scripts.truncated_hierarchy_causal_contract import (
+    BACKEND_IDS,
+    DEFAULT_MANIFEST,
+    REPRESENTATION_IDS,
+    build_plan,
+    load_manifest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github/workflows/qualify_truncated_hierarchy_causal.yml"
+TIERS = ("smoke", "confirmation")
+EXPECTED_PAIRS = {"smoke": 2, "confirmation": 16}
+EXPECTED_CELLS = {"smoke": 20, "confirmation": 160}
+
+
+@pytest.fixture(scope="module")
+def manifest() -> Mapping[str, Any]:
+    """Load and validate the prospective v3 manifest once."""
+    return load_manifest(DEFAULT_MANIFEST)
+
+
+@pytest.fixture(scope="module")
+def plans(manifest: Mapping[str, Any]) -> dict[str, Sequence[Any]]:
+    """Expand only the deterministic no-sampling plans."""
+    return {tier: build_plan(manifest, tier) for tier in TIERS}
+
+
+def _load_workflow() -> tuple[str, Mapping[str, Any]]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    loaded = yaml.load(text, Loader=yaml.BaseLoader)
+    assert isinstance(loaded, dict)
+    return text, loaded
+
+
+def _run_for(job: Mapping[str, Any], step_name: str) -> str:
+    for step in job["steps"]:
+        if step.get("name") == step_name:
+            return str(step["run"])
+    raise AssertionError(f"missing workflow step {step_name!r}")
+
+
+@pytest.mark.parametrize("tier", TIERS)
+def test_contract_pairs_are_complete_counterbalanced_ten_cell_units(
+    manifest: Mapping[str, Any], plans: Mapping[str, Sequence[Any]], tier: str
+) -> None:
+    """Each worker owns both five-form backends in the frozen paired order."""
+    units_by_pair: dict[str, list[Any]] = defaultdict(list)
+    for unit in plans[tier]:
+        units_by_pair[unit.pair_id].append(unit)
+
+    assert len(plans[tier]) == EXPECTED_CELLS[tier]
+    assert len(units_by_pair) == EXPECTED_PAIRS[tier]
+    declared_backends = tuple(backend["backend_id"] for backend in manifest["backends"])
+    for pair_id, units in units_by_pair.items():
+        assert len(units) == 2 * len(REPRESENTATION_IDS) == 10
+        assert [unit.pair_position for unit in units] == list(range(10))
+        assert {unit.pair_id for unit in units} == {pair_id}
+        assert len({unit.regime_id for unit in units}) == 1
+        assert len({unit.replicate for unit in units}) == 1
+        assert {unit.backend_id for unit in units} == set(BACKEND_IDS)
+        assert {(unit.backend_id, unit.representation_id) for unit in units} == {
+            (backend_id, representation_id)
+            for backend_id in BACKEND_IDS
+            for representation_id in REPRESENTATION_IDS
+        }
+        assert len({unit.block_id for unit in units}) == 2
+        assert len({unit.data_id for unit in units}) == 1
+        assert len({unit.start_id for unit in units}) == 1
+        for backend_id in BACKEND_IDS:
+            block = [unit for unit in units if unit.backend_id == backend_id]
+            assert [unit.block_position for unit in block] == list(range(5))
+            assert {unit.representation_id for unit in block} == set(REPRESENTATION_IDS)
+            assert len({unit.block_id for unit in block}) == 1
+        regime_index = next(
+            index
+            for index, regime in enumerate(manifest["regimes"])
+            if regime["regime_id"] == units[0].regime_id
+        )
+        backend_shift = (units[0].replicate + regime_index) % len(BACKEND_IDS)
+        expected_order = (
+            declared_backends[backend_shift:] + declared_backends[:backend_shift]
+        )
+        assert (units[0].backend_id, units[5].backend_id) == expected_order
+
+
+@pytest.mark.parametrize(("tier", "expected"), EXPECTED_PAIRS.items())
+def test_direct_matrix_cli_matches_workflow_cardinality(
+    tier: str, expected: int
+) -> None:
+    """The direct command embedded in Actions emits the frozen pair matrix."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/truncated_hierarchy_causal_contract.py",
+            "--manifest",
+            str(DEFAULT_MANIFEST),
+            "matrix",
+            "--tier",
+            tier,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert set(payload) == {"include"}
+    assert len(payload["include"]) == expected
+    assert all(
+        set(pair) == {"pair_id", "tier", "regime_id", "replicate"}
+        for pair in payload["include"]
+    )
+    assert all(pair["tier"] == tier for pair in payload["include"])
+
+
+def test_workflow_is_opt_in_same_repo_and_read_only() -> None:
+    """Untrusted forks and ordinary PR activity cannot start the causal study."""
+    text, workflow = _load_workflow()
+    triggers = workflow["on"]
+
+    assert set(triggers) == {"pull_request", "workflow_dispatch"}
+    assert triggers["pull_request"] == {"types": ["labeled"]}
+    assert triggers["workflow_dispatch"]["inputs"]["mode"]["options"] == [
+        "smoke",
+        "confirmation",
+    ]
+    assert "pull_request_target" not in text
+    assert not re.search(r"^\s*push\s*:", text, flags=re.MULTILINE)
+    assert workflow["permissions"] == {"contents": "read"}
+    prepare_condition = workflow["jobs"]["prepare"]["if"]
+    assert "run-truncated-hierarchy-causal-smoke" in prepare_condition
+    assert "run-truncated-hierarchy-causal-confirmation" in prepare_condition
+    assert "head.repo.full_name == github.repository" in prepare_condition
+    plan_step = next(
+        step
+        for step in workflow["jobs"]["prepare"]["steps"]
+        if step.get("id") == "plan"
+    )
+    assert (
+        "run-truncated-hierarchy-causal-confirmation"
+        in plan_step["env"]["REQUESTED_MODE"]
+    )
+
+
+def test_workflow_checks_out_exact_head_and_pins_remote_actions() -> None:
+    """Each job runs the selected immutable commit with pinned third parties."""
+    text, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+
+    assert "github.event.pull_request.head.sha" in workflow["env"]["CAUSAL_SHA"]
+    assert text.count("ref: ${{ env.CAUSAL_SHA }}") == len(jobs)
+    assert text.count("persist-credentials: false") == len(jobs)
+    remote_uses = re.findall(r"^\s*uses:\s*([^\s#]+)", text, flags=re.MULTILINE)
+    assert remote_uses
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", value) for value in remote_uses)
+    for job in jobs.values():
+        checkout = job["steps"][0]
+        assert checkout["uses"].startswith("actions/checkout@")
+        assert checkout["with"] == {
+            "ref": "${{ env.CAUSAL_SHA }}",
+            "persist-credentials": "false",
+        }
+
+
+def test_workflow_uses_one_frozen_profile_and_is_separate_from_v2() -> None:
+    """The v3 execution path cannot drift into old harnesses or unlocked installs."""
+    text, workflow = _load_workflow()
+
+    assert workflow["env"]["CAUSAL_MANIFEST"].endswith(
+        "truncated_hierarchy_causal_v3.json"
+    )
+    assert workflow["env"]["PROFILE_PROJECT"].endswith("current-resolved")
+    assert workflow["env"]["UV_VERSION"] == "0.11.21"
+    assert "truncated_hierarchy_v2" not in text
+    assert "truncated_hierarchy_shards.py" not in text
+    assert "truncated_hierarchy_qualification.py" not in text
+    assert "bambi-0.19" not in text
+    assert "uv lock" not in text
+    assert "pip install" not in text
+    assert text.count('python-version: "3.12"') == len(workflow["jobs"])
+    assert all(job["runs-on"] == "ubuntu-24.04" for job in workflow["jobs"].values())
+    assert all(
+        "--frozen" in step["run"]
+        for job in workflow["jobs"].values()
+        for step in job["steps"]
+        if "run" in step and "python" in step["run"]
+    )
+
+
+def test_workflow_topology_enforces_smoke_before_confirmation() -> None:
+    """Only complete, contract-valid smoke evidence unlocks confirmation."""
+    _, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+
+    assert set(jobs) == {
+        "prepare",
+        "materialize",
+        "smoke",
+        "smoke_aggregate",
+        "confirmation",
+        "confirmation_aggregate",
+    }
+    assert jobs["materialize"]["needs"] == "prepare"
+    assert jobs["smoke"]["needs"] == ["prepare", "materialize"]
+    assert jobs["smoke_aggregate"]["needs"] == [
+        "prepare",
+        "materialize",
+        "smoke",
+    ]
+    assert jobs["confirmation"]["needs"] == [
+        "prepare",
+        "materialize",
+        "smoke_aggregate",
+    ]
+    assert "needs.smoke_aggregate.result == 'success'" in jobs["confirmation"]["if"]
+    assert "run_confirmation == 'true'" in jobs["confirmation"]["if"]
+    smoke_assessment = _run_for(
+        jobs["smoke_aggregate"],
+        "Merge exact evidence and assess smoke completeness",
+    )
+    assert 'value.get("contract_valid") is True' in smoke_assessment
+    assert 'value.get("evidence_complete") is True' in smoke_assessment
+    assert 'value.get("proceed_to_confirmation") is True' in smoke_assessment
+    assert 'value.get("outcome")' not in smoke_assessment
+
+
+def test_workflow_consumes_exact_contract_matrices() -> None:
+    """Actions schedules the two/16 canonical pairs, never caller-supplied cells."""
+    _, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+    prepare = _run_for(
+        jobs["prepare"], "Validate contract and build exact backend-pair matrices"
+    )
+
+    assert "matrix --tier smoke" in prepare
+    assert "matrix --tier confirmation" in prepare
+    assert "values == (2, 16)" in prepare
+    assert jobs["smoke"]["strategy"] == {
+        "fail-fast": "false",
+        "max-parallel": "4",
+        "matrix": "${{ fromJSON(needs.prepare.outputs.smoke_matrix) }}",
+    }
+    assert jobs["confirmation"]["strategy"] == {
+        "fail-fast": "false",
+        "max-parallel": "4",
+        "matrix": "${{ fromJSON(needs.prepare.outputs.confirmation_matrix) }}",
+    }
+
+
+@pytest.mark.parametrize(
+    ("job_name", "tier"), (("smoke", "smoke"), ("confirmation", "confirmation"))
+)
+def test_each_worker_runs_one_complete_pair_and_preserves_scientific_failures(
+    job_name: str, tier: str
+) -> None:
+    """One runner call owns ten paired cells; scientific exit one remains evidence."""
+    _, workflow = _load_workflow()
+    job = workflow["jobs"][job_name]
+    step_name = f"Run one co-located ten-cell {tier} backend pair"
+    step = next(item for item in job["steps"] if item.get("name") == step_name)
+    script = step["run"]
+
+    assert script.count("run-unit") == 1
+    assert f"--tier {tier}" in script
+    assert '--pair-id "$PAIR_ID"' in script
+    assert "--block-id" not in script
+    assert '--run-dir "$run_root"' in script
+    assert '--worker-identity "$WORKER_IDENTITY"' in script
+    assert '--expected-git-commit "$CAUSAL_SHA"' in script
+    assert "runner_status=${PIPESTATUS[0]}" in script
+    assert "0|1)" in script
+    assert '*) exit "$runner_status"' in script
+    assert step["env"]["PAIR_ID"] == "${{ matrix.pair_id }}"
+    assert step["env"]["WORKER_IDENTITY"].endswith(":${{ matrix.pair_id }}")
+
+
+def test_materialization_and_aggregation_use_finalized_cli() -> None:
+    """A single job creates shared inputs and both aggregators use the run tree."""
+    _, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+    materialize = _run_for(
+        jobs["materialize"], "Freeze environment and materialize shared inputs once"
+    )
+
+    assert materialize.count("environment/environment.json") == 1
+    assert materialize.count("materialize-inputs") == 2
+    assert "materialize-inputs --tier smoke" in materialize
+    assert "--tier confirmation --run-dir" in materialize
+    for tier, job_name, step_name in (
+        (
+            "smoke",
+            "smoke_aggregate",
+            "Merge exact evidence and assess smoke completeness",
+        ),
+        (
+            "confirmation",
+            "confirmation_aggregate",
+            "Merge exact evidence and assess confirmation",
+        ),
+    ):
+        script = _run_for(jobs[job_name], step_name)
+        assert f'aggregate --tier {tier} --run-dir "$run_root"' in script
+        assert f"assess --tier {tier}" in script
+        assert '--output "$aggregate/assessment.json"' in script
+
+
+def test_public_runner_commands_use_repo_root_module_mode() -> None:
+    """Every public runner command resolves ``scripts`` in a clean checkout."""
+    text, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+    runner_module = "-m scripts.truncated_hierarchy_causal_runner"
+
+    assert "scripts/truncated_hierarchy_causal_runner.py" not in text
+    assert text.count(runner_module) == 5
+    public_runner_steps = (
+        (
+            "materialize",
+            "Freeze environment and materialize shared inputs once",
+        ),
+        ("smoke", "Run one co-located ten-cell smoke backend pair"),
+        (
+            "smoke_aggregate",
+            "Merge exact evidence and assess smoke completeness",
+        ),
+        ("confirmation", "Run one co-located ten-cell confirmation backend pair"),
+        (
+            "confirmation_aggregate",
+            "Merge exact evidence and assess confirmation",
+        ),
+    )
+    for job_name, step_name in public_runner_steps:
+        assert runner_module in _run_for(jobs[job_name], step_name)
+
+
+def test_artifacts_are_isolated_and_never_merge_overwrite() -> None:
+    """Parallel pairs retain evidence in unique artifacts with collision rejection."""
+    text, workflow = _load_workflow()
+    jobs = workflow["jobs"]
+
+    assert "merge-multiple: true" not in text
+    assert text.count("merge-multiple: false") == 2
+    assert text.count("if: always()") >= 6
+    for job_name, tier in (("smoke", "smoke"), ("confirmation", "confirmation")):
+        upload = next(
+            step
+            for step in jobs[job_name]["steps"]
+            if step.get("name") == f"Upload {tier} backend-pair evidence"
+        )
+        artifact_name = upload["with"]["name"]
+        assert f"tn-causal-{tier}-${{{{ matrix.pair_id }}}}" in artifact_name
+        assert "${{ github.run_id }}" in artifact_name
+        assert "${{ github.run_attempt }}" in artifact_name
+        assert upload["if"] == "always()"
+        assert "/logs/" not in upload["with"]["path"]
+        assert "contexts/${{ matrix.pair_id }}.json" in upload["with"]["path"]
+        log_upload = jobs[job_name]["steps"][-1]
+        assert log_upload["with"]["name"].startswith(f"tn-causal-log-{tier}-")
+        assert "${{ matrix.pair_id }}" in log_upload["with"]["name"]
+        assert log_upload["if"] == "always()"
+    assert "${{ matrix.block_id }}" not in text
+    assert "--block-id" not in text
+    for job_name in ("smoke_aggregate", "confirmation_aggregate"):
+        assembly = next(
+            step["run"]
+            for step in jobs[job_name]["steps"]
+            if step.get("name", "").startswith("Merge exact evidence")
+        )
+        assert 'merge-runs --source-dir "$pair_root"' in assembly
+        assert '--run-dir "$run_root"' in assembly
+        assert "cp --" not in assembly
+        assert "merge-multiple" not in assembly

--- a/tests/test_truncated_hierarchy_causal_workflow.py
+++ b/tests/test_truncated_hierarchy_causal_workflow.py
@@ -57,6 +57,14 @@ def _run_for(job: Mapping[str, Any], step_name: str) -> str:
     raise AssertionError(f"missing workflow step {step_name!r}")
 
 
+def test_contract_cli_uses_package_aware_module_mode() -> None:
+    """Late oracle imports must resolve on clean hosted runners."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert text.count("-m scripts.truncated_hierarchy_causal_contract") == 4
+    file_mode = "python\n            scripts/truncated_hierarchy_causal_contract.py"
+    assert file_mode not in text
+
+
 @pytest.mark.parametrize("tier", TIERS)
 def test_contract_pairs_are_complete_counterbalanced_ten_cell_units(
     manifest: Mapping[str, Any], plans: Mapping[str, Sequence[Any]], tier: str
@@ -102,14 +110,15 @@ def test_contract_pairs_are_complete_counterbalanced_ten_cell_units(
 
 
 @pytest.mark.parametrize(("tier", "expected"), EXPECTED_PAIRS.items())
-def test_direct_matrix_cli_matches_workflow_cardinality(
+def test_module_matrix_cli_matches_workflow_cardinality(
     tier: str, expected: int
 ) -> None:
     """The direct command embedded in Actions emits the frozen pair matrix."""
     completed = subprocess.run(
         [
             sys.executable,
-            "scripts/truncated_hierarchy_causal_contract.py",
+            "-m",
+            "scripts.truncated_hierarchy_causal_contract",
             "--manifest",
             str(DEFAULT_MANIFEST),
             "matrix",


### PR DESCRIPTION
## Scope

This is the B2 research-only child of #1294. It executes the prospectively frozen causal experiment for #1282 and does **not** change HSSM prior construction, parameter defaults, or user-facing runtime behavior.

The only future intersection with the robust-prior stream is a separate, evidence-driven defaults PR after this study reaches a causal conclusion.

## Design

- two exact v2-failing toy-Gaussian regimes: lower-only weak information and finite-bound near-boundary information;
- five same-natural-model representations:
  - native centered `TruncatedNormal` hierarchy;
  - independent manual centered density control;
  - centered location + ICDF-noncentered group effects;
  - ICDF-noncentered location + centered group effects;
  - fully ICDF-noncentered hierarchy;
- PyMC and NumPyro executed together on the same worker for each dataset;
- 20 smoke fits in 2 ten-cell jobs and 160 confirmation fits in 16 ten-cell jobs;
- shared byte-identical data and natural-scale starts, fresh process/cache per fit, exact RNG provenance, and all ten fits attempted after scientific failure;
- independent second-order oracle checks for value, gradient, and Hessian at fixed, start, ICDF, and independently selected trajectory points;
- raw posterior and per-draw sampler statistics retained in SHA-256-bound artifacts;
- fail-closed aggregation and classification with smoke explicitly limited to screening.

Frozen manifest semantic SHA-256:

`dde2ce8a7bdce1db72c5cb343887be6817cf56177fd9981e7d19d48963d97744`

## Evidence integrity

The assessor independently verifies artifact bytes, exact source/runtime identity, PyMC/NumPyro RNG semantics, minimum-SHA trajectory selection, source-natural-to-coordinate-to-restored-natural round trips, and raw oracle/sampler summaries. A real numerical failure remains scientific evidence; malformed or forged evidence is rejected as a contract failure.

The earlier v2 experiment and workflow remain byte-identical.

## Validation

- `237 passed` in the frozen Python 3.12 / PyMC 6.3.1 / PyTensor 3.3.0 / JAX 0.11.1 environment, including tiny real PyMC and NumPyro runs;
- independent final review: no remaining contract, workflow, or scientific blocker;
- Ruff check and format;
- mypy and Pyrefly;
- repository `prek` hooks on all ten files;
- strict YAML parse (6 jobs);
- contract validation: 20 smoke fits / 160 confirmation fits, 2 / 16 paired jobs;
- frozen v2 byte-hash audit;
- `git diff --check`.

## Run policy

Keep this PR in draft while evidence is generated. First apply the smoke label. Confirmation may run only after smoke evidence is complete and contract-valid; smoke success or failure cannot itself establish a causal root cause. No defaults change belongs in this PR.

Closes neither #1269 nor #1282.
