### PR TITLE
docs: installing the fast (GSL/OpenMP) simulator backend with pip/uv

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -39,6 +39,56 @@ pip install hssm[cuda12]  # CUDA 12
 pip install hssm[cuda13]  # CUDA 13
 ```
 
+## Optional: a faster simulator backend (GSL + OpenMP)
+
+HSSM simulates through [`ssm-simulators`](https://github.com/lnccbrown/ssm-simulators),
+whose prebuilt wheels ship a portable, single-threaded build. If the package is
+instead compiled on your machine with the GNU Scientific Library present, it
+gains a multithreaded (OpenMP) backend with a validated parallel random-number
+generator — useful when simulation is the bottleneck, for example in
+posterior-predictive sampling.
+
+First install the system libraries (a one-time step):
+
+```bash
+# macOS
+brew install gsl libomp
+
+# Debian / Ubuntu
+sudo apt-get install libgsl-dev build-essential
+```
+
+Then tell your installer to build `ssm-simulators` from source while keeping
+wheels for everything else. With `uv`, add one line to your project and every
+`uv sync` does the right thing from then on:
+
+```toml
+[tool.uv]
+no-binary-package = ["ssm-simulators"]
+```
+
+Or as a one-off install (the flag names the dependency to compile; `hssm` is
+what you are installing):
+
+```bash
+uv pip install --no-binary ssm-simulators hssm
+```
+
+```bash
+pip install hssm --no-binary ssm-simulators
+```
+
+**Verify it worked.** If GSL is not found at build time, the build still
+succeeds and silently produces the same single-threaded backend as the wheel —
+so check:
+
+```bash
+python -c "from cssm._openmp_status import is_gsl_available, is_openmp_available; print('GSL:', is_gsl_available(), '| OpenMP:', is_openmp_available())"
+```
+
+Both should print `True`. If not, confirm the system libraries above are
+installed and reinstall with the same flag.
+
 !!! note
 
     JAX's CUDA wheels are Linux-only and require a compatible NVIDIA driver


### PR DESCRIPTION
- New section in `installation.md`: the prebuilt `ssm-simulators` wheels are the portable single-threaded build; compiling from source with system GSL enables the multithreaded OpenMP backend with the validated parallel RNG — relevant wherever simulation is the bottleneck (e.g. posterior predictives).
- Documents the three routes: `[tool.uv] no-binary-package` (set-and-forget), `uv pip install --no-binary ssm-simulators hssm`, and the pip equivalent — plus the system-library prerequisites.
- Ends with the runtime verification one-liner, because the source build's no-GSL fallback is **silent**: without the check, a user with a missing header believes they got the fast build and did not.
- Verified on this machine: source build reports `GSL: True | OpenMP: True`; the PyPI wheel reports both `False`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added installation guidance for an optional faster simulator backend using GSL and OpenMP.
  - Documented system library setup for macOS and Debian/Ubuntu.
  - Added instructions for forcing a source build and verifying GSL/OpenMP availability.
  - Clarified that installations without GSL use the single-threaded backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->