### PR TITLE
Fix notebook lint before v0.5.0 release

### DIFF
--- a/docs/getting_started/getting_started.ipynb
+++ b/docs/getting_started/getting_started.ipynb
@@ -64,7 +64,6 @@
    "outputs": [],
    "source": [
     "import arviz as az\n",
-    "import numpy as np\n",
     "\n",
     "import hssm\n",
     "\n",

--- a/docs/tutorials/attentional_ddm.ipynb
+++ b/docs/tutorials/attentional_ddm.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "\n",
     "def make_fixations(n, max_d=8, seed=0):\n",
-    "    \"\"\"A batch of observed fixation sequences (the aDDM covariates).\"\"\"\n",
+    "    \"\"\"Create observed fixation sequences for the aDDM covariates.\"\"\"\n",
     "    rng = np.random.default_rng(seed)\n",
     "    r1 = rng.integers(1, 6, n).astype(np.float64)\n",
     "    r2 = rng.integers(1, 6, n).astype(np.float64)\n",
@@ -264,6 +264,7 @@
    ],
    "source": [
     "def simulate(eta, kappa, a, b, fixations, seed=1):\n",
+    "    \"\"\"Simulate aDDM observations conditioned on fixation sequences.\"\"\"\n",
     "    # theta is (n_trials, 6) = [eta, kappa, a, b, x0, t]; one row per fixation\n",
     "    # trial (all sharing these params here), n_samples=1 draw each.\n",
     "    n = fixations[\"n\"]\n",
@@ -779,7 +780,8 @@
     "    for k, v in _ef.items()\n",
     ")\n",
     "mo.md(\n",
-    "    f\"**`rv_op._extra_fields`** (observed fixations wired into PPC):\\n\\n```\\n{_rows}\\n```\"\n",
+    "    f\"**`rv_op._extra_fields`** (observed fixations wired into PPC):\\n\\n\"\n",
+    "    f\"```\\n{_rows}\\n```\"\n",
     ")"
    ]
   },

--- a/docs/tutorials/cartoon_gallery.ipynb
+++ b/docs/tutorials/cartoon_gallery.ipynb
@@ -56,7 +56,6 @@
     "import hssm\n",
     "from hssm.plotting import plot_model_cartoon\n",
     "\n",
-    "\n",
     "# The demo trace ships without predictive groups, so each plot call\n",
     "# re-samples the posterior predictive and numba prints its object-mode\n",
     "# compile notice every time (harmless; tracked in lnccbrown/HSSM#1080).\n",

--- a/docs/tutorials/main_tutorial.ipynb
+++ b/docs/tutorials/main_tutorial.ipynb
@@ -26,7 +26,6 @@
     "logging.getLogger(\"hssm\").setLevel(logging.ERROR)\n",
     "\n",
     "import arviz as az\n",
-    "import marimo as mo\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "\n",

--- a/docs/tutorials/main_tutorial_scenic_route.ipynb
+++ b/docs/tutorials/main_tutorial_scenic_route.ipynb
@@ -13,9 +13,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import marimo as mo"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -6662,7 +6660,10 @@
     ")  # z\n",
     "# simulate data\n",
     "# Turn into nice dataset\n",
-    "dataset_trialwise  # t  # parameter_matrix  # specify model (many are included in ssms)  # number of samples for each set of parameters  # (plays the role of `size` parameter in `hssm.simulate_data`)"
+    "dataset_trialwise  # t\n",
+    "# parameter_matrix; specify model (many are included in ssms)\n",
+    "# number of samples for each set of parameters (plays the role of `size`\n",
+    "# in `hssm.simulate_data`)"
    ]
   },
   {
@@ -7285,7 +7286,7 @@
     "        np.ones(data_nrows) * 0,\n",
     "        err,\n",
     "        1,\n",
-    "    )  # Our function expects inputs as float64, but they are not guaranteed to  # come in as such --> we type convert"
+    "    )  # Inputs are not guaranteed to be float64, so convert them above."
    ]
   },
   {

--- a/docs/tutorials/ppc_gallery.ipynb
+++ b/docs/tutorials/ppc_gallery.ipynb
@@ -45,7 +45,6 @@
     "\n",
     "import hssm\n",
     "\n",
-    "\n",
     "fixtures = Path(\"../../tests/fixtures\")\n",
     "cav_data = pd.read_csv(fixtures / \"cavanagh_theta_test.csv\", index_col=None)\n",
     "model = hssm.HSSM(\n",


### PR DESCRIPTION
## Summary

- apply the repository's Ruff auto-fixes to six published notebooks
- add two missing/imperative docstrings in the aDDM tutorial
- wrap long notebook source lines without changing numerical behavior or rendered meaning

This fixes the only failure found by the `v0.5.0` release pre-commit gate on current `main`.

## Validation

- `prek run --all-files`
- `pytest tests/test_docs_notebook_paths.py tests/test_docs_publication.py tests/test_notebook_workflow_support.py` (34 passed, 10 subtests passed)
- `mkdocs build --strict`
- `notebook_inspect.py check --require-executed` for all six changed notebooks
- `git diff --check`

The edits are source-only lint cleanup. Existing executed outputs remain valid; every changed notebook reports zero error outputs and no machine-local path leaks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified tutorial descriptions for fixation-sequence creation and simulator conditioning.
  * Improved Markdown formatting for rendered code examples.
  * Removed unused imports from getting-started and tutorial notebooks.
  * Cleaned up unnecessary blank lines and refined explanatory comments across several notebooks.
  * No functional behavior or public interfaces changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->