### PR TITLE
feat: add gamma_drift_angle as a supported model

### DIFF
--- a/docs/reference/models-and-likelihoods.md
+++ b/docs/reference/models-and-likelihoods.md
@@ -20,6 +20,7 @@ model.
 | `race_no_bias_angle_4` | `approx_differentiable` | `approx_differentiable` | `v0`, `v1`, `v2`, `v3`, `a`, `z`, `t`, `theta` | `0`, `1`, `2`, `3` |
 | `ddm_seq2_no_bias` | `approx_differentiable` | `approx_differentiable` | `vh`, `vl1`, `vl2`, `a`, `t` | `0`, `1`, `2`, `3` |
 | `gamma_drift` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `shape`, `scale`, `c` | `-1`, `1` |
+| `gamma_drift_angle` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `theta`, `shape`, `scale`, `c` | `-1`, `1` |
 | `lba3` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1`, `v2` | `0`, `1`, `2` |
 | `lba4` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1`, `v2`, `v3` | `0`, `1`, `2`, `3` |
 | `lba2` | `analytical` | `analytical` | `A`, `b`, `v0`, `v1` | `0`, `1` |

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -22,6 +22,7 @@ SupportedModels = Literal[
     "race_no_bias_angle_4",
     "ddm_seq2_no_bias",
     "gamma_drift",
+    "gamma_drift_angle",
     "lba3",
     "lba4",
     "lba2",

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -126,9 +126,9 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
     model
         The name of the model to use. Currently supported models are "ddm", "ddm_sdv",
         "full_ddm", "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
-        "ddm_seq2_no_bias", "gamma_drift". If any other string is passed, the model
-        will be considered custom, in which case all `model_config`, `loglik`, and
-        `loglik_kind` have to be provided by the user.
+        "ddm_seq2_no_bias", "gamma_drift", "gamma_drift_angle". If any other string
+        is passed, the model will be considered custom, in which case all
+        `model_config`, `loglik`, and `loglik_kind` have to be provided by the user.
     choices : optional
         When an `int`, the number of choices that the participants can make. If `2`, the
         choices are [-1, 1] by default. If anything greater than `2`, the choices are

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -62,9 +62,9 @@ class HSSM(HSSMBase):
     model
         The name of the model to use. Currently supported models are "ddm", "ddm_sdv",
         "full_ddm", "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
-        "ddm_seq2_no_bias", "gamma_drift". If any other string is passed, the model
-        will be considered custom, in which case all `model_config`, `loglik`, and
-        `loglik_kind` have to be provided by the user.
+        "ddm_seq2_no_bias", "gamma_drift", "gamma_drift_angle". If any other string
+        is passed, the model will be considered custom, in which case all
+        `model_config`, `loglik`, and `loglik_kind` have to be provided by the user.
     choices : optional
         When an `int`, the number of choices that the participants can make. If `2`, the
         choices are [-1, 1] by default. If anything greater than `2`, the choices are

--- a/src/hssm/modelconfig/gamma_drift_angle_config.py
+++ b/src/hssm/modelconfig/gamma_drift_angle_config.py
@@ -1,0 +1,52 @@
+from .._types import DefaultConfig  # noqa: D100
+
+
+def get_gamma_drift_angle_config() -> DefaultConfig:
+    """
+    Get the default configuration for the gamma_drift_angle model.
+
+    Returns
+    -------
+    DefaultConfig
+        A dictionary containing the default configuration settings for
+        the gamma_drift_angle model, including response variables, model
+        parameters, choices, description,
+        and likelihood specifications.
+    """
+    return {
+        "response": ["rt", "response"],
+        # Order is load-bearing: it is the column order of the ONNX input, and
+        # it must match ssms.config.model_config["gamma_drift_angle"]["params"]
+        # element for element. `theta` sits at index 4, between `t` and
+        # `shape` -- not appended at the end.
+        "list_params": ["v", "a", "z", "t", "theta", "shape", "scale", "c"],
+        "choices": [-1, 1],
+        "description": (
+            "`gamma_drift` with an angled, collapsing decision bound: a "
+            "gamma-shaped drift bump (`shape`, `scale`, signed peak `c`) on "
+            "top of a constant drift, with `theta` setting the bound's "
+            "collapse angle."
+        ),
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "gamma_drift_angle.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                # The network's training box: the full ssm-simulators bounds
+                # for gamma_drift_angle, which the production training data
+                # was sampled from (LAN_pipeline_minimal
+                # configs/production_gamma_drift_angle/).
+                "bounds": {
+                    "v": (-3.0, 3.0),
+                    "a": (0.3, 3.0),
+                    "z": (0.1, 0.9),
+                    "t": (0.001, 2.0),
+                    "theta": (-0.1, 1.3),
+                    "shape": (2.0, 10.0),
+                    "scale": (0.01, 1.0),
+                    "c": (-3.0, 3.0),
+                },
+                "extra_fields": None,
+            },
+        },
+    }

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -122,6 +122,62 @@ def test_get_lba4_config():
     assert likelihood["extra_fields"] is None
 
 
