### PR TITLE
feat: add angle_extended as a supported model

### DIFF
--- a/docs/reference/models-and-likelihoods.md
+++ b/docs/reference/models-and-likelihoods.md
@@ -14,6 +14,7 @@ model.
 | `ddm_sdv` | `analytical`, `approx_differentiable`, `blackbox` | `analytical` | `v`, `a`, `z`, `t`, `sv` | `-1`, `1` |
 | `full_ddm` | `blackbox` | `blackbox` | `v`, `a`, `z`, `t`, `sz`, `sv`, `st` | `-1`, `1` |
 | `angle` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `theta` | `-1`, `1` |
+| `angle_extended` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `theta` | `-1`, `1` |
 | `levy` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `alpha`, `t` | `-1`, `1` |
 | `ornstein` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `g`, `t` | `-1`, `1` |
 | `weibull` | `approx_differentiable` | `approx_differentiable` | `v`, `a`, `z`, `t`, `alpha`, `beta` | `-1`, `1` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "onnx>=1.16.0",
     # Direct import in hssm.plotting (gaussian_kde, chi2), not merely transitive via pymc.
     "scipy>=1.10",
-    "ssm-simulators>=0.13.1",
+    "ssm-simulators>=0.14.0",
 ]
 
 [project.urls]

--- a/src/hssm/_types.py
+++ b/src/hssm/_types.py
@@ -16,6 +16,7 @@ SupportedModels = Literal[
     "ddm_sdv",
     "full_ddm",
     "angle",
+    "angle_extended",
     "levy",
     "ornstein",
     "weibull",

--- a/src/hssm/base.py
+++ b/src/hssm/base.py
@@ -125,7 +125,8 @@ class HSSMBase(ABC, DataValidatorMixin, MissingDataMixin):
         columns "rt" and "response".
     model
         The name of the model to use. Currently supported models are "ddm", "ddm_sdv",
-        "full_ddm", "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
+        "full_ddm", "angle", "angle_extended", "levy", "ornstein", "weibull",
+        "race_no_bias_angle_4",
         "ddm_seq2_no_bias", "gamma_drift", "gamma_drift_angle". If any other string
         is passed, the model will be considered custom, in which case all
         `model_config`, `loglik`, and `loglik_kind` have to be provided by the user.

--- a/src/hssm/hssm.py
+++ b/src/hssm/hssm.py
@@ -61,7 +61,8 @@ class HSSM(HSSMBase):
         columns "rt" and "response".
     model
         The name of the model to use. Currently supported models are "ddm", "ddm_sdv",
-        "full_ddm", "angle", "levy", "ornstein", "weibull", "race_no_bias_angle_4",
+        "full_ddm", "angle", "angle_extended", "levy", "ornstein", "weibull",
+        "race_no_bias_angle_4",
         "ddm_seq2_no_bias", "gamma_drift", "gamma_drift_angle". If any other string
         is passed, the model will be considered custom, in which case all
         `model_config`, `loglik`, and `loglik_kind` have to be provided by the user.

--- a/src/hssm/modelconfig/angle_extended_config.py
+++ b/src/hssm/modelconfig/angle_extended_config.py
@@ -1,0 +1,48 @@
+from .._types import DefaultConfig  # noqa: D100
+
+
+def get_angle_extended_config() -> DefaultConfig:
+    """
+    Get the default configuration for the angle_extended model.
+
+    Returns
+    -------
+    DefaultConfig
+        A dictionary containing the default configuration settings for
+        the angle_extended model, including response variables, model
+        parameters, choices, description,
+        and likelihood specifications.
+    """
+    return {
+        "response": ["rt", "response"],
+        # Order is load-bearing: it is the column order of the ONNX input, and
+        # it must match ssms.config.model_config["angle_extended"]["params"]
+        # element for element.
+        "list_params": ["v", "a", "z", "t", "theta"],
+        "choices": [-1, 1],
+        "description": (
+            "The angle model -- constant drift with a linearly collapsing "
+            "decision bound whose collapse angle is `theta` -- with the "
+            "drift bounds widened from (-3, 3) to (-6, 6) for designs that "
+            "produce strong evidence."
+        ),
+        "likelihoods": {
+            "approx_differentiable": {
+                "loglik": "angle_extended.onnx",
+                "backend": "jax",
+                "default_priors": {},
+                # The network's training box: the full ssm-simulators bounds
+                # for angle_extended, which the production training data was
+                # sampled from (LAN_pipeline_minimal
+                # configs/production_angle_extended/).
+                "bounds": {
+                    "v": (-6.0, 6.0),
+                    "a": (0.3, 3.0),
+                    "z": (0.1, 0.9),
+                    "t": (0.001, 2.0),
+                    "theta": (-0.1, 1.3),
+                },
+                "extra_fields": None,
+            },
+        },
+    }

--- a/tests/test_modelconfig.py
+++ b/tests/test_modelconfig.py
@@ -154,7 +154,9 @@ def test_get_gamma_drift_angle_config():
     }
 
 
-@pytest.mark.parametrize("model", ["gamma_drift", "gamma_drift_angle"])
+@pytest.mark.parametrize(
+    "model", ["gamma_drift", "gamma_drift_angle", "angle_extended"]
+)
 def test_config_matches_ssms_registry(model):
     """The declared box must be the box the network was trained on.
 


### PR DESCRIPTION
Adds `angle_extended` — the angle model with drift bounds widened to (−6, 6) — as a built-in.

- New `src/hssm/modelconfig/angle_extended_config.py`; registered in `SupportedModels`, both constructor docstrings, and the docs model table.
- Bounds are the network's training box from the ssms registry: `v (−6, 6)`, `a (0.3, 3)`, `z (0.1, 0.9)`, `t (0.001, 2)`, `theta (−0.1, 1.3)`.
- `test_config_matches_ssms_registry` extended to cover it — `list_params` order, choices, and the bounds dict are asserted against `ssms.config.model_config` element-for-element.
- **Raises the `ssm-simulators` floor to `>=0.14.0`** — the first release containing `angle_extended` (v0.13.2 predates it), so without the bump a pip user could hold a registered model the simulator doesn't know.

Ordering note: `angle_extended.onnx` is on `franklab/HSSM_staging` (commit 05feb708) with a **passing** 240-fit recovery report bound to the artifact; the production promote to `franklab/HSSM` is queued behind this PR's review, same sequence as `gamma_drift_angle` (#1296). Recommend merging this only once the promote lands, for the same clean-install-404 reason CodeRabbit raised on #1296.

Testing: 944 passed (fast suite) against released `ssm-simulators 0.14.0`; repo-root ruff unchanged (10 pre-existing notebook findings on main, none in these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `angle_extended` model.
  * Added the model’s configurable parameters, response choices, likelihood, and parameter bounds.
  * Added documentation describing the model and its available likelihood kind.

* **Maintenance**
  * Updated the minimum supported `ssm-simulators` version to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->