+def test_get_gamma_drift_angle_config():
+    config = get_default_model_config("gamma_drift_angle")
+    assert config["response"] == ["rt", "response"]
+    assert config["choices"] == [-1, 1]
+    # `theta` sits at index 4, not appended after `c`. This is the ONNX input
+    # column order; getting it wrong evaluates the wrong likelihood silently.
+    assert config["list_params"] == [
+        "v",
+        "a",
+        "z",
+        "t",
+        "theta",
+        "shape",
+        "scale",
+        "c",
+    ]
+
+    likelihood = config["likelihoods"]["approx_differentiable"]
+    assert likelihood["loglik"] == "gamma_drift_angle.onnx"
+    assert likelihood["backend"] == "jax"
+    assert likelihood["bounds"] == {
+        "v": (-3.0, 3.0),
+        "a": (0.3, 3.0),
+        "z": (0.1, 0.9),
+        "t": (0.001, 2.0),
+        "theta": (-0.1, 1.3),
+        "shape": (2.0, 10.0),
+        "scale": (0.01, 1.0),
+        "c": (-3.0, 3.0),
+    }
+
+
+@pytest.mark.parametrize("model", ["gamma_drift", "gamma_drift_angle"])
+def test_config_matches_ssms_registry(model):
+    """The declared box must be the box the network was trained on.
+
+    HSSM feeds parameters to the ONNX in `list_params` order, so a wrong order
+    or a wrong bound does not raise -- it silently evaluates a different
+    likelihood. ssm-simulators is the authority for both, since the training
+    data was drawn from its registry.
+    """
+    import ssms
+
+    config = get_default_model_config(model)
+    ssms_config = ssms.config.model_config[model]
+
+    assert config["list_params"] == list(ssms_config["params"])
+    assert config["choices"] == list(ssms_config["choices"])
+
+    lower, upper = ssms_config["param_bounds"]
+    assert config["likelihoods"]["approx_differentiable"]["bounds"] == {
+        param: (low, high)
+        for param, low, high in zip(ssms_config["params"], lower, upper)
+    }
+
+
 @pytest.mark.parametrize("model", hssm.list_models())
 def test_load_all_supported_model_configs(model):
     assert isinstance(get_default_model_config(model), dict)


### PR DESCRIPTION
Adds `gamma_drift_angle` — `gamma_drift` with an angled, collapsing decision bound — as a built-in model.

- New `src/hssm/modelconfig/gamma_drift_angle_config.py`; `gamma_drift_angle` added to `SupportedModels`, the two constructor docstrings, and the docs model table.
- **`list_params` order is load-bearing.** It is the ONNX input column order, and `theta` sits at index 4 (between `t` and `shape`), matching `ssms.config.model_config["gamma_drift_angle"]["params"]`. The natural mistake — copy `gamma_drift_config.py` and add `theta` — appends it after `c`. That does not raise; it silently evaluates the collapse angle in the gamma shape slot.
- Bounds are the network's actual training box, copied from the ssms registry: `theta (-0.1, 1.3)` (cross-checks against the existing `angle_config.py`), `shape (2.0, 10.0)`, `scale (0.01, 1.0)`, `c (-3.0, 3.0)`.
- New `test_config_matches_ssms_registry`, parametrized over `gamma_drift` and `gamma_drift_angle`, asserts `list_params`, `choices`, and the bounds dict all equal the ssms registry. Verified it fails when `theta` is moved to the end — this is the guard, not decoration.

Ordering note: `gamma_drift_angle.onnx` is on `franklab/HSSM_staging` but not yet at the root of `franklab/HSSM`, so `model="gamma_drift_angle"` will resolve its config but fail to download until the artifact is promoted. Same sequence `gamma_drift` followed (config #1248, then the artifact promote).

No issue number — `gamma_drift_angle` has none open. Happy to file one if you'd prefer the branch renamed to match the repo convention.

Testing: `uv run pytest tests/ -m "not slow"` → 910 passed. `uv run ruff check .` / `format --check` clean (the 3 remaining errors are pre-existing notebook issues on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `gamma_drift_angle` built-in model.
  - Added configuration for its parameters, choices, likelihood, and parameter bounds.
  - Updated the supported-model reference documentation.

- **Tests**
  - Added coverage validating the model configuration and simulator registry alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->